### PR TITLE
Fix bug: Clicking "What's this" refreshes the form

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -386,6 +386,7 @@ label.radiobutton {
   display: inline;
   color: $aside;
   @include small-type;
+  cursor: pointer;
 }
 
 button, .button {

--- a/app/views/listings/form/_valid_until.haml
+++ b/app/views/listings/form/_valid_until.haml
@@ -1,6 +1,7 @@
 - unless @current_community.hide_expiration_date
   .inline-label-container
     = form.label :valid_until, t('.valid_until') + "*", :class => "inline"
-    = link_to t('common.what_is_this'), "#", :tabindex => "-1", :id => "help_valid_until_link", :class => "label-info"
+    %a.label-info#help_valid_until_link{tabindex: "-1"}
+      = t('common.what_is_this')
     .valid-until-dropdown
       = date_select(:listing, :valid_until, {:start_year => Time.now.year, :end_year => Time.now.year + 1, :default => 3.months.from_now}, :class => "listing_date_select")


### PR DESCRIPTION
Clicking What's this link next to the expiration date in new listing page refreshes the page due to the empty anchor link.