### PR TITLE
Added country code to paypal urls to help paypal localize their site.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -912,12 +912,4 @@ module ApplicationHelper
     end
   end
 
-  def country_code(country)
-    unless country.blank?
-      CountrySelect.countries.select{|key, hash|
-        return key if hash.downcase == country.downcase
-      }
-    end
-    return nil
-  end
 end

--- a/app/utils/localization_utils.rb
+++ b/app/utils/localization_utils.rb
@@ -1,0 +1,14 @@
+module LocalizationUtils
+  module_function
+
+  # Country code (ISO 3166-1 alpha-2) i.e. sv_SE -> SE is the country code
+  def country_code(country)
+    unless country.blank?
+      CountrySelect.countries.select{|key, hash|
+        return key if hash.downcase == country.downcase
+      }
+    end
+    return nil
+  end
+
+end

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -72,7 +72,7 @@
     - if payment_gateway == :paypal
       .row
         .col-12
-          - community_country_code = Maybe(country_code(@current_community.country)).or_else('us') # default should not happen in production
+          - community_country_code = Maybe(LocalizationUtils.country_code(@current_community.country)).or_else('us') # default should not happen in production
           - how_paypal_works_link = "https://www.paypal.com/#{community_country_code}/webapps/mpp/paypal-popup"
           %a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
             = image_tag "https://www.paypalobjects.com/webstatic/en_US/i/buttons/cc-badges-ppmcvdam.png", style: "max-width: 100%"

--- a/app/views/paypal_accounts/_ask_paypal_permissions.haml
+++ b/app/views/paypal_accounts/_ask_paypal_permissions.haml
@@ -1,7 +1,7 @@
 .row
   = form.label :paypal_email, title
 .row
-  - community_country_code = Maybe(country_code(@current_community.country)).or_else('us') # default should not happen in production
+  - community_country_code = Maybe(LocalizationUtils.country_code(@current_community.country)).or_else('us') # default should not happen in production
   - create = link_to(t("paypal_accounts.new.create_paypal_account"), "https://www.paypal.com/#{community_country_code}/signup")
   - upgrade = link_to(t("paypal_accounts.new.upgrade_paypal_account"), "https://www.paypal.com/#{community_country_code}/upgrade")
   - text = t("paypal_accounts.new.paypal_account_email_info_text", {create_paypal_account: create, upgrade_paypal_account: upgrade, currency: "<strong>#{currency}</strong>"}).html_safe


### PR DESCRIPTION
From ticket:
"These basic links seems to be quite easy to change (i.e. https://www.paypal.com/webapps/mpp/home, /signup & /login). All, we have to do is to include country code (ISO 3166-1 alpha-2) after domain name. Even though PayPal does not have localization for the requested country, it will show some defaults (i.e. https://www.paypal.com/fi/signup is in English)﻿.

If the country has several supported languages (like Belgium) it will use some defaults and shows a possibility to change it (signup & login pages have dropdown and this '/webapps/mmp/' shows the options at the bottom right corner of the page)"
