### PR TITLE
Fixes search problems with e.g. scandinavian letters by adding property utf8? to indice definitions.

### DIFF
--- a/app/indices/custom_field_value_index.rb
+++ b/app/indices/custom_field_value_index.rb
@@ -1,5 +1,11 @@
 ThinkingSphinx::Index.define :custom_field_value, :with => :active_record, :delta => ThinkingSphinx::Deltas::DelayedDelta do
 
+  #Thinking Sphinx will automatically add the SQL command SET NAMES utf8 as
+  # part of the indexing process if the database connection settings have
+  # encoding set to utf8. This is default in Rails but with Heroku, we need to
+  # be explicit.
+  set_property :utf8? => true
+
   # attributes
   has listing_id
   has custom_field_id

--- a/app/indices/listing_index.rb
+++ b/app/indices/listing_index.rb
@@ -1,5 +1,11 @@
 ThinkingSphinx::Index.define :listing, :with => :active_record, :delta => ThinkingSphinx::Deltas::DelayedDelta do
 
+  #Thinking Sphinx will automatically add the SQL command SET NAMES utf8 as
+  # part of the indexing process if the database connection settings have
+  # encoding set to utf8. This is default in Rails but with Heroku, we need to
+  # be explicit.
+  set_property :utf8? => true
+
   # limit to open listings
   where "open = '1' AND (valid_until IS NULL OR valid_until > now())"
 


### PR DESCRIPTION
Thinking Sphinx will automatically add the SQL command SET NAMES utf8 as part of the indexing process if the database connection settings have encoding set to utf8. This is the default in Rails, but with Heroku, you need to manually make sure it's part of the DATABASE_URL environment variable (e.g. mysql2://username:password@host/database?encoding=utf8). Once that's done, a re-index should have things working.

An alternative is to have the following in each index definition:

set_property :utf8? => true
