### PR TITLE
Remove duplicate entries from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,12 +70,7 @@ gem "mail_view", "~> 1.0.3"
 #ouisharelabs
 gem 'rdf-turtle'
 
-group :staging do
-  gem "airbrake", "~>3.1.12"
-  gem 'newrelic_rpm', "~>3.6.2.96"
-end
-
-group :production do
+group :staging, :production do
   gem "airbrake", "~>3.1.12"
   gem 'newrelic_rpm', "~>3.6.2.96"
 end


### PR DESCRIPTION
Deploy script complains:

```
Your Gemfile lists the gem airbrake (~> 3.1.12) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
Your Gemfile lists the gem newrelic_rpm (~> 3.6.2.96) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```
