### PR TITLE
Fix bug: No error message because of double redirect

### DIFF
--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -214,7 +214,15 @@ class PaypalAccountsController < ApplicationController
       end
 
     flash[:error] = error_msg
-    redirect_to new_paypal_account_settings_payment_path(@current_user.username)
+    redirect_to action: error_redirect_action
+  end
+
+  def error_redirect_action
+    if PaypalHelper.account_prepared_for_user?(@current_user.id, @current_community.id)
+      :show
+    else
+      :new
+    end
   end
 
   def payment_gateway_commission(community_id)

--- a/app/services/paypal_service/api/accounts.rb
+++ b/app/services/paypal_service/api/accounts.rb
@@ -245,7 +245,7 @@ module PaypalService::API
         block.call(res)
       else
         res.tap { |err_response|
-          @logger.warn("PayPal operation #{req[:method]} failed. Error code: #{err_response[:error_code]}, msg: #{err_response[:error_msg]}")
+          @logger.warn("PayPal operation failed: #{req}. Response: #{err_response}")
         }
       end
     end


### PR DESCRIPTION
When there's an error from PayPal, we lost the error message because of double rendering when user is changing her PayPal account.

Flash messages are only persisted for the next redirect. However, we are redirecting the user from `permissions_verified` -> `new` -> `show`. Instead of this, redirect from `permissions_verified` -> `show` if user account exists.