### PR TITLE
Make community or display type mandatory

### DIFF
--- a/app/helpers/transaction_helper.rb
+++ b/app/helpers/transaction_helper.rb
@@ -295,7 +295,7 @@ module TransactionHelper
         } },
         errored: ->() { {
           author: [
-            status_info(t("conversations.status.payment_errored_author", starter_name: conversation.starter.name), icon_classes: icon_for("errored"))
+            status_info(t("conversations.status.payment_errored_author", starter_name: conversation.starter.name(conversation.community)), icon_classes: icon_for("errored"))
           ],
           starter: [
             status_info(t("conversations.status.payment_errored_starter"), icon_classes: icon_for("errored"))
@@ -354,7 +354,7 @@ module TransactionHelper
       status_info(
         t("conversations.status.waiting_for_listing_author_to_deliver_listing",
           :listing_title => link_to(conversation.listing.title, conversation.listing),
-          :listing_author_name => link_to(conversation.author.name, conversation.author)
+          :listing_author_name => link_to(PersonViewUtils.person_display_name(conversation.author, conversation.community))
         ).html_safe,
         icon_classes: "ss-deliveryvan"
       )

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -322,7 +322,7 @@ class PersonMailer < ActionMailer::Base
   # Used to send notification to Sharetribe admins when somebody
   # gives feedback on Sharetribe
   def new_feedback(feedback, community)
-    subject = "New feedback from #{community.name(community.default_locale)} from user #{feedback.author.try(:name)}"
+    subject = "New feedback from #{community.name(community.default_locale)} from user #{Maybe(feedback).author.name(community).or_else(nil)}"
 
     premailer_mail(
       :to => mail_feedback_to(community, APP_CONFIG.feedback_mailer_recipients),

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -69,7 +69,7 @@ class TransactionMailer < ActionMailer::Base
         mail_params(
           @recipient,
           @community,
-          t("emails.transaction_preauthorized.subject", requester: transaction.starter.name, listing_title: transaction.listing.title))) do |format|
+          t("emails.transaction_preauthorized.subject", requester: transaction.starter.name(@community), listing_title: transaction.listing.title))) do |format|
         format.html {
           render locals: {
                    payment_expires_in_unit: expires_in[:unit],
@@ -92,7 +92,7 @@ class TransactionMailer < ActionMailer::Base
         mail_params(
           @recipient,
           @community,
-          t("emails.transaction_preauthorized_reminder.subject", requester: transaction.starter.name, listing_title: transaction.listing.title)))
+          t("emails.transaction_preauthorized_reminder.subject", requester: transaction.starter.name(@community), listing_title: transaction.listing.title)))
     end
   end
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -25,7 +25,7 @@ class Feedback < ActiveRecord::Base
   def author_name_and_email
     email_in_brackets = email.present? ? "(#{email})" : "No email provided"
     if author
-      "#{author.name} #{email_in_brackets}"
+      "#{author.name('first_name_with_initial')} #{email_in_brackets}"
     elsif !email.blank?
       "Unlogged user #{email_in_brackets}"
     else

--- a/app/models/payment_gateways/checkout.rb
+++ b/app/models/payment_gateways/checkout.rb
@@ -119,9 +119,9 @@ class Checkout < PaymentGateway
     end
 
     api_params = {
-      "company" => person.name,
+      "company" => person.name('first_name_with_initial'),
       "vat_id"  => checkout_account_params.company_id_or_personal_id,
-      "name"    => person.name,
+      "name"    => person.name('first_name_with_initial'),
       "email"   => person.confirmed_notification_email_to,
       "gsm"     => checkout_account_params.phone_number,
       "type"    => type,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -288,6 +288,10 @@ class Person < ActiveRecord::Base
   # Deprecated: This is view logic (how to display name) and thus should not be in model layer
   # Consider using PersonViewUtils
   def name(community_or_display_type=nil)
+    # TODO Make `community_or_display_type` param mandatory.
+    # The custom error is here in order to get better error message while, but it can be removed in the future.
+    raise ArgumentError.new("Missing community or display type. Can not know how to format the name") if community_or_display_type.nil?
+
     return name_or_username(community_or_display_type)
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -287,11 +287,7 @@ class Person < ActiveRecord::Base
 
   # Deprecated: This is view logic (how to display name) and thus should not be in model layer
   # Consider using PersonViewUtils
-  def name(community_or_display_type=nil)
-    # TODO Make `community_or_display_type` param mandatory.
-    # The custom error is here in order to get better error message while, but it can be removed in the future.
-    raise ArgumentError.new("Missing community or display type. Can not know how to format the name") if community_or_display_type.nil?
-
+  def name(community_or_display_type)
     return name_or_username(community_or_display_type)
   end
 

--- a/app/views/braintree_payments/edit.haml
+++ b/app/views/braintree_payments/edit.haml
@@ -23,7 +23,7 @@
   %p
     = t(".payment_receiver")
 
-    = "#{link_to payment_receiver.name, payment_receiver}".html_safe
+    = "#{link_to payment_receiver.name(@current_community), payment_receiver}".html_safe
 
   %p
     = "#{t("payments.form.product")}"
@@ -47,7 +47,7 @@
     .row
       .col-12
         %p
-          = "When you confirm the payment we will charge your credit card. We will transfer the money to #{link_to(payment_receiver.name, payment_receiver)} when a) you have marked the request completed or b) #{@conversation.automatic_confirmation_after_days} days have passed since you confirmed the payment.".html_safe
+          = "When you confirm the payment we will charge your credit card. We will transfer the money to #{link_to(payment_receiver.name(@current_community), payment_receiver)} when a) you have marked the request completed or b) #{@conversation.automatic_confirmation_after_days} days have passed since you confirmed the payment.".html_safe
 
         %p
           = "If there are any issues, you have #{@conversation.automatic_confirmation_after_days} days to cancel the request. This will notify the admin who will then contact you for a refund."

--- a/app/views/conversations/_conversation_with.haml
+++ b/app/views/conversations/_conversation_with.haml
@@ -1,14 +1,14 @@
 - if conversation.listing
   - if conversation.status.eql?("free")
-    = t("conversations.show.conversation_about_listing", :person => link_to(other_party.name, other_party), :listing => link_to(conversation.listing.title, conversation.listing)).html_safe
+    = t("conversations.show.conversation_about_listing", :person => link_to(other_party.name(@current_community), other_party), :listing => link_to(conversation.listing.title, conversation.listing)).html_safe
   - else
     - if current_user?(conversation.messages.first.sender)
       = t("conversations.show.message_sent_to")
-      = link_to other_party.name, other_party
+      = link_to other_party.name(@current_community), other_party
     - else
       = t("conversations.show.message_sent_by")
-      = link_to(other_party.name, other_party)
+      = link_to(other_party.name(@current_community), other_party)
     = t("conversations.show.in_response_to_listing")
     = link_to(conversation.listing.title, conversation.listing)
 - else
-  = t("conversations.show.conversation_with_user", :person => link_to(other_party.name, other_party)).html_safe
+  = t("conversations.show.conversation_with_user", :person => link_to(other_party.name(@current_community), other_party)).html_safe

--- a/app/views/payments/new.haml
+++ b/app/views/payments/new.haml
@@ -4,6 +4,6 @@
   %p
     = t(".payment_receiver")
 
-    = "#{link_to payment_receiver.name, payment_receiver}".html_safe
+    = "#{link_to payment_receiver.name(@current_community), payment_receiver}".html_safe
 
   = render :partial => @current_community.payment_gateway.form_template_dir + "/show"

--- a/app/views/person_mailer/confirm_reminder.html.haml
+++ b/app/views/person_mailer/confirm_reminder.html.haml
@@ -5,7 +5,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@conversation.created_at.to_date), :request_link => link_to(@conversation.listing_title, conversation_url), :other_party_full_name => @conversation.seller.name, :other_party_given_name => @conversation.seller.given_name_or_username).html_safe
+      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@conversation.created_at.to_date), :request_link => link_to(@conversation.listing_title, conversation_url), :other_party_full_name => @conversation.seller.name(@conversation.community), :other_party_given_name => @conversation.seller.given_name_or_username).html_safe
 
 %tr
   %td{:align => "left", :style => "padding-top: 25px; padding-bottom: 25px;"}

--- a/app/views/person_mailer/confirm_reminder_escrow.html.haml
+++ b/app/views/person_mailer/confirm_reminder_escrow.html.haml
@@ -5,7 +5,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request_escrow_automatic_confirmation", :date => time_ago(@conversation.created_at.to_date), :request_link => link_to(@conversation.listing_title, conversation_url), :other_party_full_name => @conversation.seller.name, :other_party_given_name => @conversation.seller.given_name_or_username, :days_to_automatic_confirmation => @conversation.automatic_confirmation_after_days).html_safe
+      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request_escrow_automatic_confirmation", :date => time_ago(@conversation.created_at.to_date), :request_link => link_to(@conversation.listing_title, conversation_url), :other_party_full_name => @conversation.seller.name(@conversation.community), :other_party_given_name => @conversation.seller.given_name_or_username, :days_to_automatic_confirmation => @conversation.automatic_confirmation_after_days).html_safe
 
 %tr
   %td{:align => "left", :style => "padding-top: 25px; padding-bottom: 25px;"}

--- a/app/views/person_mailer/escrow_canceled.html.haml
+++ b/app/views/person_mailer/escrow_canceled.html.haml
@@ -4,7 +4,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.escrow_canceled.has_marked_request_as_canceled", :other_party_full_name => @conversation.other_party(@recipient).name, :request => @conversation.listing.title)
+      = t("emails.escrow_canceled.has_marked_request_as_canceled", :other_party_full_name => @conversation.other_party(@recipient).name(@conversation.community), :request => @conversation.listing.title)
 
 %tr
   %td{:align => "left", :style => "padding-top: 15px;"}

--- a/app/views/person_mailer/payment_reminder.html.haml
+++ b/app/views/person_mailer/payment_reminder.html.haml
@@ -5,7 +5,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.payment_reminder.you_have_not_yet_paid", :listing_title => @conversation.listing.title, :other_party_name => @conversation.other_party(@recipient).name)
+      = t("emails.payment_reminder.you_have_not_yet_paid", :listing_title => @conversation.listing.title, :other_party_name => @conversation.other_party(@recipient).name(@conversation.community))
 
 %tr
   %td{:align => "left", :style => "padding-top: 25px; padding-bottom: 25px;"}

--- a/app/views/person_mailer/testimonial_reminder.html.haml
+++ b/app/views/person_mailer/testimonial_reminder.html.haml
@@ -4,7 +4,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.testimonial_reminder.you_have_not_given_feedback_yet", :name => @other_party.name, :event => link_to(@conversation.listing_title, conversation_url), :given_name => @other_party.given_name_or_username).html_safe
+      = t("emails.testimonial_reminder.you_have_not_given_feedback_yet", :name => @other_party.name(@conversation.community), :event => link_to(@conversation.listing_title, conversation_url), :given_name => @other_party.given_name_or_username).html_safe
 
 %tr
   %td{:align => "left", :style => "padding-top: 15px"}

--- a/app/views/person_mailer/transaction_confirmed.html.haml
+++ b/app/views/person_mailer/transaction_confirmed.html.haml
@@ -4,7 +4,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.transaction_confirmed.has_marked_request_as_#{@conversation.status}", :other_party_full_name => @conversation.other_party(@recipient).name, :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username, :request => @conversation.listing.title)
+      = t("emails.transaction_confirmed.has_marked_request_as_#{@conversation.status}", :other_party_full_name => @conversation.other_party(@recipient).name(@conversation.community), :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username, :request => @conversation.listing.title)
 
 %tr
   %td{:align => "left", :style => "padding-top: 15px;"}

--- a/app/views/testimonials/new.haml
+++ b/app/views/testimonials/new.haml
@@ -1,7 +1,7 @@
 - content_for :javascript do
   initialize_give_feedback_form("#{I18n.locale}","#{t('error_messages.testimonials.you_must_select_a_grade')}","#{t('error_messages.testimonials.you_must_explain_not_neutral_feedback')}");
 .centered-section.testimonial-form
-  %h2= t(".give_feedback_to", :person => transaction.other_party(@current_user).name)
+  %h2= t(".give_feedback_to", :person => transaction.other_party(@current_user).name(@current_community))
   %p= t(".this_will_be_shown_in_profile", :person => transaction.other_party(@current_user).given_name_or_username)
   = form_for testimonial, :url => person_message_feedbacks_path(:person_id => @current_user.id, :message_id => transaction.id) do |form|
     = form.error_messages

--- a/app/views/transaction_mailer/transaction_preauthorized.haml
+++ b/app/views/transaction_mailer/transaction_preauthorized.haml
@@ -3,7 +3,7 @@
 %tr
   %td{:align => "left", :style => "padding-top: 15px; padding-bottom: 25px;"}
     %font{body_font}
-      = t("emails.transaction_preauthorized.transaction_requested_by_user", :listing_title => @transaction.listing.title, :requester => @transaction.starter.name)
+      = t("emails.transaction_preauthorized.transaction_requested_by_user", :listing_title => @transaction.listing.title, :requester => @transaction.starter.name(@transaction.community))
 
 %tr
   %td{:align => "left", :style => "padding-bottom: 15px;"}

--- a/app/views/transaction_mailer/transaction_preauthorized_reminder.haml
+++ b/app/views/transaction_mailer/transaction_preauthorized_reminder.haml
@@ -3,7 +3,7 @@
 %tr
   %td{:align => "left", :style => "padding-top: 25px; padding-bottom: 25px;"}
     %font{body_font}
-      = t("emails.transaction_preauthorized_reminder.remember_to_accept", :listing_title => @transaction.listing.title, :requester => @transaction.starter.name)
+      = t("emails.transaction_preauthorized_reminder.remember_to_accept", :listing_title => @transaction.listing.title, :requester => @transaction.starter.name(@transaction.community))
 
 %tr
   %td{:align => "left", :style => "padding-bottom: 15px;"}

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -23,7 +23,7 @@ describe PersonMailer do
     email = PersonMailer.new_message_notification(@message, @community).deliver
     assert !ActionMailer::Base.deliveries.empty?
     assert_equal @test_person2.confirmed_notification_email_addresses, email.to
-    assert_equal "A new message in Sharetribe from #{@message.sender.name}", email.subject
+    assert_equal "A new message in Sharetribe from #{@message.sender.name('first_name_with_initial')}", email.subject
   end
 
   it "should send email about a new comment to own listing" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -127,8 +127,8 @@ describe Person do
       end
 
       it "returns the name of the user" do
-        @test_person.name.should_not be_blank
-        @test_person.name.should == "Ripa R"
+        @test_person.name('first_name_with_initial').should_not be_blank
+        @test_person.name('first_name_with_initial').should == "Ripa R"
       end
 
       it "returns the given or the last name of the user" do


### PR DESCRIPTION
When we display users name, we should always consider communities setting for the name display format, which can be eg. full_name or first_name_with_initials.

However, that's easy to miss, since Person#name method makes it optional to pass the community or display_name_format to the method.

This pull request changes it so that it's mandatory to pass the community of display_name_format