### PR TITLE
Feedback emails go to admins or superadmins

### DIFF
--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -317,7 +317,7 @@ class PersonMailer < ActionMailer::Base
 
     @current_community = community
     subject = "New #unanswered #feedback from #{@current_community.name('en')} community from user #{feedback.author.try(:name)} "
-    mail_to = APP_CONFIG.feedback_mailer_recipients + (@current_community.feedback_to_admin? ? ", #{@current_community.admin_emails.join(",")}" : "")
+    mail_to = @current_community.feedback_to_admin? ? @current_community.admin_emails.join(",") : APP_CONFIG.feedback_mailer_recipients
     premailer_mail(:to => mail_to,
          :from => community_specific_sender(community),
          :subject => subject,

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -155,7 +155,7 @@ describe PersonMailer do
     m.update_attribute(:admin, true)
     email = PersonMailer.new_feedback(@feedback, @community).deliver
     assert !ActionMailer::Base.deliveries.empty?
-    assert_equal [APP_CONFIG.feedback_mailer_recipients].concat(@test_person.confirmed_notification_email_addresses) , email.to
+    assert_equal @test_person.confirmed_notification_email_addresses, email.to
   end
 
   it "should send email to community admins of new member if wanted" do


### PR DESCRIPTION
Previously emails went either only to superadmins or to both admins &
superadmins. Now there’s no need to notify superadmins if the feedback
goes to admins.
