### PR TITLE
Fix network page toggle

### DIFF
--- a/app/assets/stylesheets/partials/_toggle.css.scss
+++ b/app/assets/stylesheets/partials/_toggle.css.scss
@@ -123,9 +123,6 @@
   display: block;
   cursor: pointer;
 
-  // Mobile
-  width: 100%;
-
   @include media(tablet) {
     display: inline-block;
     width: auto;

--- a/app/views/layouts/dashboard.haml
+++ b/app/views/layouts/dashboard.haml
@@ -12,7 +12,7 @@
           %li= link_to "how it works", "#how-it-works", :class => "global-navi"
           %li= link_to "blog", "http://blog.sharetribe.com/", :class => "global-navi"
           %li= link_to "contact", "mailto:info@sharetribe.com", :class => "global-navi-right"
-      .top-menu-toggle.toggle.hidden{data: {toggle: '.top-menu'}}
+      .top-menu-toggle.toggle.hidden-tablet{data: {toggle: '.top-menu'}}
         .ss-rows
     
     


### PR DESCRIPTION
- Hide in tablet
- Remove width 100% from .toggle class (doesn't hide the sharetribe logo)
