### PR TITLE
Set price_quantity_placeholder to nil when listing shape is created/u…

### DIFF
--- a/app/services/listing_service/store/shape.rb
+++ b/app/services/listing_service/store/shape.rb
@@ -12,7 +12,6 @@ module ListingService::Store::Shape
     [:transaction_process_id, :fixnum, :mandatory],
     [:shipping_enabled, :bool, :mandatory],
     [:units, :array, default: []], # Mandatory only if price_enabled
-    [:price_quantity_placeholder, one_of: [nil, :mass, :time, :long_time]], # TODO TEMP
     [:sort_priority, :fixnum],
     [:basename, :string, :mandatory]
   )
@@ -95,7 +94,7 @@ module ListingService::Store::Shape
     ActiveRecord::Base.transaction do
 
       # Save to ListingShape model
-      shape_model = ListingShape.create!(shape_with_sort.except(:units))
+      shape_model = ListingShape.create!(shape_with_sort.except(:units).merge(price_quantity_placeholder: nil))
 
       # Save units
       units.each { |unit|
@@ -128,7 +127,7 @@ module ListingService::Store::Shape
       end
 
       # Save to ListingShape model
-      shape_model.update_attributes!(HashUtils.compact(update_shape).except(:units))
+      shape_model.update_attributes!(HashUtils.compact(update_shape).except(:units).merge(price_quantity_placeholder: nil))
     end
 
     from_model(shape_model, true)

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -74,7 +74,7 @@ describe ListingService::API::Shapes do
         expect(shape[:transaction_process_id]).to eql(transaction_process_id)
         expect(shape[:name_tr_key]).to eql(name_tr_key)
         expect(shape[:action_button_tr_key]).to eql(action_button_tr_key)
-        expect(shape[:price_quantity_placeholder]).to eql(:time)
+        expect(shape[:price_quantity_placeholder]).to eql(nil)
         expect(shape[:category_ids].sort).to eq category_ids.sort
         expect(shape[:name]).to eql("selling")
 
@@ -156,6 +156,19 @@ describe ListingService::API::Shapes do
         shape_names = listings_api.shapes.get(community_id: community_id).data.map { |s| [s[:name], s[:sort_priority]] }
         expect(shape_names).to eq [["rent", 0], ["request", 5], ["sell", 10]]
       end
+
+      # TODO This spec can be removed when we remove quantity placeholder
+      it "returns old quantity placeholder" do
+        id = create_shape[:data][:id]
+
+        # FIXME Do not use models directly
+        ListingShape.find(id).update_attributes(price_quantity_placeholder: "time")
+
+        get_res = listings_api.shapes.get(community_id: community_id, listing_shape_id: id)
+
+        expect(get_res.success).to eq(true)
+        expect(get_res.data[:price_quantity_placeholder]).to eq(:time)
+      end
     end
   end
 
@@ -236,6 +249,30 @@ describe ListingService::API::Shapes do
 
         expect(update_res.success).to eq(true)
         expect(update_res.data[:shipping_enabled]).to eq(false)
+      end
+
+      # TODO This test can be removed when we remove price_quantity_placeholder
+
+      it "sets price_quantity_placeholder to nil" do
+        shape = create_shape.data
+
+        # FIXME Do not use models directly
+        ListingShape.find(shape[:id]).update_attributes(price_quantity_placeholder: "time")
+
+        get_res = listings_api.shapes.get(community_id: community_id, listing_shape_id: shape[:id])
+
+        expect(get_res.success).to eq(true)
+        expect(get_res.data[:price_quantity_placeholder]).to eq(:time)
+
+        update_res = listings_api.shapes.update(
+          community_id: community_id,
+          listing_shape_id: shape[:id],
+          opts: { shipping_enabled: false })
+
+        expect(update_res.success).to eq(true)
+        expect(update_res.data[:shipping_enabled]).to eq(false)
+        expect(update_res.data[:price_quantity_placeholder]).to eq(nil)
+
       end
     end
 


### PR DESCRIPTION
…pdated

- This allows us to enable Shape UI for marketplaces that currently have "open units" in use. Then they can go and add the custom units they need.