### PR TITLE
Remove read from transaction_type_translations

### DIFF
--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -31,7 +31,8 @@ class TransactionType < ActiveRecord::Base
     :transaction_process_id,
     :shipping_enabled,
     :name_tr_key,
-    :action_button_tr_key
+    :action_button_tr_key,
+    :url
   )
 
   belongs_to :community
@@ -43,9 +44,6 @@ class TransactionType < ActiveRecord::Base
   has_many :listing_units
 
   validates_presence_of :community
-
-  before_save :uniq_url
-
 
   # TODO this can be removed
   def self.columns
@@ -59,35 +57,6 @@ class TransactionType < ActiveRecord::Base
 
   def to_param
     url
-  end
-
-  def url_source
-    Maybe(default_translation_without_cache).name.or_else(nil).tap { |translation|
-      raise ArgumentError.new("Can not create URL for transaction type. Expected transaction type to have translation") if translation.nil?
-    }
-  end
-
-  def default_translation_without_cache
-    (translations.find { |translation| translation.locale == community.default_locale } || translations.first)
-  end
-
-  # TODO this should be done on service layer
-  def uniq_url
-    current_url = url_source.to_url
-
-    if new_record? || url != current_url
-      blacklist = ['new', 'all']
-      base_url = current_url
-      transaction_types = TransactionType.where(community_id: community_id)
-
-      i = 1
-      while blacklist.include?(current_url) || transaction_types.find { |tt| tt.url == current_url && tt.id != id }.present? do
-        current_url = "#{base_url}#{i}"
-        i += 1
-      end
-      self.url = current_url
-    end
-
   end
 
   def display_name(locale)

--- a/app/services/listing_service/store/shape.rb
+++ b/app/services/listing_service/store/shape.rb
@@ -11,7 +11,8 @@ module ListingService::Store::Shape
     [:transaction_process_id, :fixnum, :mandatory],
     [:translations, :array, :optional], # TODO Only temporary
     [:shipping_enabled, :bool, :mandatory],
-    [:units, :array, default: []] # Mandatory only if price_enabled
+    [:units, :array, default: []], # Mandatory only if price_enabled
+    [:url_source, :string, :mandatory]
   )
 
   Shape = EntityUtils.define_builder(
@@ -170,5 +171,22 @@ module ListingService::Store::Shape
       raise ArgumentError.new("Can not find listing shape without id.")
     end
   end
+
+  def uniq_url(url_source, community_id)
+    blacklist = ['new', 'all']
+    current_url = url_source.to_url
+    base_url = current_url
+
+    transaction_types = TransactionTypeModel.where(community_id: community_id)
+
+    i = 1
+    while blacklist.include?(current_url) || transaction_types.find { |tt| tt.url == current_url }.present? do
+      current_url = "#{base_url}#{i}"
+      i += 1
+    end
+    current_url
+
+  end
+
 
 end

--- a/app/services/listing_service/store/shape.rb
+++ b/app/services/listing_service/store/shape.rb
@@ -70,7 +70,10 @@ module ListingService::Store::Shape
       # TODO We should be able to create transaction_type without community
       community = Community.find(shape[:community_id])
 
-      create_tt_opts = to_tt_model_attributes(shape).except(:units, :translations)
+      url = uniq_url(shape[:url_source], shape[:community_id])
+      shape_with_url = shape.except(:url_source).merge(url: url)
+
+      create_tt_opts = to_tt_model_attributes(shape_with_url).except(:units, :translations)
       tt_model = community.transaction_types.build(create_tt_opts)
 
       units.each { |unit|

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -143,7 +143,8 @@ module TransactionTypeCreator
       name_tr_key: name_tr_key,
       action_button_tr_key: action_button_tr_key,
       translations: translations,
-      shipping_enabled: enable_shipping
+      shipping_enabled: enable_shipping,
+      url_source: translations.find { |t| t[:locale] == community.default_locale }[:name]
     )
 
     shape_res = listings_api.shapes.create(

--- a/features/communities/user_sees_available_locales.feature
+++ b/features/communities/user_sees_available_locales.feature
@@ -7,8 +7,8 @@ Feature: User sees available locales
   Scenario: User comes to multiple locale community
     Given the test community has following available locales:
       | locale |
-      | fi |
       | en |
+      | fi |
     When I am on the home page
     And I open language menu
     Then I should see "English" on the language menu

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -18,6 +18,11 @@ module CommunitySteps
       TransactionProcess.find(tt.transaction_process_id).update_attribute(:process, :postpay)
     }
   end
+
+  def save_name_and_action(community_id, groups)
+    created_translations = TranslationService::API::Api.translations.create(community_id, groups)
+    created_translations[:data].map { |translation| translation[:translation_key] }
+  end
 end
 
 World(CommunitySteps)
@@ -175,18 +180,24 @@ Given /^community "(.*?)" has following transaction types enabled:$/ do |communi
   process_id = TransactionProcess.where(community_id: current_community.id, process: :none).first.id
 
   transaction_types.hashes.map do |hash|
+    name_tr_key, action_button_tr_key = save_name_and_action(current_community.id, [
+      {translations: [ {locale: 'fi', translation: hash['fi']}, {locale: 'en', translation: hash['en']} ]},
+      {translations: [ {locale: 'fi', translation: (hash['button'] || 'Action')}, {locale: 'en', translation: (hash['button'] || 'Action')} ]}
+    ])
+
     ListingService::API::Api.shapes.create(
       community_id: current_community.id,
       opts: {
         price_enabled: true,
         shipping_enabled: false,
-        name_tr_key: 'something.here',
-        action_button_tr_key: 'something.here',
+        name_tr_key: name_tr_key,
+        action_button_tr_key: action_button_tr_key,
         transaction_process_id: process_id,
         translations: [
           {name: hash['fi'], action_button_label: (hash['button'] || "Action"), locale: 'fi'},
           {name: hash['en'], action_button_label: (hash['button'] || "Action"), locale: 'en'}
         ],
+        url_source: hash['en'],
         units: [ {type: :piece} ]
       }
     )
@@ -199,15 +210,21 @@ Given /^the community has transaction type Rent with name "(.*?)" and action but
   process_id = TransactionProcess.where(community_id: @current_community.id, process: [:preauthorize, :postpay]).first.id
   defaults = TransactionTypeCreator::DEFAULTS["Rent"]
 
+  name_tr_key, action_button_tr_key = save_name_and_action(@current_community.id, [
+    {translations: [{locale: "en", translation: name}]},
+    {translations: [{locale: "en", translation: (action_button_label || "Action")}]}
+  ])
+
   shape_res = ListingService::API::Api.shapes.create(
     community_id: @current_community.id,
     opts: {
       price_enabled: true,
       shipping_enabled: false,
-      name_tr_key: 'something.here',
-      action_button_tr_key: 'something.here',
+      name_tr_key: name_tr_key,
+      action_button_tr_key: action_button_tr_key,
       transaction_process_id: process_id,
       translations: [ {locale: "en", name: name, action_button_label: action_button_label} ],
+      url_source: name,
       units: [ {type: :day} ]
     }
   )
@@ -219,15 +236,21 @@ Given /^the community has transaction type Sell with name "(.*?)" and action but
   process_id = TransactionProcess.where(community_id: @current_community.id, process: [:preauthorize, :postpay]).first.id
   defaults = TransactionTypeCreator::DEFAULTS["Sell"]
 
+  name_tr_key, action_button_tr_key = save_name_and_action(@current_community.id, [
+    {translations: [{locale: "en", translation: name}]},
+    {translations: [{locale: "en", translation: (action_button_label || "Action")}]}
+  ])
+
   shape_res = ListingService::API::Api.shapes.create(
     community_id: @current_community.id,
     opts: {
       price_enabled: true,
       shipping_enabled: false,
-      name_tr_key: 'something.here',
-      action_button_tr_key: 'something.here',
+      name_tr_key: name_tr_key,
+      action_button_tr_key: action_button_tr_key,
       transaction_process_id: process_id,
       translations: [ {locale: "en", name: name, action_button_label: action_button_label} ],
+      url_source: name,
       units: [ {type: :piece} ]
     }
   )

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -22,7 +22,8 @@ describe ListingsController do
         transaction_process_id: process_id,
         name_tr_key: 'something.here',
         action_button_tr_key: 'something.here',
-        translations: translations.concat([{ locale: "en", name: type }])
+        translations: translations.concat([{ locale: "en", name: type }]),
+        url_source: translations.present? ? translations[0][:name] :type
       })
 
     shape = listings_api.shapes.create(community_id: community_id, opts: opts).data

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -16,14 +16,26 @@ describe ListingsController do
 
     defaults = TransactionTypeCreator::DEFAULTS[type]
 
+    # Save name to TranslationService
+    translations_with_default = translations.concat([{ locale: "en", name: type }])
+    name_group = {
+      translations: translations_with_default.map { |translation|
+          { locale: translation[:locale],
+            translation: translation[:name]
+          }
+        }
+      }
+    created_translations = TranslationService::API::Api.translations.create(community_id, [name_group])
+    name_tr_key = created_translations[:data].map { |translation| translation[:translation_key] }.first
+
     opts = defaults.merge(
       {
         shipping_enabled: false,
         transaction_process_id: process_id,
-        name_tr_key: 'something.here',
+        name_tr_key: name_tr_key,
         action_button_tr_key: 'something.here',
-        translations: translations.concat([{ locale: "en", name: type }]),
-        url_source: translations.present? ? translations[0][:name] :type
+        translations: translations_with_default,
+        url_source: Maybe(translations).first[:name].or_else(type)
       })
 
     shape = listings_api.shapes.create(community_id: community_id, opts: opts).data

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -125,7 +125,8 @@ FactoryGirl.define do
           translations: [
             { locale: "en", name: "Selling" }
           ],
-          units: [ {type: :piece} ]
+          units: [ {type: :piece} ],
+          url_source: "Selling"
         }
       ).data[:transaction_type_id])
     }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,16 +111,23 @@ FactoryGirl.define do
       FactoryGirl.build(:community)
     end
     transaction_type {
+
+      community = communities.first || FactoryGirl.create(:community)
+      # Save name to TranslationService
+      name_group = { translations: [ { locale: "en", translation: "Selling" } ] }
+      created_translations = TranslationService::API::Api.translations.create(community.id, [name_group])
+      name_tr_key = created_translations[:data].map { |translation| translation[:translation_key] }.first
+
       TransactionType.find(
         ListingService::API::Api.shapes.create(
         # If community is not given, this will create a new one which differs from the community of the listing.
         # That's an error, but tests seem to pass
-        community_id: (communities.first || FactoryGirl.create(:community)).id,
+        community_id: community.id,
         opts: {
           price_enabled: true,
           shipping_enabled: false,
           transaction_process_id: 12345,
-          name_tr_key: "something.here",
+          name_tr_key: name_tr_key,
           action_button_tr_key: "something.here",
           translations: [
             { locale: "en", name: "Selling" }

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -149,7 +149,7 @@ describe ListingService::API::Shapes do
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }
             ],
-
+            url_source: "Selling",
             units: []
           }
         ).data[:transaction_type_id]

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -26,6 +26,7 @@ describe ListingService::API::Shapes do
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }
             ],
+            url_source: "Selling",
 
             units: [
               {type: :day},
@@ -67,6 +68,7 @@ describe ListingService::API::Shapes do
         expect(tt.transaction_process_id).to eql(transaction_process_id)
         expect(tt.name_tr_key).to eql(name_tr_key)
         expect(tt.action_button_tr_key).to eql(action_button_tr_key)
+        expect(tt.url).to eql("selling")
       end
 
       it "creates new listing shape with piece unit" do
@@ -84,6 +86,7 @@ describe ListingService::API::Shapes do
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }
             ],
+            url_source: "Selling",
 
             units: [
               {type: :piece},
@@ -189,6 +192,7 @@ describe ListingService::API::Shapes do
         expect(tt.transaction_process_id).to eql(transaction_process_id)
         expect(tt.name_tr_key).to eql(name_tr_key)
         expect(tt.action_button_tr_key).to eql(action_button_tr_key)
+        expect(tt.url).to eql("selling")
       end
     end
 

--- a/spec/services/translation_service/api/translation_spec.rb
+++ b/spec/services/translation_service/api/translation_spec.rb
@@ -3,7 +3,7 @@ describe TranslationService::API::Translations do
   TranslationsAPI = TranslationService::API::Api.translations
 
   before(:each) do
-    @community_id = 1
+    @community_id = 88 # cucumber loads test data for existing test communities
     @translation_key1 = "027268a5-abbf-4191-b6bd-b1e7569b361f"
     @translation_key2 = "blaa-blaa-blaa"
     @locale_en = "en"

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -26,7 +26,7 @@ module TestHelpers
       },
       Service: {
         en: {
-          name: "Selling services", action_button_label: ""
+          name: "Selling services", action_button_label: "Offer"
         }
       }
     }
@@ -63,6 +63,21 @@ module TestHelpers
       transaction_types.each do |type, translations|
         defaults = TransactionTypeCreator::DEFAULTS[type.to_s]
 
+        name_group = {
+          translations: community.locales.map do |locale|
+            translation = translations[locale.to_sym]
+            {locale: locale, translation: translation[:name]} unless translation.blank?
+          end.compact
+        }
+        ab_group = {
+          translations: community.locales.map do |locale|
+            translation = translations[locale.to_sym]
+            {locale: locale, translation: translation[:action_button_label]} unless translation.blank?
+          end.compact
+        }
+        created_translations = TranslationService::API::Api.translations.create(community.id, [name_group, ab_group])
+        name_tr_key, action_button_tr_key = created_translations[:data].map { |translation| translation[:translation_key] }
+
         translations = community.locales.map do |locale|
           translation = translations[locale.to_sym]
 
@@ -79,9 +94,9 @@ module TestHelpers
 
         shape_opts = defaults.merge(
           transaction_process_id: processes[:none],
-          name_tr_key: 'something.here',
-          action_button_tr_key: 'something.here',
           translations: translations,
+          name_tr_key: name_tr_key,
+          action_button_tr_key: action_button_tr_key,
           shipping_enabled: false,
           url_source: url_source
         )

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -75,12 +75,15 @@ module TestHelpers
           end
         end.compact
 
+        url_source = translations.find{ |t| t[:locale] == community.default_locale }[:name]
+
         shape_opts = defaults.merge(
           transaction_process_id: processes[:none],
           name_tr_key: 'something.here',
           action_button_tr_key: 'something.here',
           translations: translations,
-          shipping_enabled: false
+          shipping_enabled: false,
+          url_source: url_source
         )
 
         listings_api = ListingService::API::Api


### PR DESCRIPTION
- "uniq_url" creation happens now in listing service
- "display_name" and "action_button_label" (in transaction_type.rb) read data now from TranslationService