### PR TITLE
Support author is not seller process

### DIFF
--- a/app/view_utils/listing_shape_data_types.rb
+++ b/app/view_utils/listing_shape_data_types.rb
@@ -30,7 +30,7 @@ module ListingShapeDataTypes
     [:price_enabled, transform_with: CHECKBOX],
     [:online_payments, transform_with: CHECKBOX],
     [:units, default: [], collection: Unit],
-    [:template, :to_symbol]
+    [:author_is_seller, :bool]
   )
 
   KEY_MAP = {

--- a/app/view_utils/listing_shape_templates.rb
+++ b/app/view_utils/listing_shape_templates.rb
@@ -45,6 +45,7 @@ class ListingShapeTemplates
         shipping_enabled: true,
         online_payments: true,
         template: :selling_products,
+        author_is_seller: true,
         units: []
       },
       {
@@ -55,6 +56,7 @@ class ListingShapeTemplates
         shipping_enabled: false,
         online_payments: true,
         template: :renting_products,
+        author_is_seller: true,
         units: [{type: :day, quantity_selector: :day}, {type: :week, quantity_selector: :number}, {type: :month, quantity_selector: :number}]
       },
       {
@@ -65,6 +67,7 @@ class ListingShapeTemplates
         shipping_enabled: false,
         online_payments: true,
         template: :offering_services,
+        author_is_seller: true,
         units: [{type: :hour, quantity_selector: :number}]
       },
       {
@@ -75,6 +78,7 @@ class ListingShapeTemplates
         shipping_enabled: false,
         online_payments: false,
         template: :giving_things_away,
+        author_is_seller: true,
         units: []
       },
       {
@@ -85,6 +89,7 @@ class ListingShapeTemplates
         shipping_enabled: false,
         online_payments: false,
         template: :requesting,
+        author_is_seller: false,
         units: []
       },
       {
@@ -95,6 +100,7 @@ class ListingShapeTemplates
         shipping_enabled: false,
         online_payments: false,
         template:  :announcement,
+        author_is_seller: true,
         units: []
       },
       {
@@ -105,6 +111,7 @@ class ListingShapeTemplates
         shipping_enabled: false,
         online_payments: false,
         template: :custom,
+        author_is_seller: true,
         units: []
       }
     ]

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -62,4 +62,4 @@
       = check_box_tag("units[#{unit[:type]}]", "true", unit[:enabled], class: "js-unit-checkbox checkbox-row-checkbox")
       = label_tag("units[#{unit[:type]}]", unit[:label], class: "checkbox-row-label js-unit-label")
 
-= hidden_field_tag("template", shape[:template])
+= hidden_field_tag("author_is_seller", shape[:author_is_seller])


### PR DESCRIPTION
The previous Order Type UI implementation completely ignored the fact that we have also processes with `author_is_seller: false`. This PR implements support for that, which means:

- Add `author_is_seller` to each template
- Change `filter` method to reject `online_payments` and `shipping` if `!author_is_seller`
- Take `author_is_seller` into account when selecting the correct transaction process.