### PR TITLE
Make transaction view tolerate missing listings

### DIFF
--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -40,6 +40,8 @@ class Admin::CommunityTransactionsController < ApplicationController
       transaction.merge({author: author, starter: starter})
     end
 
+    conversations = conversations.reject { |c| c[:discussion_type] == :not_available }
+
     conversations = WillPaginate::Collection.create(pagination_opts[:page], pagination_opts[:per_page], count) do |pager|
       pager.replace(conversations)
     end

--- a/app/services/marketplace_service/conversation.rb
+++ b/app/services/marketplace_service/conversation.rb
@@ -42,10 +42,8 @@ module MarketplaceService
 
       def deleted_conversation_placeholder
         Conversation[{
-          last_transition_at: "not available",
+          last_transition_at: :not_available,
           metadata: "this is a placeholder for conversation that was deleted, probably due a participant deleting his profile."
-          #starter_person: "not available",
-          #other_person: "not available"
         }]
       end
 

--- a/app/services/marketplace_service/transaction.rb
+++ b/app/services/marketplace_service/transaction.rb
@@ -121,7 +121,7 @@ module MarketplaceService
           transitions: transaction_model.transaction_transitions.map { |transition|
             Transition[EntityUtils.model_to_hash(transition)]
           },
-          discussion_type: Maybe(listing_model).discussion_type.to_sym.or_else("not available"),
+          discussion_type: Maybe(listing_model).discussion_type.to_sym.or_else(:not_available),
           payment_total: payment_total,
           booking: transaction_model.booking,
           __model: transaction_model
@@ -133,7 +133,7 @@ module MarketplaceService
         if transaction_model.conversation
           transaction[:conversation] = ConversationEntity.conversation(transaction_model.conversation, community_id)
         else
-          #placeholder for deleted conversation to keep transaction list working
+          # placeholder for deleted conversation to keep transaction list working
           transaction[:conversation] = ConversationEntity.deleted_conversation_placeholder
         end
         transaction


### PR DESCRIPTION
this is done bit quickly, so thorough review is welcome, and comments about if this kind of quick fix approach makes sense now?
Anyway would be great that the transaction view doesn't break like it does now, and it will take a while before we get to improve the delete user functionality, so meanwhile these kind of changes could do the job, and not endanger normal transactions where listing and author are not gone. 
