### PR TITLE
Remove unnecessary PayPal permissions

### DIFF
--- a/app/services/paypal_service/data_types/permissions.rb
+++ b/app/services/paypal_service/data_types/permissions.rb
@@ -11,9 +11,6 @@ module PaypalService
             "REFUND",
             "TRANSACTION_DETAILS",
             "EXPRESS_CHECKOUT",
-            "RECURRING_PAYMENTS",
-            "SETTLEMENT_REPORTING",
-            "RECURRING_PAYMENT_REPORT",
             "ACCESS_BASIC_PERSONAL_DATA"
           ]
         ],


### PR DESCRIPTION
Some paypal permissions that we used to request are causing issues for
customers in some specific countries. We know at least Chile and
Bulgaria to be such countries. Moreover, it turns out we probably don't
even need these permissions for anything. The bonus effect is that the
permissions list looks less intimidating for users signing up.

The permissions we remove are detailed here:
https://developer.paypal.com/docs/classic/permissions-service/integration-guide/PermissionsAbout/
