### PR TITLE
Remove multicommunity listings from database

### DIFF
--- a/db/migrate/20150317080017_remove_multi_community_listings.rb
+++ b/db/migrate/20150317080017_remove_multi_community_listings.rb
@@ -1,0 +1,25 @@
+class RemoveMultiCommunityListings < ActiveRecord::Migration
+
+  # Warning: This migration deletes data. Take backups.
+  #
+  # Background: Earlier versions of Sharetribe supported posting the same listing
+  # to multiple marketplaces. This functionality has been removed long ago. However,
+  # the existing data from communities_listings has not been removed.
+  #
+  # This migration deletes all but one community - listing relations from listings
+  # that belong to multiple communities. We use community_id from transaction_type to
+  # define the original community, in which the listing was created.
+  #
+  def up
+    execute("
+      DELETE communities_listings FROM communities_listings
+      LEFT JOIN listings ON (communities_listings.listing_id = listings.id)
+      LEFT JOIN transaction_types ON (listings.transaction_type_id = transaction_types.id)
+      WHERE communities_listings.community_id <> transaction_types.community_id
+    ")
+  end
+
+  def down
+    # This migration deletes data, so no way to down migrate it in anyway.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150316140637) do
+ActiveRecord::Schema.define(:version => 20150317080017) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"


### PR DESCRIPTION
Background: Earlier versions of Sharetribe supported posting the same listing
to multiple marketplaces. This functionality has been removed long ago. However,
the existing data from communities_listings has not been removed.

This migration deletes all but one community - listing relations from listings
that belong to multiple communities. We use community_id from transaction_type to
define the original community, in which the listing was created.