### PR TITLE
More robust time-related tests

### DIFF
--- a/spec/services/braintree_service/escrow_release_helper_spec.rb
+++ b/spec/services/braintree_service/escrow_release_helper_spec.rb
@@ -24,27 +24,30 @@ describe BraintreeService::EscrowReleaseHelper do
         end
 
         before_batch = Time.new(2014, 3, 11, 20, 0, 0, 0)
-        Timecop.freeze(before_batch)
 
-        # Hold pending
-        BraintreeApi.stub(:find_transaction) { transaction_mock.new("hold_pending") }
-        BraintreeService::EscrowReleaseHelper.release_from_escrow(community, "123")
-        @api_calls.should == 0
+        Timecop.freeze(before_batch) {
+          # Hold pending
+          BraintreeApi.stub(:find_transaction) { transaction_mock.new("hold_pending") }
+          BraintreeService::EscrowReleaseHelper.release_from_escrow(community, "123")
+          @api_calls.should == 0
+        }
 
         # Time passes 24, but still hold bending
-        Timecop.freeze(24.hours.from_now)
-        successes, failures = Delayed::Worker.new.work_off
-        successes.should == 1
-        failures.should == 0
-        @api_calls.should == 0
+        Timecop.freeze(24.hours.since(before_batch)) {
+          successes, failures = Delayed::Worker.new.work_off
+          successes.should == 1
+          failures.should == 0
+          @api_calls.should == 0
+        }
 
         # Time passes another 24, status changed to "held"
-        Timecop.freeze(24.hours.from_now)
-        BraintreeApi.stub(:find_transaction) { transaction_mock.new("held") }
-        successes, failures = Delayed::Worker.new.work_off
-        successes.should == 1
-        failures.should == 0
-        @api_calls.should == 1
+        Timecop.freeze(48.hours.since(before_batch)) {
+          BraintreeApi.stub(:find_transaction) { transaction_mock.new("held") }
+          successes, failures = Delayed::Worker.new.work_off
+          successes.should == 1
+          failures.should == 0
+          @api_calls.should == 1
+        }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,8 @@ prefork = lambda {
     config.mock_with :rspec
     config.include Devise::TestHelpers, :type => :controller
     config.include SpecUtils
+
+    Timecop.safe_mode = true
   end
 
   def uploaded_file(filename, content_type)

--- a/spec/utils/time_utils_spec.rb
+++ b/spec/utils/time_utils_spec.rb
@@ -4,7 +4,7 @@ describe TimeUtils do
 
   describe "#time_to" do
     it "returns the biggest unit and count" do
-      now = Time.now
+      now = Time.new(2015, 05, 29, 15, 13, 30, "+03:00")
       expect(TimeUtils.time_to(15.seconds.since(now), now)).to eq({unit: :seconds, count: 15})
       expect(TimeUtils.time_to(59.seconds.since(now), now)).to eq({unit: :seconds, count: 59})
       expect(TimeUtils.time_to(60.seconds.since(now), now)).to eq({unit: :minutes, count: 1})


### PR DESCRIPTION
- [X] Make `time_to` tests use specific time, which is not affected by the DST changes
- [X] Set Timecop to safe mode, which enforces the use of blocks