### PR TITLE
Remove 'email' column from 'people' table

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,7 +13,6 @@
 #  test_group_number                  :integer          default(1)
 #  active                             :boolean          default(TRUE)
 #  username                           :string(255)
-#  email                              :string(255)
 #  encrypted_password                 :string(255)      default(""), not null
 #  reset_password_token               :string(255)
 #  reset_password_sent_at             :datetime
@@ -42,7 +41,6 @@
 #
 # Indexes
 #
-#  index_people_on_email                 (email) UNIQUE
 #  index_people_on_facebook_id           (facebook_id) UNIQUE
 #  index_people_on_id                    (id)
 #  index_people_on_reset_password_token  (reset_password_token) UNIQUE

--- a/db/migrate/20150120101020_remove_people_email.rb
+++ b/db/migrate/20150120101020_remove_people_email.rb
@@ -1,0 +1,9 @@
+class RemovePeopleEmail < ActiveRecord::Migration
+  def up
+    remove_column :people, :email
+  end
+
+  def down
+    add_column :people, :email, :string, after: :username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150116125629) do
+ActiveRecord::Schema.define(:version => 20150120101020) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -748,7 +748,6 @@ ActiveRecord::Schema.define(:version => 20150116125629) do
     t.integer  "test_group_number",                                :default => 1
     t.boolean  "active",                                           :default => true
     t.string   "username"
-    t.string   "email"
     t.string   "encrypted_password",                               :default => "",    :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
@@ -776,7 +775,6 @@ ActiveRecord::Schema.define(:version => 20150116125629) do
     t.boolean  "deleted",                                          :default => false
   end
 
-  add_index "people", ["email"], :name => "index_people_on_email", :unique => true
   add_index "people", ["facebook_id"], :name => "index_people_on_facebook_id", :unique => true
   add_index "people", ["id"], :name => "index_people_on_id"
   add_index "people", ["reset_password_token"], :name => "index_people_on_reset_password_token", :unique => true

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -53,37 +53,6 @@ describe PeopleController do
     end
   end
 
-  describe "#update" do
-    it "should store the old accepted email as additional email when changing email" do
-
-      # one reason for this is that people can't use one email to create many accounts in email restricted community
-      community = FactoryGirl.build(:community, :allowed_emails => "@examplecompany.co")
-      @request.host = "#{community.domain}.lvh.me"
-      member = FactoryGirl.build(:person, :emails => [ FactoryGirl.build(:email, :address => "one@examplecompany.co")])
-      member.communities.push community
-      member.save
-
-      person_count = Person.count
-
-      sign_in_for_spec(member)
-
-      request.env["HTTP_REFERER"] = "http://test.host/en/people/#{member.id}"
-      put :update, {:person => {:email => "something@el.se"}, :person_id => member.id}
-
-      # remove "signed in" stubs
-      request.env['warden'].unstub :authenticate!
-      #request.env['warden'].stub(:authenticate!).and_throw(:warden)
-      controller.unstub :current_person
-
-      post :create, {:person => {:username => generate_random_username, :password => "test", :email => "one@examplecompany.co", :given_name => "The user who", :family_name => "tries to use taken email"}, :community => community.domain}
-
-      Person.find_by_family_name("tries to use taken email").should be_nil
-      Person.count.should == person_count
-      flash[:error].to_s.should include("The email you gave is already in use")
-
-    end
-  end
-
   describe "#create" do
 
     it "creates a person" do

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -162,7 +162,7 @@ describe PersonMailer do
     @community = FactoryGirl.create(:community, :email_admins_about_new_members => 1)
     m = CommunityMembership.create(:person_id => @test_person.id, :community_id => @community.id, :status => "accepted")
     m.update_attribute(:admin, true)
-    email = PersonMailer.new_member_notification(@test_person2, @community.domain, @test_person2.email).deliver
+    email = PersonMailer.new_member_notification(@test_person2, @community.domain, @test_person2.emails.last.address).deliver
     assert !ActionMailer::Base.deliveries.empty?
     assert_equal @test_person.confirmed_notification_email_addresses, email.to
     assert_equal "New member in #{@community.full_name('en')}", email.subject

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -13,7 +13,6 @@
 #  test_group_number                  :integer          default(1)
 #  active                             :boolean          default(TRUE)
 #  username                           :string(255)
-#  email                              :string(255)
 #  encrypted_password                 :string(255)      default(""), not null
 #  reset_password_token               :string(255)
 #  reset_password_sent_at             :datetime
@@ -42,7 +41,6 @@
 #
 # Indexes
 #
-#  index_people_on_email                 (email) UNIQUE
 #  index_people_on_facebook_id           (facebook_id) UNIQUE
 #  index_people_on_id                    (id)
 #  index_people_on_reset_password_token  (reset_password_token) UNIQUE

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -72,7 +72,6 @@ describe Person do
         username = generate_random_username
         p = Person.create!({:username => username,
           :password => "testi",
-          :email => "#{username}@example.com",
           "given_name" => "Tero",
           "family_name" => "Turari"})
         Person.find(p.id).should_not be_nil


### PR DESCRIPTION
- email column has not been in use for a while
- all emails have been migrated to separate emails table

- [ ] Fix new user form