### PR TITLE
Fix double render error

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,6 +6,9 @@ class MessagesController < ApplicationController
 
   before_filter do |controller|
     controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_send_a_message")
+  end
+
+  before_filter do |controller|
     controller.ensure_authorized t("layouts.notifications.you_are_not_authorized_to_do_this")
   end
 


### PR DESCRIPTION
Fixes: https://sharetribe.airbrake.io/projects/15448/groups/1231173430372828613

Steps to reprocude:
1. Login to Sharetribe
2. Open two tabs (with the same user logged in)
3. Send profile message (or any message) to another user
4. Go to inbox and go to the "conversation" view of the message thread you just started
5. In another tab, log out
6. Back in the first tab (while the browser still thinks you are logged in), send a message to the other party of the conversation

Result: See the console for Double render error

Please note, that this fixes only the error (for airbrake cleaning purpose). It doesn't make the interface nice (Please wait... hangs there)
