### PR TITLE
Update conversation when participation is updated

### DIFF
--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,6 +1,6 @@
 class Participation < ActiveRecord::Base
 
-  belongs_to :conversation, :dependent => :destroy, inverse_of: :participations
+  belongs_to :conversation, :dependent => :destroy, inverse_of: :participations, touch: true
   belongs_to :person
   has_one :testimonial
 


### PR DESCRIPTION
In order to invalidate cache key in global header.
