### PR TITLE
Entity field key must be a Symbol

### DIFF
--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -189,6 +189,7 @@ module EntityUtils
   def parse_specs(specs)
     specs.reduce({}) do |fs, full_field_spec|
       f_name, *spec = *full_field_spec
+      raise ArgumentError.new("Field key must be a Symbol, was: '#{f_name}' (#{f_name.class.name})") unless f_name.is_a? Symbol
       fs[f_name] = parse_spec(spec)
       fs
     end

--- a/spec/utils/entity_utils_spec.rb
+++ b/spec/utils/entity_utils_spec.rb
@@ -171,6 +171,16 @@ describe EntityUtils do
     expect(default.call({})).to eq({name: []})
   end
 
+  it "#define_builder accepts only symbol keys" do
+    msg = ->(val, class_name) {
+      "Field key must be a Symbol, was: '#{val}' (#{class_name})"
+    }
+
+    expect { EntityUtils.define_builder([nil, :string, :mandatory]) }.to raise_error( msg.call("", "NilClass") )
+    expect { EntityUtils.define_builder(["key", :string, :mandatory]) }.to raise_error( msg.call("key", "String") )
+    expect { EntityUtils.define_builder([:key, :string, :mandatory]) }.not_to raise_error
+  end
+
   it "#define_builder can nest other builders for collections" do
     name_details_entity = EntityUtils.define_builder(
       [:type, :mandatory, one_of: [:first, :middle, :last]],


### PR DESCRIPTION
Why: `deserialize` method relies on the fact that the field key is always symbol, even though that's not enforced by the code. This PR adds a check that ensures the key is always a symbol.