### PR TITLE
Remove russian gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'delayed_job', "~>3.0.5"
 gem 'delayed_job_active_record'
 gem 'json', "~>1.8.0"
 gem 'multi_json', "~>1.7.3" # 1.8.0 caused "invalid byte sequence in UTF-8" at heroku
-gem 'russian'
 gem 'web_translate_it'
 gem 'postmark-rails' # could be removed as not currently used
 gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,8 +402,6 @@ GEM
     ruby-prof (0.14.2)
     ruby-progressbar (1.4.2)
     rubyzip (1.1.7)
-    russian (0.6.0)
-      i18n (>= 0.5.0)
     sass (3.2.10)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
@@ -552,7 +550,6 @@ DEPENDENCIES
   rspec-rails (~> 2.99.0)
   rubocop
   ruby-prof
-  russian
   sass (~> 3.2.9)
   sass-rails
   selenium-webdriver (~> 2.43.0)


### PR DESCRIPTION
- I see no reason why our Russian translations should not work without this gem
- russian gem uses I18n.backend internal methods, thus it doesn't work with Chained I18n backend, see more: https://github.com/yaroslav/russian/issues/53