### PR TITLE
Show missing payment warning only for listings with price

### DIFF
--- a/app/services/marketplace_service/listing.rb
+++ b/app/services/marketplace_service/listing.rb
@@ -127,11 +127,17 @@ module MarketplaceService
         listing.merge(transaction_type: MarketplaceService::Listing::Entity.transaction_type(listing_model.transaction_type))
       end
 
-      def open_listings_for(community_id, person_id)
-        ListingModel.includes(:communities).where(
-          "communities.id" => community_id,
-          "author_id" => person_id,
-          :open => true)
+      def open_listings_with_price_for(community_id, person_id)
+        ListingModel
+          .includes(:communities)
+          .includes(:transaction_type)
+          .where(
+            {
+              communities: { id: community_id },
+              transaction_types: { price_field: true },
+              author_id: person_id,
+              open: true
+            })
           .map { |l| MarketplaceService::Listing::Entity.listing(l) }
       end
     end

--- a/app/view_utils/paypal_helper.rb
+++ b/app/view_utils/paypal_helper.rb
@@ -81,7 +81,7 @@ module PaypalHelper
   def open_listings_with_missing_payment_info?(user_id, community_id)
     paypal_active?(community_id) &&
     !user_and_community_ready_for_payments?(user_id, community_id) &&
-    !MarketplaceService::Listing::Query.open_listings_for(community_id, user_id).empty?
+    !MarketplaceService::Listing::Query.open_listings_with_price_for(community_id, user_id).empty?
   end
 
   def accounts_api


### PR DESCRIPTION
- If user has a listing with transaction type "Give", there's no need for PayPal account, thus we should not show the warning about missing account