### PR TITLE
Fix FB like button text language on few locales

### DIFF
--- a/app/views/layouts/_facebook_sdk.haml
+++ b/app/views/layouts/_facebook_sdk.haml
@@ -2,7 +2,11 @@
   - when :en then "en_US"
   - when :ca then "ca_ES"
   - when :"es-ES" then "es_ES"
-  - else "#{I18n.locale}_#{I18n.locale.to_s.upcase}"
+  - when :"zh" then "zh_CN"
+  - when :"ja" then "ja_JP"
+  - when :"sv" then "sv_SE"
+  - when :"da-DK" then "da_DK"
+  - else "#{I18n.locale.to_s.split("-").first}_#{I18n.locale.to_s.split("-").first.upcase}"
 
 <div id="fb-root"></div>
 <script>


### PR DESCRIPTION
Minor fix to way we send our locale for FB like button.
Better default for future additions and fixes few cases manually.

A better future step to take would be to use full locales internally. No didn't feel useful to try to parse those from current short locales, so I fixed our else branch and added few manual rows. The idea is that this part doesn't need to be touched usually. If clients connect with us (like they did now) to get the button in their language we can add it quickly. But most might work with the default, or be happy with "like".