### PR TITLE
change inviter.email to inviter.confirmed_notification_email_to

### DIFF
--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -249,7 +249,7 @@ class PersonMailer < ActionMailer::Base
     premailer_mail(:to => @invitation.email,
          :from => community_specific_sender(@invitation.community),
          :subject => subject,
-         :reply_to => @invitation.inviter.email)
+         :reply_to => @invitation.inviter.confirmed_notification_email_to)
   end
 
   # A message from the community admin to a single community member


### PR DESCRIPTION
https://trello.com/c/xlOXDMCA/1328-add-reply-to-link-to-invitation-emails 