### PR TITLE
Fix bug: Wrong unit is selected

### DIFF
--- a/app/utils/hash_utils.rb
+++ b/app/utils/hash_utils.rb
@@ -63,6 +63,14 @@ module HashUtils
     end
   end
 
+  # Return true if given subset of fields in both hashes are equal
+  #
+  # Usage:
+  #  suq_eq({a: 1, b: 2, c: 3}, {a: 1, b: 2, c: 4}, :a, :b) => true
+  def sub_eq(a, b, *keys)
+    a.slice(*keys) == b.slice(*keys)
+  end
+
   #
   # deep_contains({a: 1}, {a: 1, b: 2}) => true
   # deep_contains({a: 2}, {a: 1, b: 2}) => false

--- a/app/view_utils/listing_view_utils.rb
+++ b/app/view_utils/listing_view_utils.rb
@@ -15,19 +15,16 @@ module ListingViewUtils
   # - units, array from shape[:units]
   # - selected, symbol of unit type
   #
-  # units => [
-  #   ['Day', :day, true]
-  #   ['Hour', :hour, false]
-  # ]
   def unit_options(units, selected_unit = nil)
-    units.map { |unit|
+
+    units
+      .map { |u| HashUtils.compact(u) }
+      .map { |unit|
       {
         display: translate_unit(unit[:type], unit[:name_tr_key]),
         value: Unit.serialize(unit),
         kind: unit[:kind],
-        selected: selected_unit.present? &&
-          unit[:name_tr_key] == selected_unit[:unit_tr_key] &&
-          unit[:selector_tr_key] == selected_unit[:unit_selector_tr_key]
+        selected: selected_unit.present? && HashUtils.sub_eq(unit, selected_unit, :type, :name_tr_key, :selector_tr_key)
       }
     }
   end

--- a/spec/utils/hash_utils_spec.rb
+++ b/spec/utils/hash_utils_spec.rb
@@ -55,6 +55,11 @@ describe HashUtils do
       .to eq({first: "First", age: 55})
   end
 
+  it "#sub_eq" do
+    expect(HashUtils.sub_eq({a: 1, b: 2, c: 3}, {a: 1, b: 2, c: 4}, :a, :b)).to eq(true)
+    expect(HashUtils.sub_eq({a: 1, b: 2, c: 3}, {a: 3, b: 2, c: 4}, :a, :b)).to eq(false)
+  end
+
   describe "#transpose" do
     let(:h) { {a: [1, 2, 3], b: [2, 3, 4], c: [2]} }
 


### PR DESCRIPTION
Steps to reproduce:

- Add an order type with two predefined units
- Add a new listing, select the last unit from the dropdown
- Edit the listing

Expected: The previously selected unit is selected by default in the dropdown menu

Actual: The first unit is selected.

![screen shot 2015-06-04 at 16 13 17](https://cloud.githubusercontent.com/assets/429876/7984849/b7961fb8-0ad4-11e5-8165-cf13e4d0a0a1.png)
