### PR TITLE
Fix "you must accept or reject within <gateway specific days> days" error

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -296,6 +296,10 @@ module ApplicationHelper
     return time
   end
 
+  def translate_time_to(unit, count)
+    t("timestamps.time_to.#{unit}", count: count)
+  end
+
   # used to escape strings to URL friendly format
   def self.escape_for_url(str)
      URI.escape(str, Regexp.new("[^-_!~*()a-zA-Z\\d]"))

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -5,14 +5,16 @@
 # - transaction status changes
 # - reminders
 #
+
+include ApplicationHelper
+include ListingsHelper
+
 class TransactionMailer < ActionMailer::Base
   include MailUtils
 
   default :from => APP_CONFIG.sharetribe_mail_from_address
   layout 'email'
 
-  include ApplicationHelper
-  include ListingsHelper
   include MoneyRails::ActionViewExtension # this is for humanized_money_with_symbol
 
   add_template_helper(EmailTemplateHelper)

--- a/app/utils/time_utils.rb
+++ b/app/utils/time_utils.rb
@@ -11,4 +11,46 @@ module TimeUtils
   def utc_str_to_time(str)
     ActiveSupport::TimeZone["UTC"].parse(str)
   end
+
+  # Example:
+  #
+  # time_to(<15 seconds>)  => {unit: :seconds, count: 15}
+  # time_to(<59 seconds>)  => {unit: :seconds, count: 59}
+  # time_to(<60 seconds>)  => {unit: :minutes, count: 1}
+  # time_to(<61 seconds>)  => {unit: :minutes, count: 1}
+  # time_to(<119 seconds>) => {unit: :minutes, count: 1}
+  # time_to(<120 seconds>) => {unit: :minutes, count: 2}
+  # time_to(<59 minutes>)  => {unit: :minutes, count: 59}
+  # time_to(<60 minutes>)  => {unit: :hours, count: 1}
+  # time_to(<61 minutes>)  => {unit: :hours, count: 1}
+  # time_to(<119 minutes>) => {unit: :hours, count: 1}
+  # time_to(<120 minutes>) => {unit: :hours, count: 2}
+  # time_to(<23 hours>)    => {unit: :hours, count: 23}
+  # time_to(<24 hours>)    => {unit: :days, count: 1}
+  # time_to(<25 hours>)    => {unit: :days, count: 1}
+  # time_to(<47 hours>)    => {unit: :days, count: 1}
+  # time_to(<48 hours>)    => {unit: :days, count: 2}
+  # time_to(<30 days>)     => {unit: :days, count: 30}
+  #
+  # This is a bit similar than application_helper.rb time_ago method
+  #
+  def time_to(to_time, from_time = Time.now)
+    multiplies = [
+      [:seconds, 1],
+      [:minutes, 60],
+      [:hours, 60*60],
+      [:days, 60*60*24]
+      # add more if needed
+    ]
+
+    diff = (to_time - from_time).to_i
+
+    multiplies.inject([:seconds, diff]) { |result, (unit, multiplier)|
+      if diff >= multiplier
+        {unit: unit, count: (diff / multiplier)}
+      else
+        result
+      end
+    }
+  end
 end

--- a/app/views/transaction_mailer/transaction_preauthorized.haml
+++ b/app/views/transaction_mailer/transaction_preauthorized.haml
@@ -8,6 +8,6 @@
 %tr
   %td{:align => "left", :style => "padding-bottom: 15px;"}
     %font{body_font}
-      = t("emails.transaction_preauthorized.you_have_days_to_accept", :payment_expires_in_days => payment_expires_in_days)
+      = t("emails.transaction_preauthorized.you_have_time_to_accept", :payment_expires_in => translate_time_to(payment_expires_in_unit, payment_expires_in_count))
 
 = render :partial => "person_mailer/action_button", :locals => { :text => t("emails.transaction_preauthorized.click_here_to_reply"), :url => reply_url}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -903,7 +903,7 @@ en:
     transaction_preauthorized:
       subject: "%{requester} has requested and authorized payment for %{listing_title}"
       transaction_requested_by_user: "%{requester} has requested and authorized payment for \"%{listing_title}\""
-      you_have_days_to_accept: "You need to accept or reject the request within %{payment_expires_in_days} days. If you accept within this timeframe, the payment will go through. If you don't accept, the request will be automatically rejected and you will not get paid."
+      you_have_time_to_accept: "You need to accept or reject the request within %{payment_expires_in}. If you accept within this timeframe, the payment will go through. If you don't accept, the request will be automatically rejected and you will not get paid."
       click_here_to_reply: "Click here to respond to the request"
     transaction_preauthorized_reminder:
       subject: "Remember to accept the request from %{requester} about listing %{listing_title}"
@@ -2025,6 +2025,19 @@ en:
     days_since:
       one: "%{count} day"
       other: "%{count} days"
+    time_to:
+      seconds:
+        one: "%{count} second"
+        other: "%{count} seconds"
+      minutes:
+        one: "%{count} minute"
+        other: "%{count} minutes"
+      hours:
+        one: "%{count} hour"
+        other: "%{count} hours"
+      days:
+        one: "%{count} day"
+        other: "%{count} days"
   transactions:
     initiate:
       booked_days: "Booked days:"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -2013,6 +2013,19 @@ fi:
     days_since:
       one: päivän
       other: "%{count} päivän"
+    time_to:
+      seconds:
+        one: "%{count} sekunnin"
+        other: "%{count} sekunnin"
+      minutes:
+        one: "%{count} minuutin"
+        other: "%{count} minuutin"
+      hours:
+        one: "%{count} tunnin"
+        other: "%{count} tunnin"
+      days:
+        one: "%{count} päivän"
+        other: "%{count} päivän"
   transactions:
     initiate:
       booked_days: "Valitut päivät:"

--- a/spec/utils/time_utils_spec.rb
+++ b/spec/utils/time_utils_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe TimeUtils do
+
+  describe "#time_to" do
+    it "returns the biggest unit and count" do
+      now = Time.now
+      expect(TimeUtils.time_to(15.seconds.since(now), now)).to eq({unit: :seconds, count: 15})
+      expect(TimeUtils.time_to(59.seconds.since(now), now)).to eq({unit: :seconds, count: 59})
+      expect(TimeUtils.time_to(60.seconds.since(now), now)).to eq({unit: :minutes, count: 1})
+      expect(TimeUtils.time_to(61.seconds.since(now), now)).to eq({unit: :minutes, count: 1})
+      expect(TimeUtils.time_to(119.seconds.since(now), now)).to eq({unit: :minutes, count: 1})
+      expect(TimeUtils.time_to(120.seconds.since(now), now)).to eq({unit: :minutes, count: 2})
+      expect(TimeUtils.time_to(59.minutes.since(now), now)).to eq({unit: :minutes, count: 59})
+      expect(TimeUtils.time_to(60.minutes.since(now), now)).to eq({unit: :hours, count: 1})
+      expect(TimeUtils.time_to(61.minutes.since(now), now)).to eq({unit: :hours, count: 1})
+      expect(TimeUtils.time_to(119.minutes.since(now), now)).to eq({unit: :hours, count: 1})
+      expect(TimeUtils.time_to(120.minutes.since(now), now)).to eq({unit: :hours, count: 2})
+      expect(TimeUtils.time_to(23.hours.since(now), now)).to eq({unit: :hours, count: 23})
+      expect(TimeUtils.time_to(24.hours.since(now), now)).to eq({unit: :days, count: 1})
+      expect(TimeUtils.time_to(25.hours.since(now), now)).to eq({unit: :days, count: 1})
+      expect(TimeUtils.time_to(47.hours.since(now), now)).to eq({unit: :days, count: 1})
+      expect(TimeUtils.time_to(48.hours.since(now), now)).to eq({unit: :days, count: 2})
+      expect(TimeUtils.time_to(30.days.since(now), now)).to eq({unit: :days, count: 30})
+    end
+  end
+end


### PR DESCRIPTION
Currently, we should in the preauthorization mail that "you have to accept or reject without <paymet_gateway_specific_days> days". However, in some cases we automatically reject the transaction before that (booking).

This pull request fixes that.

- [X] Add `time_to` helper
- [X] Better expires at logic: take the payment gateway specific expiration day of booking day
- [ ] \(should I do this?\) Save the auto reject time to transaction.
