### PR TITLE
limit sphinx to index only open listings

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -124,6 +124,10 @@ class Listing < ActiveRecord::Base
   
   # Index for sphinx search
   define_index do
+    
+    # limit to open listings
+    where "open = '1' AND (valid_until IS NULL OR valid_until > now())"
+    
     # fields
     indexes title
     indexes description


### PR DESCRIPTION
This should help the complaints of using too much data for our plan in production and help the preproduction to start at all. (As the amount of data is the same)
