### PR TITLE
Do not use fixture data for RSpec tests

### DIFF
--- a/custom_plan.rb
+++ b/custom_plan.rb
@@ -11,14 +11,15 @@ class CustomPlan < Zeus::Rails
   def test_environment
     super
 
-    # Populate db with default data
+    # Clean database
     require 'database_cleaner'
     DatabaseCleaner.clean_with(:truncation)
-    TestHelpers.load_default_test_data_to_db_before_suite
-    TestHelpers.load_default_test_data_to_db_before_test
   end
 
   def cucumber_environment
+    # Populate db with default data
+    TestHelpers.load_default_test_data_to_db_before_suite
+    TestHelpers.load_default_test_data_to_db_before_test
 
     # Ensure sphinx directories exist for the test environment
     ThinkingSphinx::Test.init

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -7,16 +7,22 @@ describe PeopleController do
   end
 
   describe "#check_email_availability" do
+    before(:each) do
+      @request.host = "#{FactoryGirl.create(:community).ident}.lvh.me"
+    end
+
     it "should return available if email not in use" do
-      @request.host = "test.lvh.me"
       get :check_email_availability,  {:person => {:email => "totally_random_email_not_in_use@example.com"}, :format => :json}
       response.body.should == "true"
     end
   end
 
   describe "#check_email_availability" do
+    before(:each) do
+      @request.host = "#{FactoryGirl.create(:community).ident}.lvh.me"
+    end
+
     it "should return unavailable if email is in use" do
-      @request.host = "test.lvh.me"
       person = FactoryGirl.create(:person, :emails => [ FactoryGirl.create(:email, :address => "test@example.com")])
 
       get :check_email_availability,  {:person => {:email_attributes => {:address => "test@example.com"} }, :format => :json}
@@ -28,8 +34,6 @@ describe PeopleController do
     end
 
     it "should return NOT available for user's own adress" do
-      @request.host = "test.lvh.me"
-
       person = FactoryGirl.create(:person)
       sign_in person
 
@@ -41,9 +45,11 @@ describe PeopleController do
   end
 
   describe "#check_email_availability_and_validity" do
-    it "should return available for user's own adress" do
-      @request.host = "test.lvh.me"
+    before(:each) do
+      @request.host = "#{FactoryGirl.create(:community).ident}.lvh.me"
+    end
 
+    it "should return available for user's own adress" do
       person = FactoryGirl.create(:person)
       sign_in person
 
@@ -87,7 +93,7 @@ describe PeopleController do
   describe "#create" do
 
     it "creates a person" do
-      @request.host = "test.lvh.me"
+      @request.host = "#{FactoryGirl.create(:community).ident}.lvh.me"
       person_count = Person.count
       username = generate_random_username
       post :create, {:person => {:username => username, :password => "test", :email => "#{username}@example.com", :given_name => "", :family_name => ""}, :community => "test"}

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,9 +2,22 @@ require 'spec_helper'
 
 describe SessionsController, "POST create" do
 
+  before(:each) do
+    community1 = FactoryGirl.create(:community, :consent => "test_consent0.1", :settings => {"locales" => ["en", "fi"]}, :real_name_required => true)
+    person1 = FactoryGirl.create(:person, :username => "testpersonusername", :is_admin => 0, "locale" => "en", :encrypted_password => "64ae669314a3fb4b514fa5607ef28d3e1c1937a486e3f04f758270913de4faf5", :password_salt => "vGpGrfvaOhp3", :given_name => "Kassi", :family_name => "Testperson1", :phone_number => "0000-123456", :created_at => "2012-05-04 18:17:04")
+
+    FactoryGirl.create(:community_membership, :person => person1,
+                        :community => community1,
+                        :admin => 1,
+                        :consent => "test_consent0.1",
+                        :last_page_load_date => DateTime.now,
+                        :status => "accepted" )
+
+    @request.host = "#{community1.ident}.lvh.me"
+  end
+
   it "redirects back to original community's domain" do
-    @request.host = "test.lvh.me"
-    post :create, {:person  => {:login => "kassi_testperson1", :password => "testi"}}
-    response.should redirect_to "http://test.lvh.me/?locale=en"
+    post :create, {:person  => {:login => "testpersonusername", :password => "testi"}}
+    response.should redirect_to "http://#{@request.host}/?locale=en"
   end
 end


### PR DESCRIPTION
- Faster RSpec environment load for Zeus
- More isolated RSpec tests
- Now it is possible to add binding.pry breakpoints to the code that is used for creating fixture data. Before this change, the Zeus RSpec environment load stopped if there was a breakpoint. This of course happens still with the cucumber environment, but that's not a big issue I guess.