### PR TITLE
Specify to infer spec type from file location

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,10 @@ prefork = lambda {
     config.mock_with :rspec
     config.include Devise::TestHelpers, :type => :controller
     config.include SpecUtils
+
+    # rspec-rails 3 will no longer automatically infer an example group's spec type
+    # from the file location. Explicitly opt-in to this feature using this snippet:
+    config.infer_spec_type_from_file_location!
   end
 
   def uploaded_file(filename, content_type)


### PR DESCRIPTION
To get rid of the warning for the coming rspec3.