### PR TITLE
Stop validating booking not in past @ server side

### DIFF
--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -15,7 +15,6 @@ class PreauthorizeTransactionsController < ApplicationController
   BookingForm = FormUtils.define_form("BookingForm", :start_on, :end_on)
     .with_validations do
       validates :start_on, :end_on, presence: true
-      validates_date :start_on, on_or_after: :today
       validates_date :end_on, on_or_after: :start_on
     end
 


### PR DESCRIPTION
- This is validated already @ client side by js, there we
  use browser timezone.
- Don't validate server side anymore because there we don't know
  the correct timezone for the marketplace. Before this change we've
  used single server timezone to determine what "today" means, which is
  obviously a bad idea for most marketplaces.
