### PR TITLE
I18n warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,8 @@ module Kassi
     # This is the list of all possible locales. Part of the translations may be unfinished.
     config.AVAILABLE_LOCALES = Sharetribe::AVAILABLE_LOCALES
 
+    I18n.enforce_available_locales = true
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/lib/selenium_webdriver_phantomjs_monkey_patch.rb
+++ b/lib/selenium_webdriver_phantomjs_monkey_patch.rb
@@ -8,7 +8,7 @@
 ##
 # Disable port prober
 #
-# - The default port for PhantoJS WebDriver is 8910
+# - The default port for PhantomJS WebDriver is 8910
 # - PortProber uses 8910, but if it's not free, it tries 8911 etc.
 # - Disable port prober
 #


### PR DESCRIPTION
1. Get rid of the warning: [deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
2. Fix typo

This is my first pull request. I also want to try the process.