### PR TITLE
Fix issue with locale extract metho

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -121,7 +121,7 @@ class SessionsController < ApplicationController
   def facebook
     @person = Person.find_for_facebook_oauth(request.env["omniauth.auth"], @current_user)
 
-    I18n.locale = exctract_locale_from_url(request.env['omniauth.origin']) if request.env['omniauth.origin']
+    I18n.locale = URLUtils.extract_locale_from_url(request.env['omniauth.origin']) if request.env['omniauth.origin']
 
     if @person
       flash[:notice] = t("devise.omniauth_callbacks.success", :kind => "Facebook")
@@ -157,7 +157,7 @@ class SessionsController < ApplicationController
 
   # Callback from Omniauth failures
   def failure
-    I18n.locale = exctract_locale_from_url(request.env['omniauth.origin']) if request.env['omniauth.origin']
+    I18n.locale = URLUtils.extract_locale_from_url(request.env['omniauth.origin']) if request.env['omniauth.origin']
     error_message = params[:error_reason] || "login error"
     kind = env["omniauth.error.strategy"].name.to_s || "Facebook"
     flash[:error] = t("devise.omniauth_callbacks.failure",:kind => kind.humanize, :reason => error_message.humanize)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -495,12 +495,6 @@ module ApplicationHelper
     Thread.current[:current_community_service_name] || APP_CONFIG.global_service_name || "Sharetribe"
   end
 
-  # returns the locale part from url.
-  # e.g. from "kassi.eu/es/listings" returns es
-  def exctract_locale_from_url(url)
-    url[/^([^\/]*\/\/)?[^\/]+\/(\w{2})(\/.*)?/,2]
-  end
-
   # Helper method for javascript. Return "undefined"
   # if tribe has no location.
   def tribe_latitude

--- a/app/utils/url_utils.rb
+++ b/app/utils/url_utils.rb
@@ -14,4 +14,12 @@ module URLUtils
     uri.query = args.empty? ? nil : URI.encode_www_form(args)
     uri.to_s
   end
+
+  # http://www.sharetribe.com/en/people -> en
+  # http://www.sharetribe.com/en-US/people -> en-US
+  #
+  # Returns the first "folder" in path. Does not validate the locale
+  def extract_locale_from_url(url)
+    URI(url).path.split('/')[1]
+  end
 end

--- a/spec/utils/url_utils_spec.rb
+++ b/spec/utils/url_utils_spec.rb
@@ -14,4 +14,10 @@ describe URLUtils do
     expect(URLUtils.remove_query_param("http://www.google.com?q=how+to+create+a+marketplace&start=10", "start"))
       .to eql("http://www.google.com?q=how+to+create+a+marketplace")
   end
+
+  it "#extract_locale_from_url" do
+    expect(URLUtils.extract_locale_from_url('http://www.sharetribe.com/')).to eql(nil)
+    expect(URLUtils.extract_locale_from_url('http://www.sharetribe.com/en/people')).to eql('en')
+    expect(URLUtils.extract_locale_from_url('http://www.sharetribe.com/en-US/people')).to eql('en-US')
+  end
 end


### PR DESCRIPTION
Currently, only two letters were extracter. Thus, for tr-TR, we returned only tr and the page was not found.
