### PR TITLE
Disable email delivery errors in development by default

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Kassi::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send
-  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.raise_delivery_errors = false
 
   # Enable sending mail from localhost
   ActionMailer::Base.smtp_settings = {


### PR DESCRIPTION
The rationale behind `actionmailer.raise_delivery_errors` being false by default is that you normally don't care if emails are delivered while in development, and most of the time, you don't want them to be.

Without this change, user creation crashes on localhost with the default settings.
