### PR TITLE
Change the class attr selector

### DIFF
--- a/app/assets/stylesheets/partials/_fluid-grid.css.scss
+++ b/app/assets/stylesheets/partials/_fluid-grid.css.scss
@@ -35,11 +35,11 @@ $bottom-gutter: lines(0.5);
   }
 
   @include media(tablet) {
-    [class^=col]:first-child {
+    [class*=col-]:first-child {
       padding-left: 0;
     }
 
-    [class^=col]:last-child {
+    [class*=col-]:last-child {
       padding-right: 0;
     }
   }


### PR DESCRIPTION
We have some rows that are not correctly aligned:

![screen shot 2015-05-22 at 11 50 33](https://cloud.githubusercontent.com/assets/429876/7768013/ce5aa714-007f-11e5-93f3-576bdd38dcae.png)

The reason for this is that we use other classes with the `.col-*` `div` and the current class attribute selector does not match.

For example, instead of this:

```haml
.row
  .myclass.col-12
```

We should use:

```haml
.row
  .col-12
    .myclass
```

This pull request changes the class attribute selector so that it's perfectly ok to use the `.myclass.col-12` version.

Fixed version:

![screen shot 2015-05-22 at 11 47 40](https://cloud.githubusercontent.com/assets/429876/7768045/29354be4-0080-11e5-9e76-242e74cf488f.png)

