### PR TITLE
Pass IDs as array, not comma separated string

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -57,9 +57,15 @@ class ListingsController < ApplicationController
     end
   end
 
+  # "2,3,4, 563" => [2, 3, 4, 563]
+  def numbers_str_to_array(str)
+    str.split(",").map { |num| num.to_i }
+  end
+
   # Used to show multiple listings in one bubble
   def listing_bubble_multiple
-    @listings = Listing.visible_to(@current_user, @current_community, params[:ids]).order("id DESC")
+    ids = numbers_str_to_array(params[:ids])
+    @listings = Listing.visible_to(@current_user, @current_community, ids).order("id DESC")
     if @listings.size > 0
       render :partial => "homepage/listing_bubble_multiple"
     else


### PR DESCRIPTION
Fix the issue with blank listings on map if there are multiple listings in the same location:

![screen shot 2014-11-28 at 15 50 32](https://cloud.githubusercontent.com/assets/429876/5228680/5ee81440-7716-11e4-9f04-7ed6a30ee78d.png)

Pass the ids as an array, not as comma separated list.
