### PR TITLE
Fix double category listing shapes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,6 +68,7 @@ module ApplicationHelper
       "social_media" => "ss-share",
       "analytics" => "ss-analytics",
       "openbook" => "ss-openbook",
+      "order_types" => "ss-cart",
 
       # Default category & share type icons
       "offer" => "ss-share",
@@ -631,7 +632,7 @@ module ApplicationHelper
       unless gw
         links << {
           :text => t("admin.listing_shapes.index.listing_shapes"),
-          :icon_class => icon_class("form"),
+          :icon_class => icon_class("order_types"),
           :path => admin_listing_shapes_path,
           :name => "listing_shapes"
         }

--- a/app/models/category_listing_shape.rb
+++ b/app/models/category_listing_shape.rb
@@ -8,7 +8,7 @@
 # Indexes
 #
 #  index_category_listing_shapes_on_category_id  (category_id)
-#  index_listing_shape_category_joins            (listing_shape_id,category_id)
+#  unique_listing_shape_category_joins           (listing_shape_id,category_id) UNIQUE
 #
 
 class CategoryListingShape < ActiveRecord::Base

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -154,22 +154,11 @@ module TransactionTypeCreator
 
     raise ArgumentError.new("Could not create new shape: #{shape_opts}") unless shape_res.success
 
-    new_shape = shape_res.data
-
-    # Categories
-    community.categories.each do |category|
-      use_in_category(category, new_shape[:id])
-    end
-
-    new_shape
+    shape_res.data
   end
 
   def available_types
     TransactionTypeCreator::DEFAULTS.map { |type, _| type }
-  end
-
-  def use_in_category(category, listing_shape_id)
-    CategoryListingShape.create!(category_id: category.id, listing_shape_id: listing_shape_id)
   end
 
   def get_or_create_transaction_process(community_id:, process:, author_is_seller:)

--- a/db/migrate/20150518120830_remove_duplicate_category_listing_shapes.rb
+++ b/db/migrate/20150518120830_remove_duplicate_category_listing_shapes.rb
@@ -1,0 +1,24 @@
+class RemoveDuplicateCategoryListingShapes < ActiveRecord::Migration
+  def up
+    add_column :category_listing_shapes, :temp_id, :primary_key
+
+    execute("
+      DELETE category_listing_shapes
+      FROM category_listing_shapes
+      LEFT OUTER JOIN (
+        SELECT MIN(temp_id) as temp_id, category_id, listing_shape_id
+        FROM category_listing_shapes
+        GROUP BY category_id, listing_shape_id
+      ) AS keep_rows ON (
+        category_listing_shapes.temp_id = keep_rows.temp_id
+      )
+      WHERE keep_rows.temp_id IS NULL
+    ")
+
+    remove_column :category_listing_shapes, :temp_id
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/migrate/20150518123758_unique_category_listing_shapes.rb
+++ b/db/migrate/20150518123758_unique_category_listing_shapes.rb
@@ -1,0 +1,14 @@
+class UniqueCategoryListingShapes < ActiveRecord::Migration
+  def up
+    remove_index :category_listing_shapes, name: "index_listing_shape_category_joins"
+
+    add_index :category_listing_shapes, [:listing_shape_id, :category_id], name: "unique_listing_shape_category_joins", unique: true
+  end
+
+  def down
+    remove_index :category_listing_shapes, name: "unique_listing_shape_category_joins"
+
+    add_index :category_listing_shapes, [:listing_shape_id, :category_id], name: "index_listing_shape_category_joins"
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150518120830) do
+ActiveRecord::Schema.define(:version => 20150518123758) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(:version => 20150518120830) do
   end
 
   add_index "category_listing_shapes", ["category_id"], :name => "index_category_listing_shapes_on_category_id"
-  add_index "category_listing_shapes", ["listing_shape_id", "category_id"], :name => "index_listing_shape_category_joins"
+  add_index "category_listing_shapes", ["listing_shape_id", "category_id"], :name => "unique_listing_shape_category_joins", :unique => true
 
   create_table "category_translations", :force => true do |t|
     t.integer  "category_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150508141500) do
+ActiveRecord::Schema.define(:version => 20150518120830) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -65,6 +65,7 @@ describe MarketplaceService::API::Marketplaces do
       expect(s[:shipping_enabled]).to eql false
 
       # check that category and shape are linked
+      expect(CategoryListingShape.where(listing_shape_id: s[:id]).count).to eq(1)
       expect(CategoryListingShape.where(listing_shape_id: s[:id]).first.category).to eql c.categories.first
     end
 


### PR DESCRIPTION
The problem: When creating a new marketplace the ListingService's Shape API associates the new shape to the new category. After that, the soon-to-be-removed TransactionTypeCreater creates another association. Thus, there are duplicate rows in the `category_listing_shapes` table.

- [x] Do not create duplicate associations
- [x] Add migration that removes duplicated rows
- [x] Add UNIQUE index to prevent this happening in the future