### PR TITLE
Move shipping address to tx entity

### DIFF
--- a/app/controllers/accept_preauthorized_conversations_controller.rb
+++ b/app/controllers/accept_preauthorized_conversations_controller.rb
@@ -126,7 +126,7 @@ class AcceptPreauthorizedConversationsController < ApplicationController
       payment_gateway: :paypal,
       discussion_type: transaction_conversation[:discussion_type],
       listing: @listing,
-      booking: @listing_conversation.booking,
+      booking: transaction[:booking],
       orderer: @listing_conversation.starter,
       sum: transaction[:item_total],
       fee: transaction[:commission_total],

--- a/app/controllers/accept_preauthorized_conversations_controller.rb
+++ b/app/controllers/accept_preauthorized_conversations_controller.rb
@@ -131,7 +131,7 @@ class AcceptPreauthorizedConversationsController < ApplicationController
       sum: transaction[:item_total],
       fee: transaction[:commission_total],
       shipping_price: transaction[:shipping_price],
-      shipping_address: transaction_conversation[:shipping_address],
+      shipping_address: transaction[:shipping_address],
       seller_gets: transaction[:checkout_total] - transaction[:commission_total],
       form: @listing_conversation, # TODO FIX ME, DONT USE MODEL
       form_action: acceptance_preauthorized_person_message_path(

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -10,47 +10,37 @@ class TransactionsController < ApplicationController
   MessageForm = Form::Message
 
   def show
-    transaction = MarketplaceService::Transaction::Query.transaction_with_conversation(
+    transaction_conversation = MarketplaceService::Transaction::Query.transaction_with_conversation(
       params[:id],
       @current_user.id,
       @current_community.id)
 
-    if transaction.blank?
+    tx = TransactionService::Transaction.get(community_id: @current_community.id, transaction_id: params[:id])
+         .maybe()
+         .or_else(nil)
+
+    if !tx
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
       return redirect_to root
     end
 
-    conversation = transaction[:conversation]
-
-    other = conversation[:other_person]
-    conversation[:other_party] = person_entity_with_url(other)
-    transaction[:listing_url] = listing_path(id: transaction[:listing][:id])
-
-    # TODO Copy-paste code
-    # Move to service
-    transaction_type = TransactionType.find(transaction[:listing][:transaction_type_id])
-    transaction[:new_transaction_path] = if transaction_type.price_per.present?
-      book_path(:listing_id => transaction[:listing][:id])
-    else
-      preauthorize_payment_path(:listing_id => transaction[:listing][:id])
-    end
-    transaction[:action_button_label] = transaction_type.action_button_label(I18n.locale)
-
-    not_author = transaction[:listing][:author_id] != @current_user.id
-    requires_payment = transaction_type.price_field? && @current_community.payments_in_use?
-    transaction[:show_call_to_action] = transaction[:status] == "free" && requires_payment && not_author
-
+    tx_model = Transaction.where(id: tx[:id]).first
+    conversation = transaction_conversation[:conversation]
+    listing = Listing.where(id: tx[:listing_id]).first
 
     messages_and_actions = TransactionViewUtils::merge_messages_and_transitions(
       TransactionViewUtils.conversation_messages(conversation[:messages], @current_community.name_display_type),
-      TransactionViewUtils.transition_messages(transaction, conversation, @current_community.name_display_type))
+      TransactionViewUtils.transition_messages(transaction_conversation, conversation, @current_community.name_display_type))
 
     MarketplaceService::Transaction::Command.mark_as_seen_by_current(params[:id], @current_user.id)
 
     render "transactions/show", locals: {
       messages: messages_and_actions.reverse,
-      transaction_data: transaction,
-      is_author: transaction[:listing][:author_id] == @current_user.id,
+      transaction: tx,
+      listing: listing,
+      transaction_model: tx_model,
+      conversation_other_party: person_entity_with_url(conversation[:other_person]),
+      is_author: listing.author_id == @current_user.id,
       message_form: MessageForm.new({sender_id: @current_user.id, conversation_id: conversation[:id]}),
       message_form_action: person_message_messages_path(@current_user, :message_id => conversation[:id])
     }
@@ -74,9 +64,8 @@ class TransactionsController < ApplicationController
 
   def person_entity_with_url(person_entity)
     person_entity.merge({
-                          url: person_path(id: person_entity[:username]),
-                          display_name: PersonViewUtils.person_entity_display_name(person_entity, @current_community.name_display_type)
-                        })
+      url: person_path(id: person_entity[:username]),
+      display_name: PersonViewUtils.person_entity_display_name(person_entity, @current_community.name_display_type)})
   end
 
   def paypal_process

--- a/app/services/marketplace_service/transaction.rb
+++ b/app/services/marketplace_service/transaction.rb
@@ -23,19 +23,7 @@ module MarketplaceService
         :conversation,
         :booking,
         :created_at,
-        :shipping_address,
         :__model
-      )
-
-      ShippingAddress = EntityUtils.define_entity(
-        :name,
-        :phone,
-        :street1,
-        :street2,
-        :postal_code,
-        :city,
-        :state_or_province,
-        :country
       )
 
       Transition = EntityUtils.define_entity(
@@ -117,7 +105,6 @@ module MarketplaceService
             end
           end
 
-        shipping_address = ShippingAddress[EntityUtils.model_to_hash(transaction_model.shipping_address)]
 
         Transaction[EntityUtils.model_to_hash(transaction_model).merge({
           status: transaction_model.current_state,
@@ -133,7 +120,6 @@ module MarketplaceService
           discussion_type: Maybe(listing_model).discussion_type.to_sym.or_else(:not_available),
           payment_total: payment_total,
           booking: transaction_model.booking,
-          shipping_address: shipping_address,
           __model: transaction_model
         })]
       end

--- a/app/services/transaction_service/data_types/transaction.rb
+++ b/app/services/transaction_service/data_types/transaction.rb
@@ -24,7 +24,8 @@ module TransactionService::DataTypes::Transaction
     [:commission_total, :money],
     [:checkout_total, :money],
     [:charged_commission, :money],
-    [:payment_gateway_fee, :money])
+    [:payment_gateway_fee, :money],
+    [:shipping_address, :hash])
 
   TransactionResponse = EntityUtils.define_builder(
     [:transaction, :hash, :mandatory],

--- a/app/services/transaction_service/data_types/transaction.rb
+++ b/app/services/transaction_service/data_types/transaction.rb
@@ -25,7 +25,8 @@ module TransactionService::DataTypes::Transaction
     [:checkout_total, :money],
     [:charged_commission, :money],
     [:payment_gateway_fee, :money],
-    [:shipping_address, :hash])
+    [:shipping_address, :hash],
+    [:booking, :hash])
 
   TransactionResponse = EntityUtils.define_builder(
     [:transaction, :hash, :mandatory],

--- a/app/services/transaction_service/paypal_events.rb
+++ b/app/services/transaction_service/paypal_events.rb
@@ -42,14 +42,19 @@ module TransactionService::PaypalEvents
     community_id = details.delete(:community_id)
     transaction_id = details.delete(:transaction_id)
 
-    if(details.values.any?)
+    if shipping_fields_present?(details)
       TransactionStore.upsert_shipping_address(
         community_id: community_id,
         transaction_id: transaction_id,
         addr: details)
     end
   end
+
   # Privates
+
+  def shipping_fields_present?(details)
+    details.except(:status).values.any?
+  end
 
   ## Mapping from payment transition to transaction transition
 

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -50,9 +50,15 @@ module TransactionService::Transaction
 
   # TODO should require community_id
   # TODO Return type should be Result (wraps current return type)
+  # Deprecated
   def query(transaction_id)
     tx = TxStore.get(transaction_id)
     to_tx_response(tx)
+  end
+
+  def get(community_id:, transaction_id:)
+    tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
+    Result::Success.new(to_tx_response(tx))
   end
 
   def has_unfinished_transactions(person_id)
@@ -202,7 +208,8 @@ module TransactionService::Transaction
         commission_total: commission_total,
         charged_commission: payment_details[:charged_commission],
         payment_gateway_fee: payment_details[:payment_gateway_fee],
-        shipping_address: tx[:shipping_address]})
+        shipping_address: tx[:shipping_address],
+        booking: tx[:booking]})
   end
 
   def calculate_commission(item_total, commission_from_seller, minimum_commission)

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -48,6 +48,7 @@ module TransactionService::Transaction
   end
 
 
+  # TODO should require community_id
   # TODO Return type should be Result (wraps current return type)
   def query(transaction_id)
     tx = TxStore.get(transaction_id)
@@ -200,7 +201,8 @@ module TransactionService::Transaction
         checkout_total: payment_details[:total_price],
         commission_total: commission_total,
         charged_commission: payment_details[:charged_commission],
-        payment_gateway_fee: payment_details[:payment_gateway_fee]})
+        payment_gateway_fee: payment_details[:payment_gateway_fee],
+        shipping_address: tx[:shipping_address]})
   end
 
   def calculate_commission(item_total, commission_from_seller, minimum_commission)

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -57,6 +57,11 @@ module EntityUtils
         "#{field}: Value must be a Time. Was: #{v} (#{v.class.name})."
       end
     },
+    date: -> (_, v, field) {
+      unless (v.nil? || v.is_a?(Date))
+        "#{field}: Value must be a Date. Was: #{v} (#{v.class.name})."
+      end
+    },
     fixnum: -> (_, v, field) {
       unless (v.nil? || v.is_a?(Fixnum))
         "#{field}: Value must be a Fixnum. Was: #{v} (#{v.class.name})."

--- a/app/views/transactions/_details.haml
+++ b/app/views/transactions/_details.haml
@@ -1,27 +1,17 @@
-- listing = transaction[:listing]
-
 .message-avatar-padding
   .row
     .col-12
 
       %h2
-        = link_to_unless listing[:deleted], listing[:title], transaction[:listing_url]
+        = link_to_unless listing[:deleted], listing[:title], listing_path(id: listing[:id])
 
-      - Maybe(transaction)[:booking].each do |booking|
-        = render partial: "transactions/details/booking", locals: { booking: booking, price_per_day: listing[:price] }
-      = render partial: "transactions/details/sum_or_price", locals: { sum: transaction[:payment_total], price: listing[:price], quantity: listing[:quantity], excludes_vat: @current_community.vat.present? }
+      - if tx[:booking]
+        = render partial: "transactions/details/booking", locals: { booking: tx[:booking], price_per_day: tx[:listing_price] }
 
-      - if transaction[:shipping_address].values.any?
-        = render partial: "transactions/shipping_address", locals: { shipping_address: transaction[:shipping_address] }
+      = render partial: "transactions/details/sum_or_price", locals: { sum: tx[:payment_total], price: tx[:listing_price], quantity: tx[:quantity], excludes_vat: @current_community.vat.present? }
 
-      - if transaction[:show_call_to_action]
-        -# Show Call to Action button for free conversations
+      - if tx[:shipping_address] && tx[:shipping_address].values.any?
+        = render partial: "transactions/shipping_address", locals: { shipping_address: tx[:shipping_address] }
 
-        / -# Hide the button temporarily as no support for Booking of Paypal
-        / = link_to transaction[:new_transaction_path], :class => "message-book-button" do
-        /   .content
-        /     = transaction[:action_button_label]
-
-      - else
-        %div{:id => "transaction_status"}
-          = render :partial => "transactions/status/status", :locals => { :__transaction_model => transaction[:__model], is_author: is_author }
+      %div{:id => "transaction_status"}
+        = render :partial => "transactions/status/status", :locals => { :__transaction_model => transaction_model, is_author: is_author }

--- a/app/views/transactions/details/_booking.html.erb
+++ b/app/views/transactions/details/_booking.html.erb
@@ -1,10 +1,10 @@
 <ul class="no-bullets">
   <li>
     <div>
-      <%= l booking.start_on, format: :long_with_abbr_day_name %>
+      <%= l booking[:start_on], format: :long_with_abbr_day_name %>
       -
-      <%= l booking.end_on, format: :long_with_abbr_day_name %>
-      (<%= pluralize(booking.duration, t("conversations.details.day"), t("conversations.details.days")) %>)
+      <%= l booking[:end_on], format: :long_with_abbr_day_name %>
+      (<%= pluralize(booking[:duration], t("conversations.details.day"), t("conversations.details.days")) %>)
     </div>
   </li>
   <li>

--- a/app/views/transactions/show.haml
+++ b/app/views/transactions/show.haml
@@ -1,6 +1,6 @@
-= render :partial => "conversations/conversation_header", locals: {other_party: transaction_data[:conversation][:other_party]}
+= render :partial => "conversations/conversation_header", locals: {other_party: conversation_other_party}
 
 .centered-section-wide
-  = render :partial => "transactions/details", locals: {transaction: transaction_data, is_author: is_author}
+  = render :partial => "transactions/details", locals: {tx: transaction, transaction_model: transaction_model, listing: listing, is_author: is_author}
 
   = render :partial => "conversations/messages_and_form", locals: {message_form: message_form, message_form_action: message_form_action, messages: messages}

--- a/spec/services/transaction_service/paypal_events_spec.rb
+++ b/spec/services/transaction_service/paypal_events_spec.rb
@@ -234,9 +234,16 @@ describe TransactionService::PaypalEvents do
       ).to include(@order_details)
     end
 
-    it "handles empty shipping address" do
+    it "doesn't record shipping address with no fields" do
       TransactionService::PaypalEvents.update_transaction_details(:success,
         {}.merge(transaction_id: @transaction_with_msg.id, community_id: @cid))
+
+      expect(Transaction.find(@transaction_with_msg.id).shipping_address).to be nil
+    end
+
+    it "doesn't record shipping address with only status field" do
+      TransactionService::PaypalEvents.update_transaction_details(:success,
+        {status: "None"}.merge(transaction_id: @transaction_with_msg.id, community_id: @cid))
 
       expect(Transaction.find(@transaction_with_msg.id).shipping_address).to be nil
     end


### PR DESCRIPTION
Shipping address was first implemented as part of the deprecated transaction_with_conversation entity format. Here we move it to current version transaction entity and read the data from the new place consistently.