### PR TITLE
Remove UTF8 checkmark from homepage search

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -36,7 +36,7 @@
     pressing send from either search bar of filter list will send all the form fields
 
   - if params[:controller] == "homepage" && params[:action] == "index"
-    = form_tag({ :action => :index, :controller => :homepage}, :method => "get", :id => "homepage-filters") do
+    %form{method: "get", id: "homepage-filters"}
       - params.except("action", "controller", "q", "view", "utf8").each do |param, value|
         - unless param.match(/^filter_option/) || param.match(/^checkbox_filter_option/) || param.match(/^nf_/) || param.match(/^price_/)
           = hidden_field_tag param, value


### PR DESCRIPTION
Rails adds utf8='checkmark' to form posts (also if method is GET). This is for IE5-8. See more: http://stackoverflow.com/questions/3222013/what-is-the-snowman-param-in-ruby-on-rails-3-forms-for/3348524#3348524

However, this breaks BingBot (https://sharetribe.airbrake.io/projects/15448/groups/1157264204336826281)

**Solution:** Remove the utf8 checkmark from homepage search by not using default form helper.
