### PR TITLE
Don't use work "paid" when it's actually about "authorization"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -650,10 +650,10 @@ en:
       request_confirmed: Completed
       request_canceled: Canceled
       request_paid: "Payment successful"
-      request_preauthorized: "Payment successful"
+      request_preauthorized: "Payment authorized"
       skip_feedback: "Skip feedback"
       waiting_for_listing_author_to_accept_offer: "Waiting for %{listing_author_name} to accept the offer"
-      waiting_for_listing_author_to_accept_request: "Waiting for %{listing_author_name} to accept the request"
+      waiting_for_listing_author_to_accept_request: "Waiting for %{listing_author_name} to accept the request. As soon as %{listing_author_name} accepts, you will be charged."
       waiting_for_you_to_accept_request: "Waiting for you to accept the request"
       waiting_confirmation_from_requester: "Waiting for %{requester_name} to mark the request completed"
       waiting_confirmation_from_you: "Waiting for you to mark the request completed"
@@ -897,9 +897,9 @@ en:
       remember_to_give_feedback_to: "Reminder: remember to give feedback to %{name}"
       you_have_not_given_feedback_yet: "You have not yet given feedback to %{name} about event '%{event}'. Remember to give feedback on how %{given_name} performed in the event."
     transaction_preauthorized:
-      subject: "%{requester} has requested and paid for %{listing_title}"
-      transaction_requested_by_user: "%{requester} has requested and paid for \"%{listing_title}\""
-      you_have_days_to_accept: "You need to accept or reject the request within %{payment_expires_in_days} days. If you don't accept within this timeframe, the request will be automatically rejected and you will not get paid."
+      subject: "%{requester} has requested and authorized payment for %{listing_title}"
+      transaction_requested_by_user: "%{requester} has requested and authorized for \"%{listing_title}\""
+      you_have_days_to_accept: "You need to accept or reject the request within %{payment_expires_in_days} days. If you accept within this timeframe, the payment will go through. If you don't accept, the request will be automatically rejected and you will not get paid."
       click_here_to_reply: "Click here to respond to the request"
     transaction_preauthorized_reminder:
       subject: "Remember to accept the request from %{requester} about listing %{listing_title}"


### PR DESCRIPTION
This was a request from a customer. Using work "paid" is misleading when actually only "authorization" has happened.

- [X] Change the transaction conversation page (screenshot)
- [X] Change the notification email

![screen shot 2015-05-25 at 09 38 03](https://cloud.githubusercontent.com/assets/429876/7793860/25169bcc-02cd-11e5-92be-64d16f52eb54.png)
