### PR TITLE
Add missing processes

### DIFF
--- a/db/migrate/20150429155804_create_missing_processes.rb
+++ b/db/migrate/20150429155804_create_missing_processes.rb
@@ -1,0 +1,43 @@
+class CreateMissingProcesses < ActiveRecord::Migration
+  def up
+    # add 'none', author_is_seller: true
+    execute("
+      INSERT INTO transaction_processes (
+        community_id, author_is_seller, process, created_at, updated_at)
+      (
+        SELECT c.id, true, 'none', NOW(), NOW()
+        FROM communities c
+
+        # Avoid duplicates
+        LEFT JOIN transaction_processes tp ON (
+          tp.community_id = c.id AND
+          tp.author_is_seller = true AND
+          tp.process = 'none')
+
+        WHERE tp.id IS NULL
+      )
+    ")
+
+    # add 'none', author_is_seller: false
+    execute("
+      INSERT INTO transaction_processes (
+        community_id, author_is_seller, process, created_at, updated_at)
+      (
+        SELECT c.id, false, 'none', NOW(), NOW()
+        FROM communities c
+
+        # Avoid duplicates
+        LEFT JOIN transaction_processes tp ON (
+          tp.community_id = c.id AND
+          tp.author_is_seller = false AND
+          tp.process = 'none')
+
+        WHERE tp.id IS NULL
+      )
+    ")
+  end
+
+  def down
+    # Nothing
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150426113955) do
+ActiveRecord::Schema.define(:version => 20150429155804) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -71,15 +71,26 @@ describe MarketplaceService::API::Marketplaces do
     it "should have preauthorize_payments enabled" do
       community_hash = create(@community_params)
       c = Community.find(community_hash[:id])
-      processes = TransactionService::API::Api.processes.get(community_id: c.id).data
-      expect(processes.any? { |p| p[:process] == :preauthorize }).to eq(true)
+      processes = TransactionService::API::Api.processes
+                  .get(community_id: c.id).data
+                  .map { |p| p.slice(:author_is_seller, :process) }
+
+      expect(processes.size).to eq 3
+      expect(processes.include?({ author_is_seller: true, process: :preauthorize})).to eq true
+      expect(processes.include?({ author_is_seller: false, process: :none})).to eq true
+      expect(processes.include?({ author_is_seller: true, process: :none})).to eq true
     end
 
     it "should create marketplace without payment process" do
       community_hash = create(@community_params.merge(payment_process: :none))
       c = Community.find(community_hash[:id])
-      processes = TransactionService::API::Api.processes.get(community_id: c.id).data
-      expect(processes.any? { |p| p[:process] == :none }).to eq(true)
+      processes = TransactionService::API::Api.processes
+                  .get(community_id: c.id).data
+                  .map { |p| p.slice(:author_is_seller, :process) }
+
+      expect(processes.size).to eq 2
+      expect(processes.include?({ author_is_seller: false, process: :none})).to eq true
+      expect(processes.include?({ author_is_seller: true, process: :none})).to eq true
     end
 
     it "should have community customizations" do


### PR DESCRIPTION
This PR adds two processes, none & author_is_seller: false and none & author_is_seller: true to all marketplaces that do not yet have these processes