### PR TITLE
1/3 Listing price units

### DIFF
--- a/app/models/listing_unit.rb
+++ b/app/models/listing_unit.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: listing_units
+#
+#  id                  :integer          not null, primary key
+#  unit_type           :string(32)       not null
+#  translation_key     :string(64)
+#  transaction_type_id :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
+class ListingUnit < ActiveRecord::Base
+  attr_accessible(
+    :transaction_type_id,
+    :unit_type,
+    :translation_key
+  )
+end

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -39,6 +39,7 @@ class TransactionType < ActiveRecord::Base
   has_many :category_transaction_types, :dependent => :destroy
   has_many :categories, :through => :category_transaction_types
   has_many :listings
+  has_many :listing_units
 
   validates_presence_of :community
 

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -30,7 +30,9 @@ class TransactionType < ActiveRecord::Base
     :price_quantity_placeholder,
     :price_per,
     :transaction_process_id,
-    :shipping_enabled
+    :shipping_enabled,
+    :name_tr_key,
+    :action_button_tr_key
   )
 
   belongs_to :community

--- a/app/services/listing_service/api/api.rb
+++ b/app/services/listing_service/api/api.rb
@@ -1,0 +1,13 @@
+module ListingService::API
+  class Api
+    class << self
+      attr_accessor(
+        :shapes_api
+      )
+    end
+
+    def self.shapes
+      self.shapes_api ||= ListingService::API::Shapes.new
+    end
+  end
+end

--- a/app/services/listing_service/api/shapes.rb
+++ b/app/services/listing_service/api/shapes.rb
@@ -22,10 +22,9 @@ module ListingService::API
 
     # TODO Move transaction_type creation inside the API
     # That way we can get rid of the transaction_type_id
-    def create(community_id:, transaction_type_id:, opts:)
+    def create(community_id:, opts:)
       Result::Success.new(ShapeStore.create(
         community_id: community_id,
-        transaction_type_id: transaction_type_id,
         opts: opts
       ))
     end

--- a/app/services/listing_service/api/shapes.rb
+++ b/app/services/listing_service/api/shapes.rb
@@ -1,0 +1,34 @@
+module ListingService::API
+  ShapeStore = ListingService::Store::Shapes
+
+  class Shapes
+
+    # TODO Get rid of transaction_type_id
+    # Current implementation can seach listing shapes by transaction_type_id or listing_shape_id.
+    # This will change in the future.
+    def get(community_id:, listing_shape_id: nil, transaction_type_id: nil)
+      find_opts = {
+        community_id: community_id,
+        listing_shape_id: listing_shape_id,
+        transaction_type_id: transaction_type_id
+      }
+
+      Maybe(ShapeStore.get(find_opts)).map { |shape|
+        Result::Success.new(shape)
+      }.or_else {
+        Result::Error.new("Can not find listing shape for #{find_opts}")
+      }
+    end
+
+    # TODO Move transaction_type creation inside the API
+    # That way we can get rid of the transaction_type_id
+    def create(community_id:, transaction_type_id:, opts:)
+      Result::Success.new(ShapeStore.create(
+        community_id: community_id,
+        transaction_type_id: transaction_type_id,
+        opts: opts
+      ))
+    end
+
+  end
+end

--- a/app/services/listing_service/api/shapes.rb
+++ b/app/services/listing_service/api/shapes.rb
@@ -1,5 +1,5 @@
 module ListingService::API
-  ShapeStore = ListingService::Store::Shapes
+  ShapeStore = ListingService::Store::Shape
 
   class Shapes
 

--- a/app/services/listing_service/listing_shapes_api.md
+++ b/app/services/listing_service/listing_shapes_api.md
@@ -22,8 +22,8 @@ Request body:
 , name_tr_key: TranslationKey.new("listing_shape.1234.123")
 , action_button_tr_key: TranslationKey.new("action_button.1234.123")
 , units:
-  [ { unit\_type: "day" }
-  , { unit\_type: "custom"
+  [ { unit_type: :day }
+  , { unit_type: :custom
     , label: TransactionKey.new("unit.1234.123")
     }
   ]
@@ -40,8 +40,8 @@ Response:
 , name_tr_key: TranslationKey.new("listing_shape.1234.123")
 , action_button_tr_key: TranslationKey.new("action_button.1234.123")
 , units:
-  [ { unit\_type: "day" }
-  , { unit\_type: "custom"
+  [ { unit_type: :day }
+  , { unit_type: :custom
     , label: TransactionKey.new("unit.1234.123")
     }
   ]
@@ -62,8 +62,8 @@ Response:
 , name_tr_key: TranslationKey.new("listing_shape.1234.123")
 , action_button_tr_key: TranslationKey.new("action_button.1234.123")
 , units:
-  [ { unit\_type: "day" }
-  , { unit\_type: "custom"
+  [ { unit_type: :day }
+  , { unit_type: :custom
     , label: TransactionKey.new("unit.1234.123")
     }
   ]

--- a/app/services/listing_service/listing_shapes_api.md
+++ b/app/services/listing_service/listing_shapes_api.md
@@ -7,11 +7,45 @@ Request: empty
 Response:
 
 ```ruby
-[ { id: 123
-  , name: TranslationKey.new("listing_shape.1234.123")
-  }
-, ...
+[
+# Array of listing shapes, see the format below
 ]
+```
+
+## POST /:community_id
+
+Request body:
+
+```ruby
+{ price_enabled: true
+, transaction_process_id: 123
+, name_tr_key: TranslationKey.new("listing_shape.1234.123")
+, action_button_tr_key: TranslationKey.new("action_button.1234.123")
+, units:
+  [ { unit\_type: "day" }
+  , { unit\_type: "custom"
+    , label: TransactionKey.new("unit.1234.123")
+    }
+  ]
+}
+```
+
+Response:
+
+```ruby
+{ id: 12345
+, community_id: 9876
+, price_enabled: true
+, transaction_process_id: 123
+, name_tr_key: TranslationKey.new("listing_shape.1234.123")
+, action_button_tr_key: TranslationKey.new("action_button.1234.123")
+, units:
+  [ { unit\_type: "day" }
+  , { unit\_type: "custom"
+    , label: TransactionKey.new("unit.1234.123")
+    }
+  ]
+}
 ```
 
 ## GET /:community_id/:listing_shape_id
@@ -21,21 +55,17 @@ Request: empty
 Response:
 
 ```ruby
-[ { id: 123
-  , name: TranslationKey.new("listing_shape.1234.123")
-  , ...
-  , ...
-  , custom_fields: [ ... ]
-  , units:
-    [ { unit\_type: "day"}
-    , { unit\_type: "custom"
-      , label: TransactionKey.new("unit.1234.123")
-      }
-    ]
-  }
-  ,
-
-  ...
-
-]
+{ id: 12345
+, community_id: 9876
+, price_enabled: true
+, transaction_process_id: 123
+, name_tr_key: TranslationKey.new("listing_shape.1234.123")
+, action_button_tr_key: TranslationKey.new("action_button.1234.123")
+, units:
+  [ { unit\_type: "day" }
+  , { unit\_type: "custom"
+    , label: TransactionKey.new("unit.1234.123")
+    }
+  ]
+}
 ```

--- a/app/services/listing_service/listing_shapes_api.md
+++ b/app/services/listing_service/listing_shapes_api.md
@@ -1,0 +1,41 @@
+# listing_shapes/v1/
+
+## GET /:community_id/
+
+Request: empty
+
+Response:
+
+```ruby
+[ { id: 123
+  , name: TranslationKey.new("listing_shape.1234.123")
+  }
+, ...
+]
+```
+
+## GET /:community_id/:listing_shape_id
+
+Request: empty
+
+Response:
+
+```ruby
+[ { id: 123
+  , name: TranslationKey.new("listing_shape.1234.123")
+  , ...
+  , ...
+  , custom_fields: [ ... ]
+  , units:
+    [ { unit\_type: "day"}
+    , { unit\_type: "custom"
+      , label: TransactionKey.new("unit.1234.123")
+      }
+    ]
+  }
+  ,
+
+  ...
+
+]
+```

--- a/app/services/listing_service/store/shape.rb
+++ b/app/services/listing_service/store/shape.rb
@@ -1,4 +1,4 @@
-module ListingService::Store::Shapes
+module ListingService::Store::Shape
 
   TransactionTypeModel = ::TransactionType
   ListingUnitModel = ::ListingUnit

--- a/app/services/listing_service/store/shapes.rb
+++ b/app/services/listing_service/store/shapes.rb
@@ -1,0 +1,61 @@
+module ListingService::Store::Shapes
+
+  TransactionTypeModel = ::TransactionType
+  ListingUnitModel = ::ListingUnit
+
+  NewShape = EntityUtils.define_builder(
+    [:units, :array, :mandatory]
+  )
+
+  Shape = EntityUtils.define_builder(
+    # TODO Currently we don't have Shape model, i.e. we don't have Shape id
+    # [:id, :fixnum, :mandatory]
+    [:transaction_type_id, :fixnum, :optional], # TODO Only temporary
+    [:community_id, :fixnum, :mandatory],
+    [:units, :array, :mandatory]
+  )
+
+  Unit = EntityUtils.define_builder(
+    [:type, :to_symbol, one_of: [:piece, :hour, :day, :night, :week, :month, :custom]],
+    [:translation_key, :optional] # TODO Validate or transform to TranslationKey
+    )
+
+  module_function
+
+  # TODO Remove transaction_type_id
+  def get(community_id:, transaction_type_id: nil, listing_shape_id: nil)
+    if transaction_type_id
+      model = TransactionTypeModel.where(community_id: community_id, id: transaction_type_id).first
+      from_transaction_type_model(model)
+    elsif listing_shape_id
+      raise NotImplementedError.new("Can not find listing shape by listing_shape_id, yet. Specify transaction_type_id instead.")
+    else
+      rase ArgumentError.new("Can not find listing shape without id.")
+    end
+  end
+
+  def create(community_id:, transaction_type_id:, opts:)
+    shape = NewShape.call(opts.merge(community_id: community_id))
+    units = opts[:units].map { |unit| Unit.call(unit) }
+
+    # TODO only units are saved. Save also transaction_type_id to units.
+    saved_units = units.map { |unit|
+      Unit.call(
+        HashUtils.rename_keys({unit_type: :type},
+          EntityUtils.model_to_hash(
+            ListingUnit.create!(
+              HashUtils.rename_keys({type: :unit_type}, unit).merge(
+                transaction_type_id: transaction_type_id)))))
+    }
+  end
+
+  def from_transaction_type_model(model)
+    Maybe(model).map { |m|
+      hash = HashUtils.rename_keys({id: :transaction_type_id}, EntityUtils.model_to_hash(m))
+      hash[:units] = m.listing_units.map { |unit_model|
+        Unit.call(HashUtils.rename_keys({ unit_type: :type }, EntityUtils.model_to_hash(unit_model))) }
+      Shape.call(hash)
+    }.or_else(nil)
+  end
+
+end

--- a/app/services/listing_service/store/shapes.rb
+++ b/app/services/listing_service/store/shapes.rb
@@ -6,6 +6,8 @@ module ListingService::Store::Shapes
   NewShape = EntityUtils.define_builder(
     [:community_id, :fixnum, :mandatory],
     [:price_enabled, :bool, :mandatory],
+    [:name_tr_key, :string, :mandatory],
+    [:action_button_tr_key, :string, :mandatory],
     [:transaction_process_id, :fixnum, :mandatory],
     [:translations, :array, :optional], # TODO Only temporary
     [:shipping_enabled, :bool, :mandatory],
@@ -18,6 +20,8 @@ module ListingService::Store::Shapes
     [:transaction_type_id, :fixnum, :optional], # TODO Only temporary
     [:community_id, :fixnum, :mandatory],
     [:price_enabled, :to_bool, :mandatory], # to_bool, because there are NULL values in db
+    [:name_tr_key, :string, :mandatory],
+    [:action_button_tr_key, :string, :mandatory],
     [:transaction_process_id, :fixnum, :mandatory],
     [:translations, :array, :optional], # TODO Only temporary
     [:units, :array, :mandatory],

--- a/app/services/listing_service/store/shapes.rb
+++ b/app/services/listing_service/store/shapes.rb
@@ -50,8 +50,6 @@ module ListingService::Store::Shapes
   def create(community_id:, opts:)
     shape = NewShape.call(opts.merge(community_id: community_id))
 
-    valid_to_create!(shape)
-
     units = shape[:units].map { |unit| Unit.call(unit) }
     translations = opts[:translations] # Skip data type and validation, because this is temporary
 
@@ -74,11 +72,6 @@ module ListingService::Store::Shapes
   end
 
   # private
-
-  def valid_to_create!(shape)
-    invalid = shape[:price_enabled] == false && !shape[:units].empty?
-    raise ArgumentError.new("If price_enabled, then units must not be empty and vice versa: #{shape}") if invalid
-  end
 
   def from_transaction_type_model(model)
     Maybe(model).map { |m|

--- a/app/services/listing_service/store/shapes.rb
+++ b/app/services/listing_service/store/shapes.rb
@@ -76,8 +76,8 @@ module ListingService::Store::Shapes
   # private
 
   def valid_to_create!(shape)
-    valid = (shape[:price_enabled] == true && !shape[:units].empty?) || (shape[:price_enabled] == false && shape[:units].empty?)
-    raise ArgumentError.new("If price_enabled, then units must not be empty and vice versa: #{shape}") unless valid
+    invalid = shape[:price_enabled] == false && !shape[:units].empty?
+    raise ArgumentError.new("If price_enabled, then units must not be empty and vice versa: #{shape}") if invalid
   end
 
   def from_transaction_type_model(model)

--- a/app/services/listing_service/store/shapes.rb
+++ b/app/services/listing_service/store/shapes.rb
@@ -9,6 +9,7 @@ module ListingService::Store::Shapes
     [:transaction_process_id, :fixnum, :mandatory],
     [:translations, :array, :optional], # TODO Only temporary
     [:units, :array, :mandatory],
+    [:shipping_enabled, :bool, :mandatory]
   )
 
   Shape = EntityUtils.define_builder(
@@ -19,7 +20,8 @@ module ListingService::Store::Shapes
     [:price_enabled, :to_bool, :mandatory], # to_bool, because there are NULL values in db
     [:transaction_process_id, :fixnum, :mandatory],
     [:translations, :array, :optional], # TODO Only temporary
-    [:units, :array, :mandatory]
+    [:units, :array, :mandatory],
+    [:shipping_enabled, :bool, :mandatory]
   )
 
   Unit = EntityUtils.define_builder(

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -59,8 +59,8 @@ module MarketplaceService::API
       community = CommunityModel.create(Helper.community_params(p, marketplace_name, locale))
 
       Helper.create_community_customization!(community, marketplace_name, locale)
-      t = Helper.create_transaction_type!(community, p[:marketplace_type], :preauthorize)
-      Helper.create_category!("Default", community, locale, t.id)
+      shape = Helper.create_transaction_type!(community, p[:marketplace_type], :preauthorize)
+      Helper.create_category!("Default", community, locale, shape[:transaction_type_id])
 
       plan_level = p[:plan_level].or_else(CommunityPlan::FREE_PLAN)
       Helper.create_community_plan!(community, {plan_level: plan_level});

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -158,8 +158,8 @@ module TransactionTypeCreator
       }
     created_translations = TranslationService::API::Api.translations.create(community.id, [name_group, action_button_group])
     result = created_translations[:data]
-    transaction_type[:name_tr_key] =          result.at(0)[:translation_key]
-    transaction_type[:action_button_tr_key] = result.at(1)[:translation_key]
+    # TODO Save the key via ListingShape API transaction_type[:name_tr_key] =          result.at(0)[:translation_key]
+    # TODO Save the key via ListingShape API transaction_type[:action_button_tr_key] = result.at(1)[:translation_key]
     transaction_type.save!
 
     # Categories

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -97,6 +97,11 @@ module EntityUtils
         "#{field}: Value must be a Money. Was: #{v}."
       end
     },
+    bool: -> (_, v, field) {
+      unless (v.nil? || v == true || v == false)
+        "#{field}: Value must be boolean true or false. Was: #{v} (#{v.class.name})."
+      end
+    },
     validate_with: -> (validator, v, field) {
       unless (validator.call(v))
         "#{field}: Custom validation failed. Was: #{v}."

--- a/db/migrate/20150317122824_create_units_table.rb
+++ b/db/migrate/20150317122824_create_units_table.rb
@@ -1,0 +1,11 @@
+class CreateUnitsTable < ActiveRecord::Migration
+  def change
+    create_table :listing_units do |t|
+      t.string :unit_type, limit: 32, null: false
+      t.string :translation_key, limit: 64
+      t.integer :transaction_type_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150319121616_move_price_per_to_listing_units.rb
+++ b/db/migrate/20150319121616_move_price_per_to_listing_units.rb
@@ -4,10 +4,7 @@ class MovePricePerToListingUnits < ActiveRecord::Migration
       INSERT INTO listing_units (unit_type, transaction_type_id, created_at, updated_at)
       (
         SELECT
-          CASE WHEN transaction_types.price_per = 'day' THEN 'day'
-               ELSE 'piece'
-          END as unit_type,
-
+          'day',
           transaction_types.id,
           transaction_types.created_at,
           transaction_types.updated_at
@@ -16,11 +13,15 @@ class MovePricePerToListingUnits < ActiveRecord::Migration
         LEFT JOIN listing_units ON (listing_units.transaction_type_id = transaction_types.id)
 
         WHERE transaction_types.price_field = 1
+          AND transaction_types.price_per = 'day'
           AND listing_units.id IS NULL
       )
 ")
   end
 
   def down
+    execute("
+      DELETE FROM listing_units
+")
   end
 end

--- a/db/migrate/20150319121616_move_price_per_to_listing_units.rb
+++ b/db/migrate/20150319121616_move_price_per_to_listing_units.rb
@@ -1,0 +1,26 @@
+class MovePricePerToListingUnits < ActiveRecord::Migration
+  def up
+    execute("
+      INSERT INTO listing_units (unit_type, transaction_type_id, created_at, updated_at)
+      (
+        SELECT
+          CASE WHEN transaction_types.price_per = 'day' THEN 'day'
+               ELSE 'piece'
+          END as unit_type,
+
+          transaction_types.id,
+          transaction_types.created_at,
+          transaction_types.updated_at
+        FROM transaction_types
+
+        LEFT JOIN listing_units ON (listing_units.transaction_type_id = transaction_types.id)
+
+        WHERE transaction_types.price_field = 1
+          AND listing_units.id IS NULL
+      )
+")
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150317142931) do
+ActiveRecord::Schema.define(:version => 20150319121616) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -471,6 +471,14 @@ ActiveRecord::Schema.define(:version => 20150317142931) do
 
   add_index "listing_images", ["listing_id"], :name => "index_listing_images_on_listing_id"
 
+  create_table "listing_units", :force => true do |t|
+    t.string   "unit_type",           :limit => 32, :null => false
+    t.string   "translation_key",     :limit => 64
+    t.integer  "transaction_type_id"
+    t.datetime "created_at",                        :null => false
+    t.datetime "updated_at",                        :null => false
+  end
+
   create_table "listings", :force => true do |t|
     t.string   "author_id"
     t.string   "category_old"

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -174,20 +174,68 @@ Given /^community "(.*?)" has following transaction types enabled:$/ do |communi
 
   process_id = TransactionProcess.where(community_id: current_community.id, process: :none).first.id
 
-  current_community.transaction_types << transaction_types.hashes.map do |hash|
-    transaction_type = FactoryGirl.build(:transaction_type, :community_id => current_community.id, :transaction_process_id => process_id)
-    transaction_type.translations.build(:name => hash['fi'], :action_button_label => (hash['button'] || "Action"), :locale => 'fi')
-    transaction_type.translations.build(:name => hash['en'], :action_button_label => (hash['button'] || "Action"), :locale => 'en')
-    transaction_type.save!
-    transaction_type
+  transaction_types.hashes.map do |hash|
+    ListingService::API::Api.shapes.create(
+      community_id: current_community.id,
+      opts: {
+        price_enabled: true,
+        name_tr_key: 'something.here',
+        action_button_tr_key: 'something.here',
+        transaction_process_id: process_id,
+        translations: [
+          {name: hash['fi'], action_button_label: (hash['button'] || "Action"), locale: 'fi'},
+          {name: hash['en'], action_button_label: (hash['button'] || "Action"), locale: 'en'}
+        ],
+        units: [ {type: :piece} ]
+      }
+    )
+
+    # transaction_type = FactoryGirl.build(:transaction_type, :community_id => current_community.id, :transaction_process_id => process_id)
+    # transaction_type.translations.build(:name => hash['fi'], :action_button_label => (hash['button'] || "Action"), :locale => 'fi')
+    # transaction_type.translations.build(:name => hash['en'], :action_button_label => (hash['button'] || "Action"), :locale => 'en')
+    # transaction_type.save!
+    # transaction_type
   end
+
+  current_community.reload
 end
 
-Given /^the community has transaction type (Sell|Rent) with name "(.*?)" and action button label "(.*?)"$/ do |type_class, name, action_button_label|
+Given /^the community has transaction type Rent with name "(.*?)" and action button label "(.*?)"$/ do |name, action_button_label|
   process_id = TransactionProcess.where(community_id: @current_community.id, process: [:preauthorize, :postpay]).first.id
-  translations = [FactoryGirl.build(:transaction_type_translation, locale: "en", name: name, action_button_label: action_button_label)]
-  @transaction_type = FactoryGirl.create("transaction_type_#{type_class.downcase}".to_sym, translations: translations, community: @current_community, transaction_process_id: process_id)
-  @transaction_type.save!
+  defaults = TransactionTypeCreator::DEFAULTS["Rent"]
+
+  shape_res = ListingService::API::Api.shapes.create(
+    community_id: @current_community.id,
+    opts: {
+      price_enabled: true,
+      name_tr_key: 'something.here',
+      action_button_tr_key: 'something.here',
+      transaction_process_id: process_id,
+      translations: [ {locale: "en", name: name, action_button_label: action_button_label} ],
+      units: [ {type: :day} ]
+    }
+  )
+
+  @transaction_type = TransactionType.find(shape_res.data[:transaction_type_id])
+end
+
+Given /^the community has transaction type Sell with name "(.*?)" and action button label "(.*?)"$/ do |name, action_button_label|
+  process_id = TransactionProcess.where(community_id: @current_community.id, process: [:preauthorize, :postpay]).first.id
+  defaults = TransactionTypeCreator::DEFAULTS["Sell"]
+
+  shape_res = ListingService::API::Api.shapes.create(
+    community_id: @current_community.id,
+    opts: {
+      price_enabled: true,
+      name_tr_key: 'something.here',
+      action_button_tr_key: 'something.here',
+      transaction_process_id: process_id,
+      translations: [ {locale: "en", name: name, action_button_label: action_button_label} ],
+      units: [ {type: :piece} ]
+    }
+  )
+
+  @transaction_type = TransactionType.find(shape_res.data[:transaction_type_id])
 end
 
 Given /^that transaction type shows the price of listing per (day)$/ do |price_per|

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -179,6 +179,7 @@ Given /^community "(.*?)" has following transaction types enabled:$/ do |communi
       community_id: current_community.id,
       opts: {
         price_enabled: true,
+        shipping_enabled: false,
         name_tr_key: 'something.here',
         action_button_tr_key: 'something.here',
         transaction_process_id: process_id,
@@ -202,6 +203,7 @@ Given /^the community has transaction type Rent with name "(.*?)" and action but
     community_id: @current_community.id,
     opts: {
       price_enabled: true,
+      shipping_enabled: false,
       name_tr_key: 'something.here',
       action_button_tr_key: 'something.here',
       transaction_process_id: process_id,
@@ -221,6 +223,7 @@ Given /^the community has transaction type Sell with name "(.*?)" and action but
     community_id: @current_community.id,
     opts: {
       price_enabled: true,
+      shipping_enabled: false,
       name_tr_key: 'something.here',
       action_button_tr_key: 'something.here',
       transaction_process_id: process_id,

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -189,12 +189,6 @@ Given /^community "(.*?)" has following transaction types enabled:$/ do |communi
         units: [ {type: :piece} ]
       }
     )
-
-    # transaction_type = FactoryGirl.build(:transaction_type, :community_id => current_community.id, :transaction_process_id => process_id)
-    # transaction_type.translations.build(:name => hash['fi'], :action_button_label => (hash['button'] || "Action"), :locale => 'fi')
-    # transaction_type.translations.build(:name => hash['en'], :action_button_label => (hash['button'] || "Action"), :locale => 'en')
-    # transaction_type.save!
-    # transaction_type
   end
 
   current_community.reload

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -18,6 +18,7 @@ describe ListingsController do
 
     opts = defaults.merge(
       {
+        shipping_enabled: false,
         transaction_process_id: process_id,
         name_tr_key: 'something.here',
         action_button_tr_key: 'something.here',

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -102,6 +102,7 @@ FactoryGirl.define do
     description("test")
     build_association(:author)
     category { TestHelpers::find_or_build_category("item") }
+    # TODO Find out if it's possible to get rid of transaction type factories
     build_association(:transaction_type_sell, as: :transaction_type)
     valid_until 3.months.from_now
     times_viewed 0
@@ -235,12 +236,14 @@ FactoryGirl.define do
     locale "en"
   end
 
+  # TODO Find out if it's possible to get rid of transaction type factories
   factory :transaction_type_translation do
     name "Selling"
     locale "en"
     build_association(:transaction_type)
   end
 
+  # TODO Find out if it's possible to get rid of transaction type factories
   factory :transaction_type do
     build_association(:community)
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -98,21 +98,36 @@ FactoryGirl.define do
   end
 
   factory :listing do
-    title "Sledgehammer"
+    title "Sledgeham!!!!!!!!!!!!!!!!!!"
     description("test")
     build_association(:author)
     category { TestHelpers::find_or_build_category("item") }
-    # TODO Find out if it's possible to get rid of transaction type factories
-    build_association(:transaction_type_sell, as: :transaction_type)
     valid_until 3.months.from_now
     times_viewed 0
     visibility "this_community"
     privacy "public"
     price Money.new(20, "USD")
-
     has_many :communities do |listing|
       FactoryGirl.build(:community)
     end
+    transaction_type {
+      TransactionType.find(
+        ListingService::API::Api.shapes.create(
+        # If community is not given, this will create a new one which differs from the community of the listing.
+        # That's an error, but tests seem to pass
+        community_id: (communities.first || FactoryGirl.create(:community)).id,
+        opts: {
+          price_enabled: true,
+          transaction_process_id: 12345,
+          name_tr_key: "something.here",
+          action_button_tr_key: "something.here",
+          translations: [
+            { locale: "en", name: "Selling" }
+          ],
+          units: [ {type: :piece} ]
+        }
+      ).data[:transaction_type_id])
+    }
   end
 
   factory :transaction do
@@ -234,32 +249,6 @@ FactoryGirl.define do
   factory :category_translation do
     name "test category"
     locale "en"
-  end
-
-  # TODO Find out if it's possible to get rid of transaction type factories
-  factory :transaction_type_translation do
-    name "Selling"
-    locale "en"
-    build_association(:transaction_type)
-  end
-
-  # TODO Find out if it's possible to get rid of transaction type factories
-  factory :transaction_type do
-    build_association(:community)
-
-    ['Sell', 'Give', 'Lend', 'Rent', 'Request', 'Service'].each do |type|
-      factory_name = "transaction_type_#{type.downcase}"
-      defaults = TransactionTypeCreator::DEFAULTS[type]
-      factory factory_name.to_sym, class: "TransactionType" do
-        price_field defaults[:price_field]
-        price_quantity_placeholder defaults[:price_quantity_placeholder]
-        price_per defaults[:price_per]
-
-        has_many :translations do |transaction_type|
-          FactoryGirl.build(:transaction_type_translation, :name => type, :transaction_type => transaction_type)
-        end
-      end
-    end
   end
 
   factory :custom_field, aliases: [:question] do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -98,7 +98,7 @@ FactoryGirl.define do
   end
 
   factory :listing do
-    title "Sledgeham!!!!!!!!!!!!!!!!!!"
+    title "Sledgehammer"
     description("test")
     build_association(:author)
     category { TestHelpers::find_or_build_category("item") }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -118,6 +118,7 @@ FactoryGirl.define do
         community_id: (communities.first || FactoryGirl.create(:community)).id,
         opts: {
           price_enabled: true,
+          shipping_enabled: false,
           transaction_process_id: 12345,
           name_tr_key: "something.here",
           action_button_tr_key: "something.here",

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -24,8 +24,7 @@ describe "CommunityMailer" do
           :title => "hammer",
           :created_at => 2.days.ago,
           :updates_email_at => 2.days.ago,
-          :description => "<b>shiny</b> new hammer, see details at http://en.wikipedia.org/wiki/MC_Hammer",
-          :transaction_type => FactoryGirl.create(:transaction_type_sell))
+          :description => "<b>shiny</b> new hammer, see details at http://en.wikipedia.org/wiki/MC_Hammer")
       @l2.communities << @c1
 
       @email = CommunityMailer.community_updates(
@@ -70,13 +69,11 @@ describe "CommunityMailer" do
       @p2.communities << @c2
 
       @l1 = FactoryGirl.create(:listing,
-          :transaction_type => FactoryGirl.create(:transaction_type_request),
           :title => "bike",
           :description => "A very nice bike",
           :created_at => 3.hours.ago,
           :author => @p1).communities = [@c1]
       @l2 = FactoryGirl.create(:listing,
-          :transaction_type => FactoryGirl.create(:transaction_type_request),
           :title => "motorbike",
           :description => "fast!",
           :created_at => 1.hours.ago,

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -150,10 +150,6 @@ describe Listing do
 
   context "with listing type 'offer'" do
 
-    before(:each) do
-      @listing.transaction_type = FactoryGirl.create(:transaction_type_give)
-    end
-
     it "should be valid when there is no valid until" do
       @listing.valid_until = nil
       @listing.should be_valid

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -111,7 +111,6 @@ describe Person do
       it "creates a new listing with the submitted attributes" do
         listing = FactoryGirl.create(:listing,
           :title => "Test",
-          :transaction_type => FactoryGirl.create(:transaction_type_sell),
           :author => @test_person
         )
         listing.title.should == "Test"

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -12,6 +12,7 @@ describe ListingService::API::Shapes do
         opts: {
           price_enabled: true,
           transaction_process_id: transaction_process_id,
+          shipping_enabled: true,
 
           # TODO Move these to translation service
           translations: [
@@ -38,6 +39,7 @@ describe ListingService::API::Shapes do
 
       expect(shape[:community_id]).to eql(community_id)
       expect(shape[:price_enabled]).to eql(true)
+      expect(shape[:shipping_enabled]).to eql(true)
       expect(shape[:transaction_process_id]).to eql(transaction_process_id)
       expect(shape[:transaction_type_id]).to be_a(Fixnum)
 

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -1,0 +1,37 @@
+describe ListingService::API::Shapes do
+
+  let(:shapes) { ListingService::API::Api.shapes }
+  let(:community_id) { FactoryGirl.create(:community).id }
+  let(:transaction_type) {
+    # TODO Temporary
+    TransactionType.new(community_id: community_id).tap { |tt|
+      tt.translations.build(locale: :en, name: "test")
+      tt.save!
+    }
+  }
+
+  describe "#create" do
+    it "creates new listing shape" do
+      shapes.create(
+        community_id: community_id,
+        transaction_type_id: transaction_type.id,
+        opts: {
+          units: [
+            {type: :day},
+            {type: :custom, translation_key: 'my.custom.units.translation'}
+          ]
+        }
+      )
+
+      res = shapes.get(community_id: community_id, transaction_type_id: transaction_type.id)
+
+      expect(res.success).to eql(true)
+
+      units = res.data[:units]
+
+      expect(units[0][:type]).to eql(:day)
+      expect(units[1][:type]).to eql(:custom)
+      expect(units[1][:translation_key]).to eql('my.custom.units.translation')
+    end
+  end
+end

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -1,21 +1,24 @@
+# coding: utf-8
 describe ListingService::API::Shapes do
 
   let(:shapes) { ListingService::API::Api.shapes }
   let(:community_id) { FactoryGirl.create(:community).id }
-  let(:transaction_type) {
-    # TODO Temporary
-    TransactionType.new(community_id: community_id).tap { |tt|
-      tt.translations.build(locale: :en, name: "test")
-      tt.save!
-    }
-  }
+  let(:transaction_process_id) { 555 }
 
   describe "#create" do
     it "creates new listing shape" do
-      shapes.create(
+      create_shape_res = shapes.create(
         community_id: community_id,
-        transaction_type_id: transaction_type.id,
         opts: {
+          price_enabled: true,
+          transaction_process_id: transaction_process_id,
+
+          # TODO Move these to translation service
+          translations: [
+            { locale: "en", name: "Selling", action_button_label: "Buy" },
+            { locale: "fi", name: "Myydään", action_button_label: "Osta" }
+          ],
+
           units: [
             {type: :day},
             {type: :custom, translation_key: 'my.custom.units.translation'}
@@ -23,11 +26,22 @@ describe ListingService::API::Shapes do
         }
       )
 
-      res = shapes.get(community_id: community_id, transaction_type_id: transaction_type.id)
+      expect(create_shape_res.success).to eql(true)
+
+      transaction_type_id = create_shape_res.data[:transaction_type_id]
+
+      res = shapes.get(community_id: community_id, transaction_type_id: transaction_type_id)
 
       expect(res.success).to eql(true)
 
-      units = res.data[:units]
+      shape = res.data
+
+      expect(shape[:community_id]).to eql(community_id)
+      expect(shape[:price_enabled]).to eql(true)
+      expect(shape[:transaction_process_id]).to eql(transaction_process_id)
+      expect(shape[:transaction_type_id]).to be_a(Fixnum)
+
+      units = shape[:units]
 
       expect(units[0][:type]).to eql(:day)
       expect(units[1][:type]).to eql(:custom)

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require 'spec_helper'
+
 describe ListingService::API::Shapes do
 
   let(:shapes) { ListingService::API::Api.shapes }
@@ -6,48 +8,154 @@ describe ListingService::API::Shapes do
   let(:transaction_process_id) { 555 }
 
   describe "#create" do
-    it "creates new listing shape" do
-      create_shape_res = shapes.create(
-        community_id: community_id,
-        opts: {
-          price_enabled: true,
-          transaction_process_id: transaction_process_id,
-          shipping_enabled: true,
+    context "success" do
+      it "creates new listing shape with day unit" do
+        create_shape_res = shapes.create(
+          community_id: community_id,
+          opts: {
+            price_enabled: true,
+            shipping_enabled: true,
+            transaction_process_id: transaction_process_id,
 
-          # TODO Move these to translation service
-          translations: [
-            { locale: "en", name: "Selling", action_button_label: "Buy" },
-            { locale: "fi", name: "Myydään", action_button_label: "Osta" }
-          ],
+            # TODO Move these to translation service
+            translations: [
+              { locale: "en", name: "Selling", action_button_label: "Buy" },
+              { locale: "fi", name: "Myydään", action_button_label: "Osta" }
+            ],
 
-          units: [
-            {type: :day},
-            {type: :custom, translation_key: 'my.custom.units.translation'}
-          ]
+            units: [
+              {type: :day},
+              # TODO Enable me {type: :custom, translation_key: 'my.custom.units.translation'}
+            ]
+          }
+        )
+
+        expect(create_shape_res.success).to eql(true)
+
+        transaction_type_id = create_shape_res.data[:transaction_type_id]
+
+        res = shapes.get(community_id: community_id, transaction_type_id: transaction_type_id)
+
+        expect(res.success).to eql(true)
+
+        shape = res.data
+
+        expect(shape[:community_id]).to eql(community_id)
+        expect(shape[:price_enabled]).to eql(true)
+        expect(shape[:shipping_enabled]).to eql(true)
+        expect(shape[:transaction_process_id]).to eql(transaction_process_id)
+        expect(shape[:transaction_type_id]).to be_a(Fixnum)
+
+        units = shape[:units]
+
+        expect(units[0][:type]).to eql(:day)
+        # TODO Enable me expect(units[1][:type]).to eql(:custom)
+        # TODO Enable me expect(units[1][:translation_key]).to eql('my.custom.units.translation')
+
+        # TODO Remove this in the future.
+        # Currently also TransactionType is saved
+        tt = TransactionType.find(shape[:transaction_type_id])
+        expect(tt.community_id).to eql(community_id)
+        expect(tt.price_field?).to eql(true)
+        expect(tt.shipping_enabled?).to eql(true)
+        expect(tt.transaction_process_id).to eql(transaction_process_id)
+        expect(tt.price_per).to eql("day")
+      end
+
+      it "creates new listing shape with piece unit" do
+        create_shape_res = shapes.create(
+          community_id: community_id,
+          opts: {
+            price_enabled: true,
+            transaction_process_id: transaction_process_id,
+            shipping_enabled: true,
+
+            # TODO Move these to translation service
+            translations: [
+              { locale: "en", name: "Selling", action_button_label: "Buy" },
+              { locale: "fi", name: "Myydään", action_button_label: "Osta" }
+            ],
+
+            units: [
+              {type: :piece},
+              # TODO Enable me {type: :custom, translation_key: 'my.custom.units.translation'}
+            ]
+          }
+        )
+
+        expect(create_shape_res.success).to eql(true)
+
+        transaction_type_id = create_shape_res.data[:transaction_type_id]
+
+        res = shapes.get(community_id: community_id, transaction_type_id: transaction_type_id)
+
+        expect(res.success).to eql(true)
+
+        shape = res.data
+
+        expect(shape[:community_id]).to eql(community_id)
+        expect(shape[:price_enabled]).to eql(true)
+        expect(shape[:shipping_enabled]).to eql(true)
+        expect(shape[:transaction_process_id]).to eql(transaction_process_id)
+        expect(shape[:transaction_type_id]).to be_a(Fixnum)
+
+        units = shape[:units]
+
+        expect(units[0][:type]).to eql(:piece)
+        # TODO Enable me expect(units[1][:type]).to eql(:custom)
+        # TODO Enable me expect(units[1][:translation_key]).to eql('my.custom.units.translation')
+
+        # TODO Remove this in the future.
+        # Currently also TransactionType is saved
+        tt = TransactionType.find(shape[:transaction_type_id])
+        expect(tt.community_id).to eql(community_id)
+        expect(tt.price_field?).to eql(true)
+        expect(tt.shipping_enabled?).to eql(true)
+        expect(tt.transaction_process_id).to eql(transaction_process_id)
+        expect(tt.price_per).to eql(nil)
+      end
+    end
+
+    context "failure" do
+      it "does not let user to create new listing shape without price but with units" do
+        shape_opts = {
+          community_id: community_id,
+          opts: {
+            price_enabled: false,
+            transaction_process_id: transaction_process_id,
+
+            # TODO Move these to translation service
+            translations: [
+              { locale: "en", name: "Selling", action_button_label: "Buy" },
+              { locale: "fi", name: "Myydään", action_button_label: "Osta" }
+            ],
+
+            units: [
+              {type: :piece}
+            ]
+          }
         }
-      )
 
-      expect(create_shape_res.success).to eql(true)
+        expect { shapes.create(shape_opts) }.to raise_error(ArgumentError)
+      end
 
-      transaction_type_id = create_shape_res.data[:transaction_type_id]
+      it "does not let user to create new listing shape with price but without units" do
+        shape_opts = {
+          community_id: community_id,
+          opts: {
+            price_enabled: true,
+            transaction_process_id: transaction_process_id,
 
-      res = shapes.get(community_id: community_id, transaction_type_id: transaction_type_id)
+            # TODO Move these to translation service
+            translations: [
+              { locale: "en", name: "Selling", action_button_label: "Buy" },
+              { locale: "fi", name: "Myydään", action_button_label: "Osta" }
+            ]
+          }
+        }
 
-      expect(res.success).to eql(true)
-
-      shape = res.data
-
-      expect(shape[:community_id]).to eql(community_id)
-      expect(shape[:price_enabled]).to eql(true)
-      expect(shape[:shipping_enabled]).to eql(true)
-      expect(shape[:transaction_process_id]).to eql(transaction_process_id)
-      expect(shape[:transaction_type_id]).to be_a(Fixnum)
-
-      units = shape[:units]
-
-      expect(units[0][:type]).to eql(:day)
-      expect(units[1][:type]).to eql(:custom)
-      expect(units[1][:translation_key]).to eql('my.custom.units.translation')
+        expect { shapes.create(shape_opts) }.to raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -154,26 +154,6 @@ describe ListingService::API::Shapes do
 
         expect { shapes.create(shape_opts) }.to raise_error(ArgumentError)
       end
-
-      it "does not let user to create new listing shape with price but without units" do
-        shape_opts = {
-          community_id: community_id,
-          opts: {
-            price_enabled: true,
-            transaction_process_id: transaction_process_id,
-            name_tr_key: name_tr_key,
-            action_button_tr_key: action_button_tr_key,
-
-            # TODO Remove these
-            translations: [
-              { locale: "en", name: "Selling", action_button_label: "Buy" },
-              { locale: "fi", name: "Myydään", action_button_label: "Osta" }
-            ]
-          }
-        }
-
-        expect { shapes.create(shape_opts) }.to raise_error(ArgumentError)
-      end
     end
   end
 end

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -6,6 +6,8 @@ describe ListingService::API::Shapes do
   let(:shapes) { ListingService::API::Api.shapes }
   let(:community_id) { FactoryGirl.create(:community).id }
   let(:transaction_process_id) { 555 }
+  let(:name_tr_key) { "listing_shape.name.123.translation" }
+  let(:action_button_tr_key) { "listing_shape.action_button.123.translation" }
 
   describe "#create" do
     context "success" do
@@ -16,6 +18,8 @@ describe ListingService::API::Shapes do
             price_enabled: true,
             shipping_enabled: true,
             transaction_process_id: transaction_process_id,
+            name_tr_key: name_tr_key,
+            action_button_tr_key: action_button_tr_key,
 
             # TODO Move these to translation service
             translations: [
@@ -45,6 +49,8 @@ describe ListingService::API::Shapes do
         expect(shape[:shipping_enabled]).to eql(true)
         expect(shape[:transaction_process_id]).to eql(transaction_process_id)
         expect(shape[:transaction_type_id]).to be_a(Fixnum)
+        expect(shape[:name_tr_key]).to eql(name_tr_key)
+        expect(shape[:action_button_tr_key]).to eql(action_button_tr_key)
 
         units = shape[:units]
 
@@ -60,6 +66,8 @@ describe ListingService::API::Shapes do
         expect(tt.shipping_enabled?).to eql(true)
         expect(tt.transaction_process_id).to eql(transaction_process_id)
         expect(tt.price_per).to eql("day")
+        expect(tt.name_tr_key).to eql(name_tr_key)
+        expect(tt.action_button_tr_key).to eql(action_button_tr_key)
       end
 
       it "creates new listing shape with piece unit" do
@@ -68,6 +76,8 @@ describe ListingService::API::Shapes do
           opts: {
             price_enabled: true,
             transaction_process_id: transaction_process_id,
+            name_tr_key: name_tr_key,
+            action_button_tr_key: action_button_tr_key,
             shipping_enabled: true,
 
             # TODO Move these to translation service
@@ -98,6 +108,8 @@ describe ListingService::API::Shapes do
         expect(shape[:shipping_enabled]).to eql(true)
         expect(shape[:transaction_process_id]).to eql(transaction_process_id)
         expect(shape[:transaction_type_id]).to be_a(Fixnum)
+        expect(shape[:name_tr_key]).to eql(name_tr_key)
+        expect(shape[:action_button_tr_key]).to eql(action_button_tr_key)
 
         units = shape[:units]
 
@@ -113,6 +125,8 @@ describe ListingService::API::Shapes do
         expect(tt.shipping_enabled?).to eql(true)
         expect(tt.transaction_process_id).to eql(transaction_process_id)
         expect(tt.price_per).to eql(nil)
+        expect(tt.name_tr_key).to eql(name_tr_key)
+        expect(tt.action_button_tr_key).to eql(action_button_tr_key)
       end
     end
 
@@ -123,8 +137,10 @@ describe ListingService::API::Shapes do
           opts: {
             price_enabled: false,
             transaction_process_id: transaction_process_id,
+            name_tr_key: name_tr_key,
+            action_button_tr_key: action_button_tr_key,
 
-            # TODO Move these to translation service
+            # TODO Remove these
             translations: [
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }
@@ -145,8 +161,10 @@ describe ListingService::API::Shapes do
           opts: {
             price_enabled: true,
             transaction_process_id: transaction_process_id,
+            name_tr_key: name_tr_key,
+            action_button_tr_key: action_button_tr_key,
 
-            # TODO Move these to translation service
+            # TODO Remove these
             translations: [
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -129,31 +129,5 @@ describe ListingService::API::Shapes do
         expect(tt.action_button_tr_key).to eql(action_button_tr_key)
       end
     end
-
-    context "failure" do
-      it "does not let user to create new listing shape without price but with units" do
-        shape_opts = {
-          community_id: community_id,
-          opts: {
-            price_enabled: false,
-            transaction_process_id: transaction_process_id,
-            name_tr_key: name_tr_key,
-            action_button_tr_key: action_button_tr_key,
-
-            # TODO Remove these
-            translations: [
-              { locale: "en", name: "Selling", action_button_label: "Buy" },
-              { locale: "fi", name: "Myydään", action_button_label: "Osta" }
-            ],
-
-            units: [
-              {type: :piece}
-            ]
-          }
-        }
-
-        expect { shapes.create(shape_opts) }.to raise_error(ArgumentError)
-      end
-    end
   end
 end

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -61,25 +61,38 @@ module TestHelpers
 
       # Load transaction types
       transaction_types.each do |type, translations|
-        default_type_opts = TransactionTypeCreator::DEFAULTS[type.to_s]
+        defaults = TransactionTypeCreator::DEFAULTS[type.to_s]
 
-        type_opts = default_type_opts.merge(
-          transaction_process_id: processes[:none])
-
-        transaction_type = community.transaction_types.build(type_opts)
-
-        community.locales.each do |locale|
+        translations = community.locales.map do |locale|
           translation = translations[locale.to_sym]
 
-          if translation then
-            tt_name = translation[:name]
-            tt_action = translation[:action_button_label]
-            transaction_type.translations.build(:locale => locale, :name => tt_name, :action_button_label => tt_action)
+          if translation
+            {
+              locale: locale,
+              name: translation[:name],
+              action_button_label: translation[:action_button_label]
+            }
           end
-        end
+        end.compact
 
-        transaction_type.save!
+        shape_opts = defaults.merge(
+          transaction_process_id: processes[:none],
+          translations: translations,
+          shipping_enabled: false
+        )
+
+        shapes_api = ListingService::API::Api.shapes
+
+        shape_res = shapes_api.create(
+          community_id: community.id,
+          opts: shape_opts
+        )
+
+        raise ArgumentError.new("Could not create new shape: #{shape_opts}") unless shape_res.success
       end
+
+      # Community has now new transaction types, so we must reload it
+      community.reload
 
       # Load categories
       categories.each do |c|

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -77,6 +77,8 @@ module TestHelpers
 
         shape_opts = defaults.merge(
           transaction_process_id: processes[:none],
+          name_tr_key: 'something.here',
+          action_button_tr_key: 'something.here',
           translations: translations,
           shipping_enabled: false
         )


### PR DESCRIPTION
## Move transaction_type 'create' behind ListingShape API

- [X] TransactionTypeCreator
- [X] Helper modules test state initializers
- [X] Factories test state initializers


## Move price_per to units

Move price_per to units table. Nothing new yet. Make sure the existing booking feature works without issues

### Deploy 1 [10/10]

- [X] Add units table
- [X] Add units Model
- [X] Write ListingShape API doc draft
- [X] Add ListingShape API and Store
- [X] Save price per to old transaction types
- [X] Save 'price_per' 'day' value to units table (unit_type: day)
- [X] Save 'price_per' NULL values to units table (unit_type: price) if price enabled
- [X] Validation: must have units if price enabled
- [X] Migrate old data from 'price_per' column to units

### Deploy 2 [0/1]

- [ ] Read from 'units' table

### Deploy 3 [0/2]

- [ ] Don't save new data to 'price_per' column
- [ ] Make TransactionType to reject 'price_per' column
