### PR TITLE
Fix pluralization error

### DIFF
--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -30,10 +30,10 @@
           %span.alert-box-icon<>
             = icon_tag("alert", ["icon-fix"])
           %span<
-            = t("admin.listing_shapes.open_listings", count: count)
-        = link_to close_listings_admin_listing_shape_path, class: "listing-shape-delete-button", confirm: t("admin.listing_shapes.confirm_close_listings", count: count) do
+            = t("admin.listing_shapes.open_listings_warning", count: count)
+        = link_to close_listings_admin_listing_shape_path, class: "listing-shape-delete-button", confirm: t("admin.listing_shapes.confirm_close_listings_action", count: count) do
           .content
-            = t("admin.listing_shapes.close_listings", count: count)
+            = t("admin.listing_shapes.close_listings_action", count: count)
 
 .row
   .col-12

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -25,7 +25,7 @@
             .content
               = t(".cancel")
         .listing-shape-delete-link-container
-          - confirm_opts = if count > 0 then {confirm: t('admin.listing_shapes.edit.confirm_delete', count: count)} else {} end
+          - confirm_opts = if count > 0 then {confirm: t('admin.listing_shapes.edit.confirm_delete_order_type', count: count)} else {} end
 
           - if cant_delete
             %a.listing-shape-delete-link.disabled

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,7 +383,7 @@ en:
         update_success: "Changes to order type '%{shape}' saved"
         update_failure: "Could not save changes. Error: %{error_msg}"
         delete: "Delete order type"
-        confirm_delete:
+        confirm_delete_order_type:
           one: "There is %{count} listing with this order type. If you delete the order type, this listing will be closed. Are you sure you want to delete the order type?"
           other: "There are %{count} listings with this order type. If you delete the order type, those listings will be closed. Are you sure you want to delete the order type?"
         can_not_delete_last: "You can't delete this order type because it's the only type in your marketplace."
@@ -392,13 +392,13 @@ en:
       listing_shape_name_placeholder: "E.g. Sell"
       action_button_label: "Checkout button label"
       action_button_placeholder: "E.g. Buy"
-      open_listings:
+      open_listings_warning:
         one: "There is %{count} open listing with this order type. If you change any of the settings below, that listing will retain the old settings. The listing can be changed to the new settings by editing it manually. If you don't want to have the listing with the old settings visible on your site, you can close it by clicking the button below."
         other: "There are %{count} open listings with this order type. If you change any of the settings below, those listings will retain the old settings. Those listings can be changed to the new settings by editing them manually. If you don't want to have any listings with the old settings visible on your site, you can close them by clicking the button below."
-      close_listings:
+      close_listings_action:
         one: "Close %{count} listing"
         other: "Close %{count} listings"
-      confirm_close_listings:
+      confirm_close_listings_action:
         one: "Are you sure you want to close %{count} listing?"
         other: "Are you sure you want to close %{count} listings?"
       successfully_closed: "Successfully closed listings"


### PR DESCRIPTION
- This error occures because these keys were already created, but later we
added the pluralization there (one, other etc.)
- For some reason, WTI can not handle this case. If we add pluralization to
existing key, we need to rename the key.
- The issue can be reproduced in production: Choose German and go to Order
Type UI