### PR TITLE
Fix token cancellation logic in new auth flow

### DIFF
--- a/app/services/transaction_service/paypal_events.rb
+++ b/app/services/transaction_service/paypal_events.rb
@@ -122,7 +122,7 @@ module TransactionService::PaypalEvents
   end
 
   def delete_transaction(cid:, tx_id:)
-    tx = TransactionModel.where(community_id: cid, id: tx_id).first
+    tx = TransactionModel.where(community_id: cid, id: tx_id, current_state: "initiated").first
 
     if tx
       tx.conversation.destroy

--- a/spec/services/paypal_service/api/payments_spec.rb
+++ b/spec/services/paypal_service/api/payments_spec.rb
@@ -234,6 +234,13 @@ describe PaypalService::API::Payments do
       expect(PaypalToken.count).to eq 0
     end
 
+    it "deletes request token when payment created" do
+      token = @payments.request(@cid, @req_info_auth)[:data]
+      @payments.create(@cid, token[:token])
+
+      expect(PaypalToken.count).to eq 0
+    end
+
     it "returns failure and fires no events when called with non-existent token" do
       res = @payments.create(@cid, "not_a_real_token")
 


### PR DESCRIPTION
This has 3 separate parts:

* Token removal was missing from the new flow in case of *successful*
payment because it was coupled with the authenticate call that we no
longer do. Now the success token removal is in parent method covering
both flows.

* Retry tokens is run at regular intervals and the intervals are
decoupled from the time at when payment process is started. Because of
this we might retry a token that was created just a second ago and the
user is still busy filling in payment details in PayPal UI. In the new
flow this created an edge case where token retry led to payment
cancellation under specific conditions because of the way
GetExpressCheckoutDetails response data doesn't sufficiently
differentiate all cases.

* When tokens are cancelled the associated transaction and conversation
are removed. The conditions under which this happens have been tightened
by requiring that only initiated transactions are removed.  This doesn't
affect anything under normal operating conditions but guards against
cases of incorrect token cancelleations so that they never delete
transaction data that has progressed from the initial initiated state.