### PR TITLE
[Pending review] Fix Android issue: Not showing listing images

### DIFF
--- a/app/assets/stylesheets/mixins/_vertical-centering.css.scss
+++ b/app/assets/stylesheets/mixins/_vertical-centering.css.scss
@@ -7,19 +7,35 @@
 @mixin vertical-centering-container {
   // Set font-size to 0 to remove the small gap between
   // inline-block elements
-  font-size: 0;
+  //
+  // Android pre Jellybean has an ugly bug, which prevents font-size 0 technique from
+  // removing the spaces between inline-blocks.
+  .no-androidprejellybean & {
+    font-size: 0;
+  }
 
   &:before {
     content: '';
     display: inline-block;
     height: 100%;
     vertical-align: middle;
+
+    // Android pre Jellybean has an ugly bug, which prevents font-size 0 technique from
+    // removing the spaces between inline-blocks.
+    .androidprejellybean & {
+      margin-right: -0.25em;
+    }
   }
 }
 
 @mixin vertical-centering-content {
   // Reset font-size
-  font-size: #{$font-size}px;
+  //
+  // Android pre Jellybean has an ugly bug, which prevents font-size 0 technique from
+  // removing the spaces between inline-blocks.
+  .no-androidprejellybean & {
+    font-size: #{$font-size}px;
+  }
 
   display: inline-block;
   vertical-align: middle;

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -25,6 +25,17 @@
 / Modernizr, in the head tag, right after stylesheets, for best performance:
 = javascript_include_tag "modernizr.min"
 
+/ Android pre Jellybean has an ugly bug, which prevents font-size 0 technique from
+/ removing the spaces between inline-blocks. Remove this piece of code when pre Jellybean becomes unsupported
+:javascript
+  Modernizr.addTest('androidPreJellybean', function(){
+    var ua = navigator.userAgent;
+    if( ua.indexOf("Android") >= 0 ) {
+      var androidversion = parseFloat(ua.slice(ua.indexOf("Android")+8));
+      return androidversion < 4.1
+    }
+  });
+
 = csrf_meta_tag
 
 %link{:rel => "image_src", :href => "https://s3.amazonaws.com/sharetribe/assets/dashboard/sharetribe_logo.png"}

--- a/app/views/layouts/_network_head.haml
+++ b/app/views/layouts/_network_head.haml
@@ -18,6 +18,17 @@
 / Modernizr, in the head tag, right after stylesheets, for best performance:
 = javascript_include_tag "modernizr.min"
 
+/ Android pre Jellybean has an ugly bug, which prevents font-size 0 technique from
+/ removing the spaces between inline-blocks. Remove this piece of code when pre Jellybean becomes unsupported
+:javascript
+  Modernizr.addTest('androidPreJellybean', function(){
+    var ua = navigator.userAgent;
+    if( ua.indexOf("Android") >= 0 ) {
+      var androidversion = parseFloat(ua.slice(ua.indexOf("Android")+8));
+      return androidversion < 4.1
+    }
+  });
+
 = csrf_meta_tag
 
 %link{:rel => "image_src", :href => "https://s3.amazonaws.com/sharetribe/assets/dashboard/sharetribe_logo.png"}


### PR DESCRIPTION
- There's a bug in pre-Jellybean android. Font-size 0 doesn't remove
  spaces between inline elements. Use Modernizr to detect Android
  version and add a CSS class to HTML tag
