### PR TITLE
Adds Application config dashboard_subdomains option

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -405,7 +405,7 @@ module ApplicationHelper
   # If we are not in a single community defined by a subdomain,
   # we are on dashboard
   def on_dashboard?
-    ["", "www","dashboardtranslate"].include?(request.subdomain) && APP_CONFIG.domain.include?(request.domain)
+    APP_CONFIG.dashboard_subdomains.include?(request.subdomain) && APP_CONFIG.domain.include?(request.domain)
   end
 
   def facebook_like(recommend=false)

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -19,6 +19,13 @@ default: &default_settings
   # If this is empty, will use the same domain for login
   login_domain:
 
+  # Fill here the subdomains which will be running the main dashboard of your application.
+  # The subdomains which are not listed here are expected to be communities.
+  dashboard_subdomains:
+    - ''
+    - 'www'
+    - 'dashboardtranslate'
+
   # Sharetribe can allow accessing data from external applications by RESTful API
   # You can enable the API by setting this value true
   api_enabled: false

--- a/lib/routes/community_domain.rb
+++ b/lib/routes/community_domain.rb
@@ -1,8 +1,6 @@
-class CommunityDomain  
+class CommunityDomain
   def self.matches?(request)
-    ! APP_CONFIG.domain.include?(request.domain) || 
-      (request.subdomain != 'www' && 
-       request.subdomain != ''    &&
-       request.subdomain != 'dashboardtranslate')
-  end  
+    ! APP_CONFIG.domain.include?(request.domain) ||
+    ! APP_CONFIG.dashboard_subdomains.include?(request.subdomain)
+  end
 end


### PR DESCRIPTION
Hello,

currently the subdomains which are running the dashboard are hardcoded (which is not convenient).
I want to easily be able to run communities on www if I want, so this patch allows to configure the dashboard subdomain.

Thanks.
