### PR TITLE
Remove rspec warnings

### DIFF
--- a/spec/services/marketplace_service/listing_spec.rb
+++ b/spec/services/marketplace_service/listing_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe MarketplaceService::Listing::Entity do
   include MarketplaceService::Listing::Entity
   include MarketplaceService::Listing::Command
@@ -29,8 +31,8 @@ describe MarketplaceService::Listing::Entity do
 
       expect(hammer.description).to be_nil
       expect(hammer.origin).to be_nil
-      expect(hammer.open).to be_false
-      expect(hammer.deleted?).to be_true
+      expect(hammer.open).to be false
+      expect(hammer.deleted?).to be true
     end
   end
 end


### PR DESCRIPTION
Get rid of these warnings:

Deprecation Warnings:

`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /Users/bing/Projects/sharetribe/spec/services/marketplace_service/listing_spec.rb:32:in `block (3 levels) in <top (required)>'.

`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/bing/Projects/sharetribe/spec/services/marketplace_service/listing_spec.rb:33:in `block (3 levels) in <top (required)>'.

--------------------------------------------------------------------------------
rspec-rails 3 will no longer automatically infer an example group's spec type
from the file location. You can explicitly opt-in to this feature using this
snippet:

RSpec.configure do |config|
  config.infer_spec_type_from_file_location!
end

If you wish to manually label spec types via metadata you can safely ignore
this warning and continue upgrading to RSpec 3 without addressing it.
--------------------------------------------------------------------------------


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.