### PR TITLE
do not use community.locales, since we don't know if those exists

### DIFF
--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -60,8 +60,7 @@ class TransactionType < ActiveRecord::Base
   def display_name(locale)
     result = TranslationService::API::Api.translations
       .get(community_id, {
-        translation_keys: [name_tr_key],
-        locales: community.locales
+        translation_keys: [name_tr_key]
       })
     find_any_translation(result[:data], locale)
   end
@@ -69,9 +68,7 @@ class TransactionType < ActiveRecord::Base
   def action_button_label(locale)
     result = TranslationService::API::Api.translations
       .get(community_id, {
-        translation_keys: [action_button_tr_key],
-        locales: community.locales,
-        fallback_locale: community.default_locale
+        translation_keys: [action_button_tr_key]
       })
     find_any_translation(result[:data], locale)
   end


### PR DESCRIPTION
Do not use community.locales, since we don't know if those exists for transaction_type (case: locale is 'en', but only existing translation for transaction_type is 'fi')