### PR TITLE
Remove private repository dependency

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,12 @@
+// The fonts file has to be the first one, since there are @imports in the fonts file
+//= require ./fonts
+
 // Vendor
 //= require jquery.nouislider
 //= require jquery.fileupload
 //= require datepicker3
 
 //= require ./reset
-//= require ./fonts
 //= require ./main
 
 //= require_tree ./partials

--- a/app/assets/stylesheets/fonts.scss.erb
+++ b/app/assets/stylesheets/fonts.scss.erb
@@ -6,4 +6,4 @@
   (e.g. by replacing the whole line with font-awesome.min import)
 */
 
-<%= (APP_CONFIG.icon_pack == "font-awesome" ? "@import 'font-awesome.min';" : "@import 'ss-social';\n@import 'ss-pika';").html_safe %>
+<%= (APP_CONFIG.icon_pack == "font-awesome" ? "@import 'font-awesome.min';" : "@import '#{APP_CONFIG.ss_social_location}';\n@import '#{APP_CONFIG.ss_pika_location}';").html_safe %>

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -50,11 +50,6 @@
 
   = render :partial => "layouts/google_analytics_script"
 
-  /[if lt IE 9]
-    - if APP_CONFIG.icon_pack == "ss-pika"
-      = javascript_include_tag "ss-social"
-      = javascript_include_tag "ss-pika"
-
   -#
     Most of the JavaScript should be for performance reasons at the end of the body
 

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -182,7 +182,7 @@ default: &default_settings
 
   # If icon_pack is set to "ss-pika", set the location for the icon pack
   # This setting is irrelevant to Open Source developers, since ss icon pack
-  # does not include to the Open Source distribution
+  # is not included in the Open Source distribution
   ss_pika_location: "ss-pika"
   ss_social_location: "ss-social"
 

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -180,6 +180,12 @@ default: &default_settings
   # Currently only othe option is "ss-pika" (a proprietary icon set)
   icon_pack: "font-awesome"
 
+  # If icon_pack is set to "ss-pika", set the location for the icon pack
+  # This setting is irrelevant to Open Source developers, since ss icon pack
+  # does not include to the Open Source distribution
+  ss_pika_location: "ss-pika"
+  ss_social_location: "ss-social"
+
   # The default consent (terms of use) all the communities will use.
   # It's just a string that tells the version of the consent.
   consent: "SHARETRIBE1.0"


### PR DESCRIPTION
Currently we have a private Github repo which contains:

- Mangopay key file (not needed anymore)
- ss-pika/ss-social webfonts

This pull request removes the mangopay key because it's not needed, and it moves webfonts to S3.

The good thing is that:

- Now we can link Heroku to Github and see exactly which commit was deployed and also we can see the code diff easily
- New developer does not need to setup the private repository access
- Simplifies the deployment

Bad:

- New developer has to copy webfonts to local machine manually