### PR TITLE
Dynamically add option, without server request

### DIFF
--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -16,7 +16,6 @@ class Admin::CustomFieldsController < ApplicationController
     @community = @current_community
     @custom_field = Dropdown.new
     @custom_field.options = [CustomFieldOption.new, CustomFieldOption.new]
-    session[:option_amount] = 2
   end
   
   def create
@@ -34,7 +33,6 @@ class Admin::CustomFieldsController < ApplicationController
     @selected_left_navi_link = "listing_fields"
     @community = @current_community
     @custom_field = CustomField.find(params[:id])
-    session[:option_amount] = @custom_field.options.size
   end
   
   def update
@@ -52,13 +50,6 @@ class Admin::CustomFieldsController < ApplicationController
 
     flash[:error] = "Field doesn't belong to current community" unless success
     redirect_to admin_custom_fields_path
-  end
-  
-  def add_option
-    session[:option_amount] += 1
-    respond_to do |format|
-      format.js { render :layout => false }
-    end
   end
 
   def order

--- a/app/views/admin/custom_fields/_new_option.haml
+++ b/app/views/admin/custom_fields/_new_option.haml
@@ -1,23 +1,22 @@
-- option_id = option.id || ('new-' + index.to_s)
 .custom-field-option-container{:data => {:"field-id" => "#{option_id}"}}
-  .custom-field-option-locales{:id => "custom_field_option_#{index}"}
+  .custom-field-option-locales
     .row
-      .col-8{:class => available_locales.size > 1 ? "" : "custom-field-column-without-bottom-margin"}
+      - show_locales = available_locales.size > 1
+      .col-8{:class => show_locales ? "" : "custom-field-column-without-bottom-margin"}
         = fields_for "custom_field[option_attributes][#{option_id}][]", option do |option_form|
-          - show_locales = available_locales.size > 1
           - input_col_size = show_locales ? "9" : "12"
           - available_locales.each do |locale_name, locale_value|
             .row.custom-field-option-locale-row
               - if show_locales
                 .col-3.custom-field-option-locale-column
-                  = label_tag "custom_field[option_attributes][#{index}][title_attributes][#{locale_value}]", locale_name + ": ", :class => "custom-field-option-with-multiple-locales-label"
+                  = label_tag "custom_field[option_attributes][#{option_id}][title_attributes][#{locale_value}]", locale_name + ": ", :class => "custom-field-option-with-multiple-locales-label"
               .custom-field-option-locale-column{:class => "col-#{input_col_size}"}
                 = text_field_tag "custom_field[option_attributes][#{option_id}][title_attributes][#{locale_value}]", option.title(locale_value), :class => "required", :value => option.title(locale_value)
-          = hidden_field_tag "custom_field[option_attributes][#{option_id}][sort_priority]", "#{index}", :class => "custom-field-hidden-sort-priority"
+          = hidden_field_tag "custom_field[option_attributes][#{option_id}][sort_priority]", sort_priority, :class => "custom-field-hidden-sort-priority"
       .col-4.custom-field-actions
-        - link_class = "custom-field-option-#{(available_locales.size > 1 ? "with" : "without")}-locale-remove"
+        - link_class = "custom-field-option-#{(show_locales ? "with" : "without")}-locale-remove"
         
-        = link_to "#", :class => "custom-field-option-remove #{link_class}", :tabindex => "-1", :id => "remove-option-#{index}" do
+        = link_to "#", :class => "custom-field-option-remove #{link_class}", :tabindex => "-1", :id => "custom-field-option-remove-#{option_id}" do
           = icon_tag("cross", ["icon-fix"])
         = link_to '#', :class => "custom-fields-action-up" do
           = icon_tag("directup", ["icon-fix"])

--- a/app/views/admin/custom_fields/add_option.js.erb
+++ b/app/views/admin/custom_fields/add_option.js.erb
@@ -1,4 +1,0 @@
-/* Add a new option field */
-$("#options").append("<%= escape_javascript(render(:partial => 'admin/custom_fields/new_option', :locals => {:option => CustomFieldOption.new, :index => session[:option_amount]})) %>");
-ST.newOptionAdded();
-ST.customFieldOptionOrder.add("new-<%= session[:option_amount]%>");

--- a/app/views/admin/custom_fields/edit.haml
+++ b/app/views/admin/custom_fields/edit.haml
@@ -1,5 +1,5 @@
 - content_for :javascript do
-  initialize_admin_listing_field_form_view("#{I18n.locale}", "#edit_dropdown_#{@custom_field.id}", #{session[:option_amount]});
+  initialize_admin_listing_field_form_view("#{I18n.locale}", "#edit_dropdown_#{@custom_field.id}", #{@custom_field.options.size});
   ST.customFieldOptionOrder = ST.createCustomFieldOptionOrder(".custom-field-option-container");
   
 - content_for :title_header do

--- a/app/views/admin/custom_fields/form/_field_options.haml
+++ b/app/views/admin/custom_fields/form/_field_options.haml
@@ -2,8 +2,10 @@
 .row
   .col-12
     #options.custom-field-options
+      %script{type: "text/template", class: "template", id: "new-option-tmpl"}
+        = render :partial => "new_option", :locals => { :option => CustomFieldOption.new, :option_id => "${id}", :sort_priority => "${sortPriority}" }
       - @custom_field.options.sort.each_with_index do |option, index|
-        = render :partial => "new_option", :locals => { :option => option, :index => (index + 1) }
+        = render :partial => "new_option", :locals => { :option => option, :option_id => option.id || "new-#{index+1}", :sort_priority => index }
 .row
   .col-12
-    = link_to t("admin.custom_fields.index.add_option"), add_option_admin_custom_fields_path, :remote => true, :id => "custom-fields-add-option"
+    = link_to t("admin.custom_fields.index.add_option"), "#", :id => "custom-fields-add-option"

--- a/app/views/admin/custom_fields/new.haml
+++ b/app/views/admin/custom_fields/new.haml
@@ -1,5 +1,6 @@
 - content_for :javascript do
-  initialize_admin_listing_field_form_view("#{I18n.locale}", "#new_dropdown", #{session[:option_amount]});
+  initialize_admin_listing_field_form_view("#{I18n.locale}", "#new_dropdown", 2);
+  ST.customFieldOptionOrder = ST.createCustomFieldOptionOrder(".custom-field-option-container");
   
 - content_for :title_header do
   %h1

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -67,8 +67,8 @@ When /^I add a new custom field "(.*?)"$/ do |field_name|
     And I fill in "custom_field[option_attributes][new-2][title_attributes][en]" with "Appartment"
     And I fill in "custom_field[option_attributes][new-2][title_attributes][fi]" with "Asunto"
     And I follow "custom-fields-add-option"
-    And I fill in "custom_field[option_attributes][new-3][title_attributes][en]" with "House"
-    And I fill in "custom_field[option_attributes][new-3][title_attributes][fi]" with "Talo"
+    When I fill in "custom_field[option_attributes][jsnew-1][title_attributes][en]" with "House"
+    And I fill in "custom_field[option_attributes][jsnew-1][title_attributes][fi]" with "Talo"
     And I press submit
   }
 end
@@ -81,8 +81,8 @@ When /^I add a new custom field "(.*?)" with invalid data$/ do |field_name|
     And I fill in "custom_field[option_attributes][new-1][title_attributes][fi]" with "Huone"
     And I fill in "custom_field[option_attributes][new-2][title_attributes][en]" with "Appartment"
     And I follow "custom-fields-add-option"
-    And I fill in "custom_field[option_attributes][new-3][title_attributes][en]" with "House"
-    And I fill in "custom_field[option_attributes][new-3][title_attributes][fi]" with "Talo"
+    And I fill in "custom_field[option_attributes][jsnew-1][title_attributes][en]" with "House"
+    And I fill in "custom_field[option_attributes][jsnew-1][title_attributes][fi]" with "Talo"
     And I press submit
   }
 end
@@ -133,12 +133,12 @@ When /^I edit dropdown "(.*?)" options$/ do |field_name|
     And I fill in "custom_field[option_attributes][#{@custom_field.options[1].id}][title_attributes][en]" with "House2"
     And I fill in "custom_field[option_attributes][#{@custom_field.options[1].id}][title_attributes][fi]" with "Talo2"
     And I follow "custom-fields-add-option"
-    And I fill in "custom_field[option_attributes][new-3][title_attributes][en]" with "House3"
-    And I fill in "custom_field[option_attributes][new-3][title_attributes][fi]" with "Talo3"
+    And I fill in "custom_field[option_attributes][jsnew-1][title_attributes][en]" with "House3"
+    And I fill in "custom_field[option_attributes][jsnew-1][title_attributes][fi]" with "Talo3"
     And I follow "custom-fields-add-option"
-    And I fill in "custom_field[option_attributes][new-4][title_attributes][en]" with "House4"
-    And I fill in "custom_field[option_attributes][new-4][title_attributes][fi]" with "Talo4"
-    And I follow "remove-option-1"
+    And I fill in "custom_field[option_attributes][jsnew-2][title_attributes][en]" with "House4"
+    And I fill in "custom_field[option_attributes][jsnew-2][title_attributes][fi]" with "Talo4"
+    And I follow "custom-field-option-remove-1"
     And I press submit
   }
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -17,6 +17,17 @@ module FillInHelpers
     with = options.delete(:with)
     first(:fillable_field, locator, options).set(with)
   end
+
+  def fill_in_nth(locator, n, options={})
+    # Highly inspired by Capybara's fill_in implementation
+    # https://github.com/jnicklas/capybara/blob/80befdad73c791eeaea50a7cbe23f04a445a24bc/lib/capybara/node/actions.rb#L50
+    raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
+    with = options.delete(:with)
+    results = all(:fillable_field, locator, options)
+    if results.size >= n
+      results[n - 1].set(with)
+    end
+  end
 end
 World(FillInHelpers)
 
@@ -67,9 +78,12 @@ When /^(?:|I )fill in "([^"]*)" with "([^"]*)"(?: within "([^"]*)")?$/ do |field
   end
 end
 
-When /^(?:|I )fill in first "([^"]*)" with "([^"]*)"(?: within "([^"]*)")?$/ do |field, value, selector|
+When /^(?:|I )fill in (first|second|third) "([^"]*)" with "([^"]*)"(?: within "([^"]*)")?$/ do |ordinal, field, value, selector|
+  nums = {"first" => 1, "second" => 2, "third" => 3}
+  n = nums[ordinal]
+
   with_scope(selector) do
-    fill_in_first(field, :with => value)
+    fill_in_nth(field, n, :with => value)
   end
 end
 


### PR DESCRIPTION
Fixes bug, steps to reproduce:
1. Go to production
2. Edit custom field
3. Add two options by double clicking "Add new option" button
4. Change the order of options
