### PR TITLE
Move render blocking JavaScript at the bottom of body

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -344,7 +344,9 @@ module ApplicationHelper
       :div1       => target_id
     }
     
-    javascript_tag("$('#{target_id}').pageless(#{opts.to_json});")
+    content_for :extra_javascript do
+      javascript_tag("$('#{target_id}').pageless(#{opts.to_json});")
+    end
   end
   
   # Class is selected if conversation type is currently selected

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -28,11 +28,7 @@
 /[if lt IE 9]
   = stylesheet_link_tag 'old_ie'
   
-= javascript_include_tag 'application'
-= yield(:extra_javascript)
 = csrf_meta_tag
-:javascript
-  $(document).ready(function() { initialize_defaults("#{I18n.locale}"); #{yield :javascript} });
 
 %link{:rel => "image_src", :href => "https://s3.amazonaws.com/sharetribe/assets/dashboard/sharetribe_logo.png"}
 

--- a/app/views/layouts/_network_head.haml
+++ b/app/views/layouts/_network_head.haml
@@ -22,12 +22,7 @@
 /[if lt IE 9]
 = stylesheet_link_tag 'old_ie'
   
-= javascript_include_tag 'application'
-= yield(:extra_javascript)
 = csrf_meta_tag
-
-:javascript
-  $(document).ready(function() { initialize_network_defaults(); #{yield :javascript} });
 
 %link{:rel => "image_src", :href => "https://s3.amazonaws.com/sharetribe/assets/dashboard/sharetribe_logo.png"}
 

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -48,5 +48,13 @@
   -#
     Most of the JavaScript should be for performance reasons at the end of the body
 
+  = javascript_include_tag 'application'
+  = yield(:extra_javascript)
+  - if @current_community
+    :javascript
+      $(document).ready(function() { initialize_defaults("#{I18n.locale}"); #{yield :javascript} });
+  - else
+    :javascript
+      $(document).ready(function() { initialize_network_defaults(); #{yield :javascript} });
   = yield(:body_javascript)
   


### PR DESCRIPTION
**Background:**
A `<script>` block will block all the processing/rendering of DOM until the content of the `<script>` is completely loaded, evaluated and executed. Thus, all the JavaScript should be at the bottom of the DOM.

**This Pull Request:**
- Moves the JavaScript at the bottom of the page
