### PR TITLE
Remove contact button if transaction does not use payments

### DIFF
--- a/app/controllers/free_transactions_controller.rb
+++ b/app/controllers/free_transactions_controller.rb
@@ -13,21 +13,11 @@ class FreeTransactionsController < ApplicationController
     .with_validations { validates_presence_of :content, :listing_id }
 
   def new
-    @listing_conversation = new_contact_form
-    render "listing_conversations/contact", locals: {
-      contact: false,
-      contact_form: @listing_conversation,
-      create_contact: create_contact_path(:person_id => @current_user.id, :listing_id => @listing.id)
-    }
+    render_contact_form
   end
 
   def contact
-    @listing_conversation = new_contact_form
-    render "listing_conversations/contact", locals: {
-      contact: true,
-      contact_form: @listing_conversation,
-      create_contact: create_contact_path(:person_id => @current_user.id, :listing_id => @listing.id)
-    }
+    render_contact_form
   end
 
   def create_contact
@@ -70,6 +60,14 @@ class FreeTransactionsController < ApplicationController
   end
 
   private
+
+  def render_contact_form
+    @listing_conversation = new_contact_form
+    render "listing_conversations/contact", locals: {
+      contact_form: @listing_conversation,
+      create_contact: create_contact_path(:person_id => @current_user.id, :listing_id => @listing.id)
+    }
+  end
 
   def ensure_listing_author_is_not_current_user
     if @listing.author == @current_user

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -26,7 +26,6 @@ class TransactionType < ActiveRecord::Base
     :community_id,
     :price_field,
     :sort_priority,
-    :type,
     :price_quantity_placeholder,
     :price_per,
     :transaction_process_id
@@ -51,6 +50,7 @@ class TransactionType < ActiveRecord::Base
     super.reject { |c| c.name == "type" }
   end
 
+  # TODO this can be removed
   def self.inheritance_column
     :a_non_existing_column_because_we_want_to_disable_inheritance
   end
@@ -60,7 +60,9 @@ class TransactionType < ActiveRecord::Base
   end
 
   def url_source
-    Maybe(default_translation_without_cache).name.or_else(type)
+    Maybe(default_translation_without_cache).name.or_else(nil).tap { |translation|
+      raise ArgumentError.new("Can not create URL for transaction type. Expected transaction type to have translation") if translation.nil?
+    }
   end
 
   def default_translation_without_cache

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -46,6 +46,11 @@ class TransactionType < ActiveRecord::Base
 
   acts_as_url :url_source, scope: :community_id, sync_url: true, blacklist: %w{new all}
 
+  # TODO this can be removed
+  def self.columns
+    super.reject { |c| c.name == "type" }
+  end
+
   def self.inheritance_column
     :a_non_existing_column_because_we_want_to_disable_inheritance
   end
@@ -72,15 +77,5 @@ class TransactionType < ActiveRecord::Base
 
   def self.find_by_url_or_id(url_or_id)
     self.find_by_url(url_or_id) || self.find_by_id(url_or_id)
-  end
-
-  # Deprecated
-  # This method is used to define whether the transaction is inquiry, which
-  # is used to define if we show the 'contact' button or not.
-  #
-  # TODO Change the listing view so that we show the 'contact' button only if the
-  # process is preauthorize or postpay
-  def is_inquiry?
-    type == "Inquiry"
   end
 end

--- a/app/services/marketplace_service/inbox.rb
+++ b/app/services/marketplace_service/inbox.rb
@@ -85,7 +85,6 @@ module MarketplaceService
         [:listing_id, :fixnum, :mandatory],
         [:listing_title, :string, :mandatory],
         [:listing_deleted, transform_with: @tiny_int_to_bool],
-        [:transaction_type, :string, :mandatory],
 
         [:last_transition_at, :time, :mandatory],
         [:last_transition_to_state, :string, :mandatory],
@@ -307,8 +306,6 @@ module MarketplaceService
             current_participation.person_id                   AS current_id,
             other_participation.person_id                     AS other_id,
 
-            transaction_types.type                            AS transaction_type,
-
             current_participation.is_read                     AS current_is_read,
             current_participation.is_starter                  AS current_is_starter,
 
@@ -329,7 +326,6 @@ module MarketplaceService
 
           LEFT JOIN transactions      ON transactions.conversation_id = conversations.id
           LEFT JOIN listings          ON transactions.listing_id = listings.id
-          LEFT JOIN transaction_types ON listings.transaction_type_id = transaction_types.id
           LEFT JOIN payments          ON payments.transaction_id = transactions.id
           LEFT JOIN testimonials      ON (testimonials.transaction_id = transactions.id AND testimonials.author_id = #{params[:person_id]})
           LEFT JOIN participations    AS current_participation ON (current_participation.conversation_id = conversations.id AND current_participation.person_id = #{params[:person_id]})

--- a/app/services/marketplace_service/listing.rb
+++ b/app/services/marketplace_service/listing.rb
@@ -18,7 +18,6 @@ module MarketplaceService
 
       TransactionType = EntityUtils.define_builder(
         [:id, :mandatory, :fixnum],
-        [:type, :mandatory, :string],
         [:price_per, :optional, :string],
         [:price_field, :optional, :to_bool],
         [:preauthorize_payment, :optional, :to_bool],

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -11,41 +11,32 @@ module TransactionTypeCreator
 
   DEFAULTS = {
     "Give" => {
-      type: "Give",
       price_field: false
     },
     "Inquiry" => {
-      type: "Inquiry",
       price_field: false
     },
     "Lend" => {
-      type: "Lend",
       price_field: false
     },
     "Rent" => {
-      type: "Rent",
       price_field: true,
       price_per: "day"
     },
     "Request" => {
-      type: "Request",
       price_field: false,
     },
     "Sell" => {
-      type: "Sell",
       price_field: true
     },
     "Service" => {
-      type: "Service",
       price_field: true,
       price_per: "day"
     },
     "ShareForFree" => {
-      type: "ShareForFree",
       price_field: false
     },
     "Swap" => {
-      type: "Swap",
       price_field: false
     }
   }

--- a/app/views/listing_conversations/contact.haml
+++ b/app/views/listing_conversations/contact.haml
@@ -4,11 +4,7 @@
 #new_message_form.centered-section
 
   %h2
-    - if contact || @listing.transaction_type.is_inquiry?
-      = t("conversations.new.send_message_to_user", :person => link_to(@listing.author.given_name_or_username, @listing.author)).html_safe
-    - else
-      = @listing.transaction_type.action_button_label(I18n.locale)
-      = link_to(@listing.title, @listing)
+    = t("conversations.new.send_message_to_user", :person => link_to(@listing.author.given_name_or_username, @listing.author)).html_safe
 
   = form_for contact_form, :url => create_contact do |form|
 

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -136,7 +136,7 @@
           .listing-author-details
             .listing-author-name
               = link_to @listing.author.name(@current_community), @listing.author, :id => "listing-author-link", :class => "listing-author-name-link", :title => "#{@listing.author.name(@current_community)}"
-            - unless current_user?(@listing.author) || @listing.transaction_type.is_inquiry?
+            - if @listing.author != @current_user && process != :none
               .listing-author-contact
                 %a#listing-contact{href: contact_to_listing_path(:listing_id => @listing.id.to_s), :class => "listing-author-contact-button"}
                   .content

--- a/features/conversations/user_sends_a_new_message.feature
+++ b/features/conversations/user_sends_a_new_message.feature
@@ -4,58 +4,6 @@ Feature: User sends a new message
   I want to be able to send a private message to another users
 
   @javascript
-  Scenario: Asking details about a listing
-    Given there are following users:
-      | person |
-      | kassi_testperson1 |
-      | kassi_testperson2 |
-    And there is a listing with title "Hammer" from "kassi_testperson1" with category "Items" and with transaction type "Lending"
-    And I am logged in as "kassi_testperson2"
-    And I am on the homepage
-    When I follow "Hammer"
-    And I follow "listing-contact"
-    And I fill in "Message" with "What kind of hammer is this?"
-    And I press "Send message"
-    Then I should see "Message sent" within ".flash-notifications"
-    And I should see "Hammer" within "#listing-title"
-    When I follow inbox link
-    And I should see "What kind of hammer is this?"
-    And I should not see "Awaiting confirmation from listing author"
-    When I log out
-    And I log in as "kassi_testperson1"
-    And I follow inbox link
-    Then I should not see "Accept"
-    When I follow "What kind of hammer is this?"
-    Then I should not see "Accept"
-
-  @javascript
-  Scenario: Trying to ask details about a listing with inadequate information
-    Given there are following users:
-      | person |
-      | kassi_testperson1 |
-      | kassi_testperson2 |
-    And there is a listing with title "Hammer" from "kassi_testperson1" with category "Items" and with transaction type "Lending"
-    And I am logged in as "kassi_testperson2"
-    And I am on the homepage
-    When I follow "Hammer"
-    And I follow "listing-contact"
-    And I press "Send message"
-    Then I should see "This field is required."
-
-  @javascript
-  Scenario: Asking details about a listing through the listing author box link
-    Given there are following users:
-      | person |
-      | kassi_testperson1 |
-      | kassi_testperson2 |
-    And there is a listing with title "Hammer" from "kassi_testperson1" with category "Items" and with transaction type "Lending"
-    And I am logged in as "kassi_testperson2"
-    And I am on the homepage
-    When I follow "Hammer"
-    And I follow "listing-contact"
-    Then I should see "Send message to"
-
-  @javascript
   Scenario: Sending message from the profile page
     Given there are following users:
       | person |

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -14,11 +14,8 @@ module CommunitySteps
     end
 
     # also change the transaction types
-    community.transaction_types.each { |tt|
-      case tt.type
-      when "Rent", "Sell", "Service"
-        TransactionProcess.find(tt.transaction_process_id).update_attribute(:process, :postpay)
-      end
+    community.transaction_types.select { |tt| tt.price_field? }.each { |tt|
+      TransactionProcess.find(tt.transaction_process_id).update_attribute(:process, :postpay)
     }
   end
 end
@@ -178,9 +175,10 @@ Given /^community "(.*?)" has following transaction types enabled:$/ do |communi
   process_id = TransactionProcess.where(community_id: current_community.id, process: :none).first.id
 
   current_community.transaction_types << transaction_types.hashes.map do |hash|
-    transaction_type = FactoryGirl.create(:transaction_type, :type => hash['transaction_type'], :community_id => current_community.id, :transaction_process_id => process_id)
-    transaction_type.translations.create(:name => hash['fi'], :action_button_label => (hash['button'] || "Action"), :locale => 'fi')
-    transaction_type.translations.create(:name => hash['en'], :action_button_label => (hash['button'] || "Action"), :locale => 'en')
+    transaction_type = FactoryGirl.build(:transaction_type, :community_id => current_community.id, :transaction_process_id => process_id)
+    transaction_type.translations.build(:name => hash['fi'], :action_button_label => (hash['button'] || "Action"), :locale => 'fi')
+    transaction_type.translations.build(:name => hash['en'], :action_button_label => (hash['button'] || "Action"), :locale => 'en')
+    transaction_type.save!
     transaction_type
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -248,7 +248,6 @@ FactoryGirl.define do
       factory_name = "transaction_type_#{type.downcase}"
       defaults = TransactionTypeCreator::DEFAULTS[type]
       factory factory_name.to_sym, class: "TransactionType" do
-        type type
         price_field defaults[:price_field]
         price_quantity_placeholder defaults[:price_quantity_placeholder]
         price_per defaults[:price_per]

--- a/spec/models/factories_spec.rb
+++ b/spec/models/factories_spec.rb
@@ -5,7 +5,8 @@ describe "Factory Girl" do
   # List here factories that should be ignored.
   # E.g. :payment is ignored, since it's a super class and shouldn't be instantiated
   ignored_factories = [
-    :payment
+    :payment,
+    :transaction_type
   ]
 
   (FactoryGirl.factories.map(&:name) - ignored_factories).each do |factory_name|

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -66,7 +66,7 @@ module TestHelpers
         type_opts = default_type_opts.merge(
           transaction_process_id: processes[:none])
 
-        transaction_type = community.transaction_types.create!(type_opts)
+        transaction_type = community.transaction_types.build(type_opts)
 
         community.locales.each do |locale|
           translation = translations[locale.to_sym]
@@ -74,9 +74,11 @@ module TestHelpers
           if translation then
             tt_name = translation[:name]
             tt_action = translation[:action_button_label]
-            transaction_type.translations.create!(:locale => locale, :name => tt_name, :action_button_label => tt_action)
+            transaction_type.translations.build(:locale => locale, :name => tt_name, :action_button_label => tt_action)
           end
         end
+
+        transaction_type.save!
       end
 
       # Load categories


### PR DESCRIPTION
- Remove "Contact" button from listings that use non-payment transaction process
- Change the title of new transaction view to generic "Send message to..."
- Remove all references to `TransactionType.type`