### PR TITLE
Change the semantic of 'active' PayPal account

### DIFF
--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -10,12 +10,12 @@ class PaypalAccountsController < ApplicationController
   DataTypePermissions = PaypalService::DataTypes::Permissions
 
   def show
-    account_response = accounts_api.get(
+    m_account = accounts_api.get(
       community_id: @current_community.id,
       person_id: @current_user.id
-    )
-    m_account = account_response.maybe
-    return redirect_to action: :new unless m_account[:active].or_else(false)
+    ).maybe
+
+    return redirect_to action: :new unless m_account[:state].or_else(:not_verified) == :verified
 
     @selected_left_navi_link = "payments"
 
@@ -35,12 +35,12 @@ class PaypalAccountsController < ApplicationController
   end
 
   def new
-    account_response = accounts_api.get(
+    m_account = accounts_api.get(
       community_id: @current_community.id,
       person_id: @current_user.id
-    )
-    m_account = account_response.maybe
-    return redirect_to action: :show if m_account[:active].or_else(false)
+    ).maybe
+
+    return redirect_to action: :show if m_account[:state].or_else(:not_verified) == :verified
 
     @selected_left_navi_link = "payments"
     commission_from_seller = payment_gateway_commission(@current_community.id)

--- a/app/services/paypal_service/accounts_api.md
+++ b/app/services/paypal_service/accounts_api.md
@@ -42,7 +42,8 @@ Response 201 Created, with PaypalAccount body
 ```ruby
 { person_id: "person_id_1"
 , community_id: 121212
-, active: false,
+, active: true,
+, state: :not_verified,
 , paypal_email: "dev+paypal-user1@sharetribe.com"
 , payer_id: "98ASDF723S"
 , order_permission_state: :verified
@@ -93,6 +94,7 @@ Response body: PaypalAccount
 { person_id: "person_id_1"
 , community_id: 121212
 , active: true,
+, state: :verified,
 , paypal_email: "dev+paypal-user1@sharetribe.com"
 , payer_id: "98ASDF723S"
 , order_permission_state: :verified
@@ -139,6 +141,7 @@ Response body: PaypalAccount
 { person_id: "person_id_1"
 , community_id: 121212
 , active: true,
+, state: :verified,
 , paypal_email: "dev+paypal-user1@sharetribe.com"
 , payer_id: "98ASDF723S"
 , order_permission_state: :verified

--- a/app/services/paypal_service/api/accounts.rb
+++ b/app/services/paypal_service/api/accounts.rb
@@ -77,7 +77,7 @@ module PaypalService::API
                 payer_id: personal_data[:payer_id],
                 order_permission_verification_code: body[:order_permission_verification_code],
                 order_permission_scope: access_token[:scope].join(','),
-                active: person_id.nil? # activate admin account
+                active: true
               })
 
           Result::Success.new(account)
@@ -164,8 +164,7 @@ module PaypalService::API
               person_id: person_id,
               opts:
                 {
-                  billing_agreement_billing_agreement_id: billing_agreement[:billing_agreement_id],
-                  active: true
+                  billing_agreement_billing_agreement_id: billing_agreement[:billing_agreement_id]
                 })
 
             Result::Success.new(account)

--- a/app/view_utils/paypal_helper.rb
+++ b/app/view_utils/paypal_helper.rb
@@ -7,12 +7,7 @@ module PaypalHelper
   # for the community AND that the community admin has fully
   # configured the gateway.
   def community_ready_for_payments?(community_id)
-    account_response = accounts_api.get(
-      community_id: community_id
-    )
-    m_account = Maybe(account_response)[:data]
-
-    m_account[:order_permission_state].or_else(:not_verified) == :verified &&
+    account_prepared_for_community?(community_id) &&
       Maybe(TransactionService::API::Api.settings.get_active(community_id: community_id))
       .map {|res| res[:success] ? res[:data] : nil}
       .select {|set| set[:payment_gateway] == :paypal && set[:commission_from_seller] && set[:minimum_price_cents]}
@@ -24,19 +19,31 @@ module PaypalHelper
   # :paypal payment gateway and that the given user has connected his
   # paypal account.
   def user_and_community_ready_for_payments?(user_id, community_id)
-    PaypalHelper.personal_account_prepared?(user_id, community_id) &&
+    PaypalHelper.account_prepared_for_user?(user_id, community_id) &&
       PaypalHelper.community_ready_for_payments?(community_id)
   end
 
   # Check that the user has connected his paypal account for the
   # community
-  def personal_account_prepared?(user_id, community_id)
-    account_response = accounts_api.get(
+  def account_prepared_for_user?(user_id, community_id)
+    m_account = accounts_api.get(
       community_id: community_id,
       person_id: user_id
-    )
-    m_account = Maybe(account_response)[:data]
-    m_account[:active].or_else(false)
+    ).maybe
+
+    account_prepared?(m_account)
+  end
+
+  def account_prepared_for_community?(community_id)
+    m_account = accounts_api.get(
+      community_id: community_id
+    ).maybe
+
+    account_prepared?(m_account)
+  end
+
+  def account_prepared?(m_account)
+    m_account[:state].or_else(:not_verified) == :verified
   end
 
   # Check that the currently active payment gateway (there can be only

--- a/db/migrate/20150202112254_set_active_flag_to_paypal_accounts_with_permissions.rb
+++ b/db/migrate/20150202112254_set_active_flag_to_paypal_accounts_with_permissions.rb
@@ -1,0 +1,42 @@
+#
+# Change the semantics of 'active' account
+#
+# Old: Account is marked as active if:
+# - personal account: permissions and billing agreement are verified
+# - community account: permissions are verified
+#
+# New: Account is marked as active if:
+# - permissions are verified
+#
+class SetActiveFlagToPaypalAccountsWithPermissions < ActiveRecord::Migration
+  def up
+    execute("
+      UPDATE paypal_accounts
+      LEFT JOIN order_permissions ON (paypal_accounts.id = order_permissions.paypal_account_id)
+
+      SET paypal_accounts.active = order_permissions.verification_code IS NOT NULL
+    ")
+  end
+
+  def down
+    execute("
+      UPDATE paypal_accounts
+      LEFT JOIN billing_agreements ON (paypal_accounts.id = billing_agreements.paypal_account_id)
+      LEFT JOIN order_permissions ON (paypal_accounts.id = order_permissions.paypal_account_id)
+
+      SET paypal_accounts.active =
+        (
+          (
+            billing_agreements.billing_agreement_id IS NOT NULL
+            AND order_permissions.verification_code IS NOT NULL
+            AND paypal_accounts.person_id IS NOT NULL
+          )
+          OR
+          (
+            order_permissions.verification_code IS NOT NULL
+            AND paypal_accounts.person_id IS NULL
+          )
+        )
+     ")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150121130521) do
+ActiveRecord::Schema.define(:version => 20150202112254) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"

--- a/spec/services/paypal_service/api/accounts_spec.rb
+++ b/spec/services/paypal_service/api/accounts_spec.rb
@@ -186,6 +186,7 @@ describe PaypalService::API::Accounts do
 
       with_personal_account { |data|
         expect(data[:active]).to eq false
+        expect(data[:state]).to eq :not_verified
         expect(data[:order_permission_state]).to eq :pending
         expect(data[:billing_agreement_state]).to eq :not_verified
       }
@@ -200,6 +201,7 @@ describe PaypalService::API::Accounts do
 
       with_community_account { |data|
         expect(data[:active]).to eq false
+        expect(data[:state]).to eq :not_verified
         expect(data[:order_permission_state]).to eq :pending
         expect(data[:billing_agreement_state]).to eq :not_verified
       }
@@ -213,7 +215,8 @@ describe PaypalService::API::Accounts do
       create_personal_account
 
       with_personal_account { |data|
-        expect(data[:active]).to eq false
+        expect(data[:active]).to eq true
+        expect(data[:state]).to eq :not_verified
         expect(data[:email]).to eq @email
         expect(data[:payer_id]).to eq @payer_id
         expect(data[:order_permission_state]).to eq :verified
@@ -227,6 +230,7 @@ describe PaypalService::API::Accounts do
 
       with_community_account { |data|
         expect(data[:active]).to eq true
+        expect(data[:state]).to eq :verified
         expect(data[:email]).to eq @email
         expect(data[:payer_id]).to eq @payer_id
         expect(data[:order_permission_state]).to eq :verified
@@ -250,7 +254,8 @@ describe PaypalService::API::Accounts do
       }
 
       with_personal_account { |data|
-        expect(data[:active]).to eq false
+        expect(data[:active]).to eq true
+        expect(data[:state]).to eq :not_verified
         expect(data[:email]).to eq @email
         expect(data[:payer_id]).to eq @payer_id
         expect(data[:order_permission_state]).to eq :verified
@@ -270,6 +275,7 @@ describe PaypalService::API::Accounts do
 
       with_personal_account { |data|
         expect(data[:active]).to eq true
+        expect(data[:state]).to eq :verified
         expect(data[:email]).to eq @email
         expect(data[:payer_id]).to eq @payer_id
         expect(data[:order_permission_state]).to eq :verified


### PR DESCRIPTION
Change the semantic of 'active' PayPal account

Old semantic:

- Personal account was marked active when both order permissions and billing agreement were verified
- Community account was marked active when order permissions were verified

New semantic:

- All accounts are marked active after order permissions are verified
- Being 'active' does not anymore mean that the account setup is fully completed