### PR TITLE
Fix bug: Send welcome email after FB login

### DIFF
--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -91,6 +91,7 @@ class CommunityMembershipsController < ApplicationController
       invitation.use_once! if invitation.present?
 
       Delayed::Job.enqueue(CommunityJoinedJob.new(@current_user.id, @current_community.id))
+      Delayed::Job.enqueue(SendWelcomeEmail.new(@current_user.id, @current_community.id), priority: 5)
       flash[:notice] = t("layouts.notifications.you_are_now_member")
       redirect_to root
     else

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -56,7 +56,7 @@ class ConfirmationsController < Devise::ConfirmationsController
       # Accept pending community membership if needed
       if @current_community.approve_pending_membership(person, e.address)
         # If the pending membership was accepted now, it's time to send the welcome email, unless creating admin acocunt
-        PersonMailer.welcome_email(person, @current_community).deliver
+        Delayed::Job.enqueue(SendWelcomeEmail.new(person.id, @current_community.id), priority: 5)
       end
       flash[:notice] = t("layouts.notifications.additional_email_confirmed")
 

--- a/app/jobs/send_welcome_email.rb
+++ b/app/jobs/send_welcome_email.rb
@@ -1,0 +1,20 @@
+class SendWelcomeEmail < Struct.new(:person_id, :community_id)
+
+  include DelayedAirbrakeNotification
+
+  def perform
+    set_service_name!(community_id)
+    person = Person.find(person_id)
+    community = Community.find(community_id)
+
+    PersonMailer.welcome_email(person, community).deliver
+  end
+
+  private
+
+  def set_service_name!(community_id)
+    # Set the correct service name to thread for I18n to pick it
+    ApplicationHelper.store_community_service_name_to_thread_from_community_id(community_id)
+  end
+
+end


### PR DESCRIPTION
- [X] Send welcome email after FB login
- [X] Use delayed job to move the email sending away from the request cycle