### PR TITLE
Handle missing category translation

### DIFF
--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -234,7 +234,7 @@ class Admin::ListingShapesController < ApplicationController
     locale = locale.to_s
 
     pick_categories(categories, ids)
-      .map { |c| c[:translations].find { |t| t[:locale] == locale } }
+      .map { |c| Maybe(c[:translations].find { |t| t[:locale] == locale }).or_else(c[:translations].first) }
       .map { |t| t[:name] }
   end
 


### PR DESCRIPTION
Steps to reproduce

1. Add a new category, which uses only one order type
1. Add a new language and use that language
1. Go to order type admin and try to edit the order type which is the only one for the newly added category

Actual: Error, because the newly added category doesn't have translation for the newly added language

Solution: Use the first translation if nothing else is not available