### PR TITLE
Use merchant logo in Paypal checkout page

### DIFF
--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -86,6 +86,13 @@ class PreauthorizeTransactionsController < ApplicationController
     #TODO NULL in transaction.payment crashes cuz preauthorization_expiration_days
     transaction.save!
 
+    # PayPal doesn't like images with cache buster in the URL
+    logo_url = Maybe(@current_community)
+      .wide_logo
+      .select { |wl| wl.present? }
+      .url(:paypal, timestamp: false)
+      .or_else(nil)
+
     pp_result = paypal_payments_service.request(
       transaction.community_id,
       PaypalService::API::DataTypes.create_create_payment_request({
@@ -97,7 +104,7 @@ class PreauthorizeTransactionsController < ApplicationController
         order_total: @listing.price, # FIXME The price is not correct for booking
         success: paypal_checkout_order_success_url,
         cancel: paypal_checkout_order_cancel_url,
-        merchant_brand_logo_url: @current_community.wide_logo.url(:paypal, timestamp: false) # PayPal doesn't like images with cache buster in the URL
+        merchant_brand_logo_url: logo_url
       })
     )
 

--- a/app/services/paypal_service/api/data_types.rb
+++ b/app/services/paypal_service/api/data_types.rb
@@ -7,7 +7,7 @@ module PaypalService::API::DataTypes
     [:item_price, :money],
     [:merchant_id, :mandatory, :string],
     [:order_total, :mandatory, :money],
-    [:merchant_brand_logo_url, :string, :mandatory],
+    [:merchant_brand_logo_url, :string, :optional],
     [:success, :mandatory, :string],
     [:cancel, :mandatory, :string]
   )

--- a/app/services/paypal_service/data_types/merchant.rb
+++ b/app/services/paypal_service/data_types/merchant.rb
@@ -63,7 +63,7 @@ module PaypalService
         [:order_total, :mandatory, :money],
         [:success, :mandatory, :string],
         [:cancel, :mandatory, :string],
-        [:merchant_brand_logo_url, :mandatory, :string])
+        [:merchant_brand_logo_url, :optional, :string])
 
       SetExpressCheckoutOrderResponse = EntityUtils.define_builder(
         [:success, const_value: true],

--- a/app/services/paypal_service/merchant_actions.rb
+++ b/app/services/paypal_service/merchant_actions.rb
@@ -121,7 +121,8 @@ module PaypalService
         input_transformer: -> (req, config) {
           {
             SetExpressCheckoutRequestDetails: {
-              cpplogoimage: req[:merchant_brand_logo_url],
+              cppcartbordercolor: "FFFFFF",
+              cpplogoimage: req[:merchant_brand_logo_url] || "",
               ReturnURL: req[:success],
               CancelURL: req[:cancel],
               ReqConfirmShipping: 0,


### PR DESCRIPTION
Todo:
- [x] Use merchant logo
- [x] Do NOT use default (Sharetribe) logo
- [x] Use white border. The default gradient is sooo ugly.
