### PR TITLE
Per community I18n backend

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,7 @@ class ApplicationController < ActionController::Base
     # Load translations from TranslationService
     community_backend = I18n::Backend::CommunityBackend.instance
     m_community.map(&:id).each { |community_id|
-      community_backend.set_community!(community_id)
+      community_backend.community_id = community_id
       community_translations = TranslationService::API::Api.translations.get(community_id)[:data]
       TranslationServiceHelper.community_translations_for_i18n_backend(community_translations).each { |locale, data|
         # Store community translations to I18n backend.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,11 +68,12 @@ class ApplicationController < ActionController::Base
     m_community = Maybe(@current_community)
     community_locales = m_community.locales.or_else([])
     community_default_locale = m_community.default_locale.or_else("en")
+    community_id = m_community[:id].or_else(nil)
+    community_backend = I18n::Backend::CommunityBackend.instance
 
     # Load translations from TranslationService
-    community_backend = I18n::Backend::CommunityBackend.instance
-    m_community.map(&:id).each { |community_id|
-      community_backend.community_id = community_id
+    if community_id
+      community_backend.set_community!(community_id)
       community_translations = TranslationService::API::Api.translations.get(community_id)[:data]
       TranslationServiceHelper.community_translations_for_i18n_backend(community_translations).each { |locale, data|
         # Store community translations to I18n backend.
@@ -81,7 +82,7 @@ class ApplicationController < ActionController::Base
         # escape the separators (. dots) in the key
         community_backend.store_translations(locale, data, escape: false)
       }
-    }
+    end
 
     # We should fix this -- END
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,7 @@ class ApplicationController < ActionController::Base
   def set_locale
     user_locale = Maybe(@current_user).locale.or_else(nil)
 
-    # We should remove this -- START
+    # We should fix this -- START
     #
     # There are a couple of controllers (amazon ses bounces, braintree webhooks) that
     # inherit application controller, even though they shouldn't. ApplicationController
@@ -68,7 +68,21 @@ class ApplicationController < ActionController::Base
     m_community = Maybe(@current_community)
     community_locales = m_community.locales.or_else([])
     community_default_locale = m_community.default_locale.or_else("en")
-    # We should remove this -- END
+
+    # Load translations from TranslationService
+    community_backend = I18n::Backend::CommunityBackend.instance
+    m_community.map(&:id).each { |community_id|
+      community_backend.set_community!(community_id)
+      fetch_community_translations(community_id).each { |locale, data|
+        # Store community translations to I18n backend.
+        #
+        # Since the data in data hash is already flatten, we don't want to
+        # escape the separators (. dots) in the key
+        community_backend.store_translations(locale, data, escape: false)
+      }
+    }
+
+    # We should fix this -- END
 
     locale = select_locale(user_locale, params[:locale], community_locales, community_default_locale)
 
@@ -373,11 +387,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def community_translations
-    @community_translations ||= TranslationService::API::Api.translations.get(@current_community.id)[:data]
-  end
-
-  def translate(key, opts = {})
-    TranslationServiceHelper.pick_translation(key, community_translations, @current_community.locales, I18n.locale, opts)
+  def fetch_community_translations(community_id)
+    translations = TranslationService::API::Api.translations.get(community_id)[:data]
+    locale_groups = translations.group_by { |tr| tr[:locale] }
+    locale_groups.map { |(locale, translations)|
+      [locale.to_sym, translations.inject({}) { |memo, tr|
+         memo.tap { |m| m[tr[:translation_key]] = tr[:translation] }
+       }]
+    }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,8 @@ class ApplicationController < ActionController::Base
     community_backend = I18n::Backend::CommunityBackend.instance
     m_community.map(&:id).each { |community_id|
       community_backend.set_community!(community_id)
-      fetch_community_translations(community_id).each { |locale, data|
+      community_translations = TranslationService::API::Api.translations.get(community_id)[:data]
+      TranslationServiceHelper.community_translations_for_i18n_backend(community_translations).each { |locale, data|
         # Store community translations to I18n backend.
         #
         # Since the data in data hash is already flatten, we don't want to
@@ -385,15 +386,5 @@ class ApplicationController < ActionController::Base
     if APP_CONFIG.always_use_ssl
       redirect_to("https://#{request.host_with_port}#{request.fullpath}") unless request.ssl? || ( request.headers["HTTP_VIA"] && request.headers["HTTP_VIA"].include?("sharetribe_proxy")) || request.fullpath == "/robots.txt"
     end
-  end
-
-  def fetch_community_translations(community_id)
-    translations = TranslationService::API::Api.translations.get(community_id)[:data]
-    locale_groups = translations.group_by { |tr| tr[:locale] }
-    locale_groups.map { |(locale, translations)|
-      [locale.to_sym, translations.inject({}) { |memo, tr|
-         memo.tap { |m| m[tr[:translation_key]] = tr[:translation] }
-       }]
-    }
   end
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -193,8 +193,7 @@ class ListingsController < ApplicationController
         categories: ListingService::API::Api.categories.get(community_id: @current_community.id)[:data],
         shapes: get_shapes,
         locale: I18n.locale,
-        all_locales: @current_community.locales,
-        translation_cache: community_translations
+        all_locales: @current_community.locales
       )
 
       render :new, locals: {

--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -126,14 +126,10 @@ module ListingsHelper
   end
 
   def shape_name(listing)
-    # TODO Can we somehow remove this?
-    I18n::Backend::CommunityBackend.instance.set_community!(listing.communities.first.id)
     t(listing.shape_name_tr_key)
   end
 
   def action_button_label(listing)
-    # TODO Can we somehow remove this?
-    I18n::Backend::CommunityBackend.instance.set_community!(listing.communities.first.id)
     t(listing.action_button_tr_key)
   end
 end

--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -126,10 +126,14 @@ module ListingsHelper
   end
 
   def shape_name(listing)
-    ts(listing.shape_name_tr_key, community: listing.communities.first)
+    # TODO Can we somehow remove this?
+    I18n::Backend::CommunityBackend.instance.set_community!(listing.communities.first.id)
+    t(listing.shape_name_tr_key)
   end
 
   def action_button_label(listing)
-    ts(listing.action_button_tr_key, community: listing.communities.first)
+    # TODO Can we somehow remove this?
+    I18n::Backend::CommunityBackend.instance.set_community!(listing.communities.first.id)
+    t(listing.action_button_tr_key)
   end
 end

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -1,9 +1,0 @@
-module TranslationHelper
-
-  def ts(key, opts = {})
-    community = @current_community || opts[:community]
-    @community_translations ||= TranslationService::API::Api.translations.get(community.id)[:data]
-    TranslationServiceHelper.pick_translation(key, @community_translations, community.locales, I18n.locale, opts.except(:community))
-  end
-
-end

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -2,7 +2,6 @@ include ApplicationHelper
 include PeopleHelper
 include ListingsHelper
 include TruncateHtmlHelper
-include TranslationHelper
 
 class CommunityMailer < ActionMailer::Base
 

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -44,36 +44,36 @@ class CommunityMailer < ActionMailer::Base
       return
     end
 
-    set_locale @recipient.locale
-    I18n.locale = @recipient.locale  #This was added so that listing share_types get correct translation
+    with_locale(recipient.locale, community.id) do
 
-    @time_since_last_update = t("timestamps.days_since",
-        :count => time_difference_in_days(@recipient.last_community_updates_at))
-    @url_params = {}
-    @url_params[:host] = "#{@community.full_domain}"
-    @url_params[:locale] = @recipient.locale
-    @url_params[:ref] = "weeklymail"
-    @url_params.freeze # to avoid accidental modifications later
+      @time_since_last_update = t("timestamps.days_since",
+                                  :count => time_difference_in_days(@recipient.last_community_updates_at))
+      @url_params = {}
+      @url_params[:host] = "#{@community.full_domain}"
+      @url_params[:locale] = @recipient.locale
+      @url_params[:ref] = "weeklymail"
+      @url_params.freeze # to avoid accidental modifications later
 
 
-    @show_listing_shape_label = shapes.get(community_id: community.id)[:data].length > 1
+      @show_listing_shape_label = shapes.get(community_id: community.id)[:data].length > 1
 
-    @title_link_text = t("emails.community_updates.title_link_text",
-          :community_name => @community.full_name(@recipient.locale))
-    subject = t("emails.community_updates.update_mail_title", :title_link => @title_link_text)
+      @title_link_text = t("emails.community_updates.title_link_text",
+                           :community_name => @community.full_name(@recipient.locale))
+      subject = t("emails.community_updates.update_mail_title", :title_link => @title_link_text)
 
-    if APP_CONFIG.mail_delivery_method == "postmark"
-      # Postmark doesn't support bulk emails, so use Sendmail for this
-      delivery_method = :sendmail
-    else
-      delivery_method = APP_CONFIG.mail_delivery_method.to_sym unless Rails.env.test?
-    end
+      if APP_CONFIG.mail_delivery_method == "postmark"
+        # Postmark doesn't support bulk emails, so use Sendmail for this
+        delivery_method = :sendmail
+      else
+        delivery_method = APP_CONFIG.mail_delivery_method.to_sym unless Rails.env.test?
+      end
 
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => subject,
-         :delivery_method => delivery_method) do |format|
-      format.html { render :layout => 'email_blank_layout' }
+      premailer_mail(:to => @recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => subject,
+                     :delivery_method => delivery_method) do |format|
+        format.html { render :layout => 'email_blank_layout' }
+      end
     end
   end
 

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -4,7 +4,6 @@ include ApplicationHelper
 include PeopleHelper
 include ListingsHelper
 include TruncateHtmlHelper
-include TranslationHelper
 
 class PersonMailer < ActionMailer::Base
   include MailUtils
@@ -22,8 +21,8 @@ class PersonMailer < ActionMailer::Base
   def conversation_status_changed(transaction, community)
     @email_type =  (transaction.status == "accepted" ? "email_when_conversation_accepted" : "email_when_conversation_rejected")
     recipient = transaction.other_party(transaction.listing.author)
-    set_up_urls(recipinet, community, @email_type)
-    with_setup(recipient.locale, community) do
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community) do
       @transaction = transaction
 
       if @transaction.payment_gateway == "braintree" ||  @transaction.payment_process == "postpay"
@@ -124,6 +123,7 @@ class PersonMailer < ActionMailer::Base
                      :subject => t("emails.escrow_canceled.subject")) do |format|
         format.html { render "escrow_canceled" }
       end
+    end
   end
 
   def escrow_canceled(conversation, community)

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -21,86 +21,109 @@ class PersonMailer < ActionMailer::Base
 
   def conversation_status_changed(transaction, community)
     @email_type =  (transaction.status == "accepted" ? "email_when_conversation_accepted" : "email_when_conversation_rejected")
-    set_up_urls(transaction.other_party(transaction.listing.author), community, @email_type)
-    @transaction = transaction
+    recipient = transaction.other_party(transaction.listing.author)
+    set_up_urls(recipinet, community, @email_type)
+    with_setup(recipient.locale, community) do
+      @transaction = transaction
 
-    if @transaction.payment_gateway == "braintree" ||  @transaction.payment_process == "postpay"
-      # Payment url concerns only braintree and postpay, otherwise we show only the message thread
-      @payment_url = community.payment_gateway.new_payment_url(@recipient, @transaction, @recipient.locale, @url_params)
+      if @transaction.payment_gateway == "braintree" ||  @transaction.payment_process == "postpay"
+        # Payment url concerns only braintree and postpay, otherwise we show only the message thread
+        @payment_url = community.payment_gateway.new_payment_url(@recipient, @transaction, @recipient.locale, @url_params)
+      end
+
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.conversation_status_changed.your_request_was_#{transaction.status}"))
     end
-
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.conversation_status_changed.your_request_was_#{transaction.status}"))
   end
 
   def new_message_notification(message, community)
     @email_type =  "email_about_new_messages"
-    set_up_urls(message.conversation.other_party(message.sender), community, @email_type)
-    @message = message
-    sending_params = {:to => @recipient.confirmed_notification_emails_to,
-         :subject => t("emails.new_message.you_have_a_new_message", :sender_name => message.sender.name(community)),
-         :from => community_specific_sender(community)}
+    recipient = message.conversation.other_party(message.sender)
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      @message = message
+      sending_params = {:to => recipient.confirmed_notification_emails_to,
+                        :subject => t("emails.new_message.you_have_a_new_message", :sender_name => message.sender.name(community)),
+                        :from => community_specific_sender(community)}
 
-    premailer_mail(sending_params)
+      premailer_mail(sending_params)
+    end
   end
 
   def new_payment(payment, community)
     @email_type =  "email_about_new_payments"
     @payment = payment
-    set_up_urls(@payment.recipient, community, @email_type)
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_payment.new_payment"))
+    recipient = @payment.recipient
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_payment.new_payment"))
+    end
   end
 
   def receipt_to_payer(payment, community)
     @email_type =  "email_about_new_payments"
     @payment = payment
-    set_up_urls(@payment.payer, community, @email_type)
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.receipt_to_payer.receipt_of_payment"))
+    recipient = @payment.payer
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.receipt_to_payer.receipt_of_payment"))
+    end
   end
 
   def transaction_confirmed(conversation, community)
     @email_type =  "email_about_completed_transactions"
     @conversation = conversation
-    set_up_urls(@conversation.seller, community, @email_type)
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.transaction_confirmed.request_marked_as_#{@conversation.status}"))
+    recipient = conversation.seller
+    set_up_urls(conversation.seller, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.transaction_confirmed.request_marked_as_#{@conversation.status}"))
+    end
   end
 
   def transaction_automatically_confirmed(conversation, community)
     @email_type =  "email_about_completed_transactions"
     @conversation = conversation
-    set_up_urls(@conversation.buyer, community, @email_type)
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :template_path => 'person_mailer/automatic_confirmation',
-         :subject => t("emails.transaction_automatically_confirmed.subject"))
+    recipient = conversation.buyer
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :template_path => 'person_mailer/automatic_confirmation',
+                     :subject => t("emails.transaction_automatically_confirmed.subject"))
+    end
   end
 
   def booking_transaction_automatically_confirmed(transaction, community)
     @email_type = "email_about_completed_transactions"
     @transaction = transaction
-    set_up_urls(@transaction.buyer, community, @email_type)
-    mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :template_path => 'person_mailer/automatic_confirmation',
-         :subject => t("emails.booking_transaction_automatically_confirmed.subject"))
+    recipient = @transaction.buyer
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      mail(:to => @recipient.confirmed_notification_emails_to,
+           :from => community_specific_sender(community),
+           :template_path => 'person_mailer/automatic_confirmation',
+           :subject => t("emails.booking_transaction_automatically_confirmed.subject"))
+    end
   end
 
   def escrow_canceled_to(conversation, community, to)
     @email_type =  "email_about_canceled_escrow"
     @conversation = conversation
-    set_up_urls(@conversation.seller, community, @email_type)
-    premailer_mail(:to => to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.escrow_canceled.subject")) do |format|
-      format.html { render "escrow_canceled" }
-    end
+    recipient = conversation.seller
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      premailer_mail(:to => to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.escrow_canceled.subject")) do |format|
+        format.html { render "escrow_canceled" }
+      end
   end
 
   def escrow_canceled(conversation, community)
@@ -113,11 +136,14 @@ class PersonMailer < ActionMailer::Base
 
   def new_testimonial(testimonial, community)
     @email_type =  "email_about_new_received_testimonials"
-    set_up_urls(testimonial.receiver, community, @email_type)
-    @testimonial = testimonial
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_testimonial.has_given_you_feedback_in_kassi", :name => @testimonial.author.name(community)))
+    recipient = testimonial.receiver
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      @testimonial = testimonial
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_testimonial.has_given_you_feedback_in_kassi", :name => testimonial.author.name(community)))
+    end
   end
 
   # Remind users of conversations that have not been accepted or rejected
@@ -126,67 +152,80 @@ class PersonMailer < ActionMailer::Base
   # but the actual recipient is always the listing author.
   def accept_reminder(conversation, not_really_a_recipient, community)
     @email_type = "email_about_accept_reminders"
-    set_up_urls(conversation.listing.author, community, @email_type)
-    @conversation = conversation
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.accept_reminder.remember_to_accept_request", :sender_name => @conversation.other_party(@recipient).name(community)))
+    recipient = conversation.listing.author
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      @conversation = conversation
+      premailer_mail(:to => @recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.accept_reminder.remember_to_accept_request", :sender_name => conversation.other_party(recipient).name(community)))
+    end
   end
 
   # Remind users to pay
   def payment_reminder(conversation, recipient, community)
     @email_type = "email_about_payment_reminders"
-    set_up_urls(conversation.payment.payer, community, @email_type)
-    @conversation = conversation
+    recipient = conversation.payment.payer
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      @conversation = conversation
 
-    @pay_url = payment_url(conversation, recipient, @url_params)
+      @pay_url = payment_url(conversation, recipient, @url_params)
 
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.payment_reminder.remember_to_pay", :listing_title => @conversation.listing.title))
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.payment_reminder.remember_to_pay", :listing_title => conversation.listing.title))
+    end
   end
 
   # Remind user to fill in payment details
   def payment_settings_reminder(listing, recipient, community)
     set_up_urls(recipient, community)
-    @listing = listing
-    @recipient = recipient
+    with_locale(recipient.locale, community.id) do
+      @listing = listing
+      @recipient = recipient
 
-    if community.payments_in_use?
-      @payment_settings_link = payment_settings_url(MarketplaceService::Community::Query.payment_type(community.id), recipient, @url_params)
-    end
+      if community.payments_in_use?
+        @payment_settings_link = payment_settings_url(MarketplaceService::Community::Query.payment_type(community.id), recipient, @url_params)
+      end
 
-    premailer_mail(:to => recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.payment_settings_reminder.remember_to_add_payment_details")) do |format|
-            format.html {render :locals => {:skip_unsubscribe_footer => true} }
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.payment_settings_reminder.remember_to_add_payment_details")) do |format|
+        format.html {render :locals => {:skip_unsubscribe_footer => true} }
+      end
     end
   end
 
   # Braintree account was approved (via Webhook)
   def braintree_account_approved(recipient, community)
     set_up_urls(recipient, community)
-    @recipient = recipient
+    with_locale(recipient.locale, community.id) do
+      @recipient = recipient
 
-    premailer_mail(:to => recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.braintree_account_approved.account_ready")) do |format|
-            format.html {render :locals => {:skip_unsubscribe_footer => true} }
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.braintree_account_approved.account_ready")) do |format|
+        format.html {render :locals => {:skip_unsubscribe_footer => true} }
+      end
     end
   end
 
   # Remind users of conversations that have not been accepted or rejected
   def confirm_reminder(conversation, recipient, community, days_to_cancel)
     @email_type = "email_about_confirm_reminders"
-    set_up_urls(conversation.buyer, community, @email_type)
-    @conversation = conversation
-    @days_to_cancel = days_to_cancel
-    escrow = community.payment_gateway && community.payment_gateway.hold_in_escrow
-    template = escrow ? "confirm_reminder_escrow" : "confirm_reminder"
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.confirm_reminder.remember_to_confirm_request")) do |format|
-      format.html { render template }
+    recipient = conversation.buyer
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      @conversation = conversation
+      @days_to_cancel = days_to_cancel
+      escrow = community.payment_gateway && community.payment_gateway.hold_in_escrow
+      template = escrow ? "confirm_reminder_escrow" : "confirm_reminder"
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.confirm_reminder.remember_to_confirm_request")) do |format|
+        format.html { render template }
+      end
     end
   end
 
@@ -194,75 +233,90 @@ class PersonMailer < ActionMailer::Base
   def testimonial_reminder(conversation, recipient, community)
     @email_type = "email_about_testimonial_reminders"
     set_up_urls(recipient, community, @email_type)
-    @conversation = conversation
-    @other_party = @conversation.other_party(@recipient)
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.testimonial_reminder.remember_to_give_feedback_to", :name => @other_party.name))
+    with_locale(recipient.locale, community.id) do
+      @conversation = conversation
+      @other_party = @conversation.other_party(recipient)
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.testimonial_reminder.remember_to_give_feedback_to", :name => @other_party.name))
+    end
   end
 
   def new_comment_to_own_listing_notification(comment, community)
     @email_type = "email_about_new_comments_to_own_listing"
-    set_up_urls(comment.listing.author, community, @email_type)
-    @comment = comment
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_comment.you_have_a_new_comment", :author => @comment.author.name(community)))
+    recipient = comment.listing.author
+    set_up_urls(recipient, community, @email_type)
+    with_locale(recipient.locale, community.id) do
+      @comment = comment
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_comment.you_have_a_new_comment", :author => comment.author.name(community)))
+    end
   end
 
   def new_comment_to_followed_listing_notification(comment, recipient, community)
     set_up_urls(recipient, community)
-    @comment = comment
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_comment.listing_you_follow_has_a_new_comment", :author => @comment.author.name(community)))
+    with_locale(recipient.locale, community.id) do
+      @comment = comment
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_comment.listing_you_follow_has_a_new_comment", :author => comment.author.name(community)))
+    end
   end
 
   def new_update_to_followed_listing_notification(listing, recipient, community)
     set_up_urls(recipient, community)
-    @listing = listing
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_update_to_listing.listing_you_follow_has_been_updated"))
+    with_locale(recipient.locale, community.id) do
+      @listing = listing
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_update_to_listing.listing_you_follow_has_been_updated"))
+    end
   end
 
   def new_listing_by_followed_person(listing, recipient, community)
     set_up_urls(recipient, community)
-    @listing = listing
-    @no_recipient_name = true
-    @author_name = listing.author.name(community)
-    @listing_url = listing_url(@url_params.merge({:id => @listing.id}))
-    @translate_scope = [ :emails, :new_listing_by_followed_person ]
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_listing_by_followed_person.subject",
-                       :author_name => @author_name,
-                       :community => community.full_name_with_separator(recipient.locale)))
+    with_locale(recipient.locale, community.id) do
+      @listing = listing
+      @no_recipient_name = true
+      @author_name = listing.author.name(community)
+      @listing_url = listing_url(@url_params.merge({:id => listing.id}))
+      @translate_scope = [ :emails, :new_listing_by_followed_person ]
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_listing_by_followed_person.subject",
+                                   :author_name => @author_name,
+                                   :community => community.full_name_with_separator(recipient.locale)))
+    end
   end
 
   def invitation_to_kassi(invitation)
     @invitation = invitation
-    I18n.locale = @invitation.inviter.locale
-    @invitation_code_required = @invitation.community.join_with_invite_only
-    set_up_urls(nil, @invitation.community)
-    @url_params[:locale] = @invitation.inviter.locale
-    subject = t("emails.invitation_to_kassi.you_have_been_invited_to_kassi", :inviter => @invitation.inviter.name(@invitation.community), :community => @invitation.community.full_name_with_separator(@invitation.inviter.locale))
-    premailer_mail(:to => @invitation.email,
-         :from => community_specific_sender(@invitation.community),
-         :subject => subject,
-         :reply_to => @invitation.inviter.confirmed_notification_email_to)
+    mail_locale = @invitation.inviter.locale
+    @invitation_code_required = invitation.community.join_with_invite_only
+    set_up_urls(nil, invitation.community)
+    @url_params[:locale] = mail_locale
+    with_locale(mail_locale, invitation.community.id) do
+      subject = t("emails.invitation_to_kassi.you_have_been_invited_to_kassi", :inviter => invitation.inviter.name(invitation.community), :community => invitation.community.full_name_with_separator(invitation.inviter.locale))
+      premailer_mail(:to => invitation.email,
+                     :from => community_specific_sender(invitation.community),
+                     :subject => subject,
+                     :reply_to => invitation.inviter.confirmed_notification_email_to)
+    end
   end
 
   # A message from the community admin to a single community member
   def community_member_email(sender, recipient, email_subject, email_content, community)
     @email_type = "email_from_admins"
     set_up_urls(recipient, community, @email_type)
-    @email_content = email_content
-    @no_recipient_name = true
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => email_subject,
-         :reply_to => "\"#{sender.name(community)}\"<#{sender.confirmed_notification_email_to}>")
+    with_locale(recipient.locale, community.id) do
+      @email_content = email_content
+      @no_recipient_name = true
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => email_subject,
+                     :reply_to => "\"#{sender.name(community)}\"<#{sender.confirmed_notification_email_to}>")
+    end
   end
 
   # Used to send notification to Sharetribe admins when somebody
@@ -311,13 +365,14 @@ class PersonMailer < ActionMailer::Base
     @resource = email.person
     @confirmation_token = email.confirmation_token
     @host = community.full_domain
-    set_locale(email.person.locale)
-    email.update_attribute(:confirmation_sent_at, Time.now)
-    premailer_mail(:to => email.address,
-         :from => community_specific_sender(community),
-         :subject => t("devise.mailer.confirmation_instructions.subject"),
-         :template_path => 'devise/mailer',
-         :template_name => 'confirmation_instructions')
+    with_locale(email.person.locale, community) do
+      email.update_attribute(:confirmation_sent_at, Time.now)
+      premailer_mail(:to => email.address,
+                     :from => community_specific_sender(community),
+                     :subject => t("devise.mailer.confirmation_instructions.subject"),
+                     :template_path => 'devise/mailer',
+                     :template_name => 'confirmation_instructions')
+    end
   end
 
   def reset_password_instructions(person, email_address, community)
@@ -333,25 +388,29 @@ class PersonMailer < ActionMailer::Base
 
   def welcome_email(person, community, regular_email=nil, test_email=false)
     @recipient = person
-    set_locale @recipient.locale
-    @current_community = community
-    @regular_email = regular_email
-    @url_params = {}
-    @url_params[:host] = "#{@current_community.full_domain}"
-    @url_params[:locale] = @recipient.locale
-    @url_params[:ref] = "welcome_email"
-    @url_params.freeze # to avoid accidental modifications later
-    @test_email = test_email
+    recipient = person
+    with_locale(recipient.locale, community.id) do
 
-    if @recipient.has_admin_rights_in?(@current_community) && !@test_email
-      subject = t("emails.welcome_email.welcome_email_subject_for_marketplace_creator")
-    else
-      subject = t("emails.welcome_email.welcome_email_subject", :community => @current_community.full_name(@recipient.locale), :person => person.given_name_or_username)
-    end
-    premailer_mail(:to => @recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => subject) do |format|
-      format.html { render :layout => 'email_blank_layout' }
+      @current_community = community
+
+      @regular_email = regular_email
+      @url_params = {}
+      @url_params[:host] = "#{community.full_domain}"
+      @url_params[:locale] = recipient.locale
+      @url_params[:ref] = "welcome_email"
+      @url_params.freeze # to avoid accidental modifications later
+      @test_email = test_email
+
+      if @recipient.has_admin_rights_in?(community) && !@test_email
+        subject = t("emails.welcome_email.welcome_email_subject_for_marketplace_creator")
+      else
+        subject = t("emails.welcome_email.welcome_email_subject", :community => community.full_name(recipient.locale), :person => person.given_name_or_username)
+      end
+      premailer_mail(:to => recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => subject) do |format|
+        format.html { render :layout => 'email_blank_layout' }
+      end
     end
   end
 

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -31,113 +31,127 @@ class TransactionMailer < ActionMailer::Base
 
     # TODO Now that we have splitted "new message", we could be more specific here, and say that this message
     # is about a new transaction!
-    premailer_mail(
-      mail_params(recipient, community, t("emails.new_message.you_have_a_new_message", :sender_name => sender_name))) do |format|
+    with_locale(recipient.locale, community.id) do
+      premailer_mail(
+        mail_params(recipient, community, t("emails.new_message.you_have_a_new_message", :sender_name => sender_name))) do |format|
         format.html {
           render locals: {
-            recipient: recipient,
-            reply_url: reply_url,
-            sender_name: sender_name,
-          }
+                   recipient: recipient,
+                   reply_url: reply_url,
+                   sender_name: sender_name,
+                 }
         }
+      end
     end
   end
 
   def transaction_preauthorized(transaction)
     @transaction = transaction
-    @community = @transaction.community
+    @community = transaction.community
 
-    set_up_urls(@transaction.author, @transaction.community)
+    recipient = transaction.author
+    set_up_urls(recipient, transaction.community)
+    with_locale(recipient.locale, transaction.community.id) do
 
-    payment_type = MarketplaceService::Community::Query.payment_type(@community.id)
-    gateway_expires = MarketplaceService::Transaction::Entity.authorization_expiration_period(payment_type)
+      payment_type = MarketplaceService::Community::Query.payment_type(@community.id)
+      gateway_expires = MarketplaceService::Transaction::Entity.authorization_expiration_period(payment_type)
 
-    premailer_mail(
-      mail_params(
-        @recipient,
-        @community,
-        t("emails.transaction_preauthorized.subject", requester: @transaction.starter.name, listing_title: @transaction.listing.title))) do |format|
-      format.html {
-        render locals: {
-          payment_expires_in_days: gateway_expires
+      premailer_mail(
+        mail_params(
+          @recipient,
+          @community,
+          t("emails.transaction_preauthorized.subject", requester: transaction.starter.name, listing_title: transaction.listing.title))) do |format|
+        format.html {
+          render locals: {
+                   payment_expires_in_days: gateway_expires
+                 }
         }
-      }
+      end
     end
   end
 
   def transaction_preauthorized_reminder(transaction)
     @transaction = transaction
-    @community = @transaction.community
+    @community = transaction.community
 
-    set_up_urls(@transaction.author, @transaction.community)
+    recipient = transaction.author
+    set_up_urls(recipient, transaction.community)
+    with_locale(recipient.locale, transaction.community.id) do
 
-    premailer_mail(
-      mail_params(
-        @recipient,
-        @community,
-        t("emails.transaction_preauthorized_reminder.subject", requester: @transaction.starter.name, listing_title: @transaction.listing.title)))
+      premailer_mail(
+        mail_params(
+          @recipient,
+          @community,
+          t("emails.transaction_preauthorized_reminder.subject", requester: transaction.starter.name, listing_title: transaction.listing.title)))
+    end
   end
 
   def braintree_new_payment(payment, community)
+    recipient = payment.recipient
     prepare_template(community, payment.recipient, "email_about_new_payments")
+    with_locale(recipient.locale, community.id) do
 
-    service_fee = payment.total_commission
-    you_get = payment.seller_gets
+      service_fee = payment.total_commission
+      you_get = payment.seller_gets
 
-    transaction = payment.transaction
-    unit_type = translate_quantity_unit(transaction.unit_type)
-    duration = payment.transaction.booking.present? ? payment.transaction.booking.duration : nil
+      transaction = payment.transaction
+      unit_type = translate_quantity_unit(transaction.unit_type)
+      duration = payment.transaction.booking.present? ? payment.transaction.booking.duration : nil
 
-    premailer_mail(:to => payment.recipient.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_payment.new_payment")) { |format|
-      format.html {
-        render "braintree_payment_receipt_to_seller", locals: {
-          conversation_url: person_transaction_url(payment.recipient, @url_params.merge({:id => payment.transaction.id.to_s})),
-          listing_title: payment.transaction.listing_title,
-          price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
-          listing_price: humanized_money_with_symbol(payment.transaction.unit_price),
-          listing_quantity: payment.transaction.listing_quantity,
-          duration: duration,
-          payment_total: humanized_money_with_symbol(payment.total_sum),
-          payment_service_fee: humanized_money_with_symbol(-service_fee),
-          payment_seller_gets: humanized_money_with_symbol(you_get),
-          payer_full_name: payment.payer.name(community),
-          payer_given_name: payment.payer.given_name_or_username,
-          automatic_confirmation_days: payment.transaction.automatic_confirmation_after_days,
-          show_money_will_be_transferred_note: true
+      premailer_mail(:to => payment.recipient.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_payment.new_payment")) { |format|
+        format.html {
+          render "braintree_payment_receipt_to_seller", locals: {
+                   conversation_url: person_transaction_url(payment.recipient, @url_params.merge({:id => payment.transaction.id.to_s})),
+                   listing_title: payment.transaction.listing_title,
+                   price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
+                   listing_price: humanized_money_with_symbol(payment.transaction.unit_price),
+                   listing_quantity: payment.transaction.listing_quantity,
+                   duration: duration,
+                   payment_total: humanized_money_with_symbol(payment.total_sum),
+                   payment_service_fee: humanized_money_with_symbol(-service_fee),
+                   payment_seller_gets: humanized_money_with_symbol(you_get),
+                   payer_full_name: payment.payer.name(community),
+                   payer_given_name: payment.payer.given_name_or_username,
+                   automatic_confirmation_days: payment.transaction.automatic_confirmation_after_days,
+                   show_money_will_be_transferred_note: true
+                 }
         }
       }
-    }
+    end
   end
 
   def braintree_receipt_to_payer(payment, community)
-    prepare_template(community, payment.payer, "email_about_new_payments")
+    recipient = payment.payer
+    prepare_template(community, recipient, "email_about_new_payments")
+    with_locale(recipient.locale, community.id) do
 
-    unit_type = translate_quantity_unit(payment.transaction.unit_type)
-    duration = payment.transaction.booking.present? ? payment.transaction.booking.duration : nil
+      unit_type = translate_quantity_unit(payment.transaction.unit_type)
+      duration = payment.transaction.booking.present? ? payment.transaction.booking.duration : nil
 
-    premailer_mail(:to => payment.payer.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.receipt_to_payer.receipt_of_payment")) { |format|
-      format.html {
-        render "payment_receipt_to_buyer", locals: {
-          conversation_url: person_transaction_url(payment.payer, @url_params.merge({:id => payment.transaction.id.to_s})),
-          listing_title: payment.transaction.listing_title,
-          price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
-          listing_price: humanized_money_with_symbol(payment.transaction.unit_price),
-          listing_quantity: payment.transaction.listing_quantity,
-          duration: duration,
-          payment_total: humanized_money_with_symbol(payment.total_sum),
-          subtotal: humanized_money_with_symbol(payment.total_sum),
-          shipping_total: nil,
-          recipient_full_name: payment.recipient.name(community),
-          recipient_given_name: payment.recipient.given_name_or_username,
-          automatic_confirmation_days: payment.transaction.automatic_confirmation_after_days,
-          show_money_will_be_transferred_note: true
+      premailer_mail(:to => payment.payer.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.receipt_to_payer.receipt_of_payment")) { |format|
+        format.html {
+          render "payment_receipt_to_buyer", locals: {
+                   conversation_url: person_transaction_url(payment.payer, @url_params.merge({:id => payment.transaction.id.to_s})),
+                   listing_title: payment.transaction.listing_title,
+                   price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
+                   listing_price: humanized_money_with_symbol(payment.transaction.unit_price),
+                   listing_quantity: payment.transaction.listing_quantity,
+                   duration: duration,
+                   payment_total: humanized_money_with_symbol(payment.total_sum),
+                   subtotal: humanized_money_with_symbol(payment.total_sum),
+                   shipping_total: nil,
+                   recipient_full_name: payment.recipient.name(community),
+                   recipient_given_name: payment.recipient.given_name_or_username,
+                   automatic_confirmation_days: payment.transaction.automatic_confirmation_after_days,
+                   show_money_will_be_transferred_note: true
+                 }
         }
       }
-    }
+    end
   end
 
   # seller_model, buyer_model and community can be passed as params for testing purposes
@@ -151,32 +165,34 @@ class TransactionMailer < ActionMailer::Base
     gateway_fee = transaction[:payment_gateway_fee]
 
     prepare_template(community, seller_model, "email_about_new_payments")
+    with_locale(seller_model.locale, community.id) do
 
-    you_get = payment_total - service_fee - gateway_fee
+      you_get = payment_total - service_fee - gateway_fee
 
-    unit_type = translate_quantity_unit(transaction[:unit_type])
+      unit_type = translate_quantity_unit(transaction[:unit_type])
 
-    premailer_mail(:to => seller_model.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.new_payment.new_payment")) do |format|
-      format.html {
-        render "paypal_payment_receipt_to_seller", locals: {
-          conversation_url: person_transaction_url(seller_model, @url_params.merge(id: transaction[:id])),
-          listing_title: transaction[:listing_title],
-          price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
-          listing_price: humanized_money_with_symbol(transaction[:listing_price]),
-          listing_quantity: transaction[:listing_quantity],
-          duration: transaction[:booking].present? ? transaction[:booking][:duration] : nil,
-          subtotal: humanized_money_with_symbol(transaction[:item_total]),
-          payment_total: humanized_money_with_symbol(payment_total),
-          shipping_total: humanized_money_with_symbol(transaction[:shipping_price]),
-          payment_service_fee: humanized_money_with_symbol(-service_fee),
-          paypal_gateway_fee: humanized_money_with_symbol(-gateway_fee),
-          payment_seller_gets: humanized_money_with_symbol(you_get),
-          payer_full_name: buyer_model.name(community),
-          payer_given_name: buyer_model.given_name_or_username,
+      premailer_mail(:to => seller_model.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.new_payment.new_payment")) do |format|
+        format.html {
+          render "paypal_payment_receipt_to_seller", locals: {
+                   conversation_url: person_transaction_url(seller_model, @url_params.merge(id: transaction[:id])),
+                   listing_title: transaction[:listing_title],
+                   price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
+                   listing_price: humanized_money_with_symbol(transaction[:listing_price]),
+                   listing_quantity: transaction[:listing_quantity],
+                   duration: transaction[:booking].present? ? transaction[:booking][:duration] : nil,
+                   subtotal: humanized_money_with_symbol(transaction[:item_total]),
+                   payment_total: humanized_money_with_symbol(payment_total),
+                   shipping_total: humanized_money_with_symbol(transaction[:shipping_price]),
+                   payment_service_fee: humanized_money_with_symbol(-service_fee),
+                   paypal_gateway_fee: humanized_money_with_symbol(-gateway_fee),
+                   payment_seller_gets: humanized_money_with_symbol(you_get),
+                   payer_full_name: buyer_model.name(community),
+                   payer_given_name: buyer_model.given_name_or_username,
+                 }
         }
-      }
+      end
     end
   end
 
@@ -187,30 +203,32 @@ class TransactionMailer < ActionMailer::Base
     community ||= Community.find(transaction[:community_id])
 
     prepare_template(community, buyer_model, "email_about_new_payments")
+    with_locale(buyer_model.locale, community.id) do
 
-    unit_type = translate_quantity_unit(transaction[:unit_type])
+      unit_type = translate_quantity_unit(transaction[:unit_type])
 
-    premailer_mail(:to => buyer_model.confirmed_notification_emails_to,
-         :from => community_specific_sender(community),
-         :subject => t("emails.receipt_to_payer.receipt_of_payment")) { |format|
-      format.html {
-        render "payment_receipt_to_buyer", locals: {
-          conversation_url: person_transaction_url(buyer_model, @url_params.merge({:id => transaction[:id]})),
-          listing_title: transaction[:listing_title],
-          price_per_unit_title: t("emails.receipt_to_payer.price_per_unit_type", unit_type: unit_type),
-          listing_price: humanized_money_with_symbol(transaction[:listing_price]),
-          listing_quantity: transaction[:listing_quantity],
-          duration: transaction[:booking].present? ? transaction[:booking][:duration] : nil,
-          subtotal: humanized_money_with_symbol(transaction[:item_total]),
-          shipping_total: humanized_money_with_symbol(transaction[:shipping_price]),
-          payment_total: humanized_money_with_symbol(transaction[:payment_total]),
-          recipient_full_name: seller_model.name(community),
-          recipient_given_name: seller_model.given_name_or_username,
-          automatic_confirmation_days: nil,
-          show_money_will_be_transferred_note: false
+      premailer_mail(:to => buyer_model.confirmed_notification_emails_to,
+                     :from => community_specific_sender(community),
+                     :subject => t("emails.receipt_to_payer.receipt_of_payment")) { |format|
+        format.html {
+          render "payment_receipt_to_buyer", locals: {
+                   conversation_url: person_transaction_url(buyer_model, @url_params.merge({:id => transaction[:id]})),
+                   listing_title: transaction[:listing_title],
+                   price_per_unit_title: t("emails.receipt_to_payer.price_per_unit_type", unit_type: unit_type),
+                   listing_price: humanized_money_with_symbol(transaction[:listing_price]),
+                   listing_quantity: transaction[:listing_quantity],
+                   duration: transaction[:booking].present? ? transaction[:booking][:duration] : nil,
+                   subtotal: humanized_money_with_symbol(transaction[:item_total]),
+                   shipping_total: humanized_money_with_symbol(transaction[:shipping_price]),
+                   payment_total: humanized_money_with_symbol(transaction[:payment_total]),
+                   recipient_full_name: seller_model.name(community),
+                   recipient_given_name: seller_model.given_name_or_username,
+                   automatic_confirmation_days: nil,
+                   show_money_will_be_transferred_note: false
+                 }
         }
       }
-    }
+    end
   end
 
   private
@@ -226,7 +244,6 @@ class TransactionMailer < ActionMailer::Base
     @current_community = community
     @recipient = recipient
     @url_params = build_url_params(community, recipient)
-    set_locale(recipient.locale)
   end
 
   def mail_params(recipient, community, subject)

--- a/app/utils/mail_utils.rb
+++ b/app/utils/mail_utils.rb
@@ -39,9 +39,11 @@ module MailUtils
 
     if old_locale.to_sym != new_locale.to_sym
       I18n.locale = new_locale
-      # TODO store_translations here
-      block.call
-      I18n.locale = old_locale
+      begin
+        block.call
+      ensure
+        I18n.locale = old_locale
+      end
     else
       block.call
     end
@@ -61,8 +63,11 @@ module MailUtils
         # escape the separators (. dots) in the key
         community_backend.store_translations(locale, data, escape: false)
       }
-      block.call
-      community_backend.set_community!(old_community_id, clear: false)
+      begin
+        block.call
+      ensure
+        community_backend.set_community!(old_community_id, clear: false)
+      end
     else
       block.call
     end

--- a/app/utils/mail_utils.rb
+++ b/app/utils/mail_utils.rb
@@ -16,7 +16,7 @@ module MailUtils
   end
 
   def with_locale(recipient_locale, community_id = nil, &block)
-    set_locale(mail_locale) {
+    set_locale(recipient_locale) {
       set_community(community_id) {
         block.call
       }
@@ -47,13 +47,13 @@ module MailUtils
     end
   end
 
-  def set_community(new_community_id)
+  def set_community(new_community_id, &block)
     community_backend = I18n::Backend::CommunityBackend.instance
     old_community_id = community_backend.community_id
 
     if old_community_id != new_community_id
       community_backend.community_id = new_community_id
-      community_translations = TranslationService::API::Api.translations.get(community_id)[:data]
+      community_translations = TranslationService::API::Api.translations.get(new_community_id)[:data]
       TranslationServiceHelper.community_translations_for_i18n_backend(community_translations).each { |locale, data|
         # Store community translations to I18n backend.
         #

--- a/app/utils/mail_utils.rb
+++ b/app/utils/mail_utils.rb
@@ -52,7 +52,7 @@ module MailUtils
     old_community_id = community_backend.community_id
 
     if old_community_id != new_community_id
-      community_backend.community_id = new_community_id
+      community_backend.set_community!(new_community_id, clear: false)
       community_translations = TranslationService::API::Api.translations.get(new_community_id)[:data]
       TranslationServiceHelper.community_translations_for_i18n_backend(community_translations).each { |locale, data|
         # Store community translations to I18n backend.
@@ -62,7 +62,7 @@ module MailUtils
         community_backend.store_translations(locale, data, escape: false)
       }
       block.call
-      community_backend.community_id = old_community_id
+      community_backend.set_community!(old_community_id, clear: false)
     else
       block.call
     end

--- a/app/view_utils/category_view_utils.rb
+++ b/app/view_utils/category_view_utils.rb
@@ -33,7 +33,7 @@ module CategoryViewUtils
       {
         id: c[:id],
         label: pick_category_translation(c[:translations], locale, all_locales),
-        listing_shapes: embed_shape(c[:listing_shape_ids], shapes, locale, all_locales),
+        listing_shapes: embed_shape(c[:listing_shape_ids], shapes),
         subcategories: category_tree(
           categories: c[:children],
           shapes: shapes,

--- a/app/view_utils/category_view_utils.rb
+++ b/app/view_utils/category_view_utils.rb
@@ -33,13 +33,12 @@ module CategoryViewUtils
       {
         id: c[:id],
         label: pick_category_translation(c[:translations], locale, all_locales),
-        listing_shapes: embed_shape(c[:listing_shape_ids], shapes, locale, all_locales, translation_cache),
+        listing_shapes: embed_shape(c[:listing_shape_ids], shapes, locale, all_locales),
         subcategories: category_tree(
           categories: c[:children],
           shapes: shapes,
           locale: locale,
-          all_locales: all_locales,
-          translation_cache: translation_cache
+          all_locales: all_locales
         )
       }
     }

--- a/app/view_utils/category_view_utils.rb
+++ b/app/view_utils/category_view_utils.rb
@@ -28,7 +28,7 @@ module CategoryViewUtils
   #     "id" => "id"
   #   }
   # ]
-  def category_tree(categories: categories, shapes: shapes, locale:, all_locales:, translation_cache:)
+  def category_tree(categories: categories, shapes: shapes, locale:, all_locales:)
     categories.map { |c|
       {
         id: c[:id],
@@ -48,18 +48,13 @@ module CategoryViewUtils
 
   # private
 
-  def embed_shape(ids, shapes, locale, all_locales, translation_cache)
+  def embed_shape(ids, shapes)
     shapes.select { |s|
       ids.include? s[:id]
     }.map { |s|
       {
         id: s[:id],
-        label: TranslationServiceHelper.pick_translation(
-          s[:name_tr_key],
-          translation_cache,
-          all_locales,
-          locale
-        )
+        label: I18n.translate(s[:name_tr_key])
       }
     }
   end

--- a/app/view_utils/translation_service_helper.rb
+++ b/app/view_utils/translation_service_helper.rb
@@ -2,22 +2,6 @@ module TranslationServiceHelper
 
   module_function
 
-  def pick_translation(key, community_translations, community_locales, user_locale, opts = {})
-    translations_for_key = community_translations.select { |translation| translation[:translation_key] == key }
-
-    raise ArgumentError.new("Can not find any translation for key: #{key}") if translations_for_key.empty?
-
-    preferred = (opts[:locale] || user_locale).to_s
-    fallbacks = community_locales.map(&:to_s).reject { |l| l == preferred }
-    locales_ordered = [preferred].concat(fallbacks)
-
-    translations_ordered = locales_ordered.map { |l|
-      translations_for_key.find { |t| t[:locale] == l }
-    }
-
-    (translations_ordered.first || translations_for_key.first)[:translation]
-  end
-
   # In: [{translation_key: "foo", locale: "en", translation: "en foo"},
   #      {translation_key: "foo", locale: "fi", translation: "fi foo"},
   #      {translation_key: "bar", locale: "en", translation: "en bar"},

--- a/app/view_utils/translation_service_helper.rb
+++ b/app/view_utils/translation_service_helper.rb
@@ -2,6 +2,15 @@ module TranslationServiceHelper
 
   module_function
 
+  def community_translations_for_i18n_backend(translations)
+    locale_groups = translations.group_by { |tr| tr[:locale] }
+    locale_groups.map { |(locale, translations)|
+      [locale.to_sym, translations.inject({}) { |memo, tr|
+         memo.tap { |m| m[tr[:translation_key]] = tr[:translation] }
+       }]
+    }
+  end
+
   # In: [{translation_key: "foo", locale: "en", translation: "en foo"},
   #      {translation_key: "foo", locale: "fi", translation: "fi foo"},
   #      {translation_key: "bar", locale: "en", translation: "en bar"},

--- a/app/views/admin/categories/form/_category_listing_shapes.haml
+++ b/app/views/admin/categories/form/_category_listing_shapes.haml
@@ -8,6 +8,6 @@
           - checkbox_id = "listing_shape_checkbox_#{shape[:id].to_s}"
           .custom-field-categories-checkbox-container
             = check_box_tag "category[listing_shapes][][listing_shape_id]", "#{shape[:id]}", selected_shape_ids.include?(shape[:id]), :id => checkbox_id, :class => "category-listing-shape-checkbox"
-            = label_tag checkbox_id, ts(shape[:name_tr_key]), :class => "category-listing-shape-checkbox-label"
+            = label_tag checkbox_id, t(shape[:name_tr_key]), :class => "category-listing-shape-checkbox-label"
 - else
   = hidden_field_tag "category[listing_shapes][][listing_shape_id]", shapes.first[:id]

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -7,7 +7,7 @@
 = render partial: "admin/left_hand_navigation", locals: { links: admin_links_for(@current_community), selected_left_navi_link: selected_left_navi_link }
 
 .left-navi-section
-  %h2= t(".edit_listing_shape", shape: ts(shape[:name_tr_key]))
+  %h2= t(".edit_listing_shape", shape: t(shape[:name_tr_key]))
   = form_tag(admin_listing_shape_path(shape[:id]), method: :put, id: "listing_shape_form") do
 
     .translation-wrapper

--- a/app/views/admin/listing_shapes/index.haml
+++ b/app/views/admin/listing_shapes/index.haml
@@ -18,7 +18,7 @@
         %tbody
           - listing_shapes.map do |shape|
             %tr
-              %td= ts(shape[:name_tr_key])
+              %td= t(shape[:name_tr_key])
               %td= "TODO"
               %td
                 = link_to edit_admin_listing_shape_path(shape[:id]) do

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -50,7 +50,7 @@
               .toggle-header-container
                 .toggle-header
                   - if selected_shape
-                    = ts(selected_shape[:name_tr_key]).mb_chars.capitalize.to_s
+                    = t(selected_shape[:name_tr_key]).mb_chars.capitalize.to_s
                   - else
                     = t("homepage.filters.all_listing_types")
 
@@ -60,7 +60,7 @@
               = link_to t("homepage.filters.all_listing_types"), params.merge({transaction_type: "all"})
               - shapes.each do |shape|
                 = link_to params.merge({transaction_type: shape[:name]}), class:  "toggle-menu-subitem" do
-                  = ts(shape[:name_tr_key]).mb_chars.capitalize.to_s
+                  = t(shape[:name_tr_key]).mb_chars.capitalize.to_s
 
         - if @show_categories
           .toggle-container.home-toolbar-toggle-container.hidden-tablet

--- a/app/views/listings/new.haml
+++ b/app/views/listings/new.haml
@@ -29,7 +29,7 @@
       .selected-group{:name => "listing_shape"}
         - shapes.each do |value|
           %a.select.selected.hidden{:href => "#", :data => {:id => value[:id]}}
-            .link-text= t(".selected_transaction_type", :transaction_type => ts(value[:name_tr_key]))
+            .link-text= t(".selected_transaction_type", :transaction_type => t(value[:name_tr_key]))
 
   %h2.listing-form-title{:id => "foo"}
 
@@ -51,6 +51,6 @@
       .option-group{:name => "listing_shape"}
         - shapes.each do |value|
           %a.select.option.hidden{:href => "#", :data => {:id => value[:id]}}
-            .link-text= ts(value[:name_tr_key])
+            .link-text= t(value[:name_tr_key])
 
   .form-fields

--- a/config/initializers/i18n_backend.rb
+++ b/config/initializers/i18n_backend.rb
@@ -12,9 +12,13 @@ module I18n
     # `instance` method returns the singleton instance
     #
     class CommunityBackend < KeyValue
+      include Fallbacks
+
       class << self
         attr_accessor(:translation_service_backend_instance)
       end
+
+      attr_accessor :community_id
 
       def store_translations(locale, data, options = {})
         return unless @community_id
@@ -25,11 +29,6 @@ module I18n
         return unless @community_id
         super(locale, "#{@community_id}.#{key}", scope, options)
       end
-
-      def set_community!(community_id)
-        @community_id = community_id
-      end
-
 
       def self.instance
         self.translation_service_backend_instance ||= CommunityBackend.new({})
@@ -47,4 +46,3 @@ module I18n
 end
 
 I18n.backend = I18n::Backend::Chain.new(I18n::Backend::CommunityBackend.instance, I18n.backend)
-

--- a/config/initializers/i18n_backend.rb
+++ b/config/initializers/i18n_backend.rb
@@ -18,11 +18,21 @@ module I18n
         attr_accessor(:translation_service_backend_instance)
       end
 
-      attr_accessor :community_id
+      attr_reader :community_id
+
+      def set_community!(community_id, clear: true)
+        if community_id != @community_id
+          @community_id = community_id
+
+          # Clear store every time we switch community, this is not a cache
+          @store = {} if clear
+        end
+      end
 
       def store_translations(locale, data, options = {})
-        return unless @community_id
-        super(locale, wrap_community(data, @community_id), options)
+        raise ArgumentError.new("Set community via set_community! before storing translations.") unless @community_id
+
+        super(locale, {@community_id => data}, options)
       end
 
       def lookup(locale, key, scope = [], options = {})
@@ -34,13 +44,6 @@ module I18n
         self.translation_service_backend_instance ||= CommunityBackend.new({})
       end
 
-      private
-
-      def wrap_community(data, community_id)
-        hash = {}
-        hash[community_id] = data
-        return hash
-      end
     end
   end
 end

--- a/config/initializers/i18n_backend.rb
+++ b/config/initializers/i18n_backend.rb
@@ -1,0 +1,50 @@
+module I18n
+  module Backend
+
+    # A simple and minimal wrapper to KeyValue store, that allows
+    # storing per community translations
+    #
+    # Usage:
+    #
+    # First set the community_id with `set_community!` method. After that, calls to
+    # `store_translations` and `lookup` methods are sandboxed per community
+    #
+    # `instance` method returns the singleton instance
+    #
+    class CommunityBackend < KeyValue
+      class << self
+        attr_accessor(:translation_service_backend_instance)
+      end
+
+      def store_translations(locale, data, options = {})
+        return unless @community_id
+        super(locale, wrap_community(data, @community_id), options)
+      end
+
+      def lookup(locale, key, scope = [], options = {})
+        return unless @community_id
+        super(locale, "#{@community_id}.#{key}", scope, options)
+      end
+
+      def set_community!(community_id)
+        @community_id = community_id
+      end
+
+
+      def self.instance
+        self.translation_service_backend_instance ||= CommunityBackend.new({})
+      end
+
+      private
+
+      def wrap_community(data, community_id)
+        hash = {}
+        hash[community_id] = data
+        return hash
+      end
+    end
+  end
+end
+
+I18n.backend = I18n::Backend::Chain.new(I18n::Backend::CommunityBackend.instance, I18n.backend)
+

--- a/lib/i18n_action_mailer/i18n_action_mailer.rb
+++ b/lib/i18n_action_mailer/i18n_action_mailer.rb
@@ -7,24 +7,15 @@ module I18nActionMailer
 
   module InstanceMethods
     def translate(key, options = {})
-      I18n.translate(key, options.merge(:locale => self.locale))
+      I18n.translate(key, options)
     end
     alias_method :t, :translate
 
     def localize(key, options = {})
-      I18n.localize(key, options.merge(:locale => self.locale))
+      I18n.localize(key, options)
     end
     alias_method :l, :localize
-
-    def locale
-      @locale
-    end
-
-    def set_locale(locale)
-      @locale = locale
-    end
   end
-
 end
 
 ActionMailer::Base.send(:include, I18nActionMailer)

--- a/spec/i18n/community_backend_spec.rb
+++ b/spec/i18n/community_backend_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe I18n::Backend::CommunityBackend do
+
+  before(:each) do
+    @backend = I18n.backend
+    I18n.backend = I18n::Backend::CommunityBackend.new({}) # Hash as an empty key-value store
+
+    I18n.backend.set_community!(1)
+    I18n.backend.store_translations(:en, {foo: "bar"})
+    I18n.backend.store_translations(:fi, {foo: "baari"})
+
+    I18n.backend.set_community!(2)
+    I18n.backend.store_translations(:en, {foo: "baz"})
+    I18n.backend.store_translations(:fi, {foo: "baazi"})
+  end
+
+  after(:each) do
+    # clean up
+    I18n.backend = @backend
+  end
+
+  it "stores and looks translations per community" do
+    I18n.backend.set_community!(1)
+    expect(I18n.translate("foo", locale: :en)).to eq("bar")
+    expect(I18n.translate("foo", locale: :fi)).to eq("baari")
+
+    I18n.backend.set_community!(2)
+    expect(I18n.translate("foo", locale: :en)).to eq("baz")
+    expect(I18n.translate("foo", locale: :fi)).to eq("baazi")
+  end
+
+  it "does nothing if community is nil" do
+    I18n.backend.set_community!(nil)
+    expect(I18n.translate("foo", locale: :fi)).to eq("translation missing: fi.foo")
+  end
+
+end

--- a/spec/i18n/community_backend_spec.rb
+++ b/spec/i18n/community_backend_spec.rb
@@ -6,11 +6,11 @@ describe I18n::Backend::CommunityBackend do
     @backend = I18n.backend
     I18n.backend = I18n::Backend::CommunityBackend.new({}) # Hash as an empty key-value store
 
-    I18n.backend.set_community!(1)
+    I18n.backend.community_id = 1
     I18n.backend.store_translations(:en, {foo: "bar"})
     I18n.backend.store_translations(:fi, {foo: "baari"})
 
-    I18n.backend.set_community!(2)
+    I18n.backend.community_id = 2
     I18n.backend.store_translations(:en, {foo: "baz"})
     I18n.backend.store_translations(:fi, {foo: "baazi"})
   end
@@ -21,17 +21,17 @@ describe I18n::Backend::CommunityBackend do
   end
 
   it "stores and looks translations per community" do
-    I18n.backend.set_community!(1)
+    I18n.backend.community_id = 1
     expect(I18n.translate("foo", locale: :en)).to eq("bar")
     expect(I18n.translate("foo", locale: :fi)).to eq("baari")
 
-    I18n.backend.set_community!(2)
+    I18n.backend.community_id = 2
     expect(I18n.translate("foo", locale: :en)).to eq("baz")
     expect(I18n.translate("foo", locale: :fi)).to eq("baazi")
   end
 
   it "does nothing if community is nil" do
-    I18n.backend.set_community!(nil)
+    I18n.backend.community_id = nil
     expect(I18n.translate("foo", locale: :fi)).to eq("translation missing: fi.foo")
   end
 

--- a/spec/i18n/community_backend_spec.rb
+++ b/spec/i18n/community_backend_spec.rb
@@ -5,14 +5,6 @@ describe I18n::Backend::CommunityBackend do
   before(:each) do
     @backend = I18n.backend
     I18n.backend = I18n::Backend::CommunityBackend.new({}) # Hash as an empty key-value store
-
-    I18n.backend.community_id = 1
-    I18n.backend.store_translations(:en, {foo: "bar"})
-    I18n.backend.store_translations(:fi, {foo: "baari"})
-
-    I18n.backend.community_id = 2
-    I18n.backend.store_translations(:en, {foo: "baz"})
-    I18n.backend.store_translations(:fi, {foo: "baazi"})
   end
 
   after(:each) do
@@ -21,18 +13,36 @@ describe I18n::Backend::CommunityBackend do
   end
 
   it "stores and looks translations per community" do
-    I18n.backend.community_id = 1
+    I18n.backend.set_community!(1)
+    I18n.backend.store_translations(:en, {foo: "bar"})
+    I18n.backend.store_translations(:fi, {foo: "baari"})
+
     expect(I18n.translate("foo", locale: :en)).to eq("bar")
     expect(I18n.translate("foo", locale: :fi)).to eq("baari")
 
-    I18n.backend.community_id = 2
+    I18n.backend.set_community!(2)
+    I18n.backend.store_translations(:en, {foo: "baz"})
+    I18n.backend.store_translations(:fi, {foo: "baazi"})
     expect(I18n.translate("foo", locale: :en)).to eq("baz")
     expect(I18n.translate("foo", locale: :fi)).to eq("baazi")
   end
 
-  it "does nothing if community is nil" do
-    I18n.backend.community_id = nil
-    expect(I18n.translate("foo", locale: :fi)).to eq("translation missing: fi.foo")
+  it "optionally doesn't clear stored translations on community change" do
+    I18n.backend.set_community!(1)
+    I18n.backend.store_translations(:en, {foo: "bar"})
+    I18n.backend.set_community!(2, clear: false)
+    I18n.backend.store_translations(:en, {foo: "baz"})
+
+    expect(I18n.translate("foo", locale: :en)).to eq("baz")
+
+    I18n.backend.set_community!(1, clear: false)
+    expect(I18n.translate("foo", locale: :en)).to eq("bar")
+  end
+
+  it "raises error if community is nil" do
+    I18n.backend.set_community!(nil)
+    expect{ I18n.backend.store_translations(:en, {foo: "bar"}) }
+      .to raise_error
   end
 
 end


### PR DESCRIPTION
Add a new translation backend, which makes it possible to scope translations per community.

ApplicationController sets the correct scope and sets the translations, and after that we can use the `t` method to fetch the translations.

Tasks:

- [X] Implement CommunityBackend for translations
- [X] Set correct community for the translation backend in ApplicationController
- [X] Implement `with_locale { ... }` helper method, for temporary changing locale and community in mail views
- [X] Use `with_locale` in each mail view
- [X] Remove per request translation cache, that was stored as a controller instance variable
- [X] Remove some translation helper code and let the translation backend handle that logic
- [x] Periodically clean up translation store (it keeps growing when ever we add new community translations there)

After #1148 