### PR TITLE
Fix bug: Show 410 Gone when trying to access profile page of a deleted user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -222,10 +222,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def ensure_person_belongs_to_current_community!(person)
-    raise ActiveRecord::RecordNotFound.new('Not Found') unless @person.communities.include?(@current_community)
-  end
-
   def fetch_community_admin_status
     @is_current_community_admin = @current_user && @current_user.has_admin_rights_in?(@current_community)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -222,8 +222,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def person_belongs_to_current_community
-    @person = Person.find(params[:person_id] || params[:id])
+  def ensure_person_belongs_to_current_community!(person)
     raise ActiveRecord::RecordNotFound.new('Not Found') unless @person.communities.include?(@current_community)
   end
 

--- a/app/controllers/followed_people_controller.rb
+++ b/app/controllers/followed_people_controller.rb
@@ -2,7 +2,7 @@ class FollowedPeopleController < ApplicationController
 
   def index
     @person = Person.find(params[:person_id] || params[:id])
-    ensure_person_belongs_to_current_community!(@person)
+    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
 
     @followed_people = @person.followed_people
     respond_to do |format|

--- a/app/controllers/followed_people_controller.rb
+++ b/app/controllers/followed_people_controller.rb
@@ -1,8 +1,9 @@
 class FollowedPeopleController < ApplicationController
 
-  before_filter :person_belongs_to_current_community
-
   def index
+    @person = Person.find(params[:person_id] || params[:id])
+    ensure_person_belongs_to_current_community!(@person)
+
     @followed_people = @person.followed_people
     respond_to do |format|
       format.js { render :partial => "people/followed_person", :collection => @followed_people, :as => :person }

--- a/app/controllers/followed_people_controller.rb
+++ b/app/controllers/followed_people_controller.rb
@@ -2,7 +2,7 @@ class FollowedPeopleController < ApplicationController
 
   def index
     @person = Person.find(params[:person_id] || params[:id])
-    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
+    PersonViewUtils.ensure_person_belongs_to_community!(@person, @current_community)
 
     @followed_people = @person.followed_people
     respond_to do |format|

--- a/app/controllers/followers_controller.rb
+++ b/app/controllers/followers_controller.rb
@@ -6,7 +6,7 @@ class FollowersController < ApplicationController
 
   def create
     @person = Person.find(params[:person_id] || params[:id])
-    ensure_person_belongs_to_current_community!(@person)
+    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
 
     @person.followers << @current_user
     respond_to do |format|
@@ -17,7 +17,7 @@ class FollowersController < ApplicationController
 
   def destroy
     @person = Person.find(params[:person_id] || params[:id])
-    ensure_person_belongs_to_current_community!(@person)
+    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
 
     @person.followers.delete(@current_user)
     respond_to do |format|

--- a/app/controllers/followers_controller.rb
+++ b/app/controllers/followers_controller.rb
@@ -6,7 +6,7 @@ class FollowersController < ApplicationController
 
   def create
     @person = Person.find(params[:person_id] || params[:id])
-    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
+    PersonViewUtils.ensure_person_belongs_to_community!(@person, @current_community)
 
     @person.followers << @current_user
     respond_to do |format|
@@ -17,7 +17,7 @@ class FollowersController < ApplicationController
 
   def destroy
     @person = Person.find(params[:person_id] || params[:id])
-    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
+    PersonViewUtils.ensure_person_belongs_to_community!(@person, @current_community)
 
     @person.followers.delete(@current_user)
     respond_to do |format|

--- a/app/controllers/followers_controller.rb
+++ b/app/controllers/followers_controller.rb
@@ -4,9 +4,10 @@ class FollowersController < ApplicationController
     controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_view_this_content")
   end
 
-  before_filter :person_belongs_to_current_community
-
   def create
+    @person = Person.find(params[:person_id] || params[:id])
+    ensure_person_belongs_to_current_community!(@person)
+
     @person.followers << @current_user
     respond_to do |format|
       format.html { redirect_to :back }
@@ -15,6 +16,9 @@ class FollowersController < ApplicationController
   end
 
   def destroy
+    @person = Person.find(params[:person_id] || params[:id])
+    ensure_person_belongs_to_current_community!(@person)
+
     @person.followers.delete(@current_user)
     respond_to do |format|
       format.html { redirect_to :back }

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,4 +1,6 @@
 class ListingsController < ApplicationController
+  class ListingDeleted < StandardError; end
+
   include PeopleHelper
 
   # Skip auth token check as current jQuery doesn't provide it automatically
@@ -333,7 +335,7 @@ class ListingsController < ApplicationController
   def ensure_authorized_to_view
     @listing = Listing.find(params[:id])
 
-    redirect_to :error_gone if @listing.deleted?
+    raise ListingDeleted if @listing.deleted?
 
     unless @listing.visible_to?(@current_user, @current_community) || (@current_user && @current_user.has_admin_rights_in?(@current_community))
       if @listing.public?

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -33,7 +33,7 @@ class ListingsController < ApplicationController
     @selected_tribe_navi_tab = "home"
     if request.xhr? && params[:person_id] # AJAX request to load on person's listings for profile view
       @person = Person.find(params[:person_id])
-      ensure_person_belongs_to_current_community!(@person)
+      PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
 
       # Returns the listings for one person formatted for profile page view
       per_page = params[:per_page] || 200 # the point is to show all here by default

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -12,7 +12,6 @@ class ListingsController < ApplicationController
     controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_create_new_listing", :sign_up_link => view_context.link_to(t("layouts.notifications.create_one_here"), sign_up_path)).html_safe
   end
 
-  before_filter :person_belongs_to_current_community, :only => [:index]
   before_filter :save_current_path, :only => :show
   before_filter :ensure_authorized_to_view, :only => [ :show, :follow, :unfollow ]
 
@@ -29,12 +28,11 @@ class ListingsController < ApplicationController
   before_filter :is_authorized_to_post, :only => [ :new, :create ]
 
   def index
-    if params[:format] == "atom" # API request for feed
-      redirect_to :controller => "Api::ListingsController", :action => :index
-      return
-    end
     @selected_tribe_navi_tab = "home"
     if request.xhr? && params[:person_id] # AJAX request to load on person's listings for profile view
+      @person = Person.find(params[:person_id])
+      ensure_person_belongs_to_current_community!(@person)
+
       # Returns the listings for one person formatted for profile page view
       per_page = params[:per_page] || 200 # the point is to show all here by default
       page = params[:page] || 1

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -33,7 +33,7 @@ class ListingsController < ApplicationController
     @selected_tribe_navi_tab = "home"
     if request.xhr? && params[:person_id] # AJAX request to load on person's listings for profile view
       @person = Person.find(params[:person_id])
-      PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
+      PersonViewUtils.ensure_person_belongs_to_community!(@person, @current_community)
 
       # Returns the listings for one person formatted for profile page view
       per_page = params[:per_page] || 200 # the point is to show all here by default

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,4 +1,5 @@
 class PeopleController < Devise::RegistrationsController
+  class PersonDeleted < StandardError; end
 
   include PeopleHelper
 
@@ -28,7 +29,7 @@ class PeopleController < Devise::RegistrationsController
 
   def show
     @person = Person.find(params[:person_id] || params[:id])
-    return redirect_to :error_gone if @person.deleted?
+    raise PersonDeleted if @person.deleted?
     ensure_person_belongs_to_current_community!(@person)
 
     redirect_to root and return if @current_community.private? && !@current_user

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -30,7 +30,7 @@ class PeopleController < Devise::RegistrationsController
   def show
     @person = Person.find(params[:person_id] || params[:id])
     raise PersonDeleted if @person.deleted?
-    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
+    PersonViewUtils.ensure_person_belongs_to_community!(@person, @current_community)
 
     redirect_to root and return if @current_community.private? && !@current_user
     redirect_to url_for(params.merge(:locale => nil)) and return if params[:locale] # This is an important URL to keep pretty

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -30,7 +30,7 @@ class PeopleController < Devise::RegistrationsController
   def show
     @person = Person.find(params[:person_id] || params[:id])
     raise PersonDeleted if @person.deleted?
-    ensure_person_belongs_to_current_community!(@person)
+    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
 
     redirect_to root and return if @current_community.private? && !@current_user
     redirect_to url_for(params.merge(:locale => nil)) and return if params[:locale] # This is an important URL to keep pretty

--- a/app/controllers/testimonials_controller.rb
+++ b/app/controllers/testimonials_controller.rb
@@ -6,12 +6,14 @@ class TestimonialsController < ApplicationController
 
   before_filter :ensure_authorized_to_give_feedback, :except => :index
   before_filter :ensure_feedback_not_given, :except => :index
-  before_filter :person_belongs_to_current_community, :only => :index
 
   # Skip auth token check as current jQuery doesn't provide it automatically
   skip_before_filter :verify_authenticity_token, :only => [:skip]
 
   def index
+    @person = Person.find(params[:person_id] || params[:id])
+    ensure_person_belongs_to_current_community!(@person)
+
     if request.xhr?
       @testimonials = @person.received_testimonials.paginate(:per_page => params[:per_page], :page => params[:page])
       limit = params[:per_page].to_i

--- a/app/controllers/testimonials_controller.rb
+++ b/app/controllers/testimonials_controller.rb
@@ -12,7 +12,7 @@ class TestimonialsController < ApplicationController
 
   def index
     @person = Person.find(params[:person_id] || params[:id])
-    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
+    PersonViewUtils.ensure_person_belongs_to_community!(@person, @current_community)
 
     if request.xhr?
       @testimonials = @person.received_testimonials.paginate(:per_page => params[:per_page], :page => params[:page])

--- a/app/controllers/testimonials_controller.rb
+++ b/app/controllers/testimonials_controller.rb
@@ -12,7 +12,7 @@ class TestimonialsController < ApplicationController
 
   def index
     @person = Person.find(params[:person_id] || params[:id])
-    ensure_person_belongs_to_current_community!(@person)
+    PersonHelper.ensure_person_belongs_to_community!(@person, @current_community)
 
     if request.xhr?
       @testimonials = @person.received_testimonials.paginate(:per_page => params[:per_page], :page => params[:page])

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -17,9 +17,7 @@ module TransactionService::Transaction
   end
 
   def has_unfinished_transactions(person_id)
-    finished_states = ["free", "rejected", "confirmed", "canceled", "errored"]
-                      .map { |state| "'#{state}'"}
-                      .join(",")
+    finished_states = "'free', 'rejected', 'confirmed', 'canceled', 'errored'"
 
     unfinished = TransactionModel
                  .joins(:listing)

--- a/app/view_utils/person_helper.rb
+++ b/app/view_utils/person_helper.rb
@@ -1,0 +1,7 @@
+module PersonHelper
+  module_function
+
+  def ensure_person_belongs_to_current_community!(person, community)
+    raise ActiveRecord::RecordNotFound.new('Not Found') unless @person.communities.include?(community)
+  end
+end

--- a/app/view_utils/person_helper.rb
+++ b/app/view_utils/person_helper.rb
@@ -1,7 +1,0 @@
-module PersonHelper
-  module_function
-
-  def ensure_person_belongs_to_current_community!(person, community)
-    raise ActiveRecord::RecordNotFound.new('Not Found') unless @person.communities.include?(community)
-  end
-end

--- a/app/view_utils/person_view_utils.rb
+++ b/app/view_utils/person_view_utils.rb
@@ -102,4 +102,8 @@ module PersonViewUtils
       first_name
     end
   end
+
+  def ensure_person_belongs_to_community!(person, community)
+    raise ActiveRecord::RecordNotFound.new('Not Found') unless person.communities.include?(community)
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -154,6 +154,9 @@ module Kassi
       Devise::Mailer.helper :email_template
     end
 
+    # Map custom errors to error pages
+    config.action_dispatch.rescue_responses["PeopleController::PersonDeleted"] = :gone
+
     config.exceptions_app = self.routes
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -156,6 +156,7 @@ module Kassi
 
     # Map custom errors to error pages
     config.action_dispatch.rescue_responses["PeopleController::PersonDeleted"] = :gone
+    config.action_dispatch.rescue_responses["ListingsController::ListingDeleted"] = :gone
 
     config.exceptions_app = self.routes
   end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -6,6 +6,7 @@ if APP_CONFIG.use_airbrake
                             "ActionController::RoutingError",
                             #"ActionController::InvalidAuthenticityToken",
                             "ActionController::UnknownAction",
+                            "PeopleController::PersonDeleted"
                             #"CGI::Session::CookieStore::TamperedWithCookie"
                             ]
     # The erros above are the defaults (from https://github.com/airbrake/airbrake)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -6,7 +6,8 @@ if APP_CONFIG.use_airbrake
                             "ActionController::RoutingError",
                             #"ActionController::InvalidAuthenticityToken",
                             "ActionController::UnknownAction",
-                            "PeopleController::PersonDeleted"
+                            "PeopleController::PersonDeleted",
+                            "ListingsController::ListingDeleted"
                             #"CGI::Session::CookieStore::TamperedWithCookie"
                             ]
     # The erros above are the defaults (from https://github.com/airbrake/airbrake)


### PR DESCRIPTION
- Remove filter `person_belongs_to_current_community`. Instead, fetch the `@person` where needed and make sure it belongs to community by manually calling `ensure_person_belongs_to_current_community!` method.
- Fix one review comment from Olli