### PR TITLE
Add on_success and on_error to the Result object

### DIFF
--- a/app/services/result.rb
+++ b/app/services/result.rb
@@ -48,6 +48,16 @@ module Result
       end
     end
 
+    def on_success(&block)
+      block.call(data)
+      self
+    end
+
+    def on_error(&block)
+      # no-op
+      self
+    end
+
     # Success a -> Maybe a
     #
     # Usage example:
@@ -76,6 +86,16 @@ module Result
     # Error a -> Error a
     # No-op
     def and_then(&block)
+      self
+    end
+
+    def on_success(&block)
+      # no-op
+      self
+    end
+
+    def on_error(&block)
+      block.call(error_msg, data)
       self
     end
 


### PR DESCRIPTION
Adds `on_success` and `on_error` methods to Result objects. Allows us to code like this:

```ruby
validate(params) # returns Result and params as data
  .and_then { |params|
    whatever_api.update(params) # returns Result
  }.on_success {
    flash[:notice] = t('great.success')
    redirect_to some_path
  }.on_error { |error_msg|
    flash[:error] = t('something.went.wrong', error: error_msg)
    redirect_to edit_path
  }
```