### PR TITLE
Marketplace username 2/3

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
     :check_auth_token,
     :fetch_logged_in_user,
     :fetch_community,
+    :redirect_to_marketplace_domain,
     :fetch_community_membership,
     :set_locale,
     :generate_event_id,
@@ -164,6 +165,38 @@ class ApplicationController < ActionController::Base
     }
   end
 
+  def redirect_to_marketplace_domain
+    return unless @current_community
+
+    host = request.host
+    domain = @current_community.domain
+
+    if needs_redirect?(host, domain)
+      redirect_to "#{request.protocol}#{domain}"
+    end
+  end
+
+  def needs_redirect?(host, domain)
+    if domain.nil?
+      false
+    elsif is_subdomain?(domain)
+      # In the future we should not save subdomain (i.e. the usernames) to `domain` column.
+      # However, those have been left there for easier migration from domain -> usernames.
+      # We have a lot of code where `find_by_domain` is used, and we don't want to break that
+      # for now
+      false
+    elsif host == domain
+      false
+    else
+      true
+    end
+  end
+
+  def is_subdomain?(domain)
+    # Very naive
+    !domain.include?(".")
+  end
+
   # Fetch community
   #
   # 1. Try to find by domain
@@ -171,19 +204,31 @@ class ApplicationController < ActionController::Base
   # 3. Otherwise nil
   #
   def self.default_community_fetch_strategy(domain)
+    # Find by domain
     by_domain = Community.find_by_domain(domain)
 
     if by_domain.present?
-      by_domain
-    else
-      count = Community.count
-
-      if count == 1
-        Community.first
-      else
-        nil
-      end
+      return by_domain
     end
+
+    # Find by username
+    app_domain = URLUtils.strip_port_from_host(APP_CONFIG.domain)
+    ident = domain.chomp(".#{app_domain}")
+    by_ident = Community.where(ident: ident).first
+
+    if by_ident.present?
+      return by_ident
+    end
+
+    # If only one, use it
+    count = Community.count
+
+    if count == 1
+      return Community.first
+    end
+
+    # Not found, return nil
+    nil
   end
 
   # Before filter to check if current user is the member of this community

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
     domain = @current_community.domain
 
     if needs_redirect?(host, domain)
-      redirect_to "#{request.protocol}#{domain}"
+      redirect_to "#{request.protocol}#{domain}#{request.fullpath}", status: :moved_permanently
     end
   end
 

--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -1,13 +1,13 @@
 class BraintreeWebhooksController < ApplicationController
 
   skip_before_filter :verify_authenticity_token
-  skip_filter :fetch_community, :check_email_confirmation
+  skip_filter :fetch_community, :redirect_to_marketplace_domain, :check_email_confirmation
 
   before_filter :fetch_community_by_params
 
   before_filter do
     unless @current_community.braintree_in_use?
-      BTLog.error("Received webhook notification even though '#{@current_community.domain}' does not have Braintree in use")
+      BTLog.error("Received webhook notification even though '#{@current_community.ident}' does not have Braintree in use")
       render :nothing => true, :status => 400 and return
     end
   end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,5 +1,6 @@
 class CommunitiesController < ApplicationController
   skip_filter :fetch_community,
+              :redirect_to_marketplace_domain,
               :cannot_access_without_joining
 
   before_filter :ensure_no_communities

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -69,7 +69,7 @@ class CommunityMembershipsController < ApplicationController
         end
 
         # Send confirmation and make membership pending
-        Email.send_confirmation(e, request.host_with_port, @current_community)
+        Email.send_confirmation(e, @current_community)
         @community_membership.status = "pending_email_confirmation"
 
         flash[:notice] = "#{t("layouts.notifications.you_need_to_confirm_your_account_first")} #{t("sessions.confirmation_pending.check_your_email")}."

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -16,7 +16,7 @@ class ConfirmationsController < Devise::ConfirmationsController
       if Email.email_available?(params[:person][:email])
         if @current_community.email_allowed?(params[:person][:email])
           email = Email.create(:person => @current_user, :address => params[:person][:email], :send_notifications => true)
-          Email.send_confirmation(email, request.host_with_port, @current_community)
+          Email.send_confirmation(email, @current_community)
           flash[:notice] = t("sessions.confirmation_pending.check_your_email")
           redirect_to :controller => "sessions", :action => "confirmation_pending" and return
         else
@@ -32,7 +32,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     # Resend confirmation
     if email_param_present
       email = Email.find_by_address(params[:person][:email])
-      Email.send_confirmation(email, request.host_with_port, @current_community)
+      Email.send_confirmation(email, @current_community)
       flash[:notice] = t("sessions.confirmation_pending.check_your_email")
       redirect_to :controller => "sessions", :action => "confirmation_pending" and return
     end

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -13,7 +13,7 @@ class EmailsController < ApplicationController
       return redirect_to account_person_settings_path(@current_user)
     end
 
-    Email.send_confirmation(@email, request.host_with_port, @current_community)
+    Email.send_confirmation(@email, @current_community)
     flash[:notice] = t("sessions.confirmation_pending.check_your_email")
     redirect_to account_person_settings_path(@current_user)
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -25,7 +25,7 @@ class ErrorsController < ActionController::Base
   private
 
   def current_community
-    @current_community ||= Community.find_by_domain(request.host)
+    @current_community ||= ApplicationController.default_community_fetch_strategy(request.host)
   end
 
   def title(status)

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -1,6 +1,6 @@
 class IntApi::MarketplacesController < ApplicationController
 
-  skip_filter :fetch_community
+  skip_filter :fetch_community, :redirect_to_marketplace_domain
 
   before_filter :set_access_control_headers
 

--- a/app/controllers/paypal_ipn_controller.rb
+++ b/app/controllers/paypal_ipn_controller.rb
@@ -3,7 +3,7 @@ class PaypalIpnController < ApplicationController
   include PaypalService::MerchantInjector
   include PaypalService::IPNInjector
 
-  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :fetch_community_membership
+  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :redirect_to_marketplace_domain, :fetch_community_membership
   skip_filter :check_email_confirmation
 
   IPNDataTypes = PaypalService::DataTypes::IPN

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -114,7 +114,7 @@ class PeopleController < Devise::RegistrationsController
 
       redirect_to root
     else
-      Email.send_confirmation(email, request.host_with_port, @current_community)
+      Email.send_confirmation(email, @current_community)
 
       flash[:notice] = t("layouts.notifications.account_creation_succesful_you_still_need_to_confirm_your_email")
       redirect_to :controller => "sessions", :action => "confirmation_pending"
@@ -194,7 +194,7 @@ class PeopleController < Devise::RegistrationsController
 
         if params[:person][:email_attributes] && params[:person][:email_attributes][:address]
           # A new email was added, send confirmation email to the latest address
-          Email.send_confirmation(@person.emails.last, request.host_with_port, @current_community)
+          Email.send_confirmation(@person.emails.last, @current_community)
         end
 
         flash[:notice] = t("layouts.notifications.person_updated_successfully")

--- a/app/jobs/community_joined_job.rb
+++ b/app/jobs/community_joined_job.rb
@@ -14,7 +14,7 @@ class CommunityJoinedJob < Struct.new(:person_id, :community_id)
     current_user = Person.find(person_id)
     current_community = Community.find(community_id)
 
-    PersonMailer.new_member_notification(current_user, current_community.domain, current_user.emails.last.address).deliver if current_community.email_admins_about_new_members?
+    PersonMailer.new_member_notification(current_user, current_community, current_user.emails.last.address).deliver if current_community.email_admins_about_new_members?
   end
 
 end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -294,8 +294,8 @@ class PersonMailer < ActionMailer::Base
 
   # Old layout
 
-  def new_member_notification(person, community_domain, email)
-    @community = Community.find_by_domain(community_domain)
+  def new_member_notification(person, community, email)
+    @community = community
     @no_settings = true
     @person = person
     @email = email
@@ -304,17 +304,16 @@ class PersonMailer < ActionMailer::Base
          :subject => "New member in #{@community.full_name(@person.locale)}")
   end
 
-  def email_confirmation(email, host, com=nil)
-    community = com || Community.find_by_domain(host)
+  def email_confirmation(email, community)
     @current_community = community
     @no_settings = true
     @resource = email.person
     @confirmation_token = email.confirmation_token
-    @host = host
+    @host = community.full_domain
     set_locale(email.person.locale)
     email.update_attribute(:confirmation_sent_at, Time.now)
     premailer_mail(:to => email.address,
-         :from => community_specific_sender(com),
+         :from => community_specific_sender(community),
          :subject => t("devise.mailer.confirmation_instructions.subject"),
          :template_path => 'devise/mailer',
          :template_name => 'confirmation_instructions')

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -56,7 +56,7 @@ class Email < ActiveRecord::Base
     !email.present? || email.person == user
   end
 
-  def self.send_confirmation(email, host, community=nil)
-    PersonMailer.email_confirmation(email, host, community).deliver
+  def self.send_confirmation(email, community)
+    PersonMailer.email_confirmation(email, community).deliver
   end
 end

--- a/app/services/community_stylesheet_compiler.rb
+++ b/app/services/community_stylesheet_compiler.rb
@@ -35,7 +35,7 @@ module CommunityStylesheetCompiler
       prepare
 
       variable_hash = create_variable_hash(community)
-      target_file_basename = create_new_filename(community.domain)
+      target_file_basename = create_new_filename(community.ident)
       target_file_extension = use_gzip? ? "css.gz" : "css"
       target_file_path = "public/assets/#{target_file_basename}.#{target_file_extension}"
 
@@ -138,10 +138,10 @@ module CommunityStylesheetCompiler
       HashUtils.compact(hash)
     end
 
-    def create_new_filename(domain)
-      community_domain = domain.gsub(".", "_")
+    def create_new_filename(ident)
+      community_ident = ident.gsub(".", "_")
       timestamp = Time.now.strftime("%Y%m%d%H%M%S")
-      "custom-style-#{community_domain}-#{timestamp}"
+      "custom-style-#{community_ident}-#{timestamp}"
     end
   end
 end

--- a/app/services/marketplace_service/api/data_types.rb
+++ b/app/services/marketplace_service/api/data_types.rb
@@ -2,7 +2,6 @@ module MarketplaceService::API::DataTypes
 
   Marketplace = EntityUtils.define_builder(
     [:id, :mandatory, :fixnum],
-    [:domain, :mandatory, :string],
     [:ident, :mandatory, :string],
     [:url, :mandatory, :string],
     [:locales, :mandatory, :enumerable],

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -77,11 +77,10 @@ module MarketplaceService::API
       module_function
 
       def community_params(params, marketplace_name, locale)
-        domain = available_domain_based_on(marketplace_name)
+        ident = available_ident_based_on(marketplace_name)
         {
           consent: "SHARETRIBE1.0",
-          domain: domain,
-          ident: domain,
+          ident: ident,
           settings: {"locales" => [locale]},
           available_currencies: available_currencies_based_on(params[:marketplace_country].or_else("us")),
           country: params[:marketplace_country].upcase.or_else(nil)
@@ -128,25 +127,25 @@ module MarketplaceService::API
         "<h1>#{I18n.t("infos.how_to_use.default_title", locale: locale)}</h1><div>#{I18n.t("infos.how_to_use.default_content", locale: locale, :marketplace_name => marketplace_name)}</div>"
       end
 
-      def available_domain_based_on(initial_domain)
+      def available_ident_based_on(initial_ident)
 
-        if initial_domain.blank?
-          initial_domain = "trial_site"
+        if initial_ident.blank?
+          initial_ident = "trial_site"
         end
 
-        current_domain = initial_domain.to_url
-        current_domain = current_domain[0..29] #truncate to 30 chars or less
+        current_ident = initial_ident.to_url
+        current_ident = current_ident[0..29] #truncate to 30 chars or less
 
         # use basedomain as basis on new variations if current domain is not available
-        base_domain = current_domain
+        base_ident = current_ident
 
         i = 1
-        while CommunityModel.find_by_domain(current_domain) || RESERVED_DOMAINS.include?(current_domain) do
-          current_domain = "#{base_domain}#{i}"
+        while CommunityModel.exists?(ident: current_ident) || RESERVED_DOMAINS.include?(current_ident) do
+          current_ident = "#{base_ident}#{i}"
           i += 1
         end
 
-        return current_domain
+        return current_ident
       end
 
       def available_currencies_based_on(country_code)

--- a/app/services/user_service/api/users.rb
+++ b/app/services/user_service/api/users.rb
@@ -17,7 +17,7 @@ module UserService::API
       if APP_CONFIG.skip_email_confirmation
         email.confirm!
       else
-        Email.send_confirmation(email, community.full_domain, community)
+        Email.send_confirmation(email, community)
       end
 
       return user

--- a/app/utils/url_utils.rb
+++ b/app/utils/url_utils.rb
@@ -28,4 +28,10 @@ module URLUtils
   def extract_locale_from_url(url)
     URI(url).path.split('/')[1]
   end
+
+  # www.sharetribe.com => www.sharetribe.com
+  # www.sharetribe.com:3000 => www.sharetribe.com
+  def strip_port_from_host(host)
+    host.split(":").first
+  end
 end

--- a/app/views/layouts/_google_analytics_script.haml
+++ b/app/views/layouts/_google_analytics_script.haml
@@ -20,7 +20,7 @@
     = "_gaq.push(['b._setAccount', '#{@current_community.google_analytics_key}']);"
     = "_gaq.push(['b._setDomainName', '.#{request.domain}']);"
     = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.name(I18n.locale).gsub("'","")}']);"
-    = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.domain}']);"
+    = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.domain || @current_community.ident}']);"
     _gaq.push(
     ['b._setAllowLinker', true],
     ['b._trackPageview'],

--- a/app/views/layouts/_kissmetrics.haml
+++ b/app/views/layouts/_kissmetrics.haml
@@ -16,7 +16,7 @@
     </script>
   - if @current_community
     <script type="text/javascript">
-    = "_kmq.push(['set', {'SiteName' : '#{@current_community.domain}'}]);"
+    = "_kmq.push(['set', {'SiteName' : '#{@current_community.ident}'}]);"
     </script>
   - else
     <script type="text/javascript">

--- a/app/views/people/new.haml
+++ b/app/views/people/new.haml
@@ -72,7 +72,6 @@
           = link_to t(".terms"), "#", :tabindex => "-1", :id => "terms_link", :class => "form"
 
     = form.hidden_field :consent, :value => @current_community.consent
-    = hidden_field_tag :community, @current_community.domain
 
     = button_tag t('.create_new_account')
 

--- a/app/views/sessions/_new.haml
+++ b/app/views/sessions/_new.haml
@@ -37,8 +37,6 @@
         = t('common.password') + ":"
       = password_field_tag "person[password]", nil, :class => :text_field
     .form_field_container
-      - if @current_community
-        = hidden_field_tag :community, @current_community.domain
       = submit_tag(t('.login'), :class => "send_button")
     .form_field_container
       .links

--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -31,8 +31,6 @@
     %label{:for => "password"}
       = t('common.password') + ":"
     = password_field_tag "person[password]", nil, :class => :text_field, :id => :main_person_password
-    - if @current_community
-      = hidden_field_tag :community, @current_community.domain
     = button_tag(t('.login'), :class => "send_button", :id => :main_log_in_button)
     .links
       - unless @facebook_merge

--- a/features/step_definitions/admin_category_steps.rb
+++ b/features/step_definitions/admin_category_steps.rb
@@ -113,8 +113,8 @@ When /^I confirm category removal$/ do
   }
 end
 
-Given /^"(.*?)" is the only top level category in community "(.*?)"$/ do |category_name, domain|
-  community = Community.where(domain: domain).first
+Given /^"(.*?)" is the only top level category in community "(.*?)"$/ do |category_name, ident|
+  community = Community.where(ident: ident).first
   category = find_category_by_name(category_name)
   community.main_categories.each do |community_category|
     if !community_category.eql? category then community_category.destroy end

--- a/features/step_definitions/admin_custom_field_steps.rb
+++ b/features/step_definitions/admin_custom_field_steps.rb
@@ -162,7 +162,7 @@ When /^I add a new checkbox field Amenities with invalid data$/ do
 end
 
 Given /^there is a custom field "(.*?)" in community "(.*?)" for category "(.*?)"$/ do |name, community, category_name|
-  current_community = Community.find_by_domain(community)
+  current_community = Community.where(ident: community).first
   @custom_field = FactoryGirl.build(:custom_dropdown_field, {
     :community_id => current_community.id,
     :names => [CustomFieldName.create(:value => name, :locale => "en")],
@@ -172,7 +172,7 @@ Given /^there is a custom field "(.*?)" in community "(.*?)" for category "(.*?)
 end
 
 Given /^there is a numeric field "(.*?)" in community "(.*?)" for category "(.*?)" with min value "(.*?)" and max value "(.*?)"$/ do |name, community, category_name, min, max|
-  current_community = Community.find_by_domain(community)
+  current_community = Community.where(ident: community).first
   @custom_field = FactoryGirl.build(:custom_numeric_field, {
     :community_id => current_community.id,
     :names => [CustomFieldName.create(:value => name, :locale => "en")],
@@ -254,7 +254,7 @@ When /^I move custom field "(.*?)" up$/ do |custom_field|
 end
 
 Given /^there is a custom dropdown field "(.*?)" in community "(.*?)"(?: in category "([^"]*)")? with options:$/ do |name, community, category_name, options|
-  current_community = Community.find_by_domain(community)
+  current_community = Community.where(ident: community).first
   custom_field = FactoryGirl.build(:custom_dropdown_field, {
     :community_id => current_community.id,
     :names => [CustomFieldName.create(:value => name, :locale => "en")]
@@ -280,7 +280,7 @@ Given /^there is a custom dropdown field "(.*?)" in community "(.*?)"(?: in cate
 end
 
 Given /^there is a custom text field "(.*?)" in community "(.*?)"(?: in category "([^"]*)")?$/ do |name, community, category_name|
-  current_community = Community.find_by_domain(community)
+  current_community = Community.where(ident: community).first
   custom_field = FactoryGirl.build(:custom_text_field, {
     :community_id => current_community.id,
     :names => [CustomFieldName.create(:value => name, :locale => "en")]

--- a/features/step_definitions/admin_look_and_feel_steps.rb
+++ b/features/step_definitions/admin_look_and_feel_steps.rb
@@ -20,7 +20,7 @@ Then(/^I should see that the background color of Post a new listing button is "(
 end
 
 Given(/^community "(.*?)" has default browse view "(.*?)"$/) do |community, browse_view|
-  Community.find_by_domain(community).update_attributes(default_browse_view: browse_view)
+  Community.where(ident: community).first.update_attributes(default_browse_view: browse_view)
 end
 
 When(/^I change the default browse view to "(.*?)"$/) do |browse_view|
@@ -35,7 +35,7 @@ Then(/^I should see the browse view selected as "(.*?)"$/) do |browse_view|
 end
 
 Given(/^community "(.*?)" has name display type "(.*?)"$/) do |community, name_display_type|
-  Community.find_by_domain(community).update_attributes(name_display_type: name_display_type)
+  Community.where(ident: community).first.update_attributes(name_display_type: name_display_type)
 end
 
 When(/^I change the name display type to "(.*?)"$/) do |name_display_type|

--- a/features/step_definitions/listing_steps.rb
+++ b/features/step_definitions/listing_steps.rb
@@ -48,12 +48,12 @@ Given /^privacy of that listing is "([^"]*)"$/ do |privacy|
   @listing.update_attribute(:privacy, privacy)
 end
 
-Given(/^that listing belongs to community "(.*?)"$/) do |domain|
-  @listing.communities = [Community.find_by_domain(domain)]
+Given(/^that listing belongs to community "(.*?)"$/) do |ident|
+  @listing.communities = [Community.where(ident: ident).first]
 end
 
-Given /^that listing is visible to members of community "([^"]*)"$/ do |domain|
-  @listing.communities << Community.find_by_domain(domain)
+Given /^that listing is visible to members of community "([^"]*)"$/ do |ident|
+  @listing.communities << Community.where(ident: ident).first
 end
 
 Given /^that listing has a description "(.*?)"$/ do |description|
@@ -127,8 +127,8 @@ When /^I choose to view only transaction type "(.*?)"$/ do |transaction_type|
   }
 end
 
-Given /^there is a dropdown field "(.*?)" for category "(.*?)" in community "(.*?)" with options:$/ do |field_title, category_name, community_domain, opts_table|
-  @community = Community.find_by_domain(community_domain)
+Given /^there is a dropdown field "(.*?)" for category "(.*?)" in community "(.*?)" with options:$/ do |field_title, category_name, community_ident, opts_table|
+  @community = Community.where(ident: community_ident).first
   @category = find_category_by_name(category_name)
   @custom_field = FactoryGirl.build(:custom_dropdown_field, :community => @community, :names => [CustomFieldName.create(:value => field_title, :locale => "en")])
   @custom_field.category_custom_fields << FactoryGirl.build(:category_custom_field, :category => @category, :custom_field => @custom_field)
@@ -173,8 +173,8 @@ Given /^that listing has custom field "(.*?)" with value "(.*?)"$/ do |field_tit
   value.save!
 end
 
-Given /^listing comments are in use in community "(.*?)"$/ do |community_domain|
-  community = Community.find_by_domain(community_domain)
+Given /^listing comments are in use in community "(.*?)"$/ do |community_ident|
+  community = Community.where(ident: community_ident).first
   community.update_attribute(:listing_comments_in_use, true)
 end
 

--- a/features/step_definitions/organization_steps.rb
+++ b/features/step_definitions/organization_steps.rb
@@ -1,5 +1,5 @@
 Given /^community "(.*?)" allows only organizations$/ do |community|
-  c = Community.find_by_domain(community)
+  c = Community.where(ident: community).first
   c.only_organizations = true
   c.save!
 end

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -20,7 +20,7 @@ Given /^there are following Braintree accounts:$/ do |bt_accounts|
   # Create new accounts
   bt_accounts.hashes.each do |hash|
     person = Person.find_by_username(hash[:person])
-    community = Community.find_by_domain(hash[:community])
+    community = Community.where(ident: hash[:community]).first
     attributes_to_update = hash.except('person', 'community')
     @account = create_braintree_account(person, community, attributes_to_update)
   end
@@ -55,7 +55,7 @@ Then /^"(.*?)" should have required Checkout payment details saved to my account
 end
 
 When /^Braintree webhook "(.*?)" with id "(.*?)" is triggered$/ do |kind, id|
-  community = Community.where(domain: "test").first # Hard-coded default test community
+  community = Community.where(ident: "test").first # Hard-coded default test community
   signature, payload = BraintreeApi.webhook_testing_sample_notification(
     community, kind, id
   )
@@ -66,7 +66,7 @@ end
 
 When /^Braintree webhook "(.*?)" with username "(.*?)" is triggered$/ do |kind, username|
   person = Person.find_by_username(username)
-  community = Community.where(domain: "test").first # Hard-coded default test community
+  community = Community.where(ident: "test").first # Hard-coded default test community
   signature, payload = BraintreeApi.webhook_testing_sample_notification(
     community, kind, person.id
   )

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -191,20 +191,20 @@ end
 
 Given /^user "([^"]*)" is member of community "([^"]*)"$/ do |username, community|
   user = Person.find_by_username(username)
-  community = Community.find_by_domain(community)
+  community = Community.where(ident: community).first
   cm = CommunityMembership.find_by_person_id_and_community_id(user.id, community.id)
   CommunityMembership.create(:person_id => user.id, :community_id => community.id) unless cm
 end
 
 Given /^"([^"]*)" has admin rights in community "([^"]*)"$/ do |username, community|
   user = Person.find_by_username(username)
-  community = Community.find_by_domain(community)
+  community = Community.where(ident: community).first
   CommunityMembership.find_by_person_id_and_community_id(user.id, community.id).update_attribute(:admin, true)
 end
 
 Given /^"([^"]*)" does not have admin rights in community "([^"]*)"$/ do |username, community|
   user = Person.find_by_username(username)
-  community = Community.find_by_domain(community)
+  community = Community.where(ident: community).first
   CommunityMembership.find_by_person_id_and_community_id(user.id, community.id).update_attribute(:admin, false)
 end
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -2,7 +2,7 @@ Before do
   Capybara.default_host = 'test.lvh.me'
   Capybara.server_port = 9887
   Capybara.app_host = "http://test.lvh.me:9887"
-  @current_community = Community.find_by_domain("test")
+  @current_community = Community.where(ident: "test").first
 end
 
 Before('@javascript') do
@@ -26,7 +26,7 @@ end
 Before ('@subdomain2') do
   Capybara.default_host = 'test2.lvh.me'
   Capybara.app_host = "http://test2.lvh.me:9887"
-  @current_community = Community.find_by_domain("test2")
+  @current_community = Community.where(ident: "test2").first
 end
 
 Before ('@no_subdomain') do

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -47,7 +47,7 @@ module NavigationHelpers
     when /^the registration page with invitation code "(.*)"$/i
       "/en/signup?code=#{$1}"
     when /^the admin view of community "(.*)"$/i
-      edit_details_admin_community_path(:id => Community.find_by_domain($1).id, :locale => "en")
+      edit_details_admin_community_path(:id => Community.where(ident: $1).first.id, :locale => "en")
     when /the infos page/
       about_infos_path(:locale => "en")
     when /the terms page/

--- a/lib/mercury/authentication.rb
+++ b/lib/mercury/authentication.rb
@@ -3,7 +3,7 @@ module Mercury
 
     def can_edit?
       @current_user = current_person
-      @current_community = Community.find_by_domain(request.host)
+      @current_community = ApplicationController.default_community_fetch_strategy(request.host)
       @current_user && @current_community && @current_user.has_admin_rights_in?(@current_community)
     end
 

--- a/lib/tasks/sharetribe.rake
+++ b/lib/tasks/sharetribe.rake
@@ -49,7 +49,7 @@ namespace :sharetribe do
       community_sheet = spreadsheet.worksheet "Community"
       community_domain = community_sheet.row(1)[1]
 
-      c = Community.find_by_domain(community_domain)
+      c = Community.where(ident: community_domain).first
       c.destroy if c
 
       user_sheet = spreadsheet.worksheet "Users"
@@ -72,7 +72,7 @@ namespace :sharetribe do
       community_sheet = spreadsheet.worksheet "Community"
       community_domain = community_sheet.row(1)[1]
 
-      c = Community.find_by_domain(community_domain)
+      c = Community.where(ident: community_domain).first
 
       c.community_memberships.destroy_all
 

--- a/spec/controllers/admin/communities_controller_spec.rb
+++ b/spec/controllers/admin/communities_controller_spec.rb
@@ -4,7 +4,7 @@ describe Admin::CommunitiesController do
 
   before(:each) do
     @community = FactoryGirl.create(:community)
-    @request.host = "#{@community.domain}.lvh.me"
+    @request.host = "#{@community.ident}.lvh.me"
     sign_in_for_spec(create_admin_for(@community))
   end
 

--- a/spec/controllers/admin/custom_field_controller_spec.rb
+++ b/spec/controllers/admin/custom_field_controller_spec.rb
@@ -17,7 +17,7 @@ describe Admin::CustomFieldsController do
       @community = FactoryGirl.create(:community)
       @another_community = FactoryGirl.create(:community)
 
-      @request.host = "#{@community.domain}.lvh.me"
+      @request.host = "#{@community.ident}.lvh.me"
 
       @person = create_admin_for(@community)
       sign_in_for_spec(@person)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe ApplicationController do
-  #before (:each) {set_subdomain}
-
   controller do
     # a mock method to be able to call index without route
     def index
@@ -101,7 +99,7 @@ describe ApplicationController do
     end
 
     it "gets the right community by subdomain" do
-      c1 = FactoryGirl.create(:community, :domain => "test23")
+      c1 = FactoryGirl.create(:community, :ident => "test23")
       c2 = FactoryGirl.create(:community, :domain => "test23.custom.org")
       request.host = "test23.lvh.me"
       get :index
@@ -110,7 +108,7 @@ describe ApplicationController do
 
     it "gets the right community by full domain even when matching subdomain exists" do
       c1 = FactoryGirl.create(:community, :domain => "market.custom.org")
-      c2 = FactoryGirl.create(:community, :domain => "market")
+      c2 = FactoryGirl.create(:community, :ident => "market")
       request.host = "market.custom.org"
       get :index
       assigns["current_community"].id.should == c1.id

--- a/spec/controllers/braintree_account_controller_spec.rb
+++ b/spec/controllers/braintree_account_controller_spec.rb
@@ -6,7 +6,7 @@ describe BraintreeAccountsController do
       @community = FactoryGirl.create(:community)
       FactoryGirl.create(:braintree_payment_gateway, :community => @community)
 
-      @request.host = "#{@community.domain}.lvh.me"
+      @request.host = "#{@community.ident}.lvh.me"
       @person = FactoryGirl.create(:person)
       @community.members << @person
       sign_in_for_spec(@person)

--- a/spec/controllers/emails_controller_spec.rb
+++ b/spec/controllers/emails_controller_spec.rb
@@ -4,7 +4,7 @@ describe EmailsController do
   describe "#destroy" do
     before(:each) do
       @community = FactoryGirl.create(:community)
-      @request.host = "#{@community.domain}.lvh.me"
+      @request.host = "#{@community.ident}.lvh.me"
     end
 
     it "should destroy email" do

--- a/spec/controllers/int_api/marketplaces_controller_spec.rb
+++ b/spec/controllers/int_api/marketplaces_controller_spec.rb
@@ -22,12 +22,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.where(domain: "imaginationtraders").first
+      c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
       expect(c.name("fi")).to eql "ImaginationTraders"
-      expect(c.domain).to eql "imaginationtraders"
       expect(c.ident).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 
@@ -59,12 +58,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.where(domain: "imaginationtraders").first
+      c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
       expect(c.name("fi")).to eql "ImaginationTraders"
-      expect(c.domain).to eql "imaginationtraders"
       expect(c.ident).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 
@@ -92,12 +90,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.where(domain: "imaginationtraders").first
+      c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
       expect(c.name("fi")).to eql "ImaginationTraders"
-      expect(c.domain).to eql "imaginationtraders"
       expect(c.ident).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 
@@ -125,12 +122,11 @@ describe IntApi::MarketplacesController do
       r = JSON.parse(response.body)
       expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
 
-      c = Community.where(domain: "imaginationtraders").first
+      c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil
       expect(c.country).to eql "FI"
       expect(c.locales.first).to eql "fi"
       expect(c.name("fi")).to eql "ImaginationTraders"
-      expect(c.domain).to eql "imaginationtraders"
       expect(c.ident).to eql "imaginationtraders"
       expect(c.transaction_types.first.class).to eql Sell
 

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -45,7 +45,7 @@ describe ListingsController do
     @l4.save!
     @l4.update_attribute(:valid_until, 2.days.ago)
 
-    set_subdomain(@c1.domain)
+    @request.host = "#{@c1.ident}.lvh.me"
   end
 
   describe "ATOM feed" do

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -58,7 +58,7 @@ describe PeopleController do
 
       # one reason for this is that people can't use one email to create many accounts in email restricted community
       community = FactoryGirl.build(:community, :allowed_emails => "@examplecompany.co")
-      @request.host = "#{community.domain}.lvh.me"
+      @request.host = "#{community.ident}.lvh.me"
       member = FactoryGirl.build(:person, :emails => [ FactoryGirl.build(:email, :address => "one@examplecompany.co")])
       member.communities.push community
       member.save
@@ -75,7 +75,7 @@ describe PeopleController do
       #request.env['warden'].stub(:authenticate!).and_throw(:warden)
       controller.unstub :current_person
 
-      post :create, {:person => {:username => generate_random_username, :password => "test", :email => "one@examplecompany.co", :given_name => "The user who", :family_name => "tries to use taken email"}, :community => community.domain}
+      post :create, {:person => {:username => generate_random_username, :password => "test", :email => "one@examplecompany.co", :given_name => "The user who", :family_name => "tries to use taken email"}}
 
       Person.find_by_family_name("tries to use taken email").should be_nil
       Person.count.should == person_count
@@ -100,9 +100,9 @@ describe PeopleController do
       username = generate_random_username
       community = FactoryGirl.build(:community, :allowed_emails => "@examplecompany.co")
       community.save
-      @request.host = "#{community.domain}.lvh.me"
+      @request.host = "#{community.ident}.lvh.me"
 
-      post :create, {:person => {:username => username, :password => "test", :email => "#{username}@example.com", :given_name => "", :family_name => ""}, :community => community.domain}
+      post :create, {:person => {:username => username, :password => "test", :email => "#{username}@example.com", :given_name => "", :family_name => ""}}
 
       Person.find_by_username(username).should be_nil
       flash[:error].to_s.should include("This email is not allowed")
@@ -112,7 +112,7 @@ describe PeopleController do
   describe "#destroy" do
     before(:each) do
       @community = FactoryGirl.create(:community)
-      @request.host = "#{@community.domain}.lvh.me"
+      @request.host = "#{@community.ident}.lvh.me"
       @person = FactoryGirl.create(:person)
       @community.members << @person
       @id = @person.id

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -4,7 +4,7 @@ describe SessionsController, "POST create" do
 
   it "redirects back to original community's domain" do
     @request.host = "test.lvh.me"
-    post :create, {:person  => {:login => "kassi_testperson1", :password => "testi"}, :community => "test"}
+    post :create, {:person  => {:login => "kassi_testperson1", :password => "testi"}}
     response.should redirect_to "http://test.lvh.me/?locale=en"
   end
 end

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -4,7 +4,7 @@ describe SettingsController do
 
   before(:each) do
     @community = FactoryGirl.create(:community)
-    @request.host = "#{@community.domain}.lvh.me"
+    @request.host = "#{@community.ident}.lvh.me"
     @person = FactoryGirl.create(:person)
 
     FactoryGirl.create(:community_membership, :person => @person, :community => @community)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -65,7 +65,7 @@ FactoryGirl.define do
     "kassi_tester#{n}@example.com"
   end
 
-  sequence :domain do |n|
+  sequence :ident do |n|
     "sharetribe-testcommunity-#{n}"
   end
 
@@ -179,8 +179,7 @@ FactoryGirl.define do
   end
 
   factory :community do
-    domain
-    ident { generate(:domain) }
+    ident
     slogan "Test slogan"
     description "Test description"
     category "other"

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -41,7 +41,7 @@ describe "CommunityMailer" do
     end
 
     it "should have correct links" do
-      @email.should have_body_text(/.*<a href=\"http\:\/\/#{@c1.domain}\.#{APP_CONFIG.domain}\/#{@p1.locale}\/listings\/#{@l2.id}\?ref=weeklymail.*/)
+      @email.should have_body_text(/.*<a href=\"http\:\/\/#{@c1.full_domain}\/#{@p1.locale}\/listings\/#{@l2.id}\?ref=weeklymail.*/)
     end
 
     it "should include valid auth_token in links" do

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -162,7 +162,7 @@ describe PersonMailer do
     @community = FactoryGirl.create(:community, :email_admins_about_new_members => 1)
     m = CommunityMembership.create(:person_id => @test_person.id, :community_id => @community.id, :status => "accepted")
     m.update_attribute(:admin, true)
-    email = PersonMailer.new_member_notification(@test_person2, @community.domain, @test_person2.email).deliver
+    email = PersonMailer.new_member_notification(@test_person2, @community, @test_person2.email).deliver
     assert !ActionMailer::Base.deliveries.empty?
     assert_equal @test_person.confirmed_notification_email_addresses, email.to
     assert_equal "New member in #{@community.full_name('en')}", email.subject

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -113,16 +113,16 @@ describe Community do
     @community.should be_valid
   end
 
-  it "is not valid without proper domain" do
-    @community.domain = "test_community-9"
+  it "is not valid without proper ident" do
+    @community.ident = "test_community-9"
     @community.should be_valid
-    @community.domain = nil
+    @community.ident = nil
     @community.should_not be_valid
-    @community.domain = "a"
+    @community.ident = "a"
     @community.should_not be_valid
-    @community.domain = "a" * 51
+    @community.ident = "a" * 51
     @community.should_not be_valid
-    @community.domain = "´?€"
+    @community.ident = "´?€"
     @community.should_not be_valid
   end
 

--- a/spec/routing/people_routing_spec.rb
+++ b/spec/routing/people_routing_spec.rb
@@ -1,49 +1,49 @@
 require "spec_helper"
 
 describe "routing for people" do
-  
+
   before(:each) do
     @community = FactoryGirl.create(:community)
-    @protocol_and_host = "http://#{@community.domain}.test.host"
+    @protocol_and_host = "http://#{@community.ident}.test.host"
     @person = FactoryGirl.create(:person)
   end
-  
+
   it "routes /:username to people controller" do
     expect(get "/#{@person.username}").to(
       route_to(
-        { 
-          :controller => "people", 
-          :action => "show", 
-          :id => @person.username 
+        {
+          :controller => "people",
+          :action => "show",
+          :id => @person.username
         }
       )
     )
   end
-  
+
   it "routes /:username/settings to settings controller" do
     expect(get "/#{@person.username}/settings").to(
       route_to(
-        { 
-          :controller => "settings", 
-          :action => "show", 
-          :person_id => @person.username 
+        {
+          :controller => "settings",
+          :action => "show",
+          :person_id => @person.username
         }
       )
-    )    
+    )
   end
-  
+
   it "routes /en to home page" do
     expect(get "#{@protocol_and_host}/en").to(
-      route_to({ 
+      route_to({
                  :controller => "homepage",
                  :action => "index",
                  :locale => "en"
                }))
   end
-  
+
   it "routes /pt-BR to home page" do
     expect(get "/pt-BR").to(
-      route_to({ 
+      route_to({
                  :controller => "homepage",
                  :action => "index",
                  :locale => "pt-BR"
@@ -52,23 +52,23 @@ describe "routing for people" do
 
   it "routes / to home page" do
     expect(get "/").to(
-      route_to({ 
+      route_to({
                  :controller => "homepage",
                  :action => "index"
                }))
   end
-  
+
   it "routes /login to login" do
     expect(get "/login").to(
-      route_to({ 
+      route_to({
                  :controller => "sessions",
                  :action => "new"
                }))
   end
-  
+
   it "routes /logout to logout" do
     expect(get "/logout").to(
-      route_to({ 
+      route_to({
                  :controller => "sessions",
                  :action => "destroy",
                  :method => :delete
@@ -77,7 +77,7 @@ describe "routing for people" do
 
   it "routes /en/login to login" do
     expect(get "/en/login").to(
-      route_to({ 
+      route_to({
                  :controller => "sessions",
                  :action => "new",
                  :locale => "en"

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -14,17 +14,15 @@ describe MarketplaceService::API::Marketplaces do
     it "should create a marketplace" do
       c = create(@community_params)
 
-      expect(c[:domain]).to eql "localfoodgarden"
       expect(c[:ident]).to eql "localfoodgarden"
       expect(c[:locales].first).to eql "es"
       expect(c[:country]).to eql "ES"
     end
 
     it "should find a free domain, if intitial domain is taken" do
-      FactoryGirl.create(:community, :domain => "common")
+      FactoryGirl.create(:community, :ident => "common")
 
       c = create(@community_params.merge!({:marketplace_name => "Common"}))
-      expect(c[:domain]). to eql "common1"
       expect(c[:ident]). to eql "common1"
     end
 

--- a/spec/utils/url_utils_spec.rb
+++ b/spec/utils/url_utils_spec.rb
@@ -20,4 +20,9 @@ describe URLUtils do
     expect(URLUtils.extract_locale_from_url('http://www.sharetribe.com/en/people')).to eql('en')
     expect(URLUtils.extract_locale_from_url('http://www.sharetribe.com/en-US/people')).to eql('en-US')
   end
+
+  it "#strip_port_from_host" do
+    expect(URLUtils.strip_port_from_host("www.sharetribe.com")).to eql("www.sharetribe.com")
+    expect(URLUtils.strip_port_from_host("www.sharetribe.com:3000")).to eql("www.sharetribe.com")
+  end
 end

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -110,11 +110,6 @@ module TestHelpers
     return random_username
   end
 
-  def set_subdomain(subdomain = "test")
-    subdomain += "." unless subdomain.blank?
-    @request.host = "#{subdomain}.lvh.me"
-  end
-
   def sign_in_for_spec(person)
     # For some reason only sign_in (Devise) doesn't work so 2 next lines to fix that
     #sign_in person
@@ -170,19 +165,19 @@ module TestHelpers
 
   # This is loaded only once before running the whole test set
   def load_default_test_data_to_db_before_suite
-    community1 = FactoryGirl.create(:community, :domain => "test", :consent => "test_consent0.1", :settings => {"locales" => ["en", "fi"]}, :real_name_required => true)
+    community1 = FactoryGirl.create(:community, :ident => "test", :consent => "test_consent0.1", :settings => {"locales" => ["en", "fi"]}, :real_name_required => true)
     community1.community_customizations.create(name: "Sharetribe", locale: "fi")
-    community2 = FactoryGirl.create(:community, :domain => "test2", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true, :allowed_emails => "@example.com")
-    community3 = FactoryGirl.create(:community, :domain => "test3", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true)
+    community2 = FactoryGirl.create(:community, :ident => "test2", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true, :allowed_emails => "@example.com")
+    community3 = FactoryGirl.create(:community, :ident => "test3", :consent => "KASSI_FI1.0", :settings => {"locales" => ["en"]}, :real_name_required => true)
 
     [community1, community2, community3].each { |c| TestHelpers::CategoriesHelper.load_test_categories_and_transaction_types_to_db(c) }
   end
 
   # This is loaded before each test
   def load_default_test_data_to_db_before_test
-    community1 = Community.find_by_domain("test")
-    community2 = Community.find_by_domain("test2")
-    community3 = Community.find_by_domain("test3")
+    community1 = Community.where(ident: "test").first
+    community2 = Community.where(ident: "test2").first
+    community3 = Community.where(ident: "test3").first
 
     person1 = FactoryGirl.create(:person, :username => "kassi_testperson1", :is_admin => 0, "locale" => "en", :encrypted_password => "64ae669314a3fb4b514fa5607ef28d3e1c1937a486e3f04f758270913de4faf5", :password_salt => "vGpGrfvaOhp3", :given_name => "Kassi", :family_name => "Testperson1", :phone_number => "0000-123456", :created_at => "2012-05-04 18:17:04")
     person2 = FactoryGirl.create(:person, :username => "kassi_testperson2", :is_admin => false, :locale => "en", :encrypted_password => "72bf5831e031cbcf2e226847677fccd6d8ec6fe0673549a60abb5fd05f726462", :password_salt => "zXklAGLwt7Cu", :given_name => "Kassi", :family_name => "Testperson2", :created_at => "2012-05-04 18:17:04")


### PR DESCRIPTION
- [x] Use username to fetch community, if community is not found by domain
- [x] Do a redirect to the full domain, if needed.
- [x] Do NO save `domain` to communities table from a new marketplace is created
- [x] Fix tests and change factories
- [x] Remove the custom `find_by_domain` method from `Community`
- [x] Remove all usage of `find_by_domain` (expect `ApplicationController#fetch_community`)