### PR TITLE
Paypal error handling

### DIFF
--- a/app/services/paypal_service/api/billing_agreements.rb
+++ b/app/services/paypal_service/api/billing_agreements.rb
@@ -115,7 +115,7 @@ module PaypalService::API
       end
     end
 
-    def error_payment(cid, txid, payment)
+    def mark_payment_errored(cid, txid, payment)
       PaypalService::Store::PaypalPayment.update(
         data: payment.merge({
           commission_status: :errored
@@ -126,7 +126,7 @@ module PaypalService::API
 
     def commission_payment_failed(payment)
       -> (cid, txid, request, err_response) do
-        error_payment(cid, txid, payment)
+        mark_payment_errored(cid, txid, payment)
 
         log_and_return(cid, txid, request, err_response)
       end

--- a/app/services/paypal_service/api/data_types.rb
+++ b/app/services/paypal_service/api/data_types.rb
@@ -43,7 +43,7 @@ module PaypalService::API::DataTypes
     [:commission_payment_date, :time],
     [:commission_total, :money],
     [:commission_fee_total, :money],
-    [:commission_status, one_of: [:not_charged, :completed, :pending, :seller_is_admin, :below_minimum, :not_applicable]],
+    [:commission_status, one_of: [:not_charged, :completed, :pending, :seller_is_admin, :below_minimum, :not_applicable, :errored]],
     [:commission_pending_reason, transform_with: -> (v) { (v.is_a? String) ? v.downcase.gsub("-", "").to_sym : v }]
   )
 

--- a/app/services/paypal_service/api/request_wrapper.rb
+++ b/app/services/paypal_service/api/request_wrapper.rb
@@ -34,7 +34,7 @@ module PaypalService::API::RequestWrapper
   end
 
   def log_and_return(cid, txid, request, err_response, data = {})
-    @logger.warn("PayPal operation #{request[:method]} failed. Error code: #{err_response[:error_code]}, msg: #{err_response[:error_msg]}")
+    @logger.warn("PayPal operation #{request[:method]} failed. Community: #{cid}, transaction: #{txid}, error code: #{err_response[:error_code]}, msg: #{err_response[:error_msg]}")
     Result::Error.new(
       "Failed response from Paypal. Error code: #{err_response[:error_code]}, msg: #{err_response[:error_msg]}",
       {

--- a/spec/services/paypal_service/api.rb
+++ b/spec/services/paypal_service/api.rb
@@ -37,6 +37,7 @@ module PaypalService::API
     def self.reset!
       @payments = nil
       @events = nil
+      @billing_agreements = nil
       @test_merchant = nil
       @test_permissions = nil
       @api_builder = nil


### PR DESCRIPTION
- Mark commission payment status to `errored` if an error occures.
- Improve error logging by adding community and transaction ids