### PR TITLE
BraintreeService::EscrowReleaseHelper.next_settlement_batch_time not always returns next batch fixed

### DIFF
--- a/spec/services/braintree_service/escrow_release_helper_spec.rb
+++ b/spec/services/braintree_service/escrow_release_helper_spec.rb
@@ -50,17 +50,22 @@ describe BraintreeService::EscrowReleaseHelper do
   end
 
   describe "#next_escrow_release_time" do
+
+    def central_time(*args)
+      ActiveSupport::TimeZone.new("Central Time (US & Canada)").local(*args)
+    end
+
     context 'when todays batch has not been run yet' do
       it 'returns time of todays batch and buffer' do
-        next_batch = BraintreeService::EscrowReleaseHelper.next_escrow_release_time(Time.new(2014, 3, 11, 22, 0, 0, 0), 2)
-        next_batch.utc.should be_eql(Time.new(2014, 3, 12, 1, 0, 0, 0))
+        next_batch = BraintreeService::EscrowReleaseHelper.next_escrow_release_time(Time.new(2014, 3, 11, 21, 0, 0, 0), 2)
+        next_batch.should be_eql(central_time(2014, 3, 11, 19, 0, 0))
       end
     end
 
     context 'when todays batch has been run already' do
       it 'returns time of tomorrows batch and buffer' do
         next_batch = BraintreeService::EscrowReleaseHelper.next_escrow_release_time(Time.new(2014, 3, 11, 23, 10, 0, 0), 2)
-        next_batch.utc.should be_eql(Time.new(2014, 3, 13, 1, 0, 0, 0))
+        next_batch.should be_eql(central_time(2014, 3, 12, 19, 0, 0))
       end
     end
   end


### PR DESCRIPTION
This PR fixes the issue when next_settlement_batch_time returns the batch time which is more than 24 hours ahead.

* Let’s say we’re in GMT+4 and it's March 11, 20:00 GMT+0.
* Time.now returns time in current timezone, it is Mar 12, 00:00 GMT+4.
* settlement_batch_time_per_date(Time.now) will take date with current timezone applied, which is 12th.
* And will return March 12, 17:00 CST. which is Mar 12 23:00 GMT+0.  And it's not the next batch, it's 27 hours ahead.

In fact, it happens every time current hour is less or equal to current timezone offset plus 6 hours (e.g. 0:00–10:00 for GMT+4). It also means the tests are always failing at some period of the day. The futher to the east you are, the bigger this period is.

Fixes #911.