### PR TITLE
Duplicate fields after deleting category with subcategories

### DIFF
--- a/app/services/admin/category_service.rb
+++ b/app/services/admin/category_service.rb
@@ -2,16 +2,13 @@ module Admin
   module CategoryService
     class << self
       def move_custom_fields!(source_category, target_category)
-        all_custom_fields = CategoryCustomField.find_by_category_and_subcategory(source_category)
-        excluded_custom_field_ids = target_category.custom_fields.collect(&:id)
+        custom_fields_to_move = CategoryCustomField.find_by_category_and_subcategory(source_category)
 
-        custom_fields_to_move = if excluded_custom_field_ids.empty?
-          all_custom_fields
-        else
-          all_custom_fields.where("custom_field_id NOT IN (?)", excluded_custom_field_ids)
-        end
+        custom_fields_to_move.each { |category_custom_field|
+          CategoryCustomField.where(category_id: target_category.id, custom_field_id: category_custom_field.custom_field_id).first_or_create
+        }
 
-        custom_fields_to_move.update_all(:category_id => target_category.id)
+        custom_fields_to_move.delete_all
       end
 
       # Give all current `categories` and `category_to_be_merged`

--- a/spec/services/admin_category_service_spec.rb
+++ b/spec/services/admin_category_service_spec.rb
@@ -5,15 +5,19 @@ describe Admin::CategoryService do
     @category2 = FactoryGirl.create(:category, :community => @community)
     @subcategory = FactoryGirl.create(:category)
     @subcategory.update_attribute(:parent_id, @category.id)
+    @subcategory2 = FactoryGirl.create(:category)
+    @subcategory2.update_attribute(:parent_id, @category.id)
 
     @custom_field = FactoryGirl.create(:custom_field, :categories => [@category])
-    @subcustom_field = FactoryGirl.create(:custom_field, :categories => [@subcategory])
+    @subcustom_field = FactoryGirl.create(:custom_field, :categories => [@subcategory, @subcategory2])
 
     @category.reload
     @subcategory.reload
+    @subcategory2.reload
 
     @category.custom_fields.count.should == 1
     @subcategory.custom_fields.count.should == 1
+    @subcategory2.custom_fields.count.should == 1
   end
 
   def include_by_id?(xs, model)


### PR DESCRIPTION
This fixes a bug which causes duplicate custom fields after admin deletes a category with subcategories

Steps to reproduce:

1. Create top level category "Source category"
1. Create subcategory "Sub 1" under "Source category"
1. Create another subcategory "Sub 2"  under "Source category"
1. Create top level category "Target category"
1. Create a custom field and enabled it for "Sub 1" and "Sub 2"
1. Post a new listing in category "Sub 1"
1. Remove category "Source category" and select that the existing listing and custom fields will be moved to "Target category"

Result:

The custom field is in the "Target category" twice.