### PR TITLE
Fix toolbar button group with long text

### DIFF
--- a/app/assets/stylesheets/views/_home.css.scss
+++ b/app/assets/stylesheets/views/_home.css.scss
@@ -47,6 +47,7 @@
   width: 33.3%;
 
   @include media(tablet) {
+    width: auto;
     min-width: lines(5);
   }
 }


### PR DESCRIPTION
- Remove width: 33% if not in mobile
