### PR TITLE
Validate commission % has no decimals with JS

### DIFF
--- a/app/assets/javascripts/locales/fi.json
+++ b/app/assets/javascripts/locales/fi.json
@@ -5,7 +5,7 @@
     "creditcard": "Anna oikeantyyppinen luottokortin numero.",
     "date": "Anna päivämäärä oikessa muodossa.",
     "dateISO": "Anna päivämäärä oikeassa muodossa (ISO).",
-    "digits": "Tähän kenttään voit syöttää ainoastaan kirjaimia.",
+    "digits": "Tähän kenttään voit syöttää ainoastaan numeroita.",
     "email": "Anna toimiva sähköpostiosoite.",
     "equalTo": "Antamasi arvot eivät täsmää.",
     "max": "Arvo voi olla enintään {0}.",

--- a/app/assets/javascripts/paypal_account_settings.js
+++ b/app/assets/javascripts/paypal_account_settings.js
@@ -32,7 +32,8 @@ window.ST = window.ST || {};
         "paypal_preferences_form[commission_from_seller]": {
           required: true,
           number_min: commissionRange[0],
-          number_max: commissionRange[1]
+          number_max: commissionRange[1],
+          number_no_decimals: true
         },
         "paypal_preferences_form[minimum_listing_price]": {
           required: true,


### PR DESCRIPTION
Add the validation to frontend using JS validation. This is already
localized well so no need to fix the server side validation
localisation.