### PR TITLE
Go to 4-col layout if only fields that can not be filtered

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -29,7 +29,7 @@ class HomepageController < ApplicationController
     # only 1 sub share type, as that would make the listing type menu visible and it would look bit silly
     @transaction_type_menu_enabled = @transaction_types.size > 1
     @show_categories = @current_community.categories.size > 1
-    @show_custom_fields = @current_community.custom_fields.size > 0
+    @show_custom_fields = @current_community.custom_fields.select { |field| field.can_filter? }.present?
     @category_menu_enabled = @show_categories || @show_custom_fields
 
     @app_store_badge_filename = "/assets/Available_on_the_App_Store_Badge_en_135x40.svg"

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -69,6 +69,11 @@ class CustomField < ActiveRecord::Base
     TranslationCache.new(self, :names).translate(locale, :value)
   end
 
+  def can_filter?
+    # Default to false
+    false
+  end
+
   def with(expected_type, &block)
     with_type do |own_type|
       if own_type == expected_type

--- a/app/models/custom_fields/checkbox_field.rb
+++ b/app/models/custom_fields/checkbox_field.rb
@@ -24,4 +24,8 @@ class CheckboxField < OptionField
   def with_type(&block)
     block.call(:checkbox)
   end
+
+  def can_filter?
+    true
+  end
 end

--- a/app/models/custom_fields/dropdown_field.rb
+++ b/app/models/custom_fields/dropdown_field.rb
@@ -24,4 +24,8 @@ class DropdownField < OptionField
   def with_type(&block)
     block.call(:dropdown)
   end
+
+  def can_filter?
+    true
+  end
 end

--- a/app/models/custom_fields/numeric_field.rb
+++ b/app/models/custom_fields/numeric_field.rb
@@ -35,4 +35,8 @@ class NumericField < CustomField
   def with_type(&block)
     block.call(:numeric)
   end
+
+  def can_filter?
+    true
+  end
 end


### PR DESCRIPTION
We show 4-column layout on the homepage, if marketplace does not have any custom fields.

What we SHOULD do, is to go 4-column layout, if marketplace does not have any custom fields that can be filtered. All fields except Text and Date can be filtered.
