### PR TITLE
Error on this migration 20140903112203_move_checkout_data_to_checkout_account.rb

### DIFF
--- a/db/migrate/20140903112203_move_checkout_data_to_checkout_account.rb
+++ b/db/migrate/20140903112203_move_checkout_data_to_checkout_account.rb
@@ -1,7 +1,7 @@
 class MoveCheckoutDataToCheckoutAccount < ActiveRecord::Migration
   def up
-    execute("INSERT INTO checkout_accounts (company_id, merchant_id, merchant_key, person_id)
-             (SELECT company_id, checkout_merchant_id, checkout_merchant_key, id
+    execute("INSERT INTO checkout_accounts (company_id, merchant_id, merchant_key, person_id, created_at, updated_at)
+             (SELECT company_id, checkout_merchant_id, checkout_merchant_key, id, now(), now()
              FROM people
              WHERE people.checkout_merchant_key IS NOT NULL)")
   end


### PR DESCRIPTION
This is not working on a normal migration, gives a error because created_at and updated_at are not created with default values and is set up as not null.
