### PR TITLE
Save nil quantity, if the params do not include it

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -766,7 +766,10 @@ class ListingsController < ApplicationController
       price_cents: listing_params[:price_cents],
       shipping_price_cents: listing_params[:shipping_price_cents],
       shipping_price_additional_cents: listing_params[:shipping_price_additional_cents],
-      currency: listing_params[:currency]
+      currency: listing_params[:currency],
+
+      # TODO Remove this when we remove price_quantity_placeholder
+      quantity: Maybe(listing_params)[:quantity].or_else(nil)
     )
   end
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -218,6 +218,9 @@ class ListingsController < ApplicationController
         shape_name_tr_key: shape[:name_tr_key],
         action_button_tr_key: shape[:action_button_tr_key],
         current_community_id: @current_community.id,
+
+        # This can be moved when we remove price_quantity_placeholder
+        quantity: Maybe(shape)[:price_quantity_placeholder].map { |_| listing_params[:quantity] }.or_else(nil)
     ).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
     @listing = Listing.new(listing_params)
@@ -319,7 +322,11 @@ class ListingsController < ApplicationController
       shape_name_tr_key: shape[:name_tr_key],
       action_button_tr_key: shape[:action_button_tr_key],
       current_community_id: @current_community.id,
-      last_modified: DateTime.now
+      last_modified: DateTime.now,
+
+      # This can be moved when we remove price_quantity_placeholder
+      quantity: Maybe(shape)[:price_quantity_placeholder].map { |_| listing_params[:quantity] }.or_else(nil)
+
     ).merge(open_params).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
     update_successful = @listing.update_fields(listing_params)
@@ -766,10 +773,7 @@ class ListingsController < ApplicationController
       price_cents: listing_params[:price_cents],
       shipping_price_cents: listing_params[:shipping_price_cents],
       shipping_price_additional_cents: listing_params[:shipping_price_additional_cents],
-      currency: listing_params[:currency],
-
-      # TODO Remove this when we remove price_quantity_placeholder
-      quantity: Maybe(listing_params)[:quantity].or_else(nil)
+      currency: listing_params[:currency]
     )
   end
 


### PR DESCRIPTION
Why: There are already some customers that would like to use the new units, but they are also using old "free form units".

This pull request lets them to use units so that first we set manually the `price_quantity_placeholder` database value to `nil` and after that they can use the Shape UI. When new listings are created, they will use the new units. When old listings are edited, they will use the new units and (here comes the beef) **old quantity is removed from the listing**.