### PR TITLE
Recognize nil order_ids for auth flow events

### DIFF
--- a/app/services/paypal_service/data_types/ipn.rb
+++ b/app/services/paypal_service/data_types/ipn.rb
@@ -322,6 +322,8 @@ module PaypalService
           params
         )
 
+        p[:order_id] = Maybe(p)[:order_id].strip.or_else(nil)
+
         create_payment_voided(p)
       end
       private_class_method :to_payment_voided
@@ -390,6 +392,9 @@ module PaypalService
           },
           params
         )
+
+        p[:order_id] = Maybe(p)[:order_id].strip.or_else(nil)
+
         create_authorization_expired(p)
       end
       private_class_method :to_authorization_expired

--- a/spec/services/paypal_service/data_types/ipn_spec.rb
+++ b/spec/services/paypal_service/data_types/ipn_spec.rb
@@ -203,6 +203,53 @@ describe PaypalService::DataTypes::IPN do
     "ipn_track_id"=>"deb829141b651"
   }
 
+  payment_voided_no_order = {
+    "mc_gross"=>"100.00",
+    "invoice"=>"2-91",
+    "auth_exp"=>"23:50:00 Nov 06, 2014 PST",
+    "protection_eligibility"=>"Ineligible",
+    "item_number1"=>"",
+    "payer_id"=>"7LFUVCDKGARH4",
+    "tax"=>"0.00",
+    "payment_date"=>"04:15:57 Nov 03, 2014 PST",
+    "payment_status"=>"Voided",
+    "charset"=>"windows-1252",
+    "mc_shipping"=>"0.00",
+    "mc_handling"=>"0.00",
+    "first_name"=>"SandboxTest",
+    "transaction_entity"=>"auth",
+    "notify_version"=>"3.8",
+    "custom"=>"",
+    "payer_status"=>"verified",
+    "num_cart_items"=>"1",
+    "mc_handling1"=>"0.00",
+    "verify_sign"=>"AJUc1Ia4SIzAsHpmMszE5xpkoPoVAFydOpOKQmMLPy9fUgcPT8VPsa-a",
+    "payer_email"=>"dev+paypal-user2@sharetribe.com",
+    "mc_shipping1"=>"0.00",
+    "tax1"=>"0.00",
+    "parent_txn_id"=>"",
+    "txn_id"=>"8X37683373099502U",
+    "payment_type"=>"instant",
+    "remaining_settle"=>"10",
+    "auth_id"=>"8X37683373099502U",
+    "payer_business_name"=>"SandboxTest Account's Test Store",
+    "last_name"=>"Account",
+    "item_name1"=>"Testing",
+    "receiver_email"=>"dev+paypal-user1@sharetribe.com",
+    "auth_amount"=>"100.00",
+    "quantity1"=>"1",
+    "receiver_id"=>"URAPMR7WHFAWY",
+    "txn_type"=>"cart",
+    "mc_gross_1"=>"100.00",
+    "mc_currency"=>"GBP",
+    "residence_country"=>"GB",
+    "test_ipn"=>"1",
+    "transaction_subject"=>"",
+    "payment_gross"=>"",
+    "auth_status"=>"Voided",
+    "ipn_track_id"=>"deb829141b651"
+  }
+
   payment_completed = {
     "auth_amount" => "10.00",
     "auth_exp" => "23:50:02 Nov 13, 2014 PST",
@@ -614,6 +661,53 @@ describe PaypalService::DataTypes::IPN do
     "action" => "ipn_hook"
   }
 
+  authorization_expired_no_order = {
+    "mc_gross" => "20.00",
+    "invoice" => "2492-12344567",
+    "auth_exp" => "10:20:37 Jan 18, 2015 PST",
+    "protection_eligibility" => "Ineligible",
+    "item_number1" => "",
+    "payer_id" => "LLLLLLLLLHEUE",
+    "tax" => "0.00",
+    "payment_date" => "10:20:38 Dec 20, 2014 PST",
+    "payment_status" => "Expired",
+    "charset" => "windows-1252",
+    "mc_shipping" => "0.00",
+    "mc_handling" => "0.00",
+    "first_name" => "Test",
+    "transaction_entity" => "auth",
+    "notify_version" => "3.8",
+    "custom" => "",
+    "payer_status" => "verified",
+    "num_cart_items" => "1",
+    "mc_handling1" => "0.00",
+    "verify_sign" => "An5ns1Kso71238r129837019283712938-123iw0CAMnhqxqxIxCX",
+    "payer_email" => "test@example.com",
+    "mc_shipping1" => "0.00",
+    "tax1" => "0.00",
+    "parent_txn_id" => "",
+    "txn_id" => "1234556SNETHUSNTH",
+    "payment_type" => "instant",
+    "remaining_settle" => "10",
+    "auth_id" => "1234566ASDFASH81U",
+    "last_name" => "Tester",
+    "item_name1" => "Samurai Sword",
+    "receiver_email" => "rec@example.com",
+    "auth_amount" => "20.00",
+    "quantity1" => "1",
+    "receiver_id" => "123456RCEHSTN",
+    "txn_type" => "cart",
+    "mc_gross_1" => "20.00",
+    "mc_currency" => "USD",
+    "residence_country" => "US",
+    "transaction_subject" => "",
+    "payment_gross" => "20.00",
+    "auth_status" => "Expired",
+    "ipn_track_id" => "12ab3cdefgh8f",
+    "controller" => "paypal_ipn",
+    "action" => "ipn_hook"
+  }
+
   it "#from_params" do
     input_with_expected_type = [
       [billing_agreement_created, :billing_agreement_created],
@@ -624,11 +718,13 @@ describe PaypalService::DataTypes::IPN do
       [payment_completed, :payment_completed],
       [payment_pending_ext, :payment_pending_ext],
       [payment_voided, :payment_voided],
+      [payment_voided_no_order, :payment_voided],
       [payment_completed_2, :payment_completed],
       [payment_refunded_2, :payment_refunded],
       [payment_denied, :payment_denied],
       [commission_paid, :commission_paid],
-      [authorization_expired, :authorization_expired]
+      [authorization_expired, :authorization_expired],
+      [authorization_expired_no_order, :authorization_expired],
     ]
 
     input_with_expected_type.each do |(input, type)|
@@ -642,4 +738,15 @@ describe PaypalService::DataTypes::IPN do
     expect(ipn_msg[:order_id]).to be_nil
   end
 
+  it "#from_params - payment_voided_no_order" do
+    ipn_msg = PaypalService::DataTypes::IPN.from_params(payment_voided_no_order)
+
+    expect(ipn_msg[:order_id]).to be_nil
+  end
+
+  it "#from_params - authorization_expired_no_order" do
+    ipn_msg = PaypalService::DataTypes::IPN.from_params(authorization_expired_no_order)
+
+    expect(ipn_msg[:order_id]).to be_nil
+  end
 end


### PR DESCRIPTION
When we switched from the order flow to authorization flow authorization
related IPN messages no longer have parent_txn_id set because they don't
have a parent transaction. The parent transaction used to be the id of
the order. IPN sends this field non the less but with empty string
value. We didn't recognize the empty field to mean nil which caused an
attempt to update an incorrect payment at later stage of handling the
IPN message. Database prevents this with unique id constraint but this
causes an unnecessary error to pop up in airbrake. Also this would mean
we lose data if the web transaction flow would fail in the middle of
receiving success response from PayPal server. Properly handled IPN
message will reconcilate the state of the payment.