### PR TITLE
Use stringex to_url to create nicer URLs from non-ASCII Marketplace name

### DIFF
--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -88,7 +88,7 @@ module MarketplaceService::API
           initial_domain = "trial_site"
         end
 
-        current_domain = initial_domain.gsub(/[^A-Z0-9_]/i,"-").downcase
+        current_domain = initial_domain.to_url
         current_domain = current_domain[0..29] #truncate to 30 chars or less
 
         # use basedomain as basis on new variations if current domain is not available


### PR DESCRIPTION
Request:

``` json
{ "marketplace_language": "de"
, "marketplace_country": "DE"
, "admin_email": "mikko+12312412123124@sharetribe.com"
, "admin_first_name": "Eddie"
, "admin_last_name": "Admin"
, "admin_password": "secret_word"
, "marketplace_type": "product"
, "marketplace_name": "Откройте для себя нечто"
}
```

Response before fix:

``` json
{"marketplace_url":"http://-----------------------2.lvh.me:3000?auth=V7nnPE-z6Us”}
```

Response after fix:

``` json
{"marketplace_url":"http://otkroitie-dlia-siebia-niechto3.lvh.me:3000?auth=0f5GVLop5NY"}
```
