### PR TITLE
Enable quantity selectors for free transactions

### DIFF
--- a/app/assets/javascripts/transaction.js
+++ b/app/assets/javascripts/transaction.js
@@ -1,6 +1,8 @@
 window.ST = window.ST || {};
 
-window.ST.transaction = (function(_) {
+window.ST.transaction = window.ST.transaction || {};
+
+(function(module, _) {
 
   function toOpResult(submitResponse) {
     if (submitResponse.op_status_url) {
@@ -104,10 +106,8 @@ window.ST.transaction = (function(_) {
 
   }
 
-  return {
-    initializePayPalBuyForm: initializePayPalBuyForm,
-    initializeCreatePaymentPoller: initializeCreatePaymentPoller,
-    initializeFreeTransactionForm: initializeFreeTransactionForm
-  };
+  module.initializePayPalBuyForm = initializePayPalBuyForm;
+  module.initializeCreatePaymentPoller = initializeCreatePaymentPoller;
+  module.initializeFreeTransactionForm = initializeFreeTransactionForm;
 
-})(_);
+})(window.ST.transaction, _);

--- a/app/assets/javascripts/transaction.js
+++ b/app/assets/javascripts/transaction.js
@@ -1,6 +1,6 @@
 window.ST = window.ST || {};
 
-ST.transaction = (function(_) {
+window.ST.transaction = (function(_) {
 
   function toOpResult(submitResponse) {
     if (submitResponse.op_status_url) {
@@ -89,9 +89,25 @@ ST.transaction = (function(_) {
     ).onValue(function () { window.location = redirectUrl; });
   }
 
+  function initializeFreeTransactionForm(locale) {
+    window.auto_resize_text_areas("text_area");
+    $('textarea').focus();
+    var form_id = "#transaction-form";
+    $(form_id).validate({
+      rules: {
+        "message": {required: true}
+      },
+      submitHandler: function(form) {
+        window.disable_and_submit(form_id, form, "false", locale);
+      }
+  });
+
+  }
+
   return {
     initializePayPalBuyForm: initializePayPalBuyForm,
-    initializeCreatePaymentPoller: initializeCreatePaymentPoller
+    initializeCreatePaymentPoller: initializeCreatePaymentPoller,
+    initializeFreeTransactionForm: initializeFreeTransactionForm
   };
 
 })(_);

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -129,7 +129,7 @@ class ListingsController < ApplicationController
 
     payment_gateway = MarketplaceService::Community::Query.payment_type(@current_community.id)
     process = get_transaction_process(community_id: @current_community.id, transaction_process_id: @listing.transaction_process_id)
-    form_path = new_person_transaction_path(@current_user, listing_id: @listing.id)
+    form_path = new_transaction_path(listing_id: @listing.id)
 
     delivery_opts = delivery_config(@listing.require_shipping_address, @listing.pickup_enabled, @listing.shipping_price, @listing.shipping_price_additional, @listing.currency)
 

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -46,7 +46,7 @@ class PreauthorizeTransactionsController < ApplicationController
       return redirect_to error_not_found_path
     end
 
-    quantity = valid_quantity(params[:quantity])
+    quantity = TransactionViewUtils.parse_quantity(params[:quantity])
 
     vprms = view_params(listing_id: params[:listing_id],
                         quantity: quantity,
@@ -96,7 +96,7 @@ class PreauthorizeTransactionsController < ApplicationController
       return render_error_response(request.xhr?, "Delivery method is invalid.", action: :initiate)
     end
 
-    quantity = valid_quantity(preauthorize_form.quantity)
+    quantity = TransactionViewUtils.parse_quantity(preauthorize_form.quantity)
     shipping_price = shipping_price_total(@listing.shipping_price, @listing.shipping_price_additional, quantity)
 
     transaction_response = create_preauth_transaction(
@@ -206,7 +206,7 @@ class PreauthorizeTransactionsController < ApplicationController
     if @current_community.transaction_agreement_in_use? && conversation_params[:contract_agreed] != "1"
       return render_error_response(request.xhr?,
         t("error_messages.transaction_agreement.required_error"),
-        { action: :book, start_on: stringify_booking_date(start_on), end_on: stringify_booking_date(end_on) })
+        { action: :book, start_on: TransactionViewUtils.stringify_booking_data(start_on), end_on: TransactionViewUtils.stringify_booking_data(end_on) })
     end
 
     delivery_method = valid_delivery_method(delivery_method_str: preauthorize_form.delivery_method,
@@ -219,7 +219,7 @@ class PreauthorizeTransactionsController < ApplicationController
     unless preauthorize_form.valid?
       return render_error_response(request.xhr?,
         preauthorize_form.errors.full_messages.join(", "),
-       { action: :book, start_on: stringify_booking_date(start_on), end_on: stringify_booking_date(end_on) })
+       { action: :book, start_on: TransactionViewUtils.stringify_booking_data(start_on), end_on: TransactionViewUtils.stringify_booking_data(end_on) })
     end
 
     transaction_response = create_preauth_transaction(
@@ -246,7 +246,7 @@ class PreauthorizeTransactionsController < ApplicationController
           "An error occured while trying to create a new transaction: #{transaction_response[:error_msg]}"
         end
 
-      return render_error_response(request.xhr?, error, { action: :book, start_on: stringify_booking_date(start_on), end_on: stringify_booking_date(end_on) })
+      return render_error_response(request.xhr?, error, { action: :book, start_on: TransactionViewUtils.stringify_booking_data(start_on), end_on: TransactionViewUtils.stringify_booking_data(end_on) })
     end
 
     transaction_id = transaction_response[:data][:transaction][:id]
@@ -268,7 +268,7 @@ class PreauthorizeTransactionsController < ApplicationController
   end
 
   def preauthorize
-    quantity = valid_quantity(params[:quantity])
+    quantity = TransactionViewUtils.parse_quantity(params[:quantity])
     vprms = view_params(listing_id: params[:listing_id], quantity: quantity)
     braintree_settings = BraintreePaymentQuery.braintree_settings(@current_community.id)
 
@@ -310,7 +310,7 @@ class PreauthorizeTransactionsController < ApplicationController
 
     if preauthorize_form.valid?
       braintree_form = BraintreeForm.new(params[:braintree_payment])
-      quantity = valid_quantity(preauthorize_form.quantity)
+      quantity = TransactionViewUtils.parse_quantity(preauthorize_form.quantity)
 
       transaction_response = TransactionService::Transaction.create({
           transaction: {
@@ -434,22 +434,10 @@ class PreauthorizeTransactionsController < ApplicationController
     end
   end
 
-  def duration(start_on, end_on)
-    (end_on - start_on).to_i + 1
-  end
-
-  def parse_booking_date(str)
-    Date.parse(str) unless str.blank?
-  end
-
-  def stringify_booking_date(date)
-    date.iso8601
-  end
-
   def verified_booking_data(start_on, end_on)
     booking_form = BookingForm.new({
-      start_on: parse_booking_date(start_on),
-      end_on: parse_booking_date(end_on)
+      start_on: TransactionViewUtils.parse_booking_date(start_on),
+      end_on: TransactionViewUtils.parse_booking_date(end_on)
     })
 
     if !booking_form.valid?
@@ -472,14 +460,6 @@ class PreauthorizeTransactionsController < ApplicationController
     else
       :errored
     end
-  end
-
-  def valid_quantity(quantity)
-    Maybe(quantity)
-      .map {|q|
-        StringUtils.is_numeric?(q) && q.to_i > 0 ? q.to_i : 1
-      }
-      .or_else(1)
   end
 
   def braintree_gateway_locals(community_id)

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -29,7 +29,7 @@ class TransactionsController < ApplicationController
     ).on_success { |((listing_id, listing_model, author_model, process, gateway))|
       booking = listing_model.unit_type == :day
 
-      transaction_params = {listing_id: listing_model.id}.merge(params.slice(:start_on, :end_on, :quantity))
+      transaction_params = HashUtils.symbolize_keys({listing_id: listing_model.id}.merge(params.slice(:start_on, :end_on, :quantity)))
 
       case [process[:process], gateway, booking]
       when matches([:none])

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -29,7 +29,7 @@ class TransactionsController < ApplicationController
     ).on_success { |((listing_id, listing_model, author_model, process, gateway))|
       booking = listing_model.unit_type == :day
 
-      transaction_params = HashUtils.symbolize_keys({listing_id: listing_model.id}.merge(params.slice(:start_on, :end_on, :quantity)))
+      transaction_params = HashUtils.symbolize_keys({listing_id: listing_model.id}.merge(params.slice(:start_on, :end_on, :quantity, :delivery)))
 
       case [process[:process], gateway, booking]
       when matches([:none])

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -270,7 +270,7 @@ class TransactionsController < ApplicationController
              booking_start: Maybe(booking_start).map { |d| TransactionViewUtils.stringify_booking_date(d) },
              booking_end: Maybe(booking_end).map { |d| TransactionViewUtils.stringify_booking_date(d) },
              quantity: quantity,
-             form_action: person_transactions_path(listing_id: listing_model.id)
+             form_action: person_transactions_path(person_id: @current_user, listing_id: listing_model.id)
            }
   end
 end

--- a/app/services/transaction_service/gateway/free_adapter.rb
+++ b/app/services/transaction_service/gateway/free_adapter.rb
@@ -8,7 +8,7 @@ module TransactionService::Gateway
 
     def get_payment_details(tx:)
       { payment_total: nil,
-        total_price: tx[:unit_price],
+        total_price: tx[:unit_price] * tx[:listing_quantity],
         charged_commission: nil,
         payment_gateway_fee: nil }
     end

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -118,6 +118,7 @@ module EntityUtils
     to_bool: -> (_, v) { !!v },
     to_symbol: -> (_, v) { v.to_sym unless v.nil? },
     to_string: -> (_, v) { v.to_s unless v.nil? },
+    to_integer: -> (_, v) { v.to_i unless v.nil? },
     str_to_time: -> (format, v) {
       if v.nil?
         nil

--- a/app/view_utils/listing_view_utils.rb
+++ b/app/view_utils/listing_view_utils.rb
@@ -48,6 +48,9 @@ module ListingViewUtils
     end
   end
 
+  # FIXME I feel that this is not quite right.
+  # Instead of unit type, the first parameter should be selector type (number, day)
+  # and that should affect how we should the information
   def translate_quantity(type, tr_key = nil)
     case type
     when :hour

--- a/app/view_utils/transaction_view_utils.rb
+++ b/app/view_utils/transaction_view_utils.rb
@@ -160,4 +160,22 @@ module TransactionViewUtils
   def price_break_down_locals(opts)
     PriceBreakDownLocals.call(opts)
   end
+
+  def parse_booking_date(str)
+    Date.parse(str) unless str.blank?
+  end
+
+  def stringify_booking_date(date)
+    date.iso8601
+  end
+
+  def parse_quantity(quantity)
+    Maybe(quantity)
+      .select { |q| StringUtils.is_numeric?(q) }
+      .map(&:to_i)
+      .select { |q| q > 0 }
+      .or_else(1)
+  end
+
+
 end

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -25,7 +25,7 @@
       - # Currently we show the selectors only for preauth process.
       - # However, there has been a plan to introduce these in other
       - # Processes (free) as well - rap1ds, 2.6.2015
-      - if process == :preauthorize
+      - if process != :postpay
         - if @listing.unit_type == :day
           - days = [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
           - months = [:january, :february, :march, :april, :may, :june, :july, :august, :september, :october, :november, :december]

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -89,6 +89,8 @@
 
       = render partial: "delivery_opts", locals: { delivery_opts: delivery_opts, is_author: is_author }
 
+      = hidden_field_tag(:listing_id, @listing.id)
+
       %button.book-button
         .content
           = action_button_label(@listing)

--- a/app/views/transactions/new.haml
+++ b/app/views/transactions/new.haml
@@ -1,5 +1,6 @@
-- content_for :javascript do
-  initialize_send_message_form('#{I18n.locale}');
+- content_for :extra_javascript do
+  :javascript
+    ST.transaction.initializeFreeTransactionForm('#{I18n.locale}');
 
 - content_for :title_header do
   %h1

--- a/app/views/transactions/new.haml
+++ b/app/views/transactions/new.haml
@@ -19,8 +19,9 @@
         %div
           = t("listing_conversations.preauthorize.by", listing: link_to("#{listing[:title]}", listing_path(listing[:id])), author: author_link).html_safe
 
-      %li
-        = render partial: "transactions/price_break_down", locals: price_break_down
+      - m_price_break_down.each do |price_break_down|
+        %li
+          = render partial: "transactions/price_break_down", locals: price_break_down
 
   = form_tag(form_action, method: :post, id: "transaction-form") do
 

--- a/app/views/transactions/new.haml
+++ b/app/views/transactions/new.haml
@@ -1,0 +1,43 @@
+- content_for :javascript do
+  initialize_send_message_form('#{I18n.locale}');
+
+- content_for :title_header do
+  %h1
+    = action_button_label
+    = link_to(listing[:title], listing_path(listing[:id]))
+
+#new_message_form.centered-section
+
+  - author_link = link_to(author[:display_name], person_path(id: author[:username]))
+
+  .preauthorize-section
+    %h2.preauthorize-details-title
+      = t("listing_conversations.preauthorize.details")
+
+    %ul.no-bullets
+      %li
+        %div
+          = t("listing_conversations.preauthorize.by", listing: link_to("#{listing[:title]}", listing_path(listing[:id])), author: author_link).html_safe
+
+      %li
+        = render partial: "transactions/price_break_down", locals: price_break_down
+
+  = form_tag(form_action, method: :post, id: "transaction-form") do
+
+    = hidden_field_tag(:start_on, booking_start)
+    = hidden_field_tag(:end_on, booking_end)
+
+
+    .preauthorize-section
+      %h2
+        = t("conversations.new.send_message_to_user", person: author_link).html_safe
+      .row
+        .col-12
+          = text_area_tag(:message, nil, :class => "text_area")
+
+      - if quantity
+        = hidden_field_tag(:quantity, quantity)
+
+      .row
+        .col-12
+          = button_tag t("conversations.new.send_message"), :class => "send_button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,7 +335,7 @@ Kassi::Application.routes.draw do
             get :billing_agreement_cancel
           end
         end
-        resources :transactions, :only => [:show]
+        resources :transactions, only: [:show, :new]
         resource :checkout_account, only: [:new, :show, :create]
         resource :settings do
           member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,7 +335,7 @@ Kassi::Application.routes.draw do
             get :billing_agreement_cancel
           end
         end
-        resources :transactions, only: [:show, :new]
+        resources :transactions, only: [:show, :new, :create]
         resource :checkout_account, only: [:new, :show, :create]
         resource :settings do
           member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,9 @@ Kassi::Application.routes.draw do
 
     match "/transactions/op_status/:process_token" => "transactions#op_status", :as => :transaction_op_status
 
+    # All new transactions (in the future)
+    match "/transactions/new" => "transactions#new", as: :new_transaction
+
     # preauthorize flow
     match "/listings/:listing_id/preauthorize" => "preauthorize_transactions#preauthorize", :as => :preauthorize_payment
     match "/listings/:listing_id/preauthorized" => "preauthorize_transactions#preauthorized", :as => :preauthorized_payment
@@ -78,7 +81,6 @@ Kassi::Application.routes.draw do
     match "/listings/:listing_id/create_transaction" => "post_pay_transactions#create", :as => :create_transaction, :method => :post
 
     # free flow
-    match "/listings/:listing_id/reply" => "free_transactions#new", :as => :reply_to_listing
     match "/listings/:listing_id/create_contact" => "free_transactions#create_contact", :as => :create_contact
     match "/listings/:listing_id/contact" => "free_transactions#contact", :as => :contact_to_listing
 

--- a/features/conversations/inquiry.feature
+++ b/features/conversations/inquiry.feature
@@ -17,7 +17,7 @@ Feature: Inquiry
     When I follow "Test message"
     Then I should not see "Contact"
     When I press "Inquire"
-    And I fill in "Message" with "Test content"
+    And I fill in "message" with "Test content"
     And I press "Send message"
     And I log out
     And I log in as "kassi_testperson1"

--- a/features/conversations/person_transaction_process.feature
+++ b/features/conversations/person_transaction_process.feature
@@ -52,7 +52,7 @@ Feature: Transaction process between two users
     # Starting the conversation
     When I follow "Hammer"
     And I press "Offer"
-    And I fill in "Message" with "I can lend this item"
+    And I fill in "message" with "I can lend this item"
     And I press "Send"
     And the system processes jobs
     And "kassi_testperson1@example.com" should receive an email

--- a/features/conversations/user_requests_an_item_in_item_offer.feature
+++ b/features/conversations/user_requests_an_item_in_item_offer.feature
@@ -71,7 +71,7 @@ Feature: User requests an item in item offer
     And I am on the homepage
     When I follow "Hammer"
     And I press "Borrow this item"
-    Then I should see "You must sign in to Sharetribe to send a message to another user." within ".flash-notifications"
+    Then I should see "You must sign in to Sharetribe to do a transaction." within ".flash-notifications"
     And I should see "Sign in to Sharetribe" within "h1"
     When I log in as "kassi_testperson2"
 
@@ -85,7 +85,7 @@ Feature: User requests an item in item offer
     And I am on the homepage
     When I follow "Hammer"
     And I press "Borrow this item"
-    Then I should see "You must sign in to Sharetribe to send a message to another user." within ".flash-notifications"
+    Then I should see "You must sign in to Sharetribe to do a transaction." within ".flash-notifications"
     And I should see "Sign in to Sharetribe" within "h1"
     When I log in as "kassi_testperson1"
     Then I should see "You cannot send a message to yourself" within ".flash-notifications"


### PR DESCRIPTION
Merge after #1269 

All new transactions now go through the same TransactionsController#new action. In theory, listing show page doesn't now need to know details (process, payment gateways, etc.).

- [X] All transactions go through TransactionsController#new
- [X] Free transactions are rendered by TransactionsController
- [X] Other transactions are redirected to correct path
- [X] Selectors work with free transactions