### PR TITLE
handle empty name_display_type as fullname

### DIFF
--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -238,7 +238,7 @@ class PersonMailer < ActionMailer::Base
       @other_party = @conversation.other_party(recipient)
       premailer_mail(:to => recipient.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
-                     :subject => t("emails.testimonial_reminder.remember_to_give_feedback_to", :name => @other_party.name))
+                     :subject => t("emails.testimonial_reminder.remember_to_give_feedback_to", :name => @other_party.name(community)))
     end
   end
 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -284,6 +284,10 @@ class Community < ActiveRecord::Base
     end
   end
 
+  def name_display_type
+    Maybe(read_attribute('name_display_type')).or_else('fullname');
+  end
+
   def full_name(locale)
     name(locale)
   end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -145,8 +145,8 @@ class Community < ActiveRecord::Base
   VALID_BROWSE_TYPES = %{grid map list}
   validates_inclusion_of :default_browse_view, :in => VALID_BROWSE_TYPES
 
-  VALID_NAME_DISPLAY_TYPES = %{first_name_only first_name_with_initial}
-  validates_inclusion_of :default_browse_view, :in => VALID_BROWSE_TYPES, :allow_nil => true, :allow_blank => true
+  VALID_NAME_DISPLAY_TYPES = %{first_name_only first_name_with_initial full_name}
+  validates_inclusion_of :name_display_type, :in => VALID_NAME_DISPLAY_TYPES
 
   # The settings hash contains some community specific settings:
   # locales: which locales are in use, the first one is the default
@@ -282,10 +282,6 @@ class Community < ActiveRecord::Base
     else
       raise ArgumentError.new("Can not find translation for marketplace name community_id: #{id}, locale: #{locale}")
     end
-  end
-
-  def name_display_type
-    Maybe(read_attribute('name_display_type')).or_else('fullname');
   end
 
   def full_name(locale)

--- a/app/view_utils/person_view_utils.rb
+++ b/app/view_utils/person_view_utils.rb
@@ -81,7 +81,7 @@ module PersonViewUtils
       first_name_with_initial(first_name, last_name)
     when matches([__, __, true, "first_name_only"])
       first_name
-    when matches([__, __, true, "fullname"])
+    when matches([__, __, true, "full_name"])
       full_name(first_name, last_name)
     when matches([__, __, true])
       first_name_with_initial(first_name, last_name)

--- a/app/views/admin/communities/edit_look_and_feel.haml
+++ b/app/views/admin/communities/edit_look_and_feel.haml
@@ -67,7 +67,7 @@
       .col-12
         = form.label :name_display_type, t(".name_display_type")
         = render :partial => "layouts/info_text", :locals => { :text => t(".name_display_type_instructions_text") }
-        = form.select :name_display_type, [[t(".full_name"), ""], [t(".first_name_with_initial"), "first_name_with_initial"], [t(".first_name_only"), "first_name_only"]]
+        = form.select :name_display_type, [[t(".full_name"), "full_name"], [t(".first_name_with_initial"), "first_name_with_initial"], [t(".first_name_only"), "first_name_only"]]
 
     .row
       .col-12

--- a/app/views/listing_conversations/new_with_payment.haml
+++ b/app/views/listing_conversations/new_with_payment.haml
@@ -12,7 +12,7 @@
 
   = form_for contact_form, :url => contact_to_listing do |form|
 
-    = form.label :content, t("conversations.new.message_to", author_name: link_to(listing.author.name, listing.author)).html_safe
+    = form.label :content, t("conversations.new.message_to", author_name: link_to(listing.author.name(@current_community), listing.author)).html_safe
     = form.text_area :content, :class => "text_area"
     = form.hidden_field :sender_id, :value => @current_user.id
 

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -7,7 +7,7 @@
   = javascript_include_tag "https://maps.google.com/maps/api/js?sensor=true"
 
 - content_for :title, raw(@listing.title)
-- content_for :meta_author, @listing.author.name
+- content_for :meta_author, @listing.author.name(@current_community)
 - content_for :meta_description, StringUtils.first_words(@listing.description, 15)
 - content_for :meta_image, @listing.listing_images.first.image.url(:medium) if !@listing.listing_images.empty?
 - content_for :keywords, StringUtils.keywords(@listing.title)

--- a/app/views/person_mailer/new_payment.html.haml
+++ b/app/views/person_mailer/new_payment.html.haml
@@ -3,7 +3,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.new_payment.you_have_received_new_payment", :listing_title => @payment.transaction.listing.title, :payment_sum => humanized_money_with_symbol(@payment.total_sum), :payer_full_name => @payment.payer.name, :payer_given_name => @payment.payer.given_name_or_username).html_safe
+      = t("emails.new_payment.you_have_received_new_payment", :listing_title => @payment.transaction.listing.title, :payment_sum => humanized_money_with_symbol(@payment.total_sum), :payer_full_name => @payment.payer.name(@payment.community), :payer_given_name => @payment.payer.given_name_or_username).html_safe
 
 %tr
   %td{:align => "left", :style => "padding: 10px 0;"}

--- a/db/migrate/20150508141500_change_name_display_type_in_communities.rb
+++ b/db/migrate/20150508141500_change_name_display_type_in_communities.rb
@@ -1,0 +1,15 @@
+class ChangeNameDisplayTypeInCommunities < ActiveRecord::Migration
+  def up
+    execute("UPDATE communities
+      SET name_display_type='full_name'
+      WHERE name_display_type = '';
+    ")
+  end
+
+  def down
+    execute("UPDATE communities
+      SET name_display_type=''
+      WHERE name_display_type = 'full_name';
+    ")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150507165715) do
+ActiveRecord::Schema.define(:version => 20150508141500) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"

--- a/spec/view_utils/person_view_utils_spec.rb
+++ b/spec/view_utils/person_view_utils_spec.rb
@@ -47,7 +47,7 @@ describe PersonViewUtils do
       last_name: "Doe",
       organization_name: "John D Inc.",
       username: "johnd",
-      name_display_type: "fullname",
+      name_display_type: "full_name",
       is_organization: false,
       is_deleted: false,
       deleted_user_text: "Deleted user")).to eql("John Doe")
@@ -74,7 +74,7 @@ describe PersonViewUtils do
   end
 
   it "#person_entity_display_name" do
-    expect(PersonViewUtils.person_entity_display_name(nil, "fullname"))
+    expect(PersonViewUtils.person_entity_display_name(nil, "full_name"))
       .to eql(I18n.translate("common.removed_user"))
   end
 


### PR DESCRIPTION
Better solution might be to make db migration and change the behaviour in 5++ files. 
However, is this good enough?
(This comment is related to first commit)