### PR TITLE
Bundle install without AWS SDK

### DIFF
--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -7,6 +7,7 @@ echo "SUITE: ${SUITE}"
 
 if [ "$SUITE" = "rspec" ]
 then
+	gem install nokogiri -- --use-system-libraries
 	gem install bundler specific_install
 	# Install a modified version of bundle_cache gem
 	# If the modifications get merged to bundle_cache use the upstream repo, not this one
@@ -15,6 +16,7 @@ then
 	exit
 elif [ "$SUITE" = "rubocop" ]
 then
+	gem install nokogiri -- --use-system-libraries
 	gem install bundler specific_install
 	# Install a modified version of bundle_cache gem
 	# If the modifications get merged to bundle_cache use the upstream repo, not this one
@@ -23,6 +25,7 @@ then
 	exit
 elif [ "$SUITE" = "cucumber" ]
 then
+	gem install nokogiri -- --use-system-libraries
 	gem install bundler specific_install
 	# Install a modified version of bundle_cache gem
 	# If the modifications get merged to bundle_cache use the upstream repo, not this one
@@ -31,6 +34,7 @@ then
 	exit
 elif [ "$SUITE" = "mocha" ]
 then
+	gem install nokogiri -- --use-system-libraries
 	gem install bundler specific_install
 	# Install a modified version of bundle_cache gem
 	# If the modifications get merged to bundle_cache use the upstream repo, not this one


### PR DESCRIPTION
Pull requests' tests are currently failing because of missing AWS keys. This should fix the issue.
