### PR TITLE
Remove units from shapes without price migrations

### DIFF
--- a/db/migrate/20150609085555_remove_units_from_shape_without_price.rb
+++ b/db/migrate/20150609085555_remove_units_from_shape_without_price.rb
@@ -1,0 +1,13 @@
+class RemoveUnitsFromShapeWithoutPrice < ActiveRecord::Migration
+  def up
+    execute("
+      DELETE listing_units FROM listing_units
+      LEFT JOIN listing_shapes ON listing_units.listing_shape_id = listing_shapes.id
+      WHERE listing_shapes.price_enabled = 0
+    ")
+  end
+
+  def down
+    # Nothing
+  end
+end


### PR DESCRIPTION
- We shouldn't have units for shapes that do not have price enabled. However, probably due to earlier migrations, this has happened. This PR fixes the issue by removing units from shapes that do not have price enabled.