### PR TITLE
Increase limits on customization page content

### DIFF
--- a/app/models/community_customization.rb
+++ b/app/models/community_customization.rb
@@ -12,14 +12,14 @@
 #  updated_at                                 :datetime         not null
 #  blank_slate                                :text
 #  welcome_email_content                      :text
-#  how_to_use_page_content                    :text
-#  about_page_content                         :text
+#  how_to_use_page_content                    :text(16777215)
+#  about_page_content                         :text(16777215)
 #  terms_page_content                         :text(16777215)
-#  privacy_page_content                       :text
+#  privacy_page_content                       :text(16777215)
 #  storefront_label                           :string(255)
 #  signup_info_content                        :text
-#  private_community_homepage_content         :text
-#  verification_to_post_listings_info_content :text
+#  private_community_homepage_content         :text(16777215)
+#  verification_to_post_listings_info_content :text(16777215)
 #  search_placeholder                         :string(255)
 #  transaction_agreement_label                :string(255)
 #  transaction_agreement_content              :text(16777215)
@@ -50,16 +50,19 @@ class CommunityCustomization < ActiveRecord::Base
     :transaction_agreement_label,
     :transaction_agreement_content
 
+  # Set sane limits for content length. These are either driven by
+  # column length in MySQL or, in case of :mediumtext type, set low
+  # enough to prevent excess storage usage.
   validates_length_of :blank_slate, maximum: 65535
   validates_length_of :welcome_email_content, maximum: 65535
-  validates_length_of :how_to_use_page_content, maximum: 65535
-  validates_length_of :about_page_content, maximum: 65535
-  validates_length_of :terms_page_content, maximum: 16777215
-  validates_length_of :privacy_page_content, maximum: 65535
+  validates_length_of :how_to_use_page_content, maximum: 262140
+  validates_length_of :about_page_content, maximum: 262140
+  validates_length_of :terms_page_content, maximum: 393210
+  validates_length_of :privacy_page_content, maximum: 262140
   validates_length_of :signup_info_content, maximum: 65535
-  validates_length_of :private_community_homepage_content, maximum: 65535
-  validates_length_of :verification_to_post_listings_info_content, maximum: 65535
-  validates_length_of :transaction_agreement_content, maximum: 16777215
+  validates_length_of :private_community_homepage_content, maximum: 262140
+  validates_length_of :verification_to_post_listings_info_content, maximum: 262140
+  validates_length_of :transaction_agreement_content, maximum: 262140
 
   belongs_to :community
 end

--- a/db/migrate/20150609084012_increase_customization_length_limits.rb
+++ b/db/migrate/20150609084012_increase_customization_length_limits.rb
@@ -1,0 +1,17 @@
+class IncreaseCustomizationLengthLimits < ActiveRecord::Migration
+  def up
+   change_column :community_customizations, :how_to_use_page_content, :mediumtext
+   change_column :community_customizations, :about_page_content, :mediumtext
+   change_column :community_customizations, :privacy_page_content, :mediumtext
+   change_column :community_customizations, :private_community_homepage_content, :mediumtext
+   change_column :community_customizations, :verification_to_post_listings_info_content, :mediumtext
+  end
+
+  def down
+   change_column :community_customizations, :how_to_use_page_content, :text
+   change_column :community_customizations, :about_page_content, :text
+   change_column :community_customizations, :privacy_page_content, :text
+   change_column :community_customizations, :private_community_homepage_content, :text
+   change_column :community_customizations, :verification_to_post_listings_info_content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150528120717) do
+ActiveRecord::Schema.define(:version => 20150609084012) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -236,14 +236,14 @@ ActiveRecord::Schema.define(:version => 20150528120717) do
     t.datetime "updated_at",                                                     :null => false
     t.text     "blank_slate"
     t.text     "welcome_email_content"
-    t.text     "how_to_use_page_content"
-    t.text     "about_page_content"
+    t.text     "how_to_use_page_content",                    :limit => 16777215
+    t.text     "about_page_content",                         :limit => 16777215
     t.text     "terms_page_content",                         :limit => 16777215
-    t.text     "privacy_page_content"
+    t.text     "privacy_page_content",                       :limit => 16777215
     t.string   "storefront_label"
     t.text     "signup_info_content"
-    t.text     "private_community_homepage_content"
-    t.text     "verification_to_post_listings_info_content"
+    t.text     "private_community_homepage_content",         :limit => 16777215
+    t.text     "verification_to_post_listings_info_content", :limit => 16777215
     t.string   "search_placeholder"
     t.string   "transaction_agreement_label"
     t.text     "transaction_agreement_content",              :limit => 16777215


### PR DESCRIPTION
* Change column types in db text -> medium text to hold at most 16777215
chars.
* Use rails validations to set lower limits for users to disallow excess
data usage. The limits can be hit e.g. when users incorrectly paste
content from Word documents.