### PR TITLE
Coerce PayPal SDK's Strings into Ruby strings

### DIFF
--- a/app/services/paypal_service/merchant.rb
+++ b/app/services/paypal_service/merchant.rb
@@ -87,8 +87,8 @@ module PaypalService
     def create_failure_response(res)
       if (res.errors.length > 0)
         DataTypes.create_failure_response({
-          error_code: res.errors[0].error_code,
-          error_msg: res.errors[0].long_message
+          error_code: res.errors[0].error_code.to_s,
+          error_msg: res.errors[0].long_message.to_s
         })
       else
         DataTypes.create_failure_response({})

--- a/app/services/paypal_service/permissions.rb
+++ b/app/services/paypal_service/permissions.rb
@@ -76,7 +76,7 @@ module PaypalService
       if (res.error.length > 0)
         DataTypes.create_failure_response({
           error_code: res.error[0].error_id.to_s,
-          error_msg: res.error[0].message
+          error_msg: res.error[0].message.to_s
         })
       else
         DataTypes.create_failure_response({})


### PR DESCRIPTION
PayPal SDK has a special implementation of String that it retuns from
API calls instead of standard Ruby Strings. This causes YAML
serializaiton and deserialization used by workers to store operation
results to db to convert strings into fixnums in certain cases. To fix
this we coerce to standard strings before returning result from API.