### PR TITLE
Fix IPN bug caused by manual invoicing (Not tested in practice!)

### DIFF
--- a/app/controllers/paypal_ipn_controller.rb
+++ b/app/controllers/paypal_ipn_controller.rb
@@ -17,6 +17,8 @@ class PaypalIpnController < ApplicationController
 
       if (msg[:type] == :unknown)
         logger.warn("Unknown IPN message type: #{params}")
+      elsif (msg[:type] == :manual_invoicing)
+        logger.warn("Recived IPN message related to manual invoicing, no action taken: #{params}")
       else
         ipn_service.handle_msg(msg)
       end

--- a/app/services/paypal_service/data_types/ipn.rb
+++ b/app/services/paypal_service/data_types/ipn.rb
@@ -163,6 +163,9 @@ module PaypalService
 
         if txn_type == "mp_cancel"
           return :billing_agreement_cancelled
+        elsif txn_type == "invoice_payment"
+          # This is related to othe invoicing activity on same Paypal account
+          return :manual_invoicing
         elsif status == "pending" && reason == "order"
           return :order_created
         elsif status == "pending" && reason == "authorization"


### PR DESCRIPTION
Add handling for txn_type "invoice_payment" IPN messages.

NOTE: I didn't figure out a handy way to test this in pracitce. So suggesting to deploy and see that errors stop coming to Airbrake (and that other actions continue normally.)

But only few lines, so if someone else too takes a careful look, we should be able to minize the risk of breaking the whole IPN system due to this fix.