### PR TITLE
Add 'active' flag to PayPal account

### DIFF
--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -124,6 +124,8 @@ class Admin::PaypalPreferencesController < ApplicationController
       params[:verification_code]
     )
 
+    PaypalAccountCommand.activate_account(nil, personal_data_res[:payer_id], @current_community.id)
+
     redirect_to action: :index
   end
 

--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -124,7 +124,9 @@ class PaypalAccountsController < ApplicationController
       return flash_error_and_redirect_to_settings(error_msg: t("paypal_accounts.new.billing_agreement_wrong_account"))
     end
 
-    success = PaypalAccountCommand.confirm_billing_agreement(@current_user.id, @current_community.id, params[:token], billing_agreement_id)
+    PaypalAccountCommand.confirm_billing_agreement(@current_user.id, @current_community.id, params[:token], billing_agreement_id)
+    PaypalAccountCommand.activate_account(@current_user.id, paypal_account[:payer_id], @current_community.id)
+
     redirect_to show_paypal_account_settings_payment_path(@current_user.username)
   end
 

--- a/app/models/paypal_account.rb
+++ b/app/models/paypal_account.rb
@@ -9,6 +9,7 @@
 #  payer_id     :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  active       :boolean
 #
 # Indexes
 #

--- a/app/models/paypal_account.rb
+++ b/app/models/paypal_account.rb
@@ -9,7 +9,7 @@
 #  payer_id     :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  active       :boolean
+#  active       :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/services/paypal_service/paypal_account.rb
+++ b/app/services/paypal_service/paypal_account.rb
@@ -234,6 +234,13 @@ module PaypalService
           }
           .or_else(false)
       end
+
+      def activate_account(person_id, payer_id, community_id)
+        paypal_account = Maybe(PaypalAccountModel.where(person_id: person_id, community_id: community_id, payer_id: payer_id).first)
+        paypal_account.each { |acc| acc.update_attribute(:active, true) }
+
+        paypal_account.map { true }.or_else(false)
+      end
     end
 
     module Query

--- a/db/migrate/20150121124432_add_active_to_paypal_accounts.rb
+++ b/db/migrate/20150121124432_add_active_to_paypal_accounts.rb
@@ -1,0 +1,5 @@
+class AddActiveToPaypalAccounts < ActiveRecord::Migration
+  def change
+    add_column :paypal_accounts, :active, :boolean
+  end
+end

--- a/db/migrate/20150121124432_add_active_to_paypal_accounts.rb
+++ b/db/migrate/20150121124432_add_active_to_paypal_accounts.rb
@@ -1,5 +1,5 @@
 class AddActiveToPaypalAccounts < ActiveRecord::Migration
   def change
-    add_column :paypal_accounts, :active, :boolean
+    add_column :paypal_accounts, :active, :boolean, default: false
   end
 end

--- a/db/migrate/20150121130521_set_active_flag_to_connected_paypal_accounts.rb
+++ b/db/migrate/20150121130521_set_active_flag_to_connected_paypal_accounts.rb
@@ -1,0 +1,12 @@
+class SetActiveFlagToConnectedPaypalAccounts < ActiveRecord::Migration
+  def up
+    execute("UPDATE paypal_accounts
+             LEFT JOIN billing_agreements ON (paypal_accounts.id = billing_agreements.paypal_account_id)
+             LEFT JOIN order_permissions ON (paypal_accounts.id = order_permissions.paypal_account_id)
+             SET paypal_accounts.active = (billing_agreements.billing_agreement_id IS NOT NULL AND order_permissions.verification_code IS NOT NULL)")
+  end
+
+  def down
+    execute("UPDATE paypal_accounts SET active = 0")
+  end
+end

--- a/db/migrate/20150121130521_set_active_flag_to_connected_paypal_accounts.rb
+++ b/db/migrate/20150121130521_set_active_flag_to_connected_paypal_accounts.rb
@@ -3,7 +3,21 @@ class SetActiveFlagToConnectedPaypalAccounts < ActiveRecord::Migration
     execute("UPDATE paypal_accounts
              LEFT JOIN billing_agreements ON (paypal_accounts.id = billing_agreements.paypal_account_id)
              LEFT JOIN order_permissions ON (paypal_accounts.id = order_permissions.paypal_account_id)
-             SET paypal_accounts.active = (billing_agreements.billing_agreement_id IS NOT NULL AND order_permissions.verification_code IS NOT NULL)")
+
+             SET paypal_accounts.active =
+               (
+                 (
+                   billing_agreements.billing_agreement_id IS NOT NULL
+                   AND order_permissions.verification_code IS NOT NULL
+                   AND paypal_accounts.person_id IS NOT NULL
+                 )
+                 OR
+                 (
+                   order_permissions.verification_code IS NOT NULL
+                   AND paypal_accounts.person_id IS NULL
+                 )
+               )
+            ")
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150116125629) do
+ActiveRecord::Schema.define(:version => 20150121130521) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -645,6 +645,7 @@ ActiveRecord::Schema.define(:version => 20150116125629) do
     t.string   "payer_id"
     t.datetime "created_at",   :null => false
     t.datetime "updated_at",   :null => false
+    t.boolean  "active"
   end
 
   add_index "paypal_accounts", ["community_id"], :name => "index_paypal_accounts_on_community_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -643,9 +643,9 @@ ActiveRecord::Schema.define(:version => 20150121130521) do
     t.integer  "community_id"
     t.string   "email"
     t.string   "payer_id"
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
-    t.boolean  "active"
+    t.datetime "created_at",                      :null => false
+    t.datetime "updated_at",                      :null => false
+    t.boolean  "active",       :default => false
   end
 
   add_index "paypal_accounts", ["community_id"], :name => "index_paypal_accounts_on_community_id"


### PR DESCRIPTION
_(This Pull Request is part of a bigger project Switch PayPal account)_

**1. Add `active` column to the `paypal_accounts` table**

* Add schema migration
* Add a migration that sets correct value to the `active` column for existing PayPal accounts based on their permission/billing agreement status

**2. Make new accounts active after permissions/billing agreement has been set**

* Make admin account active after the account has been successfully connected
* Make personal account active after the account has been successfully connected and billing agreement is set


The `active` value is just stored to DB, but not used in anyway in this PR. Selecting the account based on the active flag is for upcoming Pull Requests.