### PR TITLE
Transaction process

### DIFF
--- a/app/controllers/admin/community_customizations_controller.rb
+++ b/app/controllers/admin/community_customizations_controller.rb
@@ -6,7 +6,7 @@ class Admin::CommunityCustomizationsController < ApplicationController
     # @community_customization is fetched in application_controller
     @community_customizations ||= find_or_initialize_customizations(@current_community.locales)
     @show_transaction_agreement = @current_community.transaction_types.any? do |transaction_type|
-      transaction_type.preauthorize_payment
+      transaction_type.transaction_process.process == :preauthorize
     end
   end
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -110,7 +110,7 @@ class ListingsController < ApplicationController
 
     payment_gateway = MarketplaceService::Community::Query.payment_type(@current_community.id)
 
-    payment_process = select_payment_process(
+    payment_process = ListingsController.select_payment_process(
       price_field: @listing.transaction_type.price_field?,
       preauthorize: @listing.transaction_type.preauthorize_payment?,
       payment_gateway_available: payment_gateway.present?)
@@ -512,7 +512,8 @@ class ListingsController < ApplicationController
     end
   end
 
-  def select_payment_process(price_field:, payment_gateway_available:, preauthorize:)
+  # This is wrong place, yes, but this method will be soon removed
+  def self.select_payment_process(price_field:, payment_gateway_available:, preauthorize:)
     case [price_field, payment_gateway_available, preauthorize]
     when matches([false])
       :none

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -110,15 +110,10 @@ class ListingsController < ApplicationController
 
     payment_gateway = MarketplaceService::Community::Query.payment_type(@current_community.id)
 
-    payment_process = ListingsController.select_payment_process(
-      price_field: @listing.transaction_type.price_field?,
-      preauthorize: @listing.transaction_type.preauthorize_payment?,
-      payment_gateway_available: payment_gateway.present?)
-
     form_path = select_new_transaction_path(
       listing_id: @listing.id.to_s,
       payment_gateway: payment_gateway,
-      payment_process: payment_process,
+      payment_process: @listing.transaction_type.transaction_process.process,
       booking: @listing.transaction_type.price_per.present?
     )
 
@@ -509,20 +504,6 @@ class ListingsController < ApplicationController
       [can_post, error_msg]
     else
       [true, ""]
-    end
-  end
-
-  # This is wrong place, yes, but this method will be soon removed
-  def self.select_payment_process(price_field:, payment_gateway_available:, preauthorize:)
-    case [price_field, payment_gateway_available, preauthorize]
-    when matches([false])
-      :none
-    when matches([__, false])
-      :none
-    when matches([__, __, true])
-      :preauthorize
-    else
-      :postpay
     end
   end
 

--- a/app/models/transaction_process.rb
+++ b/app/models/transaction_process.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: transaction_processes
+#
+#  id         :integer          not null, primary key
+#  process    :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class TransactionProcess < ActiveRecord::Base
   attr_accessible :process
   has_one :transaction_type

--- a/app/models/transaction_process.rb
+++ b/app/models/transaction_process.rb
@@ -1,0 +1,4 @@
+class TransactionProcess < ActiveRecord::Base
+  attr_accessible :process
+  has_one :transaction_type
+end

--- a/app/models/transaction_process.rb
+++ b/app/models/transaction_process.rb
@@ -11,4 +11,8 @@
 class TransactionProcess < ActiveRecord::Base
   attr_accessible :process
   has_one :transaction_type
+
+  def process
+    read_attribute(:process).to_sym
+  end
 end

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class TransactionType < ActiveRecord::Base
@@ -29,6 +31,8 @@ class TransactionType < ActiveRecord::Base
   has_many :category_transaction_types, :dependent => :destroy
   has_many :categories, :through => :category_transaction_types
   has_many :listings
+
+  belongs_to :transaction_process
 
   validates_presence_of :community
 

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/give.rb
+++ b/app/models/transaction_types/give.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Give < Offer

--- a/app/models/transaction_types/give.rb
+++ b/app/models/transaction_types/give.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/inquiry.rb
+++ b/app/models/transaction_types/inquiry.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Inquiry < TransactionType

--- a/app/models/transaction_types/inquiry.rb
+++ b/app/models/transaction_types/inquiry.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/lend.rb
+++ b/app/models/transaction_types/lend.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Lend < Offer

--- a/app/models/transaction_types/lend.rb
+++ b/app/models/transaction_types/lend.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/offer.rb
+++ b/app/models/transaction_types/offer.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Offer < TransactionType

--- a/app/models/transaction_types/offer.rb
+++ b/app/models/transaction_types/offer.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/offer.rb
+++ b/app/models/transaction_types/offer.rb
@@ -41,14 +41,15 @@ class Offer < TransactionType
   end
 
   def status_after_reply
-    if price_field? && community.payments_in_use?
-      if preauthorize_payment?
-        "preauthorize"
-      else
-        "pending"
-      end
-    else
+    case transaction_process.process
+    when :preauthorize
+      "preauthorize"
+    when :postpay
+      "pending"
+    when :none
       "free"
+    else
+      raise ArgumentError.new("Can not find order flow for process #{process}")
     end
   end
 

--- a/app/models/transaction_types/rent.rb
+++ b/app/models/transaction_types/rent.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Rent < Offer

--- a/app/models/transaction_types/rent.rb
+++ b/app/models/transaction_types/rent.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/request.rb
+++ b/app/models/transaction_types/request.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Request < TransactionType

--- a/app/models/transaction_types/request.rb
+++ b/app/models/transaction_types/request.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/sell.rb
+++ b/app/models/transaction_types/sell.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Sell < Offer

--- a/app/models/transaction_types/sell.rb
+++ b/app/models/transaction_types/sell.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/service.rb
+++ b/app/models/transaction_types/service.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Service < Offer

--- a/app/models/transaction_types/service.rb
+++ b/app/models/transaction_types/service.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/share_for_free.rb
+++ b/app/models/transaction_types/share_for_free.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class ShareForFree < Offer

--- a/app/models/transaction_types/share_for_free.rb
+++ b/app/models/transaction_types/share_for_free.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/models/transaction_types/swap.rb
+++ b/app/models/transaction_types/swap.rb
@@ -5,6 +5,7 @@
 #  id                         :integer          not null, primary key
 #  type                       :string(255)
 #  community_id               :integer
+#  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
 #  preauthorize_payment       :boolean          default(FALSE)
@@ -16,8 +17,9 @@
 #
 # Indexes
 #
-#  index_transaction_types_on_community_id  (community_id)
-#  index_transaction_types_on_url           (url)
+#  index_transaction_types_on_community_id            (community_id)
+#  index_transaction_types_on_transaction_process_id  (transaction_process_id)
+#  index_transaction_types_on_url                     (url)
 #
 
 class Swap < Offer

--- a/app/models/transaction_types/swap.rb
+++ b/app/models/transaction_types/swap.rb
@@ -8,7 +8,6 @@
 #  transaction_process_id     :integer
 #  sort_priority              :integer
 #  price_field                :boolean
-#  preauthorize_payment       :boolean          default(FALSE)
 #  price_quantity_placeholder :string(255)
 #  price_per                  :string(255)
 #  created_at                 :datetime         not null

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -97,7 +97,7 @@ module MarketplaceService::API
 
       def create_transaction_type!(community, marketplace_type)
         transaction_type_name = transaction_type_name(marketplace_type)
-        TransactionTypeCreator.create(community, transaction_type_name)
+        TransactionTypeCreator.create(community, transaction_type_name, payment_gateway_available: true)
       end
 
       def create_community_customization!(community, marketplace_name, locale)

--- a/app/services/payment_registration_guard.rb
+++ b/app/services/payment_registration_guard.rb
@@ -21,7 +21,7 @@ class PaymentRegistrationGuard
   end
 
   def preauthorize_flow_in_use?
-    @listing.transaction_type.preauthorize_payment?
+    @listing.transaction_type.transaction_process.process == :preauthorize
   end
 
   def not_registered_already?

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -89,9 +89,6 @@ module TransactionTypeCreator
       })
     end
 
-    #enable preauthorized payments
-    transaction_type.preauthorize_payment = true
-
     create_transaction_process!(community, transaction_type, opts[:payment_gateway_available])
 
     transaction_type.save!

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -115,12 +115,26 @@ module TransactionTypeCreator
   # This method is only temporary implementation for the transaction_process change
   def create_transaction_process!(community, transaction_type, payment_gateway_available)
     payment_gateway_available = payment_gateway_available || MarketplaceService::Community::Query.payment_type(community.id).present?
-    process = ListingsController.select_payment_process(
+    process = select_payment_process(
           price_field: transaction_type.price_field?,
-          preauthorize: transaction_type.preauthorize_payment?,
+          preauthorize: true,
           payment_gateway_available: payment_gateway_available)
 
     transaction_type.create_transaction_process({ process: process })
   end
+
+  def select_payment_process(price_field:, payment_gateway_available:, preauthorize:)
+    case [price_field, payment_gateway_available, preauthorize]
+    when matches([false])
+      :none
+    when matches([__, false])
+      :none
+    when matches([__, __, true])
+      :preauthorize
+    else
+      :postpay
+    end
+  end
+
 
 end

--- a/db/migrate/20150303134630_create_transaction_processes.rb
+++ b/db/migrate/20150303134630_create_transaction_processes.rb
@@ -1,0 +1,9 @@
+class CreateTransactionProcesses < ActiveRecord::Migration
+  def change
+    create_table :transaction_processes do |t|
+      t.string :process, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150303140556_add_transaction_process_id_to_transaction_type.rb
+++ b/db/migrate/20150303140556_add_transaction_process_id_to_transaction_type.rb
@@ -1,0 +1,10 @@
+class AddTransactionProcessIdToTransactionType < ActiveRecord::Migration
+  def up
+    add_column :transaction_types, :transaction_process_id, :int, after: :community_id
+    add_index :transaction_types, :transaction_process_id
+  end
+
+  def down
+    remove_column :transaction_types, :transaction_process_id
+  end
+end

--- a/db/migrate/20150304074313_populate_transaction_process.rb
+++ b/db/migrate/20150304074313_populate_transaction_process.rb
@@ -1,0 +1,39 @@
+class PopulateTransactionProcess < ActiveRecord::Migration
+  def up
+    add_column :transaction_processes, :transaction_type_id, :int
+
+    execute("
+      INSERT INTO transaction_processes (process, transaction_type_id, created_at, updated_at)
+      (
+        SELECT
+          CASE WHEN transaction_types.price_field = 0                 THEN 'none'
+               WHEN payment_settings.id IS NOT NULL                   THEN payment_settings.payment_process
+               WHEN payment_gateways.type = 'Checkout'                THEN 'postpay'
+               WHEN payment_gateways.type = 'BraintreePaymentGateway' THEN IF(transaction_types.preauthorize_payment, 'preauthorize', 'postpay')
+               ELSE 'none'
+          END as process,
+          transaction_types.id,
+          transaction_types.created_at,
+          transaction_types.updated_at
+        FROM transaction_types
+
+        LEFT JOIN payment_settings ON (payment_settings.community_id = transaction_types.community_id AND payment_settings.active = 1)
+        LEFT JOIN payment_gateways ON (payment_gateways.community_id = transaction_types.community_id)
+
+        WHERE transaction_types.transaction_process_id IS NULL
+      )
+    ")
+
+    execute("
+     UPDATE transaction_types, transaction_processes
+     SET transaction_types.transaction_process_id = transaction_processes.id
+     WHERE transaction_processes.transaction_type_id = transaction_types.id")
+
+    remove_column :transaction_processes, :transaction_type_id
+  end
+
+  def down
+    execute("DELETE from transaction_processes")
+    execute("UPDATE transaction_types SET transaction_process_id = NULL")
+  end
+end

--- a/db/migrate/20150304094048_remove_preauthorize_payment_from_transaction_types.rb
+++ b/db/migrate/20150304094048_remove_preauthorize_payment_from_transaction_types.rb
@@ -1,0 +1,14 @@
+class RemovePreauthorizePaymentFromTransactionTypes < ActiveRecord::Migration
+  def up
+    remove_column :transaction_types, :preauthorize_payment
+  end
+
+  def down
+    add_column :transaction_types, :preauthorize_payment, :boolean, after: :price_field
+
+    execute("
+      UPDATE transaction_types, transaction_processes SET transaction_types.preauthorize_payment = (transaction_processes.process = 'preauthorize')
+      WHERE transaction_types.transaction_process_id = transaction_processes.id
+    ")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -874,6 +874,7 @@ ActiveRecord::Schema.define(:version => 20150304084451) do
   create_table "transaction_types", :force => true do |t|
     t.string   "type"
     t.integer  "community_id"
+    t.integer  "transaction_process_id"
     t.integer  "sort_priority"
     t.boolean  "price_field"
     t.boolean  "preauthorize_payment",       :default => false
@@ -885,6 +886,7 @@ ActiveRecord::Schema.define(:version => 20150304084451) do
   end
 
   add_index "transaction_types", ["community_id"], :name => "index_transaction_types_on_community_id"
+  add_index "transaction_types", ["transaction_process_id"], :name => "index_transaction_types_on_transaction_process_id"
   add_index "transaction_types", ["url"], :name => "index_transaction_types_on_url"
 
   create_table "transactions", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -841,6 +841,12 @@ ActiveRecord::Schema.define(:version => 20150304084451) do
   add_index "testimonials", ["receiver_id"], :name => "index_testimonials_on_receiver_id"
   add_index "testimonials", ["transaction_id"], :name => "index_testimonials_on_transaction_id"
 
+  create_table "transaction_processes", :force => true do |t|
+    t.string   "process",    :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
   create_table "transaction_transitions", :force => true do |t|
     t.string   "to_state"
     t.text     "metadata"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150304084451) do
+ActiveRecord::Schema.define(:version => 20150304094048) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -877,11 +877,10 @@ ActiveRecord::Schema.define(:version => 20150304084451) do
     t.integer  "transaction_process_id"
     t.integer  "sort_priority"
     t.boolean  "price_field"
-    t.boolean  "preauthorize_payment",       :default => false
     t.string   "price_quantity_placeholder"
     t.string   "price_per"
-    t.datetime "created_at",                                    :null => false
-    t.datetime "updated_at",                                    :null => false
+    t.datetime "created_at",                 :null => false
+    t.datetime "updated_at",                 :null => false
     t.string   "url"
   end
 

--- a/features/conversations/transaction_is_automatically_completed.feature
+++ b/features/conversations/transaction_is_automatically_completed.feature
@@ -9,8 +9,11 @@ Feature: Automatic transaction completition
       | paula  | paula@example.com  |
       | jeremy | jeremy@example.com |
     And the community has payments in use via BraintreePaymentGateway
+    And the community has transaction type Sell with name "Selling" and action button label "Buy"
+    And that transaction does not use payment preauthorization
+    And that transaction belongs to category "Items"
     And Braintree escrow release is mocked
-    And there is a listing with title "Snowboard" from "jeremy"
+    And there is a listing with title "Snowboard" from "jeremy" with category "Items" and with transaction type "Selling"
     And the price of that listing is 20.00 USD
     And there is a pending request "I'd like to buy this" from "paula" about that listing
     And the request is paid

--- a/features/conversations/transaction_with_escrow_is_automatically_completed.feature
+++ b/features/conversations/transaction_with_escrow_is_automatically_completed.feature
@@ -10,8 +10,11 @@ Feature: Automatic transaction with escrow completition
       | jeremy |
 
     Given community "test" has payments in use via BraintreePaymentGateway
+    And the community has transaction type Sell with name "Selling" and action button label "Buy"
+    And that transaction does not use payment preauthorization
+    And that transaction belongs to category "Items"
     And Braintree escrow release is mocked
-    And there is a listing with title "Snowboard" from "jeremy"
+    And there is a listing with title "Snowboard" from "jeremy" with category "Items" and with transaction type "Selling"
     And the price of that listing is 12.00 USD
     And there is a pending request "I'd like to buy this" from "paula" about that listing
     And the request is paid

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -12,6 +12,14 @@ module CommunitySteps
     else
       FactoryGirl.create(:braintree_payment_gateway, :community => community, :type => gateway_name)
     end
+
+    # also change the transaction types
+    community.transaction_types.each { |tt|
+      case tt.type
+      when "Rent", "Sell", "Service"
+        tt.transaction_process.update_attribute(:process, :postpay)
+      end
+    }
   end
 end
 
@@ -171,6 +179,8 @@ Given /^community "(.*?)" has following transaction types enabled:$/ do |communi
     transaction_type = FactoryGirl.create(:transaction_type, :type => hash['transaction_type'], :community_id => current_community.id)
     transaction_type.translations.create(:name => hash['fi'], :action_button_label => (hash['button'] || "Action"), :locale => 'fi')
     transaction_type.translations.create(:name => hash['en'], :action_button_label => (hash['button'] || "Action"), :locale => 'en')
+    transaction_type.create_transaction_process(process: :none)
+    transaction_type.save!
     transaction_type
   end
 end
@@ -178,6 +188,8 @@ end
 Given /^the community has transaction type (Sell|Rent) with name "(.*?)" and action button label "(.*?)"$/ do |type_class, name, action_button_label|
   translations = [FactoryGirl.build(:transaction_type_translation, locale: "en", name: name, action_button_label: action_button_label)]
   @transaction_type = FactoryGirl.create("transaction_type_#{type_class.downcase}".to_sym, translations: translations, community: @current_community)
+  @transaction_type.create_transaction_process(process: :preauthorize)
+  @transaction_type.save!
 end
 
 Given /^that transaction type shows the price of listing per (day)$/ do |price_per|
@@ -186,11 +198,11 @@ Given /^that transaction type shows the price of listing per (day)$/ do |price_p
 end
 
 Given /^that transaction uses payment preauthorization$/ do
-  @transaction_type.update_attribute(:preauthorize_payment, true)
+  @transaction_type.transaction_process.update_attribute(:process, :preauthorize)
 end
 
 Given /^that transaction does not use payment preauthorization$/ do
-  @transaction_type.update_attribute(:preauthorize_payment, false)
+  @transaction_type.transaction_process.update_attribute(:process, :postpay)
 end
 
 Given /^that transaction belongs to category "(.*?)"$/ do |category_name|

--- a/features/step_definitions/conversation_steps.rb
+++ b/features/step_definitions/conversation_steps.rb
@@ -30,7 +30,7 @@ def create_transaction(community, listing, starter, message, payment_gateway = :
     starter: starter,
     conversation: build_conversation(community, listing, starter, message),
     payment_gateway: payment_gateway,
-    payment_process: listing.transaction_type.preauthorize_payment ? :preauthorized : :postpay,
+    payment_process: listing.transaction_type.process == :preauthorize ? :preauthorized : :postpay,
     automatic_confirmation_after_days: community.automatic_confirmation_after_days
   )
 end

--- a/features/step_definitions/conversation_steps.rb
+++ b/features/step_definitions/conversation_steps.rb
@@ -30,7 +30,7 @@ def create_transaction(community, listing, starter, message, payment_gateway = :
     starter: starter,
     conversation: build_conversation(community, listing, starter, message),
     payment_gateway: payment_gateway,
-    payment_process: listing.transaction_type.process == :preauthorize ? :preauthorized : :postpay,
+    payment_process: listing.transaction_type.transaction_process.process == :preauthorize ? :preauthorize : :postpay,
     automatic_confirmation_after_days: community.automatic_confirmation_after_days
   )
 end

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -62,7 +62,7 @@ describe MarketplaceService::API::Marketplaces do
       community_hash = create(@community_params)
       c = Community.find(community_hash[:id])
 
-      expect(c.transaction_types.pluck(:preauthorize_payment).all?).to be true
+      expect(c.transaction_types.map { |tt| tt.transaction_process.process == :preauthorize }.all?).to be true
     end
 
     it "should have community customizations" do

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -5,28 +5,43 @@ module TestHelpers
 
     DEFAULT_TRANSACTION_TYPES_FOR_TESTS = {
       Sell: {
-        en: {
-          name: "Selling", action_button_label: "Buy this item"
+        process: :preauthorize,
+        translations: {
+          en: {
+            name: "Selling", action_button_label: "Buy this item"
+          }
         }
       },
       Lend: {
-        en: {
-          name: "Lending", action_button_label: "Borrow this item"
+        process: :none,
+        translations: {
+          en: {
+            name: "Lending", action_button_label: "Borrow this item"
+          }
         }
       },
       Rent: {
-        en: {
-          name: "Renting", action_button_label: "Rent this item"
+        process: :preauthorize,
+        translations: {
+          en: {
+            name: "Renting", action_button_label: "Rent this item"
+          }
         }
       },
       Request: {
-        en: {
-          name: "Requesting", action_button_label: "Offer"
+        process: :none,
+        translations: {
+          en: {
+            name: "Requesting", action_button_label: "Offer"
+          }
         }
       },
       Service: {
-        en: {
-          name: "Selling services", action_button_label: ""
+        process: :preauthorize,
+        translations: {
+          en: {
+            name: "Selling services", action_button_label: ""
+          }
         }
       }
     }
@@ -48,11 +63,13 @@ module TestHelpers
 
     def self.load_categories_and_transaction_types_to_db(community, transaction_types, categories)
       # Load transaction types
-      transaction_types.each do |type, translations|
+      transaction_types.each do |type, opts|
 
         transaction_type = Object.const_get(type.to_s).create!(:type => type, :community_id => community.id)
+        transaction_type.create_transaction_process(process: opts[:process])
+        transaction_type.save!
         community.locales.each do |locale|
-          translation = translations[locale.to_sym]
+          translation = opts[:translations][locale.to_sym]
 
           if translation then
             tt_name = translation[:name]

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -66,7 +66,13 @@ module TestHelpers
       transaction_types.each do |type, opts|
 
         transaction_type = Object.const_get(type.to_s).create!(:type => type, :community_id => community.id)
-        transaction_type.create_transaction_process(process: opts[:process])
+
+        # Make all transaction types to use :none process
+        # This is not exactly in line with our applications default behaviour
+        # but in Cucumber tests the free is good default since there are a lot of modifier that say for example
+        # Given this community uses preauthorize
+        #
+        transaction_type.create_transaction_process(process: :none)
         transaction_type.save!
         community.locales.each do |locale|
           translation = opts[:translations][locale.to_sym]


### PR DESCRIPTION
Deploy 1:
- [x] Create a TransactionProcess model
- [x] Each TransactionType has one TransactionProcess. Actually, the relation is `belongs_to` since the foreign key is in the TransactionType model
- [x] Save TransactionProcess in TransactionTypeCreator

Deploy 2:
- [x] Populate the TransactionProcess model with data from TransactionType

Deploy 3:
- [x] Read from TransactionProcess
- [x] Do not write process to TransactionType

Deploy 4:
- [x] Remove `preauthorize_payment` from `transaction_types`