### PR TITLE
Use tr service for tx type

### DIFF
--- a/app/services/listing_service/store/shape.rb
+++ b/app/services/listing_service/store/shape.rb
@@ -11,7 +11,8 @@ module ListingService::Store::Shape
     [:transaction_process_id, :fixnum, :mandatory],
     [:translations, :array, :optional], # TODO Only temporary
     [:shipping_enabled, :bool, :mandatory],
-    [:units, :array, default: []] # Mandatory only if price_enabled
+    [:units, :array, default: []], # Mandatory only if price_enabled
+    [:url_source, :string, :mandatory]
   )
 
   Shape = EntityUtils.define_builder(
@@ -69,7 +70,10 @@ module ListingService::Store::Shape
       # TODO We should be able to create transaction_type without community
       community = Community.find(shape[:community_id])
 
-      create_tt_opts = to_tt_model_attributes(shape).except(:units, :translations)
+      url = uniq_url(shape[:url_source], shape[:community_id])
+      shape_with_url = shape.except(:url_source).merge(url: url)
+
+      create_tt_opts = to_tt_model_attributes(shape_with_url).except(:units, :translations)
       tt_model = community.transaction_types.build(create_tt_opts)
 
       units.each { |unit|
@@ -170,5 +174,22 @@ module ListingService::Store::Shape
       raise ArgumentError.new("Can not find listing shape without id.")
     end
   end
+
+  def uniq_url(url_source, community_id)
+    blacklist = ['new', 'all']
+    current_url = url_source.to_url
+    base_url = current_url
+
+    transaction_types = TransactionTypeModel.where(community_id: community_id)
+
+    i = 1
+    while blacklist.include?(current_url) || transaction_types.find { |tt| tt.url == current_url }.present? do
+      current_url = "#{base_url}#{i}"
+      i += 1
+    end
+    current_url
+
+  end
+
 
 end

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -143,7 +143,8 @@ module TransactionTypeCreator
       name_tr_key: name_tr_key,
       action_button_tr_key: action_button_tr_key,
       translations: translations,
-      shipping_enabled: enable_shipping
+      shipping_enabled: enable_shipping,
+      url_source: translations.find { |t| t[:locale] == community.default_locale }[:name]
     )
 
     shape_res = listings_api.shapes.create(

--- a/app/services/translation_service/api/translations.rb
+++ b/app/services/translation_service/api/translations.rb
@@ -2,7 +2,9 @@ module TranslationService::API
 
   class Translations
 
-    TranslationStore = TranslationService::Store::Translation
+    def initialize
+      @store = TranslationService::Store::Translation::CachedTranslationStore.new
+    end
 
 
     ## GET /translations/:community_id/
@@ -10,7 +12,7 @@ module TranslationService::API
       params = TranslationService::DataTypes::Translation
         .validate_find_params(request_params)
 
-      Result::Success.new(TranslationStore.get({
+      Result::Success.new(@store.get({
                             community_id: community_id
                             }.merge(params)))
     end
@@ -26,7 +28,7 @@ module TranslationService::API
       groups = TranslationService::DataTypes::Translation
         .validate_translation_groups({translation_groups: translation_groups})
 
-      Result::Success.new(TranslationStore.create({
+      Result::Success.new(@store.create({
                             community_id: community_id,
                             translation_groups: groups[:translation_groups]
                           }))
@@ -45,7 +47,7 @@ module TranslationService::API
       params = TranslationService::DataTypes::Translation
         .validate_delete_params(translation_keys: translation_keys)
 
-      Result::Success.new(TranslationStore.delete({
+      Result::Success.new(@store.delete({
                             community_id: community_id
                             }.merge(params)))
 

--- a/app/services/translation_service/store/translation.rb
+++ b/app/services/translation_service/store/translation.rb
@@ -7,213 +7,240 @@ module TranslationService::Store::Translation
     [:locale, :mandatory, :string],
     [:translation])
 
-
   module_function
 
-  # Create translations
-  # Format for translation_groups:
-  # [ { translation_key: nil // optional key - if defined it will override previous translations
-  #   , translations:
-  #     [ { locale: "en-US"
-  #       , translation: "Welcome"
-  #       }
-  #     , { locale: "fi-FI"
-  #       , translation: "Tervetuloa"
-  #       }
-  #     ]
-  #   }
-  # ]
-  def create(community_id:, translation_groups: [])
+  class CachedTranslationStore
 
-    translation_groups
-      .map { |group|
-        key = Maybe(group[:translation_key]).or_else(gen_translation_uuid(community_id))
+    def initialize
+      @local_cache = {}
+    end
 
-        translations = group[:translations]
-          .map { |translation|
+    # Create translations
+    # Format for translation_groups:
+    # [ { translation_key: nil // optional key - if defined it will override previous translations
+    #   , translations:
+    #     [ { locale: "en-US"
+    #       , translation: "Welcome"
+    #       }
+    #     , { locale: "fi-FI"
+    #       , translation: "Tervetuloa"
+    #       }
+    #     ]
+    #   }
+    # ]
+    def create(community_id:, translation_groups: [])
+      created_translations = translation_groups
+        .map { |group|
+          key = Maybe(group[:translation_key]).or_else(gen_translation_uuid(community_id))
 
-            translation_hash = {
-              community_id: community_id,
-              translation_key: key,
-              locale: translation[:locale],
-              translation: translation[:translation]
+          translations = group[:translations]
+            .map { |translation|
+
+              translation_hash = {
+                community_id: community_id,
+                translation_key: key,
+                locale: translation[:locale],
+                translation: translation[:translation]
+              }
+              save_translation(translation_hash)
             }
-            save_translation(translation_hash)
+
+          { translation_key: key,
+            translations: translations
           }
-
-        { translation_key: key,
-          translations: translations
         }
-      }
-  end
 
-  # Get translations
-  # Format for params:
-  # {community_id: 1, translation_keys: ["aa", "bb", "cc"], locales: ["en", "fi-FI", "sv-SE"], fallback_locale: "en"}
-  def get(community_id:, translation_keys: [], locales: [], fallback_locale:nil)
-
-    # add missing values if we know what values are expected
-    if locales.present?
-      locales_with_fallback = locales | [fallback_locale] if fallback_locale.present?
-      translations = get_translations(get_search_hash(community_id, translation_keys, locales_with_fallback))
-      fill_in_delta(translations, translation_keys, locales, fallback_locale)
-    else
-      get_translations(get_search_hash(community_id, translation_keys, locales))
+      invalidate_cache(community_id)
+      created_translations
     end
 
-  end
+    # Get translations
+    # Format for params:
+    # {community_id: 1, translation_keys: ["aa", "bb", "cc"], locales: ["en", "fi-FI", "sv-SE"], fallback_locale: "en"}
+    def get(community_id:, translation_keys: [], locales: [], fallback_locale:nil)
 
-  # Delete translations
-  # Format for params:
-  # {community_id: 1, translation_keys: ["aa", "bb", "cc"]}
-  def delete(community_id:, translation_keys: [])
-    Maybe(CommunityTranslationModel
-        .where(community_id: community_id, translation_key: translation_keys)
-      )
-      .map { |models|
-        models.map { |model|
-          hash = from_model(model)
-          model.destroy
-          hash
-        }
-      }
-      .or_else([])
-  end
-
-
-  # Privates
-
-  def gen_translation_uuid(community_id)
-    SecureRandom.uuid
-  end
-
-  def get_translations(options)
-    options.assert_valid_keys(:community_id, :translation_key, :locale)
-    Maybe(CommunityTranslationModel
-        .where(options)
-        .order("translation_key ASC")
-      )
-      .map { |models|
-        from_model_array(models)
-      }
-      .or_else([])
-  end
-
-  def create_translation(options)
-    options.assert_valid_keys(:community_id, :translation_key, :locale, :translation)
-    from_model(CommunityTranslationModel.create!(options))
-  end
-
-  def update_translation(options)
-    options.assert_valid_keys(:id, :translation)
-    from_model(CommunityTranslationModel.update(options[:id], options.slice(:translation)))
-  end
-
-  def save_translation(options)
-    options.assert_valid_keys(:community_id, :translation_key, :locale, :translation)
-
-    existing_translation = CommunityTranslationModel
-      .where(options.slice(:community_id, :translation_key, :locale))
-      .first
-
-    if existing_translation.present?
-      update_translation(id: existing_translation.id, translation: options[:translation])
-    else
-      create_translation(options.slice(:community_id, :translation_key, :locale, :translation))
-    end
-
-  end
-
-  def get_search_hash(community_id, translation_keys, locales)
-    search_hash = { community_id: community_id }
-
-    if translation_keys.present? && translation_keys.kind_of?(Array)
-      search_hash.merge!(translation_key: translation_keys)
-    end
-
-    if locales.present? && locales.kind_of?(Array)
-      search_hash.merge!(locale: locales)
-    end
-    search_hash
-  end
-
-  # if translation_hash does not include all combinations, add them
-  def fill_in_delta(translations_hash, translation_keys, locales, fallback_locale)
-
-    keys =
-      if translation_keys.present?
-        translation_keys
+      # add missing values if we know what values are expected
+      if locales.present?
+        locales_with_fallback = locales | [fallback_locale] if fallback_locale.present?
+        translations = get_translations(get_search_hash(community_id, translation_keys, locales_with_fallback))
+        fill_in_delta(translations, translation_keys, locales, fallback_locale)
       else
-        translations_hash
-          .map { |translation|
-            translation[:translation_key]
-          }
-          .uniq
+        get_translations(get_search_hash(community_id, translation_keys, locales))
       end
 
-    results = []
-    keys.each { |key|
-      locales.each { |locale|
+    end
 
-        results.push(
-          Maybe(
-            translations_hash.find { |t|
-              t[:translation_key] == key && t[:locale] == locale && !t[:translation].empty?
-            }
+    # Delete translations
+    # Format for params:
+    # {community_id: 1, translation_keys: ["aa", "bb", "cc"]}
+    def delete(community_id:, translation_keys: [])
+      deleted_translations =
+        Maybe(CommunityTranslationModel
+            .where(community_id: community_id, translation_key: translation_keys)
           )
-          .or_else(create_delta_result(translations_hash, key, locale, fallback_locale))
-        )
+          .map { |models|
+            models.map { |model|
+              hash = from_model(model)
+              model.destroy
+              hash
+            }
+          }
+          .or_else([])
+      invalidate_cache(community_id)
+      deleted_translations
+    end
 
+
+    private
+
+    def gen_translation_uuid(community_id)
+      SecureRandom.uuid
+    end
+
+    def get_translations(options)
+      options.assert_valid_keys(:community_id, :translation_keys, :locales)
+      community_translations_cache(options[:community_id])
+        .select { |translation|
+          key_match = Maybe(options[:translation_keys]).map {|keys| keys.include?(translation[:translation_key]) }.or_else(true)
+          locale_match = Maybe(options[:locales]).map { |locales| locales.include?(translation[:locale]) }.or_else(true)
+          key_match && locale_match
+        }
+    end
+
+    def create_translation(options)
+      options.assert_valid_keys(:community_id, :translation_key, :locale, :translation)
+      from_model(CommunityTranslationModel.create!(options))
+    end
+
+    def update_translation(options)
+      options.assert_valid_keys(:id, :translation)
+      from_model(CommunityTranslationModel.update(options[:id], options.slice(:translation)))
+    end
+
+    def save_translation(options)
+      options.assert_valid_keys(:community_id, :translation_key, :locale, :translation)
+
+      existing_translation = CommunityTranslationModel
+        .where(options.slice(:community_id, :translation_key, :locale))
+        .first
+
+      if existing_translation.present?
+        update_translation(id: existing_translation.id, translation: options[:translation])
+      else
+        create_translation(options.slice(:community_id, :translation_key, :locale, :translation))
+      end
+
+    end
+
+    def get_search_hash(community_id, translation_keys, locales)
+      search_hash = { community_id: community_id }
+
+      if translation_keys.present? && translation_keys.kind_of?(Array)
+        search_hash.merge!(translation_keys: translation_keys)
+      end
+
+      if locales.present? && locales.kind_of?(Array)
+        search_hash.merge!(locales: locales)
+      end
+      search_hash
+    end
+
+    # if translation_hash does not include all combinations, add them
+    def fill_in_delta(translations_hash, translation_keys, locales, fallback_locale)
+
+      keys =
+        if translation_keys.present?
+          translation_keys
+        else
+          translations_hash
+            .map { |translation|
+              translation[:translation_key]
+            }
+            .uniq
+        end
+
+      results = []
+      keys.each { |key|
+        locales.each { |locale|
+
+          results.push(
+            Maybe(
+              translations_hash.find { |t|
+                t[:translation_key] == key && t[:locale] == locale && !t[:translation].empty?
+              }
+            )
+            .or_else(create_delta_result(translations_hash, key, locale, fallback_locale))
+          )
+
+        }
       }
-    }
-    results
-  end
+      results
+    end
 
-  def create_delta_result(translations_hash, translation_key, locale, fallback_locale)
-    translations_with_key = translations_hash.select { |t|
-      t[:translation_key] == translation_key && t[:translation].present?
-    }
+    def create_delta_result(translations_hash, translation_key, locale, fallback_locale)
+      translations_with_key = translations_hash.select { |t|
+        t[:translation_key] == translation_key && t[:translation].present?
+      }
 
-    fallback = Maybe(
-      translations_with_key.find { |t|
-        if fallback_locale.present? then t[:locale] == fallback_locale else false end;
-      })
-      .or_else(nil)
+      fallback = Maybe(
+        translations_with_key.find { |t|
+          if fallback_locale.present? then t[:locale] == fallback_locale else false end;
+        })
+        .or_else(nil)
 
-    use_fallback = fallback_locale.present? && fallback.present?
-    Translation.call({
-        translation_key: translation_key,
-        locale: use_fallback ? fallback[:locale] : locale,
-        translation: use_fallback ? fallback[:translation] : nil
-      }).merge(error_message(translations_with_key.present?, use_fallback))
+      use_fallback = fallback_locale.present? && fallback.present?
+      Translation.call({
+          translation_key: translation_key,
+          locale: use_fallback ? fallback[:locale] : locale,
+          translation: use_fallback ? fallback[:translation] : nil
+        }).merge(error_message(translations_with_key.present?, use_fallback))
 
-  end
+    end
 
-  def error_message(has_translations_with_key, use_fallback)
-    if !has_translations_with_key
-      # no translations for requested translation_key
-      { error: :TRANSLATION_KEY_MISSING }
-    elsif !use_fallback
-      # no translation for requested locale
-      { error: :TRANSLATION_LOCALE_MISSING }
-    else
-      # translation has a different locale as a fallback option
-      { warn: :TRANSLATION_LOCALE_MISSING }
+    def error_message(has_translations_with_key, use_fallback)
+      if !has_translations_with_key
+        # no translations for requested translation_key
+        { error: :TRANSLATION_KEY_MISSING }
+      elsif !use_fallback
+        # no translation for requested locale
+        { error: :TRANSLATION_LOCALE_MISSING }
+      else
+        # translation has a different locale as a fallback option
+        { warn: :TRANSLATION_LOCALE_MISSING }
+      end
+    end
+
+    def from_model_array(models)
+      models
+        .map { |model|
+          from_model(model)
+        }
+    end
+
+    def from_model(model)
+      Maybe(model)
+        .map { |m| EntityUtils.model_to_hash(m) }
+        .map { |hash| Translation.call(hash) }
+        .or_else(nil)
+    end
+
+
+    def community_translations_cache(community_id)
+      @local_cache[community_id] ||=
+        Rails.cache.fetch(cache_key(community_id)) do
+          from_model_array(
+            CommunityTranslationModel
+              .where(community_id: community_id))
+        end
+    end
+
+    def cache_key(community_id)
+      "/translation_service/community/#{community_id}"
+    end
+
+    def invalidate_cache(community_id)
+      @local_cache[community_id] = nil
+      Rails.cache.delete(cache_key(community_id))
     end
   end
-
-  def from_model_array(models)
-    models
-      .map { |model|
-        from_model(model)
-      }
-  end
-
-  def from_model(model)
-    Maybe(model)
-      .map { |m| EntityUtils.model_to_hash(m) }
-      .map { |hash| Translation.call(hash) }
-      .or_else(nil)
-  end
-
 end

--- a/app/services/translation_service/store/translation.rb
+++ b/app/services/translation_service/store/translation.rb
@@ -11,10 +11,6 @@ module TranslationService::Store::Translation
 
   class CachedTranslationStore
 
-    def initialize
-      @local_cache = {}
-    end
-
     # Create translations
     # Format for translation_groups:
     # [ { translation_key: nil // optional key - if defined it will override previous translations
@@ -194,7 +190,6 @@ module TranslationService::Store::Translation
           locale: use_fallback ? fallback[:locale] : locale,
           translation: use_fallback ? fallback[:translation] : nil
         }).merge(error_message(translations_with_key.present?, use_fallback))
-
     end
 
     def error_message(has_translations_with_key, use_fallback)
@@ -226,12 +221,11 @@ module TranslationService::Store::Translation
 
 
     def community_translations_cache(community_id)
-      @local_cache[community_id] ||=
-        Rails.cache.fetch(cache_key(community_id)) do
-          from_model_array(
-            CommunityTranslationModel
-              .where(community_id: community_id))
-        end
+      Rails.cache.fetch(cache_key(community_id)) do
+        from_model_array(
+          CommunityTranslationModel
+            .where(community_id: community_id))
+      end
     end
 
     def cache_key(community_id)
@@ -239,7 +233,6 @@ module TranslationService::Store::Translation
     end
 
     def invalidate_cache(community_id)
-      @local_cache[community_id] = nil
       Rails.cache.delete(cache_key(community_id))
     end
   end

--- a/features/communities/user_sees_available_locales.feature
+++ b/features/communities/user_sees_available_locales.feature
@@ -7,8 +7,8 @@ Feature: User sees available locales
   Scenario: User comes to multiple locale community
     Given the test community has following available locales:
       | locale |
-      | fi |
       | en |
+      | fi |
     When I am on the home page
     And I open language menu
     Then I should see "English" on the language menu

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -18,6 +18,11 @@ module CommunitySteps
       TransactionProcess.find(tt.transaction_process_id).update_attribute(:process, :postpay)
     }
   end
+
+  def save_name_and_action(community_id, groups)
+    created_translations = TranslationService::API::Api.translations.create(community_id, groups)
+    created_translations[:data].map { |translation| translation[:translation_key] }
+  end
 end
 
 World(CommunitySteps)
@@ -175,18 +180,24 @@ Given /^community "(.*?)" has following transaction types enabled:$/ do |communi
   process_id = TransactionProcess.where(community_id: current_community.id, process: :none).first.id
 
   transaction_types.hashes.map do |hash|
+    name_tr_key, action_button_tr_key = save_name_and_action(current_community.id, [
+      {translations: [ {locale: 'fi', translation: hash['fi']}, {locale: 'en', translation: hash['en']} ]},
+      {translations: [ {locale: 'fi', translation: (hash['button'] || 'Action')}, {locale: 'en', translation: (hash['button'] || 'Action')} ]}
+    ])
+
     ListingService::API::Api.shapes.create(
       community_id: current_community.id,
       opts: {
         price_enabled: true,
         shipping_enabled: false,
-        name_tr_key: 'something.here',
-        action_button_tr_key: 'something.here',
+        name_tr_key: name_tr_key,
+        action_button_tr_key: action_button_tr_key,
         transaction_process_id: process_id,
         translations: [
           {name: hash['fi'], action_button_label: (hash['button'] || "Action"), locale: 'fi'},
           {name: hash['en'], action_button_label: (hash['button'] || "Action"), locale: 'en'}
         ],
+        url_source: hash['en'],
         units: [ {type: :piece} ]
       }
     )
@@ -199,15 +210,21 @@ Given /^the community has transaction type Rent with name "(.*?)" and action but
   process_id = TransactionProcess.where(community_id: @current_community.id, process: [:preauthorize, :postpay]).first.id
   defaults = TransactionTypeCreator::DEFAULTS["Rent"]
 
+  name_tr_key, action_button_tr_key = save_name_and_action(@current_community.id, [
+    {translations: [{locale: "en", translation: name}]},
+    {translations: [{locale: "en", translation: (action_button_label || "Action")}]}
+  ])
+
   shape_res = ListingService::API::Api.shapes.create(
     community_id: @current_community.id,
     opts: {
       price_enabled: true,
       shipping_enabled: false,
-      name_tr_key: 'something.here',
-      action_button_tr_key: 'something.here',
+      name_tr_key: name_tr_key,
+      action_button_tr_key: action_button_tr_key,
       transaction_process_id: process_id,
       translations: [ {locale: "en", name: name, action_button_label: action_button_label} ],
+      url_source: name,
       units: [ {type: :day} ]
     }
   )
@@ -219,15 +236,21 @@ Given /^the community has transaction type Sell with name "(.*?)" and action but
   process_id = TransactionProcess.where(community_id: @current_community.id, process: [:preauthorize, :postpay]).first.id
   defaults = TransactionTypeCreator::DEFAULTS["Sell"]
 
+  name_tr_key, action_button_tr_key = save_name_and_action(@current_community.id, [
+    {translations: [{locale: "en", translation: name}]},
+    {translations: [{locale: "en", translation: (action_button_label || "Action")}]}
+  ])
+
   shape_res = ListingService::API::Api.shapes.create(
     community_id: @current_community.id,
     opts: {
       price_enabled: true,
       shipping_enabled: false,
-      name_tr_key: 'something.here',
-      action_button_tr_key: 'something.here',
+      name_tr_key: name_tr_key,
+      action_button_tr_key: action_button_tr_key,
       transaction_process_id: process_id,
       translations: [ {locale: "en", name: name, action_button_label: action_button_label} ],
+      url_source: name,
       units: [ {type: :piece} ]
     }
   )

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -16,13 +16,26 @@ describe ListingsController do
 
     defaults = TransactionTypeCreator::DEFAULTS[type]
 
+    # Save name to TranslationService
+    translations_with_default = translations.concat([{ locale: "en", name: type }])
+    name_group = {
+      translations: translations_with_default.map { |translation|
+          { locale: translation[:locale],
+            translation: translation[:name]
+          }
+        }
+      }
+    created_translations = TranslationService::API::Api.translations.create(community_id, [name_group])
+    name_tr_key = created_translations[:data].map { |translation| translation[:translation_key] }.first
+
     opts = defaults.merge(
       {
         shipping_enabled: false,
         transaction_process_id: process_id,
-        name_tr_key: 'something.here',
+        name_tr_key: name_tr_key,
         action_button_tr_key: 'something.here',
-        translations: translations.concat([{ locale: "en", name: type }])
+        translations: translations_with_default,
+        url_source: Maybe(translations).first[:name].or_else(type)
       })
 
     shape = listings_api.shapes.create(community_id: community_id, opts: opts).data

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,21 +111,29 @@ FactoryGirl.define do
       FactoryGirl.build(:community)
     end
     transaction_type {
+
+      community = communities.first || FactoryGirl.create(:community)
+      # Save name to TranslationService
+      name_group = { translations: [ { locale: "en", translation: "Selling" } ] }
+      created_translations = TranslationService::API::Api.translations.create(community.id, [name_group])
+      name_tr_key = created_translations[:data].map { |translation| translation[:translation_key] }.first
+
       TransactionType.find(
         ListingService::API::Api.shapes.create(
         # If community is not given, this will create a new one which differs from the community of the listing.
         # That's an error, but tests seem to pass
-        community_id: (communities.first || FactoryGirl.create(:community)).id,
+        community_id: community.id,
         opts: {
           price_enabled: true,
           shipping_enabled: false,
           transaction_process_id: 12345,
-          name_tr_key: "something.here",
+          name_tr_key: name_tr_key,
           action_button_tr_key: "something.here",
           translations: [
             { locale: "en", name: "Selling" }
           ],
-          units: [ {type: :piece} ]
+          units: [ {type: :piece} ],
+          url_source: "Selling"
         }
       ).data[:transaction_type_id])
     }

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -26,6 +26,7 @@ describe ListingService::API::Shapes do
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }
             ],
+            url_source: "Selling",
 
             units: [
               {type: :day},
@@ -67,6 +68,7 @@ describe ListingService::API::Shapes do
         expect(tt.transaction_process_id).to eql(transaction_process_id)
         expect(tt.name_tr_key).to eql(name_tr_key)
         expect(tt.action_button_tr_key).to eql(action_button_tr_key)
+        expect(tt.url).to eql("selling")
       end
 
       it "creates new listing shape with piece unit" do
@@ -84,6 +86,7 @@ describe ListingService::API::Shapes do
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }
             ],
+            url_source: "Selling",
 
             units: [
               {type: :piece},
@@ -146,7 +149,7 @@ describe ListingService::API::Shapes do
               { locale: "en", name: "Selling", action_button_label: "Buy" },
               { locale: "fi", name: "Myydään", action_button_label: "Osta" }
             ],
-
+            url_source: "Selling",
             units: []
           }
         ).data[:transaction_type_id]
@@ -189,6 +192,7 @@ describe ListingService::API::Shapes do
         expect(tt.transaction_process_id).to eql(transaction_process_id)
         expect(tt.name_tr_key).to eql(name_tr_key)
         expect(tt.action_button_tr_key).to eql(action_button_tr_key)
+        expect(tt.url).to eql("selling")
       end
     end
 

--- a/spec/services/translation_service/api/translation_spec.rb
+++ b/spec/services/translation_service/api/translation_spec.rb
@@ -3,7 +3,7 @@ describe TranslationService::API::Translations do
   TranslationsAPI = TranslationService::API::Api.translations
 
   before(:each) do
-    @community_id = 1
+    @community_id = 88 # cucumber loads test data for existing test communities
     @translation_key1 = "027268a5-abbf-4191-b6bd-b1e7569b361f"
     @translation_key2 = "blaa-blaa-blaa"
     @locale_en = "en"

--- a/spec/services/translation_service/api/translation_spec.rb
+++ b/spec/services/translation_service/api/translation_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 describe TranslationService::API::Translations do
 
   TranslationsAPI = TranslationService::API::Api.translations

--- a/test/helper_modules.rb
+++ b/test/helper_modules.rb
@@ -26,7 +26,7 @@ module TestHelpers
       },
       Service: {
         en: {
-          name: "Selling services", action_button_label: ""
+          name: "Selling services", action_button_label: "Offer"
         }
       }
     }
@@ -63,6 +63,21 @@ module TestHelpers
       transaction_types.each do |type, translations|
         defaults = TransactionTypeCreator::DEFAULTS[type.to_s]
 
+        name_group = {
+          translations: community.locales.map do |locale|
+            translation = translations[locale.to_sym]
+            {locale: locale, translation: translation[:name]} unless translation.blank?
+          end.compact
+        }
+        ab_group = {
+          translations: community.locales.map do |locale|
+            translation = translations[locale.to_sym]
+            {locale: locale, translation: translation[:action_button_label]} unless translation.blank?
+          end.compact
+        }
+        created_translations = TranslationService::API::Api.translations.create(community.id, [name_group, ab_group])
+        name_tr_key, action_button_tr_key = created_translations[:data].map { |translation| translation[:translation_key] }
+
         translations = community.locales.map do |locale|
           translation = translations[locale.to_sym]
 
@@ -75,12 +90,15 @@ module TestHelpers
           end
         end.compact
 
+        url_source = translations.find{ |t| t[:locale] == community.default_locale }[:name]
+
         shape_opts = defaults.merge(
           transaction_process_id: processes[:none],
-          name_tr_key: 'something.here',
-          action_button_tr_key: 'something.here',
           translations: translations,
-          shipping_enabled: false
+          name_tr_key: name_tr_key,
+          action_button_tr_key: action_button_tr_key,
+          shipping_enabled: false,
+          url_source: url_source
         )
 
         listings_api = ListingService::API::Api


### PR DESCRIPTION
transaction_types do not have translations for default_locale in every situation
I.e. if admin wants to change language from 'fi' to 'en', we don't want to break his/hers website for any moment. 

At some point we probably need to create a tool for changing default locale (and adding new locales) for transaction_type, categories, etc.

c372046 is old reviewed PR #1086 (the origin for this revert-revert)
ec2157c is new code (fix for relying on default_locale)