### PR TITLE
Add Source Sans Pro from Google Web fonts

### DIFF
--- a/app/assets/stylesheets/type.scss
+++ b/app/assets/stylesheets/type.scss
@@ -98,7 +98,7 @@ $giga-type:    110;
 @mixin big-type {
   font-size: em($big-type); // roughly 16*1.382 (shorter part of golden ratio)
   line-height: lines(1, $big-type); // 24px
-  font-weight: 500;
+  font-weight: 600;
 }
 
 @mixin large-type {

--- a/app/views/layouts/_head.haml
+++ b/app/views/layouts/_head.haml
@@ -8,6 +8,7 @@
   = render :partial => "layouts/kissmetrics"
   
   %meta{charset: "utf-8" }
+  %link{href: "http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700", rel: "stylesheet", type: "text/css"}
   %meta{content: "width=device-width, initial-scale=1", name: "viewport"}
   %meta{ :property => "og:type", :content =>"website"}
   %meta{ :property => "fb:admins", :content =>"Gnomet,juhomakkonen"}


### PR DESCRIPTION
Added web font `link` element in the `head` element right after the charset.

Google instructs to add the `link` element as the first element in `head`, but I've read that charset `meta` tag should be always the first one. That's why I put the `link` right after charset.

According to this SA answer (http://stackoverflow.com/questions/12316501/including-google-web-fonts-link-or-import), using `link` instead of `@import` is the way to go.
