### PR TITLE
Shape ui edit basics

### DIFF
--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -1,0 +1,13 @@
+class Admin::ListingShapesController < ApplicationController
+  before_filter :ensure_is_admin
+
+  # TODO before_filter :feature_flag
+
+  def index
+    render("index",
+           locals: {
+             selected_left_navi_link: "listing_shapes",
+             listing_shapes: [{id: 1, name: "Selling products", categories: "Foo, Bar, Doo"},
+                              {id: 2, name: "Renting spaces", categories: "Quux, Wau, Ohno"}]})
+  end
+end

--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -39,7 +39,7 @@ class Admin::ListingShapesController < ApplicationController
     shape = get_shape(@current_community.id, params[:id])
     return redirect_to error_not_found_path if shape.nil?
 
-    render_edit(shape, @current_community.id, available_locales())
+    render("edit", locals: edit_view_locals(shape, available_locales()))
   end
 
   def update
@@ -67,20 +67,18 @@ class Admin::ListingShapesController < ApplicationController
       return redirect_to admin_listing_shapes_path
     else
       flash[:error] = t("admin.listing_shapes.edit.update_failure")
-      return render_edit(shape, @current_community.id, available_locales())
+      render("edit", locals: edit_view_locals(shape, available_locales()))
     end
   end
 
 
   private
 
-  def render_edit(shape, community_id, available_locs)
-    render("edit",
-           locals: {
-             selected_left_navi_link: LISTING_SHAPES_NAVI_LINK,
-             shape: shape,
-             shape_form: to_form(shape, community_id, available_locs.map(&:second)),
-             locale_name_mapping: available_locs.map { |name, l| [l, name]}.to_h })
+  def edit_view_locals(shape, available_locs)
+    { selected_left_navi_link: LISTING_SHAPES_NAVI_LINK,
+      shape: shape,
+      shape_form: to_form(shape, available_locs.map(&:second)),
+      locale_name_mapping: available_locs.map { |name, l| [l, name]}.to_h  }
   end
 
   def all_shapes(community_id)
@@ -95,16 +93,16 @@ class Admin::ListingShapesController < ApplicationController
       .or_else(nil)
   end
 
-  def to_form(shape, community_id, locales)
+  def to_form(shape, locales)
     trs = TranslationServiceHelper.to_key_locale_hash(
-      get_translations(shape, community_id, locales))
+      get_translations(shape, locales))
 
     ListingShapeForm.new(name: trs[shape[:name_tr_key]], action_button_label: trs[shape[:action_button_tr_key]], shipping_enabled: shape[:shipping_enabled])
   end
 
-  def get_translations(shape, community_id, locales)
+  def get_translations(shape, locales)
     translations_api.translations.get(
-      community_id,
+      shape[:community_id],
       translation_keys: [shape[:name_tr_key], shape[:action_button_tr_key]],
       locales: locales)
       .maybe()
@@ -112,12 +110,7 @@ class Admin::ListingShapesController < ApplicationController
   end
 
   def update_translations(community_id, key_locale_hash)
-    tr_groups = key_locale_hash.map { |key, key_ts|
-      { translation_key: key, translations: key_ts.map { |loc, t|
-          t.present? ? { locale: loc, translation: t } : nil
-        }.compact
-      }}
-
+    tr_groups = TranslationServiceHelper.to_per_key_translations(key_locale_hash)
     translations_api.translations.create(community_id, tr_groups)
   end
 

--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -7,7 +7,13 @@ class Admin::ListingShapesController < ApplicationController
     render("index",
            locals: {
              selected_left_navi_link: "listing_shapes",
-             listing_shapes: [{id: 1, name: "Selling products", categories: "Foo, Bar, Doo"},
-                              {id: 2, name: "Renting spaces", categories: "Quux, Wau, Ohno"}]})
+             listing_shapes: listing_api.shapes.get(community_id: @current_community.id).maybe().or_else([])})
+  end
+
+
+  private
+
+  def listing_api
+    ListingService::API::Api
   end
 end

--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -3,17 +3,86 @@ class Admin::ListingShapesController < ApplicationController
 
   # TODO before_filter :feature_flag
 
+  LISTING_SHAPES_NAVI_LINK = "listing_shapes"
+
+  # :id=>127,
+  # :transaction_type_id=>65,
+  # :community_id=>10,
+  # :price_enabled=>false,
+  # :name_tr_key=>"transaction_type_translation.name.65",
+  # :action_button_tr_key=>
+  # "transaction_type_translation.action_button_label.65",
+  # :transaction_process_id=>17,
+  # :translations=>nil,
+  # :units=>[],
+  # :shipping_enabled=>false,
+  # :price_quantity_placeholder=>nil
+
+  ListingShapeForm = FormUtils.define_form(
+    "ListingShapeForm",
+    :name,
+    :action_button_label,
+    :shipping_enabled)
+
   def index
     render("index",
            locals: {
-             selected_left_navi_link: "listing_shapes",
-             listing_shapes: listing_api.shapes.get(community_id: @current_community.id).maybe().or_else([])})
+             selected_left_navi_link: LISTING_SHAPES_NAVI_LINK,
+             listing_shapes: all_shapes(@current_community.id)})
+  end
+
+  def edit
+    shape = get_shape(@current_community.id, params[:id])
+    return redirect_to error_not_found_path if shape.nil?
+
+    render("edit",
+           locals: {
+             selected_left_navi_link: LISTING_SHAPES_NAVI_LINK,
+             shape: shape,
+             shape_form: to_form(shape, @current_community.id, available_locales().map(&:second)),
+             locale_name_mapping: available_locales().map { |name, l| [l, name]}.to_h })
+  end
+
+  def update
+    binding.pry
   end
 
 
   private
 
+  def all_shapes(community_id)
+    listing_api.shapes.get(community_id: community_id)
+      .maybe()
+      .or_else([])
+  end
+
+  def get_shape(community_id, listing_shape_id)
+    listing_api.shapes.get(community_id: community_id, listing_shape_id: listing_shape_id)
+      .maybe()
+      .or_else(nil)
+  end
+
+  def to_form(shape, community_id, locales)
+    trs = TranslationServiceHelper.to_key_locale_hash(
+      get_translations(shape, community_id, locales))
+
+    ListingShapeForm.new(name: trs[shape[:name_tr_key]], action_button_label: trs[shape[:action_button_tr_key]], shipping_enabled: shape[:shipping_enabled])
+  end
+
+  def get_translations(shape, community_id, locales)
+    translations_api.translations.get(
+      community_id,
+      translation_keys: [shape[:name_tr_key], shape[:action_button_tr_key]],
+      locales: locales)
+      .maybe()
+      .or_else([])
+  end
+
   def listing_api
     ListingService::API::Api
+  end
+
+  def translations_api
+    TranslationService::API::Api
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -622,16 +622,18 @@ module ApplicationHelper
         :icon_class => icon_class("form"),
         :path => admin_custom_fields_path,
         :name => "listing_fields"
-      },
+      }
+    ]
 
-      # TODO Feature flag for inclusion
-      {
+    # TODO Feature flag for inclusion based upon community
+    if false
+      links << {
         :text => t("admin.listing_shapes.index.listing_shapes"),
         :icon_class => icon_class("form"),
         :path => admin_listing_shapes_path,
         :name => "listing_shapes"
       }
-    ]
+    end
 
     if PaypalHelper.paypal_active?(@current_community.id)
       links << {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -552,6 +552,7 @@ module ApplicationHelper
     }
   end
 
+  # rubocop:disable all
   # Admin view left hand navigation content
   def admin_links_for(community)
     links = [
@@ -685,6 +686,7 @@ module ApplicationHelper
 
     links
   end
+  # rubocop:enable all
 
   # Settings view left hand navigation content
   def settings_links_for(person, community=nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -621,6 +621,14 @@ module ApplicationHelper
         :icon_class => icon_class("form"),
         :path => admin_custom_fields_path,
         :name => "listing_fields"
+      },
+
+      # TODO Feature flag for inclusion
+      {
+        :text => t("admin.listing_shapes.index.listing_shapes"),
+        :icon_class => icon_class("form"),
+        :path => admin_listing_shapes_path,
+        :name => "listing_shapes"
       }
     ]
 

--- a/app/view_utils/listing_shape_helper.rb
+++ b/app/view_utils/listing_shape_helper.rb
@@ -1,6 +1,9 @@
 
 module ListingShapeHelper
 
+
+  PREDEFINED_UNIT_TYPES = [:piece, :hour, :day, :night, :week, :month]
+
   module_function
 
   # deprecated
@@ -17,4 +20,9 @@ module ListingShapeHelper
   def process_to_direction(process)
     process[:author_is_seller] ? "offer" : "request"
   end
+
+  def predefined_unit_types
+    PREDEFINED_UNIT_TYPES
+  end
+
 end

--- a/app/view_utils/translation_service_helper.rb
+++ b/app/view_utils/translation_service_helper.rb
@@ -18,10 +18,33 @@ module TranslationServiceHelper
     (translations_ordered.first || translations_for_key.first)[:translation]
   end
 
+  # In: [{translation_key: "foo", locale: "en", translation: "en foo"},
+  #      {translation_key: "foo", locale: "fi", translation: "fi foo"},
+  #      {translation_key: "bar", locale: "en", translation: "en bar"},
+  #      {translation_key: "bar", locale: "fi", translation: "fi bar"}]
+  #
+  # Out: { "foo" => { "en" => "en foo", "fi" => "fi foo"},
+  #        "bar" => { "en" => "en bar", "fi" => "fi bar"} }
   def to_key_locale_hash(ts)
     ts.group_by { |t| t[:translation_key] }
       .map { |key, key_ts| [key, key_ts.group_by { |t| t[:locale] }]}
       .map { |key, key_ts| [key, key_ts.map { |loc, t| [loc, t.first[:translation]]}.to_h]}
       .to_h
+  end
+
+  # In: { "foo" => { "en" => "en foo", "fi" => "fi foo"},
+  #       "bar" => { "en" => "en bar", "fi" => "fi bar"} }
+  #
+  # Out: [{translation_key: "foo", translations:
+  #         [ {locale: "en", translation: "en foo"}, {locale: "fi", translation: "fi foo"}]},
+  #       {translation_key: "bar", translations:
+  #         [ {locale: "en", translation: "en bar"}, {locale: "fi", translation: "fi bar"}] }]
+  #
+  # Note! This is a not a reverse of to_key_locale_hash
+  def to_per_key_translations(key_locale_hash)
+    key_locale_hash.map { |key, key_ts|
+      { translation_key: key, translations: key_ts.map { |loc, t|
+          t.present? ? { locale: loc, translation: t } : nil
+        }.compact }}
   end
 end

--- a/app/view_utils/translation_service_helper.rb
+++ b/app/view_utils/translation_service_helper.rb
@@ -17,4 +17,11 @@ module TranslationServiceHelper
 
     (translations_ordered.first || translations_for_key.first)[:translation]
   end
+
+  def to_key_locale_hash(ts)
+    ts.group_by { |t| t[:translation_key] }
+      .map { |key, key_ts| [key, key_ts.group_by { |t| t[:locale] }]}
+      .map { |key, key_ts| [key, key_ts.map { |loc, t| [loc, t.first[:translation]]}.to_h]}
+      .to_h
+  end
 end

--- a/app/views/admin/_left_hand_navigation.haml
+++ b/app/views/admin/_left_hand_navigation.haml
@@ -5,6 +5,8 @@
 
 = render :partial => "admin/uservoice_widget" if APP_CONFIG.uservoice_widget_url.present?
 
+- sel_link = (local_assigns.has_key? :selected_left_navi_link) ? selected_left_navi_link : @selected_left_navi_link
+
 .left-navi
 
   .admin-left-navi-link-group-title
@@ -12,7 +14,7 @@
 
   .admin-left-navi-link-group
     - links_general.each do |link|
-      %a{:id => link[:id], :href => link[:path], :title => link[:text], :class => (link[:name].eql?(@selected_left_navi_link) ? "selected left-navi-link" : "left-navi-link"), "data-uv-trigger" => link[:data_uv_trigger]}
+      %a{:id => link[:id], :href => link[:path], :title => link[:text], :class => (link[:name].eql?(sel_link) ? "selected left-navi-link" : "left-navi-link"), "data-uv-trigger" => link[:data_uv_trigger]}
         .left-navi-link-icon{:class => link[:icon_class]}
         .left-navi-link-text= link[:text]
 
@@ -21,7 +23,7 @@
 
   .admin-left-navi-link-group
     - links_manage.each do |link|
-      %a{:id => link[:id], :href => link[:path], :title => link[:text], :class => (link[:name].eql?(@selected_left_navi_link) ? "selected left-navi-link" : "left-navi-link")}
+      %a{:id => link[:id], :href => link[:path], :title => link[:text], :class => (link[:name].eql?(sel_link) ? "selected left-navi-link" : "left-navi-link")}
         .left-navi-link-icon{:class => link[:icon_class]}
         .left-navi-link-text= link[:text]
 
@@ -30,13 +32,13 @@
 
   .admin-left-navi-link-group.admin-left-navi-link-group-last
     - links_configure.each do |link|
-      %a{:id => link[:id], :href => link[:path], :title => link[:text], :class => (link[:name].eql?(@selected_left_navi_link) ? "selected left-navi-link" : "left-navi-link")}
+      %a{:id => link[:id], :href => link[:path], :title => link[:text], :class => (link[:name].eql?(sel_link) ? "selected left-navi-link" : "left-navi-link")}
         .left-navi-link-icon{:class => link[:icon_class]}
         .left-navi-link-text= link[:text]
 
 
 - links.each do |link|
-  - if link[:name].eql?(@selected_left_navi_link)
+  - if link[:name].eql?(sel_link)
     .left-navi-dropdown.toggle.with-borders.hidden-tablet{data: {toggle: '.left-navi-menu'}}
       .icon-with-text{:class => link[:icon_class]}
       .text-with-icon= link[:text]

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -1,11 +1,14 @@
 - content_for :title_header do
   %h1= t("layouts.admin.admin")
 
+- content_for :javascript do
+  $('#listing_shape_form').validate();
+
 = render partial: "admin/left_hand_navigation", locals: { links: admin_links_for(@current_community), selected_left_navi_link: selected_left_navi_link }
 
 .left-navi-section
   %h2= t(".edit_listing_shape", shape: ts(shape[:name_tr_key]))
-  = form_tag(admin_listing_shape_path(shape[:id]), method: :put) do
+  = form_tag(admin_listing_shape_path(shape[:id]), method: :put, id: "listing_shape_form") do
 
     .translation-wrapper
       .input-header= t("admin.listing_shapes.listing_shape_name")
@@ -15,7 +18,7 @@
           .name-locale-label.col-2
             = label_tag "name[#{loc}]", locale_name_mapping[loc]
           .name-locale-text_field.col-10
-            = text_field_tag "name[#{loc}]", t
+            = text_field_tag("name[#{loc}]", t, class: "required")
 
     .translation-wrapper
       .input-header= t("admin.listing_shapes.action_button_label")
@@ -25,7 +28,7 @@
           .name-locale-label.col-2
             = label_tag "action_button_label[#{loc}]", locale_name_mapping[loc]
           .name-locale-text_field.col-10
-            = text_field_tag "action_button_label[#{loc}]", t
+            = text_field_tag("action_button_label[#{loc}]", t, class: "required")
 
     .row
       .col-12

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -1,0 +1,37 @@
+- content_for :title_header do
+  %h1= t("layouts.admin.admin")
+
+= render partial: "admin/left_hand_navigation", locals: { links: admin_links_for(@current_community), selected_left_navi_link: selected_left_navi_link }
+
+.left-navi-section
+  %h2= t(".edit_listing_shape", shape: ts(shape[:name_tr_key]))
+  = form_tag(admin_listing_shape_path(shape[:id]), method: :put) do
+
+    .translation-wrapper
+      .input-header= t("admin.listing_shapes.listing_shape_name")
+      = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.listing_shape_name_desc")}
+      - shape_form.name.map do |loc, t|
+        .row
+          .name-locale-label.col-2
+            = label_tag "name[#{loc}]", locale_name_mapping[loc]
+          .name-locale-text_field.col-10
+            = text_field_tag "name[#{loc}]", t
+
+    .translation-wrapper
+      .input-header= t("admin.listing_shapes.action_button_label")
+      = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.action_button_label_desc")}
+      - shape_form.action_button_label.map do |loc, t|
+        .row
+          .name-locale-label.col-2
+            = label_tag "action_button_label[#{loc}]", locale_name_mapping[loc]
+          .name-locale-text_field.col-10
+            = text_field_tag "action_button_label[#{loc}]", t
+
+    .row
+      .col-12
+        .inline-button-container
+          = button_tag t(".update")
+        .inline-button-container
+          %a{href: admin_listing_shapes_path, class: "cancel-button"}
+            .content
+              = t(".cancel")

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -33,6 +33,18 @@
         = check_box_tag(:shipping_enabled, "true", shape_form.shipping_enabled, class: "checkbox-row-checkbox")
         = label_tag(:shipping_enabled, t("admin.listing_shapes.shipping_label"), class: "checkbox-row-label")
 
+
+    .row
+      .col-12
+        = label_tag("units_title", t("admin.listing_shapes.units_title"), class: "input")
+        = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.units_desc")}
+    - shape_form.units.map do |unit|
+      .row
+        .col-12
+          = check_box_tag("units[#{unit[:type]}]", "true", unit[:enabled], class: "checkbox-row-checkbox")
+          = label_tag("units[#{unit[:type]}]", unit[:label], class: "checkbox-row-label")
+
+
     .row
       .col-12
         .inline-button-container

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -29,6 +29,12 @@
 
     .row
       .col-12
+        = label_tag("shipping_title", t("admin.listing_shapes.shipping_title"), class: "input")
+        = check_box_tag(:shipping_enabled, "true", shape_form.shipping_enabled, class: "checkbox-row-checkbox")
+        = label_tag(:shipping_enabled, t("admin.listing_shapes.shipping_label"), class: "checkbox-row-label")
+
+    .row
+      .col-12
         .inline-button-container
           = button_tag t(".update")
         .inline-button-container

--- a/app/views/admin/listing_shapes/index.haml
+++ b/app/views/admin/listing_shapes/index.haml
@@ -27,9 +27,9 @@
           - listing_shapes.map do |shape|
             %tr
               %td
-                = shape[:name]
+                = ts(shape[:name_tr_key])
               %td
-                = shape[:categories]
+                = "TODO"
               %td
                 = link_to edit_admin_listing_shape_path(shape[:id]) do
                   = icon_tag("edit", ["icon-fix"])

--- a/app/views/admin/listing_shapes/index.haml
+++ b/app/views/admin/listing_shapes/index.haml
@@ -1,35 +1,25 @@
 - content_for :title_header do
-  %h1
-    = t("layouts.admin.admin")
-    = "-"
-    = t(".listing_shapes")
+  %h1= t("layouts.admin.admin")
 
 = render partial: "admin/left_hand_navigation", locals: { links: admin_links_for(@current_community), selected_left_navi_link: selected_left_navi_link }
 
 .left-navi-section
   .row
     .col-12
-      %h1
-        = t(".listing_shapes")
-
-      .p
-        = t(".description")
+      %h1= t(".listing_shapes")
+      .p= t(".description")
 
   .row
     .col-12
       %table
         %thead
-          %th
-            = t(".header.listing_shape_name")
-          %th
-            = t(".header.listing_shape_categories")
+          %th= t(".header.listing_shape_name")
+          %th= t(".header.listing_shape_categories")
         %tbody
           - listing_shapes.map do |shape|
             %tr
-              %td
-                = ts(shape[:name_tr_key])
-              %td
-                = "TODO"
+              %td= ts(shape[:name_tr_key])
+              %td= "TODO"
               %td
                 = link_to edit_admin_listing_shape_path(shape[:id]) do
                   = icon_tag("edit", ["icon-fix"])

--- a/app/views/admin/listing_shapes/index.haml
+++ b/app/views/admin/listing_shapes/index.haml
@@ -1,0 +1,40 @@
+- content_for :title_header do
+  %h1
+    = t("layouts.admin.admin")
+    = "-"
+    = t(".listing_shapes")
+
+= render partial: "admin/left_hand_navigation", locals: { links: admin_links_for(@current_community), selected_left_navi_link: selected_left_navi_link }
+
+.left-navi-section
+  .row
+    .col-12
+      %h1
+        = t(".listing_shapes")
+
+      .p
+        = t(".description")
+
+  .row
+    .col-12
+      %table
+        %thead
+          %th
+            = t(".header.listing_shape_name")
+          %th
+            = t(".header.listing_shape_categories")
+        %tbody
+          - listing_shapes.map do |shape|
+            %tr
+              %td
+                = shape[:name]
+              %td
+                = shape[:categories]
+              %td
+                = link_to edit_admin_listing_shape_path(shape[:id]) do
+                  = icon_tag("edit", ["icon-fix"])
+                = icon_tag("cross", ["icon-fix"])
+
+  .row
+    .col-12
+      = link_to t(".create_a_new_listing_shape"), new_admin_listing_shape_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,14 @@ en:
         header:
           listing_shape_name: "Order type name"
           listing_shape_categories: "Order type categories"
+      edit:
+        edit_listing_shape: "Edit order type '%{shape}'"
+        update: "Save"
+        cancel: "Cancel"
+      listing_shape_name: "Name"
+      listing_shape_name_desc: "This is the order type name identifying this order type in order type selection when user posts a new listing."
+      action_button_label: "Checkout button label"
+      action_button_label_desc: "This is the checkout button label shown on the listing page."
     categories:
       edit:
         edit_listing_category: "Edit category '%{category}'"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,13 @@
 en:
   admin:
+    listing_shapes:
+      index:
+        listing_shapes: "Order types"
+        description: "Order types determine what kind of orders are enabled in your marketplace. For instance, you can define whether you allow your sellers to define a shipping fee, or whether your providers can sell items or rent them per day or per hour. You can add multiple different order types and tie them to different listing categories. One category could also have multiple order types (for instance, you could enable both sales and rentals of cars in the same marketplace.)"
+        create_a_new_listing_shape: "+ Create a new order type"
+        header:
+          listing_shape_name: "Order type name"
+          listing_shape_categories: "Order type categories"
     categories:
       edit:
         edit_listing_category: "Edit category '%{category}'"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,15 @@ en:
       action_button_label_desc: "This is the checkout button label shown on the listing page."
       shipping_title: "Shipping"
       shipping_label: "Shipping fee enabled"
+      units_title: "Pricing units"
+      units_desc: "Listing price is always shown as \"price per pricing unit\". An example: \"$39 per hour\". An exception: \"per piece\" text will not be shown, so if you select \"per piece\", price will simply be shown as \"$39\"."
+      units:
+        piece: "Per piece"
+        hour: "Per hour"
+        day: "Per day"
+        night: "Per night"
+        week: "Per week"
+        month: "Per month"
     categories:
       edit:
         edit_listing_category: "Edit category '%{category}'"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,10 +12,14 @@ en:
         edit_listing_shape: "Edit order type '%{shape}'"
         update: "Save"
         cancel: "Cancel"
+        update_success: "Changes to order type '%{shape}' saved"
+        update_failure: "Something went wrong. Could not save changes."
       listing_shape_name: "Name"
       listing_shape_name_desc: "This is the order type name identifying this order type in order type selection when user posts a new listing."
       action_button_label: "Checkout button label"
       action_button_label_desc: "This is the checkout button label shown on the listing page."
+      shipping_title: "Shipping"
+      shipping_label: "Shipping fee enabled"
     categories:
       edit:
         edit_listing_category: "Edit category '%{category}'"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Kassi::Application.routes.draw do
           post :order
         end
       end
+      resources :listing_shapes
     end
 
     resources :invitations

--- a/spec/view_utils/translation_service_helper_spec.rb
+++ b/spec/view_utils/translation_service_helper_spec.rb
@@ -1,0 +1,36 @@
+# coding: utf-8
+require 'spec_helper'
+
+describe TranslationServiceHelper do
+
+  it "#to_key_local_hash" do
+    expect(TranslationServiceHelper.to_key_locale_hash(
+            [{translation_key: "foo", locale: "en", translation: "en foo"},
+             {translation_key: "foo", locale: "fi", translation: "fi foo"},
+             {translation_key: "bar", locale: "en", translation: "en bar"},
+             {translation_key: "bar", locale: "fi", translation: "fi bar"}]))
+      .to eq({ "foo" => { "en" => "en foo", "fi" => "fi foo"},
+               "bar" => { "en" => "en bar", "fi" => "fi bar"} })
+  end
+
+  it "#to_per_key_translations" do
+    expect(TranslationServiceHelper.to_per_key_translations(
+            { "foo" => { "en" => "en foo", "fi" => "fi foo"},
+              "bar" => { "en" => "en bar", "fi" => "fi bar"} }))
+      .to eq([{translation_key: "foo",
+               translations: [ {locale: "en", translation: "en foo"},
+                               {locale: "fi", translation: "fi foo"}]},
+              {translation_key: "bar",
+               translations: [ {locale: "en", translation: "en bar"},
+                               {locale: "fi", translation: "fi bar"}] }])
+
+    expect(TranslationServiceHelper.to_per_key_translations(
+            { "foo" => { "en" => "en foo", "fi" => nil},
+              "bar" => { "en" => "", "fi" => "fi bar"} }))
+      .to eq([{translation_key: "foo",
+               translations: [{locale: "en", translation: "en foo"}]},
+              {translation_key: "bar",
+               translations: [{locale: "fi", translation: "fi bar"}]}])
+  end
+
+end


### PR DESCRIPTION
First step of Shape UI. List and edit existing listing shapes for a community. The code is currently disabled and the item hidden from menu but can be safely merged to master and deployed to prod already.