### PR TITLE
Fix frontpage cache

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -889,12 +889,4 @@ module ApplicationHelper
       content_for :extra_javascript do js end
     end
   end
-
-  # FIXME, remove this.
-  #
-  # Temporary solution to turn off template caching
-  def no_cache(_, &block)
-    block.call
-  end
-
 end

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -9,6 +9,9 @@ module CacheHelper
   # used for things that are stored completely on Sharetribe db
   KASSI_DATA_CACHE_EXPIRE_TIME = 4.hours
 
+  # used to ensure "soft changes" e.g. translation updates propagate to cached fragments eventually
+  FRAGMENT_CACHE_EXPIRE_TIME = 4.hours
+
   def self.favors_last_changed
     Rails.cache.fetch("favors_last_changed", :expires_in => KASSI_DATA_CACHE_EXPIRE_TIME) {Time.now.to_i}
   end
@@ -64,6 +67,10 @@ module CacheHelper
 
   # * people_last_changed (Time.now.to_i) tästä ei voi olla varmaa tietoa, joten oltava myös expire-aika
   # * groups_last_changed (Time.now.to_i) tästä ei voi olla varmaa tietoa, joten oltava myös expire-aika
+
+  def frontpage_fragment_cache(type, listing, &block)
+    cache([type, I18n.locale, listing, listing.author, @current_community, MoneyRails::Configuration.no_cents_if_whole], :expires_in => FRAGMENT_CACHE_EXPIRE_TIME, &block)
+  end
 
   private
 

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -69,7 +69,8 @@ module CacheHelper
   # * groups_last_changed (Time.now.to_i) tästä ei voi olla varmaa tietoa, joten oltava myös expire-aika
 
   def frontpage_fragment_cache(type, listing, &block)
-    cache([type, I18n.locale, listing, listing.author, @current_community, MoneyRails::Configuration.no_cents_if_whole], :expires_in => FRAGMENT_CACHE_EXPIRE_TIME, &block)
+    listings_i18n_digest = Rails.cache.fetch(["listings_i18n", @current_community, I18n.locale], :expires_in => 5.minutes) { Digest::MD5.hexdigest I18n.t(["listings"]).to_s }
+    cache([type, listings_i18n_digest, @current_community, listing, listing.author, MoneyRails::Configuration.no_cents_if_whole], :expires_in => FRAGMENT_CACHE_EXPIRE_TIME, &block)
   end
 
   private

--- a/app/views/homepage/_grid_item.haml
+++ b/app/views/homepage/_grid_item.haml
@@ -1,4 +1,4 @@
-- no_cache(["grid_item", listing, listing.author, @current_community, MoneyRails::Configuration.no_cents_if_whole]) do
+- frontpage_fragment_cache("grid_item", listing) do
   .home-fluid-thumbnail-grid-item
     %div
       -# Listing image

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -1,4 +1,4 @@
-- no_cache(["list_item", listing, listing.author, @current_community, MoneyRails::Configuration.no_cents_if_whole]) do
+- frontpage_fragment_cache("list_item", listing) do
   .home-list-item
     - if listing.listing_images.size > 0
       = link_to listing, :class => "home-list-image-container-desktop" do

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -21,7 +21,8 @@ task :deploy_to, [:destination] do |t, args|
   deploy(
     :destination => args[:destination],
     :migrations => env_to_bool('migrations', nil),
-    :css => env_to_bool('css', nil)
+    :css => env_to_bool('css', nil),
+    :clear_cache => env_to_bool('clear_cache', nil)
   )
 end
 
@@ -46,8 +47,9 @@ def deploy(params)
   puts "Deploying from: #{@branch}"
   puts "Deploying to:   #{@destination}"
   puts "Deploy options:"
-  puts "  css:        #{params[:css]}"
-  puts "  migrations: #{params[:migrations]}"
+  puts "  css:         #{params[:css]}"
+  puts "  migrations:  #{params[:migrations]}"
+  puts "  clear cache: #{params[:clear_cache]}"
 
   if @destination == "production"
     puts ""
@@ -84,6 +86,8 @@ def deploy(params)
   abort_if_css_modifications if params[:css].nil?
 
   deploy_to_server
+
+  clear_cache if params[:clear_cache]
 
   unless migrations.empty?
     run_migrations(migrations)
@@ -235,4 +239,10 @@ def parse_added_migration_files(new_files)
       description: parsed[2].humanize
     }
   }
+end
+
+def clear_cache
+  puts "Clearing Rails cache..."
+  heroku("run rails runner Rails.cache.clear --app #{@app}")
+  puts "Rails cache cleared"
 end


### PR DESCRIPTION
Changes in .yml translations and user locale now affect cache key. Fragments have an expiration time of 4 hours to ensure all changes are at least eventually visible.

Remaining issues:
* Routes changes still break stuff if the cached fragments link to an old route.
* In Memcached you can only delete a single item or the entire cache, so invalidating things manually is hard.