### PR TITLE
Cancel action is done by starter

### DIFF
--- a/app/view_utils/transaction_view_utils.rb
+++ b/app/view_utils/transaction_view_utils.rb
@@ -91,7 +91,7 @@ module TransactionViewUtils
       }
     when "canceled"
       {
-        sender: author,
+        sender: starter,
         mood: :negative
       }
     when "confirmed"


### PR DESCRIPTION
Request can be cancelled in following cases:
1. Postpay, author has accepted the request and set up the invoice, but requester decides not to pay
2. Postpay, author has accepted, requester has paid but not received the product (thus, not confirming the transaction)
3. Preauth, requester has paid, author has accepted, requester has not received the product (thus, not confirming the transaction)

The actor is always the requester.
