### PR TITLE
Remove community name

### DIFF
--- a/app/jobs/invitation_created_job.rb
+++ b/app/jobs/invitation_created_job.rb
@@ -8,7 +8,7 @@ class InvitationCreatedJob < Struct.new(:invitation_id, :community_id)
   def before(job)
     # Set the correct service name to thread for I18n to pick it
     community = Community.find(community_id)
-    ApplicationHelper.store_community_service_name_to_thread(community.name)
+    ApplicationHelper.store_community_service_name_to_thread(community.name(community.default_locale))
   end
 
   def perform

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -284,7 +284,7 @@ class PersonMailer < ActionMailer::Base
   # Used to send notification to Sharetribe admins when somebody
   # gives feedback on Sharetribe
   def new_feedback(feedback, community)
-    subject = "New #unanswered #feedback from #{community.name('en')} community from user #{feedback.author.try(:name)} "
+    subject = "New #unanswered #feedback from #{community.name(community.default_locale)} community from user #{feedback.author.try(:name)} "
 
     premailer_mail(
       :to => mail_feedback_to(community, APP_CONFIG.feedback_mailer_recipients),

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -263,7 +263,13 @@ class Community < ActiveRecord::Base
   attr_accessor :terms
 
   def name(locale)
-    community_customizations.where(locale: locale).first.name
+    customization = community_customizations.where(locale: locale).first
+
+    if customization
+      customization.name
+    else
+      raise ArgumentError.new("Can not find translation for marketplace name community_id: #{id}, locale: #{locale}")
+    end
   end
 
   def full_name(locale)

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -3,7 +3,6 @@
 # Table name: communities
 #
 #  id                                         :integer          not null, primary key
-#  name                                       :string(255)
 #  domain                                     :string(255)
 #  created_at                                 :datetime
 #  updated_at                                 :datetime
@@ -135,7 +134,6 @@ class Community < ActiveRecord::Base
 
   monetize :minimum_price_cents, :allow_nil => true, :with_model_currency => :default_currency
 
-  validates_length_of :name, :in => 2..50
   validates_length_of :domain, :in => 2..50
   validates_format_of :domain, :with => /\A[A-Z0-9_\-\.]*\z/i
   validates_uniqueness_of :domain

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -264,18 +264,8 @@ class Community < ActiveRecord::Base
 
   attr_accessor :terms
 
-  def name(locale=nil)
-    if locale
-      if cc = community_customizations.find_by_locale(locale)
-        cc.name
-      else
-        community_customizations.find_by_locale(locales.first).name
-      end
-    else
-      # TODO: this is not required any more when we remove "name" column,
-      # from community, this should be removed after that.
-      read_attribute(:name)
-    end
+  def name(locale)
+    community_customizations.where(locale: locale).first.name
   end
 
   def full_name(locale)

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -44,9 +44,8 @@ module MarketplaceService::API
       def community_params(params, marketplace_name, locale)
         {
           consent: "SHARETRIBE1.0",
-          domain: available_domain_based_on(params[:marketplace_name].get),
+          domain: available_domain_based_on(marketplace_name),
           settings: {"locales" => [locale]},
-          name: marketplace_name,
           available_currencies: available_currencies_based_on(params[:marketplace_country].or_else("us")),
           country: params[:marketplace_country].upcase.or_else(nil)
         }

--- a/db/migrate/20150206151234_remove_name_from_communities.rb
+++ b/db/migrate/20150206151234_remove_name_from_communities.rb
@@ -1,0 +1,9 @@
+class RemoveNameFromCommunities < ActiveRecord::Migration
+  def up
+    remove_column :communities, :name
+  end
+
+  def down
+    add_column :communities, :name, :string, after: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150206125017) do
+ActiveRecord::Schema.define(:version => 20150206151234) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -125,7 +125,6 @@ ActiveRecord::Schema.define(:version => 20150206125017) do
   add_index "comments", ["listing_id"], :name => "index_comments_on_listing_id"
 
   create_table "communities", :force => true do |t|
-    t.string   "name"
     t.string   "domain"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/features/step_definitions/admin_category_steps.rb
+++ b/features/step_definitions/admin_category_steps.rb
@@ -113,8 +113,8 @@ When /^I confirm category removal$/ do
   }
 end
 
-Given /^"(.*?)" is the only top level category in community "(.*?)"$/ do |category_name, community|
-  community = Community.find_by_name(community)
+Given /^"(.*?)" is the only top level category in community "(.*?)"$/ do |category_name, domain|
+  community = Community.where(domain: domain).first
   category = find_category_by_name(category_name)
   community.main_categories.each do |community_category|
     if !community_category.eql? category then community_category.destroy end

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -22,7 +22,7 @@ Given /^there are following communities:$/ do |communities_table|
     domain = hash[:community]
     existing_community = Community.find_by_domain(domain)
     existing_community.destroy if existing_community
-    @hash_community = FactoryGirl.create(:community, :name => domain, :domain => domain, :settings => {"locales" => ["en", "fi"]})
+    @hash_community = FactoryGirl.create(:community, :domain => domain, :settings => {"locales" => ["en", "fi"]})
 
     attributes_to_update = hash.except('community')
     @hash_community.update_attributes(attributes_to_update) unless attributes_to_update.empty?
@@ -49,8 +49,8 @@ Given /^the terms of community "([^"]*)" are changed to "([^"]*)"$/ do |communit
   Community.find_by_domain(community).update_attribute(:consent, terms)
 end
 
-Given /^"(.*?)" is a member of community "(.*?)"$/ do |username, community_name|
-  community = Community.find_by_name!(community_name)
+Given /^"(.*?)" is a member of community "(.*?)"$/ do |username, domain|
+  community = Community.where(domain: domain).first
   person = Person.find_by_username!(username)
   membership = FactoryGirl.create(:community_membership, :person => person, :community => community)
   membership.save!

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -55,7 +55,7 @@ Then /^"(.*?)" should have required Checkout payment details saved to my account
 end
 
 When /^Braintree webhook "(.*?)" with id "(.*?)" is triggered$/ do |kind, id|
-  community = Community.find_by_name("test") # Hard-coded default test community
+  community = Community.where(domain: "test").first # Hard-coded default test community
   signature, payload = BraintreeApi.webhook_testing_sample_notification(
     community, kind, id
   )
@@ -66,7 +66,7 @@ end
 
 When /^Braintree webhook "(.*?)" with username "(.*?)" is triggered$/ do |kind, username|
   person = Person.find_by_username(username)
-  community = Community.find_by_name("test") # Hard-coded default test community
+  community = Community.where(domain: "test").first # Hard-coded default test community
   signature, payload = BraintreeApi.webhook_testing_sample_notification(
     community, kind, person.id
   )

--- a/spec/controllers/int_api/marketplaces_controller_spec.rb
+++ b/spec/controllers/int_api/marketplaces_controller_spec.rb
@@ -22,11 +22,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.find_by_name("ImaginationTraders")
+      c = Community.where(domain: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
-      expect(c.name).to eql "ImaginationTraders"
+      expect(c.name("fi")).to eql "ImaginationTraders"
       expect(c.domain).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 
@@ -58,11 +58,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.find_by_name("ImaginationTraders")
+      c = Community.where(domain: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
-      expect(c.name).to eql "ImaginationTraders"
+      expect(c.name("fi")).to eql "ImaginationTraders"
       expect(c.domain).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 
@@ -90,11 +90,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.find_by_name("ImaginationTraders")
+      c = Community.where(domain: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
-      expect(c.name).to eql "ImaginationTraders"
+      expect(c.name("fi")).to eql "ImaginationTraders"
       expect(c.domain).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 
@@ -122,11 +122,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.find_by_name("ImaginationTraders")
+      c = Community.where(domain: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
-      expect(c.name).to eql "ImaginationTraders"
+      expect(c.name("fi")).to eql "ImaginationTraders"
       expect(c.domain).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -173,7 +173,6 @@ FactoryGirl.define do
   end
 
   factory :community do
-    name { generate(:domain) }
     domain
     slogan "Test slogan"
     description "Test description"

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -1,10 +1,9 @@
-# encoding: UTF-8
+# encoding: utf-8
 # == Schema Information
 #
 # Table name: communities
 #
 #  id                                         :integer          not null, primary key
-#  name                                       :string(255)
 #  domain                                     :string(255)
 #  created_at                                 :datetime
 #  updated_at                                 :datetime
@@ -110,15 +109,6 @@ describe Community do
 
   it "is valid with valid attributes" do
     @community.should be_valid
-  end
-
-  it "is not valid without proper name" do
-    @community.name = nil
-    @community.should_not be_valid
-    @community.name = "a"
-    @community.should_not be_valid
-    @community.name = "a" * 51
-    @community.should_not be_valid
   end
 
   it "is not valid without proper domain" do

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -170,9 +170,10 @@ module TestHelpers
 
   # This is loaded only once before running the whole test set
   def load_default_test_data_to_db_before_suite
-    community1 = FactoryGirl.create(:community, :domain => "test", :name => "Test", :consent => "test_consent0.1", :settings => {"locales" => ["en", "fi"]}, :real_name_required => true)
-    community2 = FactoryGirl.create(:community, :domain => "test2", :name => "Test2", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true, :allowed_emails => "@example.com")
-    community3 = FactoryGirl.create(:community, :domain => "test3", :name => "Test3", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true)
+    community1 = FactoryGirl.create(:community, :domain => "test", :consent => "test_consent0.1", :settings => {"locales" => ["en", "fi"]}, :real_name_required => true)
+    community1.community_customizations.create(name: "Sharetribe", locale: "fi")
+    community2 = FactoryGirl.create(:community, :domain => "test2", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true, :allowed_emails => "@example.com")
+    community3 = FactoryGirl.create(:community, :domain => "test3", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true)
 
     [community1, community2, community3].each { |c| TestHelpers::CategoriesHelper.load_test_categories_and_transaction_types_to_db(c) }
   end


### PR DESCRIPTION
Community name is not used anymore. We use always the translated community name from community customizations.

- [x] Before deploy, make sure that all communities have translations for the community name
