### PR TITLE
[Pending tests to run] Faster Zeus RSpec startup

### DIFF
--- a/custom_plan.rb
+++ b/custom_plan.rb
@@ -9,8 +9,17 @@ class CustomPlan < Zeus::Rails
   #  # see https://github.com/burke/zeus/blob/master/docs/ruby/modifying.md
   # end
 
-  def cucumber_environment
+  def test_environment
+    super
 
+    # Populate db with default data
+    require 'database_cleaner'
+    DatabaseCleaner.clean_with(:truncation)
+    load_default_test_data_to_db_before_suite
+    load_default_test_data_to_db_before_test
+  end
+
+  def cucumber_environment
 
     # Ensure sphinx directories exist for the test environment
     ThinkingSphinx::Test.init
@@ -22,12 +31,6 @@ class CustomPlan < Zeus::Rails
     # With Zeus we don't care if it stays running afterwards. It's anyway restarted next time Zeus starts
     # And keeping it running makes running new tests much faster
     ThinkingSphinx::Test.start
-
-    # Populate db with default data
-    require 'database_cleaner'
-    DatabaseCleaner.clean_with(:truncation)
-    load_default_test_data_to_db_before_suite
-    load_default_test_data_to_db_before_test
   end
 end
 

--- a/spec/support/database_cleanup.rb
+++ b/spec/support/database_cleanup.rb
@@ -14,7 +14,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
-    clean_db.call
+    if !defined?(Zeus)
+      clean_db.call
+    end
   end
 
   config.before(:each) do


### PR DESCRIPTION
**Problem** 

There was some annoying delay (around 6 seconds) when starting `zeus rspec` or autorunning tests with `guard`. This was because before suite hook, which loaded default test data to database.

**Solution**

As with cucumber, the test data is now loaded on zeus startup.

**What needs to be done before merging**

Wait for Travis tests to pass. If ok, then merge.
