### PR TITLE
Tweet without transaction type and marketplace name

### DIFF
--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -56,8 +56,10 @@
             .listing-fb-like-button
               = facebook_like(current_user?(@listing.author))
             .listing-tweet-button
-              = link_to("", "https://twitter.com/share", :class => "twitter-share-button", "data-count" => "horizontal", "data-via" => (@current_community.twitter_handle || "Sharetribe"))
-              %script{:type => "text/javascript", :src => "https://platform.twitter.com/widgets.js"}
+              = link_to("", "https://twitter.com/share", :class => "twitter-share-button", "data" => {count: "horizontal", via: (@current_community.twitter_handle || "Sharetribe"), text: @listing.title })
+              - content_for :extra_javascript do
+                :javascript
+                  !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
 
     - unless (@listing.closed? && !current_user?(@listing.author)) || !@current_community.listing_comments_in_use
       .view-item


### PR DESCRIPTION
The default message for a tweet is now: "<listing title> <listing url> via <twitter handle"
