### PR TITLE
Query username against plain column value

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -206,7 +206,7 @@ class Person < ActiveRecord::Base
     conditions = warden_conditions.dup
     if login = conditions.delete(:login)
 
-      matched = where(conditions).where(["lower(username) = :value", { :value => login.downcase }]).first
+      matched = where(conditions).where(username: login.downcase).first
 
       if matched
         return matched


### PR DESCRIPTION
Username is already lower case in DB. Querying against plain column
value allows using DB index for username.