### PR TITLE
Improve listing form param validator

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -210,7 +210,7 @@ class ListingsController < ApplicationController
     end
 
     listing_params = normalize_price_params(listing_params)
-    m_unit = select_unit(params, shape)
+    m_unit = select_unit(listing_params, shape)
 
     listing_params = create_listing_params(listing_params).merge(
         listing_shape_id: shape[:id],

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -451,14 +451,8 @@ class ListingsController < ApplicationController
 
   def select_unit(params, shape)
     m_unit = Maybe(shape)[:units].map { |units|
-      shape[:units].length == 1 ? shape[:units].first : parse_unit(params)
+      units.length == 1 ? units.first : units.find { |u| u[:type] == params[:unit].to_sym }
     }
-  end
-
-  def parse_unit(params)
-    m_unit = Maybe(listing_params)[:unit].map { |unit_param|
-      ListingViewUtils.decode_unit(unit_param)
-    }.or_else(nil)
   end
 
   def unit_to_listing_opts(m_unit)

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -199,11 +199,20 @@ class ListingsController < ApplicationController
       params[:listing].delete("origin_loc_attributes")
     end
 
-    params[:listing] = normalize_price_params(params[:listing])
     shape = get_shape(Maybe(params)[:listing][:listing_shape_id].to_i.or_else(nil))
+
+    listing_params = ListingFormViewUtils.filter(params[:listing], shape)
+    validation_result = ListingFormViewUtils.validate(listing_params, shape)
+
+    unless validation_result.success
+      flash[:error] = t("listings.error.something_went_wrong", error_code: validation_result.data.join(', '))
+      return redirect_to new_listing_path
+    end
+
+    listing_params = normalize_price_params(listing_params)
     m_unit = select_unit(params, shape)
 
-    listing_params = create_listing_params(params[:listing]).merge(
+    listing_params = create_listing_params(listing_params).merge(
         listing_shape_id: shape[:id],
         transaction_process_id: shape[:transaction_process_id],
         shape_name_tr_key: shape[:name_tr_key],
@@ -211,15 +220,7 @@ class ListingsController < ApplicationController
         current_community_id: @current_community.id,
     ).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
-    filtered_listing_params = ListingFormViewUtils.filter(listing_params, shape)
-    validation_result = ListingFormViewUtils.validate(filtered_listing_params, shape)
-
-    unless validation_result.success
-      flash[:error] = t("listings.error.something_went_wrong", error_code: validation_result.data.join(', '))
-      return redirect_to new_listing_path
-    end
-
-    @listing = Listing.new(filtered_listing_params)
+    @listing = Listing.new(listing_params)
 
     @listing.author = @current_user
 
@@ -305,13 +306,22 @@ class ListingsController < ApplicationController
       end
     end
 
-    params[:listing] = normalize_price_params(params[:listing])
     shape = get_shape(params[:listing][:listing_shape_id])
-    m_unit = select_unit(params, shape)
+
+    listing_params = ListingFormViewUtils.filter(params[:listing], shape)
+    validation_result = ListingFormViewUtils.validate(listing_params, shape)
+
+    unless validation_result.success
+      flash[:error] = t("listings.error.something_went_wrong", error_code: validation_result.data.join(', '))
+      return redirect_to edit_listing_path
+    end
+
+    listing_params = normalize_price_params(listing_params)
+    m_unit = select_unit(listing_params, shape)
 
     open_params = @listing.closed? ? {open: true} : {}
 
-    listing_params = create_listing_params(params[:listing]).merge(
+    listing_params = create_listing_params(listing_params).merge(
       transaction_process_id: shape[:transaction_process_id],
       shape_name_tr_key: shape[:name_tr_key],
       action_button_tr_key: shape[:action_button_tr_key],
@@ -319,15 +329,7 @@ class ListingsController < ApplicationController
       last_modified: DateTime.now
     ).merge(open_params).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
-    filtered_listing_params = ListingFormViewUtils.filter(listing_params, shape)
-    validation_result = ListingFormViewUtils.validate(filtered_listing_params, shape)
-
-    unless validation_result.success
-      flash[:error] = t("listings.error.something_went_wrong", error_code: validation_result.data.join(', '))
-      return redirect_to edit_listing_path
-    end
-
-    update_successful = @listing.update_fields(filtered_listing_params)
+    update_successful = @listing.update_fields(listing_params)
 
     upsert_field_values!(@listing, params[:custom_fields])
 
@@ -454,7 +456,7 @@ class ListingsController < ApplicationController
   end
 
   def parse_unit(params)
-    m_unit = Maybe(params)[:listing][:unit].map { |unit_param|
+    m_unit = Maybe(listing_params)[:unit].map { |unit_param|
       ListingViewUtils.decode_unit(unit_param)
     }.or_else(nil)
   end

--- a/app/view_utils/listing_form_view_utils.rb
+++ b/app/view_utils/listing_form_view_utils.rb
@@ -4,13 +4,12 @@ module ListingFormViewUtils
   def filter(params, shape)
     filter_fields = []
 
-    filter_fields << :price_cents unless shape[:price_enabled]
+    filter_fields << :price unless shape[:price_enabled]
     filter_fields << :currency unless shape[:price_enabled]
     filter_fields << :unit_type unless shape[:units].present?
-    filter_fields << :shipping_price_cents unless shape[:shipping_enabled]
-    filter_fields << :shipping_price_additional_cents unless shape[:shipping_enabled]
-    filter_fields << :require_shipping_address unless shape[:shipping_enabled]
-    filter_fields << :pickup_enabled unless shape[:shipping_enabled]
+    filter_fields << :shipping_price unless shape[:shipping_enabled]
+    filter_fields << :shipping_price_additional unless shape[:shipping_enabled]
+    filter_fields << :delivery_methods unless shape[:shipping_enabled]
 
     params.except(*filter_fields)
   end
@@ -18,12 +17,12 @@ module ListingFormViewUtils
   def validate(params, shape)
     errors = []
 
-    errors << :price_required if (params[:price_cents].nil?) && shape[:price_enabled]
-    errors << :currency_required if params[:currency].blank? && shape[:price_enabled]
-    errors << :unit_required if params[:unit_type].blank? && shape[:units].present?
-    errors << :quantity_selector_required if params[:quantity_selector].blank? && shape[:units].present?
-    errors << :unit_does_not_belong if params[:unit_type].present? && !shape[:units].include?({type: params[:unit_type], quantity_selector: params[:quantity_selector]})
-    errors << :delivery_method_required if (params[:require_shipping_address].nil? && params[:pickup_enabled].nil?) && shape[:shipping_enabled]
+    errors << :price_required if shape[:price_enabled] && params[:price].nil?
+    errors << :currency_required if shape[:price_enabled] && params[:currency].blank?
+    errors << :unit_required if shape[:units].present? && params[:unit_type].blank?
+    errors << :unit_does_not_belong if shape[:units].present? && !shape[:units].include?({type: params[:unit_type], quantity_selector: params[:quantity_selector]})
+    errors << :delivery_method_required if shape[:shipping_enabled] && params[:delivery_methods].empty?
+    errors << :unknown_delivery_method if shape[:shipping_enabled] && params[:delivery_methods].any? { |method| !["shipping", "pickup"].include?(method) }
 
     if errors.empty?
       Result::Success.new

--- a/app/view_utils/listing_form_view_utils.rb
+++ b/app/view_utils/listing_form_view_utils.rb
@@ -6,7 +6,7 @@ module ListingFormViewUtils
 
     filter_fields << :price unless shape[:price_enabled]
     filter_fields << :currency unless shape[:price_enabled]
-    filter_fields << :unit_type unless shape[:units].present?
+    filter_fields << :unit unless shape[:units].present?
     filter_fields << :shipping_price unless shape[:shipping_enabled]
     filter_fields << :shipping_price_additional unless shape[:shipping_enabled]
     filter_fields << :delivery_methods unless shape[:shipping_enabled]
@@ -19,8 +19,8 @@ module ListingFormViewUtils
 
     errors << :price_required if shape[:price_enabled] && params[:price].nil?
     errors << :currency_required if shape[:price_enabled] && params[:currency].blank?
-    errors << :unit_required if shape[:units].present? && params[:unit_type].blank?
-    errors << :unit_does_not_belong if shape[:units].present? && !shape[:units].include?({type: params[:unit_type], quantity_selector: params[:quantity_selector]})
+    errors << :unit_required if shape[:units].present? && params[:unit].blank?
+    errors << :unit_does_not_belong if shape[:units].present? && params[:unit].present? && !shape[:units].any? { |u| u[:type] == params[:unit].to_sym }
     errors << :delivery_method_required if shape[:shipping_enabled] && params[:delivery_methods].empty?
     errors << :unknown_delivery_method if shape[:shipping_enabled] && params[:delivery_methods].any? { |method| !["shipping", "pickup"].include?(method) }
 

--- a/app/view_utils/listing_view_utils.rb
+++ b/app/view_utils/listing_view_utils.rb
@@ -5,38 +5,20 @@ module ListingViewUtils
 
   # parameters:
   # - units, array from shape[:units]
-  # - selected, hash of {type, quantity_selector, translation_key}
+  # - selected, symbol of unit type
+  #
   # units => [
-  #   ['day', {type: 'day', quantity_selector: 'day'}, false]
-  #   ['hour', {type: 'hour', quantity_selector: 'number'}, false]
-  #   ['three hours', {type: 'custom', quantity_selector: 'number', translation_key: 'abcd-1231-12332-accc}, false]
+  #   ['Day', :day, true]
+  #   ['Hour', :hour, false]
   # ]
   def unit_options(units, selected_unit = nil)
     units.map { |unit|
-      value = encode_unit(unit)
-      is_selected = unit == selected_unit
-
       {
         display: translate_unit(unit[:type], unit[:translation_key]),
-        value: value,
-        selected: is_selected
+        value: unit[:type],
+        selected: unit == selected_unit
       }
     }
-  end
-
-  def encode_unit(unit)
-    HashUtils.compact(unit).to_json
-  end
-
-  def decode_unit(unit)
-    json = JSON.parse(unit)
-
-    HashUtils.compact(
-      {
-        type: json["type"].to_sym,
-        quantity_selector: json["quantity_selector"].to_sym,
-        translation_key: json["translation_key"]
-      })
   end
 
   def translate_unit(type, tr_key)

--- a/spec/view_utils/listing_form_view_utils_spec.rb
+++ b/spec/view_utils/listing_form_view_utils_spec.rb
@@ -16,8 +16,8 @@ describe ListingFormViewUtils do
       expect_filter({currency: "EUR"}, {price_enabled: true}).to include(:currency)
       expect_filter({currency: "EUR"}, {price_enabled: false}).not_to include(:currency)
 
-      expect_filter({unit_type: :day}, {units: [{type: :day, quantity_selector: :number}]}).to include(:unit_type)
-      expect_filter({unit_type: :day}, {units: []}).not_to include(:unit_type)
+      expect_filter({unit: "day"}, {units: [{type: :day, quantity_selector: :number}]}).to include(:unit)
+      expect_filter({unit: "day"}, {units: []}).not_to include(:unit)
 
       expect_filter({delivery_methods: ["shipping"]}, {shipping_enabled: true}).to include(:delivery_methods)
       expect_filter({delivery_methods: ["shipping"]}, {shipping_enabled: false}).not_to include(:delivery_methods)
@@ -58,10 +58,9 @@ describe ListingFormViewUtils do
       expect_error({currency: "EUR"}, {price_enabled: true}, :price_required)
       expect_error({}, {price_enabled: true}, :price_required, :currency_required)
 
-      expect_valid({unit_type: :day, quantity_selector: :day}, {units: [{type: :day, quantity_selector: :day}]})
+      expect_valid({unit: "day"}, {units: [{type: :day, quantity_selector: :day}]})
       expect_valid({}, {units: []})
-      expect_error({unit_type: :night}, {units: [{type: :day, quantity_selector: :day}]}, :unit_does_not_belong)
-      expect_error({unit_type: :day, quantity_selector: :number}, {units: [{type: :day, quantity_selector: :day}]}, :unit_does_not_belong)
+      expect_error({unit: "night"}, {units: [{type: :day, quantity_selector: :day}]}, :unit_does_not_belong)
       expect_error({}, {units: [{type: :day, quantity_selector: :day}]}, :unit_required)
 
       expect_valid({delivery_methods: ["shipping", "pickup"]}, {shipping_enabled: true})

--- a/spec/view_utils/listing_form_view_utils_spec.rb
+++ b/spec/view_utils/listing_form_view_utils_spec.rb
@@ -10,8 +10,8 @@ describe ListingFormViewUtils do
     end
 
     it "filters fields that do not belong to the shape" do
-      expect_filter({price_cents: 5000}, {price_enabled: true}).to include(:price_cents)
-      expect_filter({price_cents: 5000}, {price_enabled: false}).not_to include(:price_cents)
+      expect_filter({price: "50.0"}, {price_enabled: true}).to include(:price)
+      expect_filter({price: "50.0"}, {price_enabled: false}).not_to include(:price)
 
       expect_filter({currency: "EUR"}, {price_enabled: true}).to include(:currency)
       expect_filter({currency: "EUR"}, {price_enabled: false}).not_to include(:currency)
@@ -19,17 +19,14 @@ describe ListingFormViewUtils do
       expect_filter({unit_type: :day}, {units: [{type: :day, quantity_selector: :number}]}).to include(:unit_type)
       expect_filter({unit_type: :day}, {units: []}).not_to include(:unit_type)
 
-      expect_filter({require_shipping_address: true}, {shipping_enabled: true}).to include(:require_shipping_address)
-      expect_filter({require_shipping_address: true}, {shipping_enabled: false}).not_to include(:require_shipping_address)
+      expect_filter({delivery_methods: ["shipping"]}, {shipping_enabled: true}).to include(:delivery_methods)
+      expect_filter({delivery_methods: ["shipping"]}, {shipping_enabled: false}).not_to include(:delivery_methods)
 
-      expect_filter({pickup_enabled: true}, {shipping_enabled: true}).to include(:pickup_enabled)
-      expect_filter({pickup_enabled: true}, {shipping_enabled: false}).not_to include(:pickup_enabled)
+      expect_filter({shipping_price: "50.00"}, {shipping_enabled: true}).to include(:shipping_price)
+      expect_filter({shipping_price: "50.00"}, {shipping_enabled: false}).not_to include(:shipping_price)
 
-      expect_filter({shipping_price_cents: 5000}, {shipping_enabled: true}).to include(:shipping_price_cents)
-      expect_filter({shipping_price_cents: 5000}, {shipping_enabled: false}).not_to include(:shipping_price_cents)
-
-      expect_filter({shipping_price_additional_cents: 5000}, {shipping_enabled: true}).to include(:shipping_price_additional_cents)
-      expect_filter({shipping_price_additional_cents: 5000}, {shipping_enabled: false}).not_to include(:shipping_price_additional_cents)
+      expect_filter({shipping_price_additional: "50.00"}, {shipping_enabled: true}).to include(:shipping_price_additional)
+      expect_filter({shipping_price_additional: "50.00"}, {shipping_enabled: false}).not_to include(:shipping_price_additional)
     end
   end
 
@@ -56,8 +53,8 @@ describe ListingFormViewUtils do
     end
 
     it "validates the params" do
-      expect_valid({price_cents: 5000, currency: "EUR"}, {price_enabled: true})
-      expect_error({price_cents: 5000}, {price_enabled: true}, :currency_required)
+      expect_valid({price: "50.00", currency: "EUR"}, {price_enabled: true})
+      expect_error({price: "50.00"}, {price_enabled: true}, :currency_required)
       expect_error({currency: "EUR"}, {price_enabled: true}, :price_required)
       expect_error({}, {price_enabled: true}, :price_required, :currency_required)
 
@@ -67,8 +64,9 @@ describe ListingFormViewUtils do
       expect_error({unit_type: :day, quantity_selector: :number}, {units: [{type: :day, quantity_selector: :day}]}, :unit_does_not_belong)
       expect_error({}, {units: [{type: :day, quantity_selector: :day}]}, :unit_required)
 
-      expect_valid({require_shipping_address: true}, {shipping_enabled: true})
-      expect_error({}, {shipping_enabled: true}, :delivery_method_required)
+      expect_valid({delivery_methods: ["shipping", "pickup"]}, {shipping_enabled: true})
+      expect_error({delivery_methods: []}, {shipping_enabled: true}, :delivery_method_required)
+      expect_error({delivery_methods: ["homedelivery"]}, {shipping_enabled: true}, :unknown_delivery_method)
     end
   end
 end


### PR DESCRIPTION
This PR improves the new/edit listing form validation logic and fixes one bug

- Validation is now done before processing (parsing) the listing params.
- The unit value is simplified (we don't need to include the quantity_selector and do that hacky wacky JSON encode/decode thing)
- Fixes bug: Unit type is not updated correctly when editing