### PR TITLE
Cache listing item partials.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem 'paypal-sdk-permissions',
   :ref    => 'c0240bee9f94fe6338d67b4f754e1a11ce81619a'
 gem 'paypal-sdk-merchant', '~> 1.116.0'
 gem 'airbrake', '~>4.1.0'
+gem 'cache_digests'
 
 group :staging, :production do
   gem 'newrelic_rpm', '~> 3.9.1.236'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,9 @@ GEM
     braintree (2.30.0)
       builder (>= 2.0.0)
     builder (3.0.4)
+    cache_digests (0.3.1)
+      actionpack (>= 3.2)
+      thread_safe
     callsite (0.0.11)
     capybara (2.2.1)
       mime-types (>= 1.16)
@@ -503,6 +506,7 @@ DEPENDENCIES
   aws-sdk
   better_errors
   braintree
+  cache_digests
   capybara
   coffee-rails (~> 3.2.2)
   compass-rails

--- a/app/models/listing_image.rb
+++ b/app/models/listing_image.rb
@@ -23,7 +23,7 @@
 
 class ListingImage < ActiveRecord::Base
 
-  belongs_to :listing
+  belongs_to :listing, touch: true
   belongs_to :author, :class_name => "Person"
 
   # see paperclip (for image_processing column)

--- a/app/views/homepage/_grid_item.haml
+++ b/app/views/homepage/_grid_item.haml
@@ -1,4 +1,4 @@
-- cache(listing) do
+- cache(["grid_item", listing, listing.author, @current_community]) do
   .home-fluid-thumbnail-grid-item
     %div
       -# Listing image

--- a/app/views/homepage/_grid_item.haml
+++ b/app/views/homepage/_grid_item.haml
@@ -1,11 +1,12 @@
-.home-fluid-thumbnail-grid-item
-  %div
-    -# Listing image
-    = render :partial => "layouts/grid_item_listing_image", :locals => {:listing => listing, :modifier_class => ""}
+- cache(listing) do
+  .home-fluid-thumbnail-grid-item
+    %div
+      -# Listing image
+      = render :partial => "layouts/grid_item_listing_image", :locals => {:listing => listing, :modifier_class => ""}
 
-    -# Listing author details
-    .home-fluid-thumbnail-grid-author
-      .home-fluid-thumbnail-grid-author-avatar
-        = small_avatar_thumb(listing.author, :class => "home-fluid-thumbnail-grid-author-avatar-image")
-      = link_to(listing.author, :class => "home-fluid-thumbnail-grid-author-name") do
-        = listing.author.name(@current_community)
+      -# Listing author details
+      .home-fluid-thumbnail-grid-author
+        .home-fluid-thumbnail-grid-author-avatar
+          = small_avatar_thumb(listing.author, :class => "home-fluid-thumbnail-grid-author-avatar-image")
+        = link_to(listing.author, :class => "home-fluid-thumbnail-grid-author-name") do
+          = listing.author.name(@current_community)

--- a/app/views/homepage/_grid_item.haml
+++ b/app/views/homepage/_grid_item.haml
@@ -1,4 +1,4 @@
-- cache(["grid_item", listing, listing.author, @current_community]) do
+- cache(["grid_item", listing, listing.author, @current_community, MoneyRails::Configuration.no_cents_if_whole]) do
   .home-fluid-thumbnail-grid-item
     %div
       -# Listing image

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -1,4 +1,4 @@
-- cache(listing) do
+- cache(["list_item", listing, listing.author, @current_community]) do
   .home-list-item
     - if listing.listing_images.size > 0
       = link_to listing, :class => "home-list-image-container-desktop" do

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -1,52 +1,53 @@
-.home-list-item
-  - if listing.listing_images.size > 0
-    = link_to listing, :class => "home-list-image-container-desktop" do
-      = image_tag listing.listing_images.first.image.url(:small_3x2), {:alt => listed_listing_title(listing), :class => "home-list-image"}
-  - if listing.listing_images.size > 0
-    = link_to listing, :class => "home-list-image-container-mobile" do
-      = image_tag listing.listing_images.first.image.url(:thumb), {:alt => listed_listing_title(listing), :class => "home-list-image"}
-  .home-list-details-right
-    .home-list-price
-      - if listing.price
-        .home-list-price-value
-          = humanized_money_with_symbol(listing.price).upcase
-        - price_text = nil
-        - if listing.quantity.present?
-          - price_text = t("listings.form.price.per") + " " + listing.quantity
-        - elsif listing.unit_type
-          - price_text = price_quantity_per_unit(listing)
+- cache(listing) do
+  .home-list-item
+    - if listing.listing_images.size > 0
+      = link_to listing, :class => "home-list-image-container-desktop" do
+        = image_tag listing.listing_images.first.image.url(:small_3x2), {:alt => listed_listing_title(listing), :class => "home-list-image"}
+    - if listing.listing_images.size > 0
+      = link_to listing, :class => "home-list-image-container-mobile" do
+        = image_tag listing.listing_images.first.image.url(:thumb), {:alt => listed_listing_title(listing), :class => "home-list-image"}
+    .home-list-details-right
+      .home-list-price
+        - if listing.price
+          .home-list-price-value
+            = humanized_money_with_symbol(listing.price).upcase
+          - price_text = nil
+          - if listing.quantity.present?
+            - price_text = t("listings.form.price.per") + " " + listing.quantity
+          - elsif listing.unit_type
+            - price_text = price_quantity_per_unit(listing)
 
-        - if price_text.present?
-          .home-list-price-quantity{:title => price_text}
-            = price_text
-      - else
-        .home-list-listing-shape-value
-          = shape_name(listing)
-
-  %div{:class => (listing.listing_images.size > 0 ? "home-list-details-with-image" : "")}
-    %h2.home-list-title
-      = link_to listing do
-        = listing.title
-        - if @current_community.show_category_in_listing_list
-          %a.home-share-type-link{:href => root_path(:transaction_type => shape_name_map[listing.listing_shape_id], :view => :list)}
-            = icon_tag(listing.icon_name, ["icon-fix"])
+          - if price_text.present?
+            .home-list-price-quantity{:title => price_text}
+              = price_text
+        - else
+          .home-list-listing-shape-value
             = shape_name(listing)
 
-  .home-list-author{:class => (listing.listing_images.size > 0 ? "home-list-author-with-listing-image" : "home-list-author-without-listing-image")}
-    .home-list-avatar
-      = small_avatar_thumb(listing.author)
-    .home-list-author-details
-      = link_to listing.author :class => "home-list-author-name" do
-        = listing.author.name(@current_community)
-      - if @current_community.testimonials_in_use
-        .home-list-author-reviews
-          - if listing.author.received_testimonials.size > 0
-            = icon_tag("testimonial")
-            = pluralize(listing.author.received_testimonials.size, t(".review"), t(".reviews"))
+    %div{:class => (listing.listing_images.size > 0 ? "home-list-details-with-image" : "")}
+      %h2.home-list-title
+        = link_to listing do
+          = listing.title
+          - if @current_community.show_category_in_listing_list
+            %a.home-share-type-link{:href => root_path(:transaction_type => shape_name_map[listing.listing_shape_id], :view => :list)}
+              = icon_tag(listing.icon_name, ["icon-fix"])
+              = shape_name(listing)
 
-  .home-list-price-mobile{:class => (listing.listing_images.size > 0 ? "home-list-price-mobile-with-listing-image" : "home-list-price-mobile-without-listing-image")}
-    - if listing.price
-      = humanized_money_with_symbol(listing.price).upcase
-    - else
-      %span.smaller
-        = shape_name(listing)
+    .home-list-author{:class => (listing.listing_images.size > 0 ? "home-list-author-with-listing-image" : "home-list-author-without-listing-image")}
+      .home-list-avatar
+        = small_avatar_thumb(listing.author)
+      .home-list-author-details
+        = link_to listing.author :class => "home-list-author-name" do
+          = listing.author.name(@current_community)
+        - if @current_community.testimonials_in_use
+          .home-list-author-reviews
+            - if listing.author.received_testimonials.size > 0
+              = icon_tag("testimonial")
+              = pluralize(listing.author.received_testimonials.size, t(".review"), t(".reviews"))
+
+    .home-list-price-mobile{:class => (listing.listing_images.size > 0 ? "home-list-price-mobile-with-listing-image" : "home-list-price-mobile-without-listing-image")}
+      - if listing.price
+        = humanized_money_with_symbol(listing.price).upcase
+      - else
+        %span.smaller
+          = shape_name(listing)

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -1,4 +1,4 @@
-- cache(["list_item", listing, listing.author, @current_community]) do
+- cache(["list_item", listing, listing.author, @current_community, MoneyRails::Configuration.no_cents_if_whole]) do
   .home-list-item
     - if listing.listing_images.size > 0
       = link_to listing, :class => "home-list-image-container-desktop" do


### PR DESCRIPTION
This should increase front page performance pretty easily. Performance testing with siege on `testing` gave an increase of 1,08 -> 2,02 trans/sec, details below:

Before:
```
Transactions:		         194 hits
Availability:		      100.00 %
Elapsed time:		      179.16 secs
Data transferred:	        1.86 MB
Response time:		        4.03 secs
Transaction rate:	        1.08 trans/sec
Throughput:		        0.01 MB/sec
Concurrency:		        4.36
Successful transactions:         194
Failed transactions:	           0
Longest transaction:	        9.96
Shortest transaction:	        1.43
```

After:
```
Transactions:		         364 hits
Availability:		      100.00 %
Elapsed time:		      179.93 secs
Data transferred:	        3.38 MB
Response time:		        1.94 secs
Transaction rate:	        2.02 trans/sec
Throughput:		        0.02 MB/sec
Concurrency:		        3.92
Successful transactions:         364
Failed transactions:	           0
Longest transaction:	       10.77
Shortest transaction:	        0.74
```