### PR TITLE
Fix 'See how it looks like' to 'See how it looks' in communities/edit_details

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,7 +67,7 @@ en:
         edit_signup_info: "Signup info"
         edit_signup_info_description: "This is an info text that can be shown to users in the signup page. There you can give the users instructions for signing up, information like where to get an invite, etc. By default there are no instructions."
         edit_info: "Edit information"
-        see_how_it_looks_like: "See how it looks like"
+        see_how_it_looks_like: "See how it looks"
         verification_to_post_listings_info_content: "Info text to non-verified users"
         verification_to_post_listings_info_content_description: "This marketplace requires people to be verified manually by admin before they can post listings. Here you can set the default text that is shown to non-verified users when they try to post a new listing."
         verification_to_post_listings_info_content_default: "This marketplace requires people to be verified manually by admin before they can post listings. You have not yet been verified. Please %{contact_admin_link} to be verified."


### PR DESCRIPTION
"See how it looks like" is both popular and incorrect. 

http://english.stackexchange.com/questions/55672/is-it-what-it-looks-like-or-how-it-looks-like
