### PR TITLE
EntityUtils.define_builder improvements

### DIFF
--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -254,10 +254,7 @@ module EntityUtils
 
   def transform_and_validate(fields, input)
     output = transform_all(fields, input)
-    errors = validate_all(fields, output).map { |err|
-      err[:msg] = "#{err[:field]}: #{err[:msg]}"
-      err
-    }
+    errors = validate_all(fields, output)
 
     {value: output, errors: errors}
   end
@@ -322,7 +319,10 @@ module EntityUtils
       result = transform_and_validate(fields, data)
 
       if !result[:errors].empty?
-        msg = result[:errors].map { |error| error[:msg] }.join(", ")
+        msg = result[:errors].map { |error|
+          "#{error[:field]}: #{error[:msg]}"
+        }.join(", ")
+
         if opts[:result]
           Result::Error.new(msg, result[:errors])
         else

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -174,9 +174,17 @@ module EntityUtils
       (parsed_spec[:transformers] || [])
       .map { |(name, param)| TRANSFORMERS[name].curry().call(param) }
     parsed_spec[:collection] =
-      parse_specs(opts[:collection] || [])
+      if opts[:collection].is_a? Proc
+        opts[:collection].call(nil, specs_only: true)
+      else
+        parse_specs(opts[:collection] || [])
+      end
     parsed_spec[:entity] =
-      parse_specs(opts[:entity] || [])
+      if opts[:entity].is_a? Proc
+        opts[:entity].call(nil, specs_only: true)
+      else
+        parse_specs(opts[:entity] || [])
+      end
 
     parsed_spec
   end
@@ -306,8 +314,11 @@ module EntityUtils
 
     -> (data, opts = {}) do
       opts = {
+        specs_only: false,
         result: false
       }.merge(opts)
+
+      return fields if opts[:specs_only]
 
       raise(TypeError, "Expecting an input hash. You gave: #{data}") unless data.is_a? Hash
 

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -38,79 +38,77 @@ module EntityUtils
   VALIDATORS = {
     mandatory: -> (_, v, _) {
       if (v.to_s.empty?)
-        "Missing mandatory value."
+        {code: :mandatory, msg: "Missing mandatory value." }
       end
     },
     optional: -> (_, v, _) { nil },
     one_of: -> (allowed, v, _) {
       unless (allowed.include?(v))
-        "Value must be one of #{allowed}. Was: #{v}."
+        {code: :one_of, msg: "Value must be one of #{allowed}. Was: #{v}." }
       end
     },
     string: -> (_, v, _) {
       unless (v.nil? || v.is_a?(String))
-        "Value must be a String. Was: #{v} (#{v.class.name})."
+        {code: :string, msg: "Value must be a String. Was: #{v} (#{v.class.name})." }
       end
     },
     time: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Time))
-        "Value must be a Time. Was: #{v} (#{v.class.name})."
+        {code: :time, msg: "Value must be a Time. Was: #{v} (#{v.class.name})." }
       end
     },
     date: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Date))
-        "Value must be a Date. Was: #{v} (#{v.class.name})."
+        {code: :date, msg: "Value must be a Date. Was: #{v} (#{v.class.name})." }
       end
     },
     fixnum: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Fixnum))
-        "Value must be a Fixnum. Was: #{v} (#{v.class.name})."
+        {code: :fixnum, msg: "Value must be a Fixnum. Was: #{v} (#{v.class.name})." }
       end
     },
     symbol: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Symbol))
-        "Value must be a Symbol. Was: #{v} (#{v.class.name})."
+        {code: :symbol, msg: "Value must be a Symbol. Was: #{v} (#{v.class.name})." }
       end
     },
     hash: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Hash))
-        "Value must be a Hash. Was: #{v} (#{v.class.name})."
+        {code: :hash, msg: "Value must be a Hash. Was: #{v} (#{v.class.name})." }
       end
     },
     callable: -> (_, v, _) {
       unless (v.nil? || v.respond_to?(:call))
-        "Value must respond to :call, i.e. be a Method or a Proc (lambda, block, etc.)."
+        {code: :callable, msg: "Value must respond to :call, i.e. be a Method or a Proc (lambda, block, etc.)." }
       end
     },
     enumerable: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Enumerable))
-        "Value must be an Enumerable. Was: #{v}."
+        {code: :enumerable, msg: "Value must be an Enumerable. Was: #{v}." }
       end
     },
     array: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Array))
-        "Value must be an Array. Was: #{v}."
+        {code: :array, msg: "Value must be an Array. Was: #{v}." }
       end
     },
     set: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Set))
-        "Value must be a Set. Was: #{v} (#{v.class.name})."
+        {code: :set, msg: "Value must be a Set. Was: #{v} (#{v.class.name})." }
       end
     },
     money: -> (_, v, _) {
       unless (v.nil? || v.is_a?(Money))
-        "Value must be a Money. Was: #{v}."
+        {code: :money, msg: "Value must be a Money. Was: #{v}." }
       end
     },
     bool: -> (_, v, _) {
       unless (v.nil? || v == true || v == false)
-        "Value must be boolean true or false. Was: #{v} (#{v.class.name})."
+        {code: :bool, msg: "Value must be boolean true or false. Was: #{v} (#{v.class.name})." }
       end
     },
     validate_with: -> (validator, v, _) {
-      unless (validator.call(v))
-        "Custom validation failed. Was: #{v}."
-      end
+      validator.call(v)
     }
   }
 
@@ -198,8 +196,8 @@ module EntityUtils
 
   def validate(validators, val, field)
     validators.reduce([]) do |res, validator|
-      err_msg = validator.call(val, field)
-      res.push({field: field.to_s, msg: err_msg}) unless err_msg.nil?
+      err = validator.call(val, field)
+      res.push({field: field.to_s, code: err[:code], msg: err[:msg]}) unless err.nil?
       res
     end
   end

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -143,7 +143,7 @@ module EntityUtils
     transform_with: -> (transformer, v) { transformer.call(v) }
   }
 
-  def categorice_spec(k)
+  def spec_category(k)
     if (VALIDATORS.keys.include?(k))
       :validators
     elsif (TRANSFORMERS.keys.include?(k))
@@ -163,7 +163,7 @@ module EntityUtils
     parsed_spec = s.zip([nil].cycle)
       .to_h
       .merge(opts)
-      .group_by { |(name, param)| categorice_spec(name) }
+      .group_by { |(name, param)| spec_category(name) }
 
     parsed_spec[:validators] =
       (parsed_spec[:validators] || [])

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -329,6 +329,7 @@ module EntityUtils
     end
 
     alias_method :call, :build
+    alias_method :[], :build
 
     def validate(data)
       with_result(

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -211,11 +211,13 @@ module EntityUtils
 
       nested_errors =
         if spec[:collection].present?
-          input[name].each_with_index.flat_map { |v, i|
-            validate_all(spec[:collection], v).map { |err|
+          input[name].each_with_index.reduce([]) { |errors, (v, i)|
+            collection_errors = validate_all(spec[:collection], v).map { |err|
               err[:field] = "#{name.to_s}[#{i}].#{err[:field]}"
               err
-            } }
+            }
+            errors.concat(collection_errors)
+          }
         elsif spec[:entity].present?
           validate_all(spec[:entity], input[name]).map { |err|
             err[:field] = "#{name.to_s}.#{err[:field]}"

--- a/spec/utils/entity_utils_spec.rb
+++ b/spec/utils/entity_utils_spec.rb
@@ -240,4 +240,31 @@ describe EntityUtils do
     expect{entity.call({tags: nil})}
       .to_not raise_error
   end
+
+  # You can enable this test to measure the performance
+  xit "#define_builder is fast" do
+    name_details_entity = EntityUtils.define_builder(
+      [:first, :string, :mandatory],
+      [:middle, :string, default: "Middle"],
+      [:last, :string, :mandatory]
+    )
+
+    entity = EntityUtils.define_builder(
+      [:name, :mandatory, entity: name_details_entity]
+    )
+    bm = 1000 * Benchmark.realtime {
+      1000.times {
+        entity.call(
+          {
+            name: {
+              first: "John",
+              last: "Doe"
+            }
+          }
+        )
+      }
+    }
+
+    expect(bm).to be < 50
+  end
 end

--- a/spec/utils/entity_utils_spec.rb
+++ b/spec/utils/entity_utils_spec.rb
@@ -241,30 +241,34 @@ describe EntityUtils do
       .to_not raise_error
   end
 
-  # You can enable this test to measure the performance
-  xit "#define_builder is fast" do
-    name_details_entity = EntityUtils.define_builder(
-      [:first, :string, :mandatory],
-      [:middle, :string, default: "Middle"],
-      [:last, :string, :mandatory]
-    )
 
-    entity = EntityUtils.define_builder(
-      [:name, :mandatory, entity: name_details_entity]
-    )
-    bm = 1000 * Benchmark.realtime {
-      1000.times {
-        entity.call(
-          {
-            name: {
-              first: "John",
-              last: "Doe"
+  it "#define_builder is fast" do
+    if false # You can enable this test to measure the performance
+
+      name_details_entity = EntityUtils.define_builder(
+        [:first, :string, :mandatory],
+        [:middle, :string, default: "Middle"],
+        [:last, :string, :mandatory]
+      )
+
+      entity = EntityUtils.define_builder(
+        [:name, :mandatory, entity: name_details_entity]
+      )
+      bm = 1000 * Benchmark.realtime {
+        1000.times {
+          entity.call(
+            {
+              name: {
+                first: "John",
+                last: "Doe"
+              }
             }
-          }
-        )
+          )
+        }
       }
-    }
 
-    expect(bm).to be < 50
+      expect(bm).to be < 0
+
+    end
   end
 end

--- a/spec/utils/entity_utils_spec.rb
+++ b/spec/utils/entity_utils_spec.rb
@@ -95,6 +95,33 @@ describe EntityUtils do
 
   end
 
+  it "#define_builder returns error field path message for nested entities" do
+    Entity = EntityUtils.define_builder(
+      [:name, :mandatory, entity: [
+         [:first, :string, :mandatory],
+         [:middle, :string, default: "Middle"],
+         [:last, :string, :mandatory]
+       ]])
+
+    # Validators
+    errors = Entity.call({name: {first: 'First', middle: 'Middle'}}, result: true).data
+    expect(errors.first[:field]).to eq("name.last")
+  end
+
+  it "#define_builder returns error field path for nested entity collection" do
+
+    Entity = EntityUtils.define_builder(
+      [:name, :mandatory, collection: [
+         [:type, :mandatory, one_of: [:first, :middle, :last]],
+         [:value, :mandatory, :string],
+         [:calling_name, default: false]
+       ]])
+
+    errors = Entity.call({name: [{type: :first, value: 'First'}, {type: :second_middle, value: 'Second Middle'}]}, result: true).data
+
+    expect(errors.first[:field]).to eq("name[1].type")
+  end
+
   it "#define_builder returns result, if result: true and does not raise an error" do
     Entity = EntityUtils.define_builder([:name, :string, :mandatory])
 

--- a/spec/utils/entity_utils_spec.rb
+++ b/spec/utils/entity_utils_spec.rb
@@ -54,6 +54,16 @@ describe EntityUtils do
         .to raise_error
   end
 
+  it "#define_builder returns result, if result: true and does not raise an error" do
+    Entity = EntityUtils.define_builder([:name, :string, :mandatory])
+
+    result = Entity.call({name: "First Last"}, result: true)
+    expect(result.success).to eq true
+
+    result = Entity.call({}, result: true)
+    expect(result.success).to eq false
+  end
+
   it "#define_builder :callable validator" do
     Entity = EntityUtils.define_builder([:say_so, :callable])
 

--- a/spec/utils/entity_utils_spec.rb
+++ b/spec/utils/entity_utils_spec.rb
@@ -27,10 +27,10 @@ describe EntityUtils do
 
     # Transforming
 
-    expect(person_entity.call({name: "First Last", sex: :m}))
+    expect(person_entity[{name: "First Last", sex: :m}])
       .to eq({type: :person, name: "First Last", age: 8, sex: :m, favorite_even_number: nil, tag: nil})
 
-    expect(person_entity.call({name: "First Last", sex: :m, age: 5}))
+    expect(person_entity[{name: "First Last", sex: :m, age: 5}])
       .to eq({type: :person, name: "First Last", age: 5, sex: :m, favorite_even_number: nil, tag: nil})
 
     expect(person_entity.call({name: "First Last", sex: :m, age: 5, tag: "hippy"}))
@@ -42,10 +42,10 @@ describe EntityUtils do
 
     # Validating
 
-    expect{person_entity.call({name: nil, sex: :m})}
+    expect{person_entity[{name: nil, sex: :m}]}
         .to raise_error
 
-    expect{person_entity.call({name: 12, sex: :m})}
+    expect{person_entity[{name: 12, sex: :m}]}
         .to raise_error
 
     expect{person_entity.call({name: "First Last", sex: :in_between})}
@@ -242,7 +242,8 @@ describe EntityUtils do
   end
 
   it "#define_builder is fast" do
-    if false # You can enable this test to measure the performance
+    enable_test = false
+    if enable_test # You can enable this test to measure the performance
 
       name_details_entity = EntityUtils.define_builder(
         [:first, :string, :mandatory],

--- a/spec/utils/entity_utils_spec.rb
+++ b/spec/utils/entity_utils_spec.rb
@@ -146,7 +146,7 @@ describe EntityUtils do
        ]])
 
     # Validators
-    errors = entity.call({name: {first: 'First', middle: 'Middle'}}, result: true).data
+    errors = entity.validate({name: {first: 'First', middle: 'Middle'}}).data
     expect(errors.first[:field]).to eq("name.last")
   end
 
@@ -159,7 +159,7 @@ describe EntityUtils do
          [:calling_name, default: false]
        ]])
 
-    errors = entity.call({name: [{type: :first, value: 'First'}, {type: :second_middle, value: 'Second Middle'}]}, result: true).data
+    errors = entity.validate({name: [{type: :first, value: 'First'}, {type: :second_middle, value: 'Second Middle'}]}).data
 
     expect(errors.first[:field]).to eq("name[1].type")
   end
@@ -167,7 +167,7 @@ describe EntityUtils do
   it "#define_builder returns and error code and a message" do
     entity = EntityUtils.define_builder([:name, :string, :mandatory])
 
-    expect(entity.call({}, result: true).data.first[:code]).to eq :mandatory
+    expect(entity.validate({}).data.first[:code]).to eq :mandatory
 
     CustomValidatorEntity = EntityUtils.define_builder(
       [:name, validate_with: ->(v) {
@@ -176,17 +176,17 @@ describe EntityUtils do
          end
        }])
 
-    expect(CustomValidatorEntity.call({name: "first"}, result: true).data.first[:code]).to eq :capital_letter
+    expect(CustomValidatorEntity.validate({name: "first"}).data.first[:code]).to eq :capital_letter
 
   end
 
   it "#define_builder returns result, if result: true and does not raise an error" do
     entity = EntityUtils.define_builder([:name, :string, :mandatory])
 
-    result = entity.call({name: "First Last"}, result: true)
+    result = entity.validate({name: "First Last"})
     expect(result.success).to eq true
 
-    result = entity.call({}, result: true)
+    result = entity.validate({})
     expect(result.success).to eq false
   end
 
@@ -240,7 +240,6 @@ describe EntityUtils do
     expect{entity.call({tags: nil})}
       .to_not raise_error
   end
-
 
   it "#define_builder is fast" do
     if false # You can enable this test to measure the performance


### PR DESCRIPTION
This PR aims to address the following entity builder shortcomings:

### Invalid entities always raise an error

**The problem:** If the data given to the builder is invalid, the entity builder always raises an error. This is ok if we are only using entities to prevent programming errors, but if we use entity builder e.g. for validating user input, then we want to show an informative error message instead of crashing the whole app with an exception.

**The solution:** Add `result: true` option to the entity builder call. That will wrap the entity in a Result object

**Usage:**

```ruby
res = MyEntity.call(my_entity_data, result: true)
```

### Can not nest entitites

**The problem:** There are situations when we would like to nest the entities. For example, the ListingService Shape API `#create` method takes the following hash:

```ruby
{ transaction_process_id: 123
, price_enabled: true
, ...
, units: 
  [ { type: :day }
  , { type: :custom
    , tr_key: "1231-1231-123-abd"
    }
  ]
}
```

Clearly, there are two types of entities: The **listing shape** entity and inside it a collection of **units**

**The solution:** This PR adds two new options for an entity field spec: `collection` and `entity`. `collection` can be used for a collection of entities (i.e. an array of entities, like the units in the above example) and `entity` for a single hash entity.

**Usage:**

```ruby
ListingShape = EntityUtils.define_builder(
  [:transaction_process_id, :fixnum, :mandatory],
  [:price_enabled, :bool, :mandatory],
  [:units, :optional, collection: [
    [:type, one_of: [:day, :hour, ... , :custom]],
    [:tr_key, :string, :optional]
  ]
)
```

You can also define builders for shape and units separately:

```ruby
Unit = EntityUtils.define_builder(
  [:type, one_of: [:day, :hour, ... , :custom]],
  [:tr_key, :string, :optional]
)

ListingShape = EntityUtils.define_builder(
  [:transaction_process_id, :fixnum, :mandatory],
  [:price_enabled, :bool, :mandatory],
  [:units, :optional, collection: Unit]
)
```

For a single hash entity, use `entity`:

```ruby
Name = EntityUtils.define_builder(
  [:first, :string, :mandatory],
  [:middle, :string, :optional],
  [:last, :string, :mandatory]
)

Person = EntityUtils.define_builder(
  [:name, :mandatory, entity: Name]
)
```

### Better error message

**The problem:** Error message doesn't contain the name of the field that failed the validation in a format that is easy to use (the name is in the message string). There's no error code, only the error message. This makes it impossible to translate the error message.

**The solution:** The error message contains now a full path to the items that didn't pass the validation. In addition, the error object contains error code, which makes it possible to show translated error message to the user.

**Usage:**

```ruby
TestBuilder = EntityUtils.define_builder(
  [:root, entity: [
      [:numbers, collection: [
          [:display, collection: [
              [:value, :mandatory]]]]]]])

TestBuilder.call({root: {numbers: [{display: [{value: 1}, {}]}]}}, result: true).data.first
# => {:field=>"root.numbers[0].display[1].value",
#  :code=>:mandatory,
#  :msg=>"Missing mandatory value."}
```