### PR TITLE
Tweak signup without first and last name

### DIFF
--- a/app/views/people/new.haml
+++ b/app/views/people/new.haml
@@ -47,7 +47,7 @@
     - if @current_community.only_organizations
       = form.label :organization_name, t('.organization_name')
       = form.text_field :organization_name, :class => :text_field, :maxlength => "30"
-    - else
+    - elsif @current_community.real_name_required?
       = form.label :given_name, t('.given_name')
       = form.text_field :given_name, :class => :text_field, :maxlength => "30"
       = form.label :family_name, t('.family_name')

--- a/features/people/user_creates_a_new_account.feature
+++ b/features/people/user_creates_a_new_account.feature
@@ -68,8 +68,9 @@ Feature: User creates a new account
     Then I should see "This field is required."
     When given name and last name are not required in community "test"
     And I am on the signup page
+    Then I should not see "First name"
+    And I should not see "Last name"
     When I fill in "person[username]" with random username
-    And I fill in "person[username]" with random username
     And I fill in "person_password1" with "test"
     And I fill in "Confirm password" with "test"
     And I fill in "Email address" with random email


### PR DESCRIPTION
The user's requirement is when I configurated the community with real_name_required: false, I don't want show the first name and last name on signup form.