### PR TITLE
Remove price quantity placeholder

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -210,10 +210,7 @@ class ListingsController < ApplicationController
         transaction_process_id: shape[:transaction_process_id],
         shape_name_tr_key: shape[:name_tr_key],
         action_button_tr_key: shape[:action_button_tr_key],
-        current_community_id: @current_community.id,
-
-        # This can be moved when we remove price_quantity_placeholder
-        quantity: Maybe(shape)[:price_quantity_placeholder].map { |_| listing_params[:quantity] }.or_else(nil)
+        current_community_id: @current_community.id
     ).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
     @listing = Listing.new(listing_params)
@@ -317,11 +314,7 @@ class ListingsController < ApplicationController
       shape_name_tr_key: shape[:name_tr_key],
       action_button_tr_key: shape[:action_button_tr_key],
       current_community_id: @current_community.id,
-      last_modified: DateTime.now,
-
-      # This can be moved when we remove price_quantity_placeholder
-      quantity: Maybe(shape)[:price_quantity_placeholder].map { |_| listing_params[:quantity] }.or_else(nil)
-
+      last_modified: DateTime.now
     ).merge(open_params).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
     update_successful = @listing.update_fields(listing_params)

--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -41,6 +41,6 @@ class ListingShape < ActiveRecord::Base
   has_many :listing_units
 
   def self.columns
-    super.reject { |c| c.name == "transaction_type_id" }
+    super.reject { |c| c.name == "transaction_type_id" || c.name == "price_quantity_placeholder" }
   end
 end

--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -2,19 +2,18 @@
 #
 # Table name: listing_shapes
 #
-#  id                         :integer          not null, primary key
-#  community_id               :integer          not null
-#  transaction_process_id     :integer          not null
-#  price_enabled              :boolean          not null
-#  shipping_enabled           :boolean          not null
-#  name                       :string(255)      not null
-#  name_tr_key                :string(255)      not null
-#  action_button_tr_key       :string(255)      not null
-#  price_quantity_placeholder :string(255)
-#  sort_priority              :integer          default(0), not null
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  deleted                    :boolean          default(FALSE)
+#  id                     :integer          not null, primary key
+#  community_id           :integer          not null
+#  transaction_process_id :integer          not null
+#  price_enabled          :boolean          not null
+#  shipping_enabled       :boolean          not null
+#  name                   :string(255)      not null
+#  name_tr_key            :string(255)      not null
+#  action_button_tr_key   :string(255)      not null
+#  sort_priority          :integer          default(0), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  deleted                :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/services/listing_service/store/shape.rb
+++ b/app/services/listing_service/store/shape.rb
@@ -27,8 +27,7 @@ module ListingService::Store::Shape
     [:shipping_enabled, :bool, :mandatory],
     [:name, :string, :mandatory],
     [:sort_priority, :fixnum, default: 0],
-    [:category_ids, :array],
-    [:price_quantity_placeholder, :to_symbol, one_of: [nil, :mass, :time, :long_time]] # TODO TEMP
+    [:category_ids, :array]
   )
 
   UpdateShape = EntityUtils.define_builder(
@@ -94,7 +93,7 @@ module ListingService::Store::Shape
     ActiveRecord::Base.transaction do
 
       # Save to ListingShape model
-      shape_model = ListingShape.create!(shape_with_sort.except(:units).merge(price_quantity_placeholder: nil))
+      shape_model = ListingShape.create!(shape_with_sort.except(:units))
 
       # Save units
       units.each { |unit|
@@ -127,7 +126,7 @@ module ListingService::Store::Shape
       end
 
       # Save to ListingShape model
-      shape_model.update_attributes!(HashUtils.compact(update_shape).except(:units).merge(price_quantity_placeholder: nil))
+      shape_model.update_attributes!(HashUtils.compact(update_shape).except(:units))
     end
 
     from_model(shape_model, true)

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -4,28 +4,21 @@
     = form.text_field :price, :class => "price-field", :maxlength => "10", :placeholder => "0", :value => (@listing.price ? @listing.price.to_s: 0)
     = render partial: "listings/form/currency_selector", locals: {form: form}
 
-    - if shape[:price_quantity_placeholder].present?
-      -#
-        Currently price quantity placeholder has higher priority than units.
-        This whole free text quantity thing will be removed soon
-      .quantity-description= t(".per")
-      = form.text_field :quantity, :class => "quantity-field", :placeholder => t(".#{shape[:price_quantity_placeholder].to_s}")
+    - if unit_options.empty?
+      -# No-op
+    - elsif unit_options.length == 1
+      - unit_option = unit_options.first
+      .quantity-description
+        = t(".per")
+        = unit_option[:display]
+      = hidden_field_tag("listing[unit]", unit_option[:value])
     - else
-      - if unit_options.empty?
-        -# No-op
-      - elsif unit_options.length == 1
-        - unit_option = unit_options.first
-        .quantity-description
-          = t(".per")
-          = unit_option[:display]
-        = hidden_field_tag("listing[unit]", unit_option[:value])
-      - else
-        .quantity-description
-          = t(".per")
-        %select.js-listing-unit{name: "listing[unit]"}
-          - unit_options.each do |unit_option|
-            %option{value: unit_option[:value], selected: unit_option[:selected], data: { kind: unit_option[:kind] }}
-              = unit_option[:display]
+      .quantity-description
+        = t(".per")
+      %select.js-listing-unit{name: "listing[unit]"}
+        - unit_options.each do |unit_option|
+          %option{value: unit_option[:value], selected: unit_option[:selected], data: { kind: unit_option[:kind] }}
+            = unit_option[:display]
 
     %small
       - paypal_fee_info_link = "<a href=# id='paypal_fee_info_link'>#{t(".paypal_fee_info_link_text")}</a>"

--- a/db/migrate/20150608135024_set_price_quantity_placeholder_null_to_communities_that_use_units.rb
+++ b/db/migrate/20150608135024_set_price_quantity_placeholder_null_to_communities_that_use_units.rb
@@ -1,0 +1,14 @@
+class SetPriceQuantityPlaceholderNullToCommunitiesThatUseUnits < ActiveRecord::Migration
+  def up
+    execute("
+      UPDATE listing_shapes
+      LEFT JOIN listing_units ON listing_units.listing_shape_id = listing_shapes.id
+      SET listing_shapes.price_quantity_placeholder = NULL
+      WHERE listing_shapes.price_quantity_placeholder IS NOT NULL AND listing_units.id IS NOT NULL
+")
+  end
+
+  def down
+    # Deleting data, there's no way to get it back.
+  end
+end

--- a/db/migrate/20150608140024_migrate_price_quantity_placeholder_to_units.rb
+++ b/db/migrate/20150608140024_migrate_price_quantity_placeholder_to_units.rb
@@ -1,0 +1,63 @@
+class MigratePriceQuantityPlaceholderToUnits < ActiveRecord::Migration
+  def up
+    execute("
+      INSERT INTO listing_units (unit_type, quantity_selector, kind, listing_shape_id, created_at, updated_at)
+      (
+        SELECT 'hour', 'number', 'time', listing_shapes.id, listing_shapes.created_at, listing_shapes.updated_at
+        FROM listing_shapes
+        WHERE listing_shapes.price_quantity_placeholder = 'time'
+      );
+    ")
+    execute("
+      INSERT INTO listing_units (unit_type, quantity_selector, kind, listing_shape_id, created_at, updated_at)
+      (
+        SELECT 'day', 'number', 'day', listing_shapes.id, listing_shapes.created_at, listing_shapes.updated_at
+        FROM listing_shapes
+        WHERE listing_shapes.price_quantity_placeholder = 'time'
+      );
+    ")
+    execute("
+
+      INSERT INTO listing_units (unit_type, quantity_selector, kind, listing_shape_id, created_at, updated_at)
+      (
+        SELECT 'month', 'number', 'time', listing_shapes.id, listing_shapes.created_at, listing_shapes.updated_at
+        FROM listing_shapes
+        WHERE listing_shapes.price_quantity_placeholder = 'time'
+      );
+    ")
+    execute("
+
+      # long_time ->
+
+      INSERT INTO listing_units (unit_type, quantity_selector, kind, listing_shape_id, created_at, updated_at)
+      (
+        SELECT 'week', 'number', 'time', listing_shapes.id, listing_shapes.created_at, listing_shapes.updated_at
+        FROM listing_shapes
+        WHERE listing_shapes.price_quantity_placeholder = 'long_time'
+      );
+    ")
+    execute("
+
+      INSERT INTO listing_units (unit_type, quantity_selector, kind, listing_shape_id, created_at, updated_at)
+      (
+        SELECT 'month', 'number', 'time', listing_shapes.id, listing_shapes.created_at, listing_shapes.updated_at
+        FROM listing_shapes
+        WHERE listing_shapes.price_quantity_placeholder = 'long_time'
+      );
+")
+  end
+
+  def down
+    execute("
+      DELETE listing_units FROM listing_units
+      LEFT JOIN listing_shapes ON listing_units.listing_shape_id = listing_shapes.id
+      WHERE listing_shapes.price_quantity_placeholder = 'time';
+    ")
+
+    execute("
+      DELETE listing_units FROM listing_units
+      LEFT JOIN listing_shapes ON listing_units.listing_shape_id = listing_shapes.id
+      WHERE listing_shapes.price_quantity_placeholder = 'long_time'
+")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -487,18 +487,17 @@ ActiveRecord::Schema.define(:version => 20150622080657) do
   add_index "listing_images", ["listing_id"], :name => "index_listing_images_on_listing_id"
 
   create_table "listing_shapes", :force => true do |t|
-    t.integer  "community_id",                                  :null => false
-    t.integer  "transaction_process_id",                        :null => false
-    t.boolean  "price_enabled",                                 :null => false
-    t.boolean  "shipping_enabled",                              :null => false
-    t.string   "name",                                          :null => false
-    t.string   "name_tr_key",                                   :null => false
-    t.string   "action_button_tr_key",                          :null => false
-    t.string   "price_quantity_placeholder"
-    t.integer  "sort_priority",              :default => 0,     :null => false
-    t.datetime "created_at",                                    :null => false
-    t.datetime "updated_at",                                    :null => false
-    t.boolean  "deleted",                    :default => false
+    t.integer  "community_id",                              :null => false
+    t.integer  "transaction_process_id",                    :null => false
+    t.boolean  "price_enabled",                             :null => false
+    t.boolean  "shipping_enabled",                          :null => false
+    t.string   "name",                                      :null => false
+    t.string   "name_tr_key",                               :null => false
+    t.string   "action_button_tr_key",                      :null => false
+    t.integer  "sort_priority",          :default => 0,     :null => false
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
+    t.boolean  "deleted",                :default => false
   end
 
   add_index "listing_shapes", ["community_id", "deleted", "sort_priority"], :name => "multicol_index"

--- a/spec/controllers/int_api/marketplaces_controller_spec.rb
+++ b/spec/controllers/int_api/marketplaces_controller_spec.rb
@@ -34,7 +34,6 @@ describe IntApi::MarketplacesController do
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:price_enabled]).to eql true
       expect(s[:units].empty?).to eql true
-      expect(s[:price_quantity_placeholder]).to eql nil
 
       payment_settings = TransactionService::API::Api.settings.get_active(community_id: c.id)
       expect(payment_settings[:data][:payment_gateway]).to eql :paypal
@@ -73,7 +72,6 @@ describe IntApi::MarketplacesController do
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:price_enabled]).to eql true
       expect(s[:units].empty?).to eql true
-      expect(s[:price_quantity_placeholder]).to eql nil
 
       p = c.admins.first
       expect(p).to_not be_nil
@@ -108,7 +106,6 @@ describe IntApi::MarketplacesController do
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:price_enabled]).to eql true
       expect(s[:units].empty?).to eql true
-      expect(s[:price_quantity_placeholder]).to eql nil
 
       p = c.admins.first
       expect(p).to_not be_nil
@@ -143,7 +140,6 @@ describe IntApi::MarketplacesController do
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:price_enabled]).to eql true
       expect(s[:units].empty?).to eql true
-      expect(s[:price_quantity_placeholder]).to eql nil
 
       p = c.admins.first
       expect(p).to_not be_nil

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -28,7 +28,6 @@ describe ListingService::API::Shapes do
       transaction_process_id: transaction_process_id,
       name_tr_key: name_tr_key,
       action_button_tr_key: action_button_tr_key,
-      price_quantity_placeholder: :time,
       basename: "Selling",
 
       units: [
@@ -74,7 +73,6 @@ describe ListingService::API::Shapes do
         expect(shape[:transaction_process_id]).to eql(transaction_process_id)
         expect(shape[:name_tr_key]).to eql(name_tr_key)
         expect(shape[:action_button_tr_key]).to eql(action_button_tr_key)
-        expect(shape[:price_quantity_placeholder]).to eql(nil)
         expect(shape[:category_ids].sort).to eq category_ids.sort
         expect(shape[:name]).to eql("selling")
 
@@ -156,19 +154,6 @@ describe ListingService::API::Shapes do
         shape_names = listings_api.shapes.get(community_id: community_id).data.map { |s| [s[:name], s[:sort_priority]] }
         expect(shape_names).to eq [["rent", 0], ["request", 5], ["sell", 10]]
       end
-
-      # TODO This spec can be removed when we remove quantity placeholder
-      it "returns old quantity placeholder" do
-        id = create_shape[:data][:id]
-
-        # FIXME Do not use models directly
-        ListingShape.find(id).update_attributes(price_quantity_placeholder: "time")
-
-        get_res = listings_api.shapes.get(community_id: community_id, listing_shape_id: id)
-
-        expect(get_res.success).to eq(true)
-        expect(get_res.data[:price_quantity_placeholder]).to eq(:time)
-      end
     end
   end
 
@@ -249,30 +234,6 @@ describe ListingService::API::Shapes do
 
         expect(update_res.success).to eq(true)
         expect(update_res.data[:shipping_enabled]).to eq(false)
-      end
-
-      # TODO This test can be removed when we remove price_quantity_placeholder
-
-      it "sets price_quantity_placeholder to nil" do
-        shape = create_shape.data
-
-        # FIXME Do not use models directly
-        ListingShape.find(shape[:id]).update_attributes(price_quantity_placeholder: "time")
-
-        get_res = listings_api.shapes.get(community_id: community_id, listing_shape_id: shape[:id])
-
-        expect(get_res.success).to eq(true)
-        expect(get_res.data[:price_quantity_placeholder]).to eq(:time)
-
-        update_res = listings_api.shapes.update(
-          community_id: community_id,
-          listing_shape_id: shape[:id],
-          opts: { shipping_enabled: false })
-
-        expect(update_res.success).to eq(true)
-        expect(update_res.data[:shipping_enabled]).to eq(false)
-        expect(update_res.data[:price_quantity_placeholder]).to eq(nil)
-
       end
     end
 

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -45,7 +45,6 @@ describe MarketplaceService::API::Marketplaces do
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:units].empty?).to eql true
       expect(s[:price_enabled]).to eql true
-      expect(s[:price_quantity_placeholder]).to eql nil
       expect(s[:shipping_enabled]).to eql true
 
       community_hash = create(@community_params.merge({:marketplace_type => "rental"}))
@@ -53,7 +52,6 @@ describe MarketplaceService::API::Marketplaces do
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:units][0][:type]).to eql :day
       expect(s[:price_enabled]).to eql true
-      expect(s[:price_quantity_placeholder]).to eql nil
       expect(s[:shipping_enabled]).to eql false
 
       community_hash = create(@community_params.merge({:marketplace_type => "service"}))
@@ -61,7 +59,6 @@ describe MarketplaceService::API::Marketplaces do
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:units][0][:type]).to eql :day
       expect(s[:price_enabled]).to eql true
-      expect(s[:price_quantity_placeholder]).to eql nil
       expect(s[:shipping_enabled]).to eql false
 
       # check that category and shape are linked


### PR DESCRIPTION
This PR removes `price_quantity_placeholder` code and also removes the column from database.

This PR can and should be reviewed, but let's not merge it to master yet.