### PR TITLE
Don't trust receiver_id in pp ec payment response

### DIFF
--- a/app/services/paypal_service/api/payments.rb
+++ b/app/services/paypal_service/api/payments.rb
@@ -283,7 +283,10 @@ module PaypalService::API
             payment = PaymentStore.create(
               token[:community_id],
               token[:transaction_id],
-              ec_details.merge(payment_res))
+              ec_details
+                .merge(payment_res)
+                .merge({receiver_id: m_acc[:payer_id]})
+            )
 
             payment_entity = DataTypes.create_payment(payment.merge({ merchant_id: m_acc[:person_id] }))
 

--- a/app/services/paypal_service/data_types/merchant.rb
+++ b/app/services/paypal_service/data_types/merchant.rb
@@ -96,8 +96,7 @@ module PaypalService
         [:payment_status, :mandatory, :string],
         [:pending_reason, :mandatory, :string],
         [:order_id, :mandatory, :string],
-        [:order_total, :mandatory, :money],
-        [:receiver_id, :mandatory, :string])
+        [:order_total, :mandatory, :money])
 
       DoAuthorization = EntityUtils.define_builder(
         [:method, const_value: :do_authorization],

--- a/app/services/paypal_service/merchant_actions.rb
+++ b/app/services/paypal_service/merchant_actions.rb
@@ -214,8 +214,7 @@ module PaypalService
               payment_status: payment_info.payment_status,
               pending_reason: payment_info.pending_reason,
               order_id: payment_info.transaction_id,
-              order_total: to_money(payment_info.gross_amount),
-              receiver_id: payment_info.seller_details.secure_merchant_account_id
+              order_total: to_money(payment_info.gross_amount)
             })
         }
       ),

--- a/spec/services/paypal_service/test_merchant.rb
+++ b/spec/services/paypal_service/test_merchant.rb
@@ -220,8 +220,7 @@ module PaypalService
                   payment_status: payment[:payment_status],
                   pending_reason: payment[:pending_reason],
                   order_id: payment[:order_id],
-                  order_total: payment[:order_total],
-                  receiver_id: payment[:receiver_id]
+                  order_total: payment[:order_total]
                 })
             else
               PaypalService::DataTypes::FailureResponse.call()


### PR DESCRIPTION
PayPal backend has a bug where they sometimes send an incorrect (unencrypted) merchant account id back in DoExpressCheckoutPayment response. This leads to payment not being linked to correct receiver paypal account and subsequently in the payment process not to be found. Instead, we use merchant account's payer_id that we know anyway from the context where the API call is triggered.