### PR TITLE
Use patched version of ts-delayed-delta gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,12 @@ gem "memcachier"
 gem 'kgio', "~>2.8.0"
 gem 'thinking-sphinx', '~> 3.1.1'
 gem 'flying-sphinx', "~>1.2.0"
+# Use patched v2.0.2
+# Fixes issues: Create a new delayed delta job if there is an existing delta job which has failed
 gem 'ts-delayed-delta', "~>2.0.2",
-  :git    => 'git://github.com/sharetribe/ts-delayed-delta.git',
-  :branch => 'previous-failed-job'
+  :git    => 'git://github.com/pat/ts-delayed-delta.git',
+  :branch => 'master',
+  :ref    => '839284f2f28b3f4caf3a3bf5ccde9a6d222c7f4d'
 gem 'recaptcha'
 gem 'delayed_job', "~>3.0.5"
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 GIT
-  remote: git://github.com/sharetribe/ts-delayed-delta.git
-  revision: 7944fe53e0555bfaf29c7600f010f4fabd45e891
-  branch: previous-failed-job
+  remote: git://github.com/pat/ts-delayed-delta.git
+  revision: 839284f2f28b3f4caf3a3bf5ccde9a6d222c7f4d
+  ref: 839284f2f28b3f4caf3a3bf5ccde9a6d222c7f4d
+  branch: master
   specs:
     ts-delayed-delta (2.0.2)
       delayed_job


### PR DESCRIPTION
Creates a new delayed delta job even if there is an existing job (which has failed)
