### PR TITLE
Ignore empty order_id in auth ipn msg parsing

### DIFF
--- a/app/services/paypal_service/data_types/ipn.rb
+++ b/app/services/paypal_service/data_types/ipn.rb
@@ -248,7 +248,7 @@ module PaypalService
           },
           params)
 
-        p[:order_id] = p[:order_id].strip.empty? ? nil : p[:order_id]
+        p[:order_id] = Maybe(p)[:order_id].strip.or_else(nil)
 
         create_authorization_created(
           p.merge({

--- a/app/services/paypal_service/data_types/ipn.rb
+++ b/app/services/paypal_service/data_types/ipn.rb
@@ -248,6 +248,8 @@ module PaypalService
           },
           params)
 
+        p[:order_id] = p[:order_id].strip.empty? ? nil : p[:order_id]
+
         create_authorization_created(
           p.merge({
               order_total: p[:order_id].nil? ? nil : to_money(p[:mc_gross], p[:mc_currency]),

--- a/spec/services/paypal_service/data_types/ipn_spec.rb
+++ b/spec/services/paypal_service/data_types/ipn_spec.rb
@@ -636,4 +636,10 @@ describe PaypalService::DataTypes::IPN do
     end
   end
 
+  it "#from_params - auth_no_order" do
+    ipn_msg = PaypalService::DataTypes::IPN.from_params(auth_created_no_order)
+
+    expect(ipn_msg[:order_id]).to be_nil
+  end
+
 end


### PR DESCRIPTION
When we switched from Order based paypal flow to auth based flow we no longer have orders and order ids in payments. One change that went unnoticed was an IPN message informing about authorization no longer has parent transaction id. This was incorrectly parsed as an empty string instead of nil. Because of this the payment update contained extra data and tried to insert a new payment with already existing authorization id. DB rejected this update because of unique index, and was correct in doing so. This parsing change now recognized nil order id and removes incorrect extra payment update.

https://sharetribe.airbrake.io/projects/15448/groups/1389590260555809569/notices/1434356405166769802