### PR TITLE
Message badge

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -338,23 +338,56 @@ ul {
   text-align: center;
   width: em(18, 13);
   line-height: em( (18 - 1 - 5), 13 );
-  padding: em(1, 13) 0 em(5, 13);
+  padding: 4px 5px 4px 5px;
   color: $background;
   @include border-radius( em((18/2), 13) );
   
   &.big-badge {
-    width: em(22, 13);
+    width: em(24, 13);
     line-height: em( (22 - 1 - 5), 13 );
     @include border-radius( em((22/2), 13) );
   }
   
   &.huge-badge {
-    width: em(28, 13);
-    line-height: em( (28 - 1 - 5), 13 );
-    padding: em(2, 13) 0 em(4, 13);    
+    width: em(30, 13);
+    line-height: em( (28 - 1 - 5), 13 );   
     @include border-radius( em((28/2), 13) );
   }
 }
+
+.mobile-badge {
+  @include small-type;
+  @include border-radius(10px);
+  margin-left: lines(0.25);
+  margin-top: 9px;
+  width: 20px;
+  padding-left: 7px;
+  display: inline-block;
+  background: $link;
+  color: $background;
+  
+  &.big-badge {
+    width: 27px;
+    @include border-radius(13px);
+  }
+  
+  &.huge-badge {
+    width: 34px;
+    @include border-radius(13px);
+  }
+  
+  @include media(mid-desktop) {
+    display: none;
+  }
+}
+
+.mobile-badge-menu {
+  @extend .mobile-badge;
+  margin-top: 0;
+  background: $background;
+  color: $light-body;
+}
+
 
 .icon {
   @include big-type;
@@ -555,10 +588,18 @@ label.error {
   // Positions badges in .inbox-toggle and .notifications-toggle
   position: absolute;
   top: -10px; // Magic numbers, these just look good
-  left: -5px; // Magic numbers, these just look good
+  left: 13px; // Magic numbers, these just look good
+  
+  &.big-badge {
+    width: em(24, 13);
+    line-height: em( (22 - 1 - 5), 13 );
+    @include border-radius( em((22/2), 13) );
+  }
   
   &.huge-badge {
-    right: lines(0.0625); bottom: lines(0.0625);
+    width: em(30, 13);
+    line-height: em( (28 - 1 - 5), 13 );   
+    @include border-radius( em((28/2), 13) );
   }
 }
 
@@ -3580,7 +3621,7 @@ header.marketplace-header {
   .user-menu-toggle {
     // Backup for IE
     width: 100%;
-    width: calc(100% - 7.25em);
+    width: calc(100% - 7.5em);
     position: relative;
     display: inline-block;
     vertical-align: top;
@@ -3599,7 +3640,7 @@ header.marketplace-header {
 
     .user-name {
       vertical-align: top;
-      padding: em(5) 0 0 lines(0.25);
+      padding: em(5) 0 0 lines(0.375);
       display: inline-block;
       max-width: lines(4.5);
       white-space: nowrap;
@@ -3611,7 +3652,7 @@ header.marketplace-header {
     .icon-dropdown {
       display: block;
       position: absolute;
-      top: em(18);
+      top: em(20);
       right: lines(0.5);
     }
     

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -753,11 +753,11 @@ module ApplicationHelper
   def get_badge_class(count)
     case count
     when 1..9
-      "badge"
+      ""
     when 10..99
-      "badge big-badge"
+      "big-badge"
     else
-      "badge huge-badge"
+      "huge-badge"
     end
   end
   

--- a/app/views/layouts/_badge.haml
+++ b/app/views/layouts/_badge.haml
@@ -1,3 +1,3 @@
 - if count > 0
-  %div{:class => get_badge_class(count)}
+  %div{:class => "badge #{get_badge_class(count)}"}
     = count.to_s

--- a/app/views/layouts/_global-header.haml
+++ b/app/views/layouts/_global-header.haml
@@ -37,12 +37,16 @@
       - if @current_user
         %a{:href => received_person_messages_path(:person_id => @current_user.id.to_s), title: t("layouts.conversations.messages"), :id => "inbox-link", :class => "global-navi inbox-link"}
           = icon_tag("mail", ["icon"])
-          = render :partial => "layouts/messages_badge"
+          .messages-badge
+            .badge{:class => get_badge_class(Conversation.unread_count(@current_user.id.to_s))} 
+              = Conversation.unread_count(@current_user.id.to_s)
         .user-menu-toggle.toggle.hidden{data: {toggle: '.user-menu'}}
           = image_tag @current_user.image.url(:thumb), alt: '', class: 'user-avatar'
-          .user-name= @current_user.name(@current_community)
+          .user-name
+            = @current_user.name(@current_community)
+          .mobile-badge{:class => get_badge_class(Conversation.unread_count(@current_user.id.to_s))}
+            = Conversation.unread_count(@current_user.id.to_s)
           = icon_tag("dropdown", ["icon-dropdown"])
-          = render :partial => "layouts/user_badge"
         
           %nav.user-menu.toggle-menu.hidden
             %a.profile-menu-button{href: person_path(@current_user)}
@@ -53,7 +57,8 @@
               = icon_tag("mail", ["icon-with-text"])
               .text-with-icon
                 = t("layouts.conversations.messages") 
-                = render :partial => "layouts/messages_badge"
+              .mobile-badge-menu{:class => get_badge_class(Conversation.unread_count(@current_user.id.to_s))}
+                = Conversation.unread_count(@current_user.id.to_s)
             %a.feedback-menu-button{href: new_user_feedback_path}
               = icon_tag("feedback", ["icon-with-text"])
               .text-with-icon


### PR DESCRIPTION
- Vertical center the badge number (add 1 or 2 px top padding)
- Test with huge style, which is (apparently?) applied when the number has two digits
- Badge should be visible also in mobile
