### PR TITLE
Start pp payment with button instead of pp logo

### DIFF
--- a/app/assets/stylesheets/partials/_paypal.css.scss
+++ b/app/assets/stylesheets/partials/_paypal.css.scss
@@ -3,8 +3,6 @@
 .paypal-button-wrapper {
 
   .checkout-with-paypal-button {
-    width: 100%;
-    max-width: 170px; // That's the width of the button
     float: left;
     outline: 0;
   }
@@ -12,7 +10,7 @@
     float: left;
     width: em(30);
     height: em(30);
-    margin-top: em(1);
+    margin-top: em(18);
     margin-left: lines(0.75);
   }
 }

--- a/app/views/listing_conversations/_paypal_payment_methods.haml
+++ b/app/views/listing_conversations/_paypal_payment_methods.haml
@@ -1,0 +1,14 @@
+- country_code = LocalizationUtils.country_code_valid?(country_code) ? country_code.downcase : 'us' # default should not happen in production
+- how_paypal_works_link = "https://www.paypal.com/#{country_code}/webapps/mpp/paypal-popup"
+%a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
+  = image_tag "https://www.paypalobjects.com/webstatic/en_US/i/buttons/cc-badges-ppmcvdam.png", style: "max-width: 100%"
+  - content_for :extra_javascript do
+    :javascript
+      $("#how-paypal-works-popup-link").click(function() {
+        window.open(
+          '#{how_paypal_works_link}',
+          'WIPaypal',
+          'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700'
+        );
+        return false;
+      });

--- a/app/views/listing_conversations/initiate.haml
+++ b/app/views/listing_conversations/initiate.haml
@@ -87,7 +87,11 @@
 
       .row
         .col-12.paypal-button-wrapper
-          = form.submit t("paypal.checkout_with_paypal"), type: :image, src: t("paypal.buy_now_with_paypal_button_url"), alt: t("paypal.checkout_with_paypal"), class: "checkout-with-paypal-button"
+          = form.button t("paypal.pay_with_paypal"), class: "checkout-with-paypal-button"
+
+      .row
+        .col-12
+          = render :partial => "listing_conversations/paypal_payment_methods", locals: { country_code: @current_community.country }
 
       .row
         .col-12

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -87,20 +87,7 @@
     - if payment_gateway == :paypal && @listing.transaction_type.status_after_reply != "free"
       .row
         .col-12
-          - community_country_code = LocalizationUtils.country_code_valid?(@current_community.country) ? @current_community.country.downcase : 'us' # default should not happen in production
-          - how_paypal_works_link = "https://www.paypal.com/#{community_country_code}/webapps/mpp/paypal-popup"
-          %a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
-            = image_tag "https://www.paypalobjects.com/webstatic/en_US/i/buttons/cc-badges-ppmcvdam.png", style: "max-width: 100%"
-            - content_for :extra_javascript do
-              :javascript
-                $("#how-paypal-works-popup-link").click(function() {
-                  window.open(
-                    '#{how_paypal_works_link}',
-                    'WIPaypal',
-                    'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700'
-                  );
-                  return false;
-                });
+          = render :partial => "listing_conversations/paypal_payment_methods", locals: { country_code: @current_community.country }
 
   - if is_authorized
     .listing-view-admin-links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1548,6 +1548,7 @@ en:
       account_not_verified: "You haven't verified your PayPal account. You need to go to paypal.com and verify your account before you can continue."
       account_restricted: "Your PayPal account is restricted and cannot be connected. Please log in to paypal.com to find out more what this means or get in touch with PayPal customer support to resolve the issue."
   paypal:
+    pay_with_paypal: "Proceed to payment"
     checkout_with_paypal: "Checkout with PayPal"
     cancel_succesful: "PayPal payment succesfully canceled"
     transaction:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1548,6 +1548,7 @@ fi:
       account_not_verified: "Et ole vahvistanut PayPal-tiliäsi. Sinun on vahvistettava tilisi ennen kuin voit jatkaa."
       account_restricted: "PayPal-tiliisi on rajoitetussa tilassa eikä sitä voida yhdistää. Sinun tulee kirjautua PayPal-sivustolle selvittääksesi ongelman."
   paypal:
+    pay_with_paypal: "Siirry maksamaan"
     checkout_with_paypal: "Maksa PayPal-tilillä"
     cancel_succesful: "PayPal maksu onnistuneesti peruttu."
     transaction:


### PR DESCRIPTION
- Switch PayPal button to normal button to signal that PayPal account is
  not the only payment method available via PayPal.

- Add paypal payment method logos under the button with popup link to
  "How PayPal works" to communicate available payment methods and to
  comply with PayPal guidelines.