### PR TITLE
[Pending review] Don't compile CSS on request

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -908,16 +908,6 @@ module ApplicationHelper
 
   def with_stylesheet_url(community, &block)
     stylesheet_url = if community.has_customizations?
-      unless community.has_custom_stylesheet?
-        Rails.logger.warn "Compiling stylesheet for #{community.name} on request..."
-
-        start_time = Time.now
-        CommunityStylesheetCompiler.compile(community)
-        end_time = Time.now
-
-        Rails.logger.warn "Finished compiling stylesheet for #{community.name}. Time elapsed #{(end_time - start_time)*1000} ms"
-      end
-
       community.custom_stylesheet_url
     else
       'application'

--- a/app/jobs/compile_custom_stylesheet_job.rb
+++ b/app/jobs/compile_custom_stylesheet_job.rb
@@ -8,7 +8,7 @@ class CompileCustomStylesheetJob < Struct.new(:community_id)
   
   def perform
     community = Community.find(community_id)
-    unless community.has_custom_stylesheet?
+    if community.stylesheet_needs_recompile?
       CommunityStylesheetCompiler.compile(community)
     end
   end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -297,8 +297,8 @@ class Community < ActiveRecord::Base
     Person.joins(:community_memberships).where("community_memberships.admin = '1'").group("people.id")
   end
 
-  def self.reset_custom_stylesheets!
-    Community.with_customizations.update_all(:stylesheet_url => nil)
+  def self.stylesheet_needs_recompile!
+    Community.with_customizations.update_all(:stylesheet_needs_recompile => true)
   end
 
   # approves a membership pending email if one is found

--- a/app/services/community_stylesheet_compiler.rb
+++ b/app/services/community_stylesheet_compiler.rb
@@ -17,7 +17,7 @@ module CommunityStylesheetCompiler
 
     def compile_all
       puts "Reset all custom CSS urls"
-      Community.reset_custom_stylesheets!
+      Community.stylesheet_needs_recompile!
 
       with_customizations_prioritized = Community.with_customizations.order("members_count DESC")
 
@@ -54,10 +54,12 @@ module CommunityStylesheetCompiler
       # to disturb what's happening at production.
       # Normally update the stylesheet_url
       if APP_CONFIG.preproduction
-        community.update_attribute(:preproduction_stylesheet_url, url)        
+        community.update_attribute(:preproduction_stylesheet_url, url)
       else
         community.update_attribute(:stylesheet_url, url)
       end
+
+      community.update_attribute(:stylesheet_needs_recompile, false)
     end
 
     private

--- a/db/migrate/20140314132659_add_stylesheet_needs_recompile_to_community.rb
+++ b/db/migrate/20140314132659_add_stylesheet_needs_recompile_to_community.rb
@@ -1,0 +1,5 @@
+class AddStylesheetNeedsRecompileToCommunity < ActiveRecord::Migration
+  def change
+    add_column :communities, :stylesheet_needs_recompile, :boolean, :default => 0, :after => :stylesheet_url
+  end
+end


### PR DESCRIPTION
- Add new flag "stylesheet_needs_recompile"
- Use old CSS file until the stylesheet is recompiled and the flag is
  set to _false_

Todo
- [x] Review
- [x] Test on staging
