### PR TITLE
Make FeatureFlagApi easier to test

### DIFF
--- a/app/services/feature_flag_service/api/api.rb
+++ b/app/services/feature_flag_service/api/api.rb
@@ -3,7 +3,7 @@ module FeatureFlagService::API
 
     def self.features
       @features ||= FeatureFlagService::API::Features.new(
-        FeatureFlagService::Store::CachingFeatureFlag.new)
+        FeatureFlagService::Store::CachingFeatureFlag.new(additional_flags: []))
     end
 
   end

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -8,7 +8,7 @@ module FeatureFlagService::Store
       [:features, :mandatory, :set])
 
     FLAGS = [
-
+      :shape_ui
     ].to_set
 
     def initialize(additional_flags:)

--- a/spec/services/feature_flag_service/api/features_spec.rb
+++ b/spec/services/feature_flag_service/api/features_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 
 describe FeatureFlagService::API::Features do
 
-  let(:features) { FeatureFlagService::API::Api.features }
+  let(:test_flag) { :bar_feature }
+  let(:features) { FeatureFlagService::API::Features.new(
+    FeatureFlagService::Store::CachingFeatureFlag.new(
+    additional_flags: [test_flag]
+  )) }
   let(:community_id) { 321 }
 
   context "#enable" do
@@ -16,10 +20,10 @@ describe FeatureFlagService::API::Features do
     end
 
     it "enables the given supported feature" do
-      res = features.enable(community_id: community_id, features: [:shape_ui])
+      res = features.enable(community_id: community_id, features: [test_flag])
 
       expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq([:shape_ui].to_set)
+      expect(res.data[:features]).to eq([test_flag].to_set)
     end
 
     it "does nothing if called with unknown feature" do
@@ -40,19 +44,19 @@ describe FeatureFlagService::API::Features do
     end
 
     it "disables the given supported feature" do
-      features.enable(community_id: community_id, features: [:shape_ui])
-      res = features.disable(community_id: community_id, features: [:shape_ui])
+      features.enable(community_id: community_id, features: [test_flag])
+      res = features.disable(community_id: community_id, features: [test_flag])
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq(Set.new)
     end
 
     it "does nothing if called with unknown feature" do
-      features.enable(community_id: community_id, features: [:shape_ui])
+      features.enable(community_id: community_id, features: [test_flag])
       res = features.disable(community_id: community_id, features: [:foo_feature])
 
       expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq([:shape_ui].to_set)
+      expect(res.data[:features]).to eq([test_flag].to_set)
     end
   end
 
@@ -65,11 +69,11 @@ describe FeatureFlagService::API::Features do
     end
 
     it "returns enabled features as a set" do
-      features.enable(community_id: community_id, features: [:shape_ui])
+      features.enable(community_id: community_id, features: [test_flag])
       res = features.get(community_id: community_id)
 
       expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq([:shape_ui].to_set)
+      expect(res.data[:features]).to eq([test_flag].to_set)
     end
   end
 end


### PR DESCRIPTION
Tests are relying on hard coded feature `shape_ui` which will be removed soon. That's why we need a way to inject new flags on runtime.