### PR TITLE
Use more specific mercury selection for 'When I send keys to editor'

### DIFF
--- a/features/step_definitions/mercury_steps.rb
+++ b/features/step_definitions/mercury_steps.rb
@@ -11,7 +11,9 @@ Then /^I should have editor open$/ do
 end
 
 When(/^I send keys "(.*?)" to editor$/) do |keys|
-  find("#mercury_iframe", :visible => false).native.send_keys "#{keys}"
+  page.driver.within_frame('mercury_iframe') do
+    find("[data-mercury]", :visible => false).native.send_keys "#{keys}"
+  end
 end
 
 # This method should be used when there are multiple Mercury-editable


### PR DESCRIPTION
"When I send keys :keys to editor" wasn't working on my FF 30 in OS X 10.9.3. No keys appeared on the text area and cucumber features failed.

This change fixed the problem for me.
