### PR TITLE
Fix find paypal payment

### DIFF
--- a/app/services/paypal_service/api/data_types.rb
+++ b/app/services/paypal_service/api/data_types.rb
@@ -29,7 +29,7 @@ module PaypalService::API::DataTypes
     [:payer_id, :mandatory, :string],
     [:receiver_id, :mandatory, :string],
     [:merchant_id, :mandatory, :string],
-    [:payment_status, one_of: [:pending, :completed, :refunded, :voided]],
+    [:payment_status, one_of: [:pending, :completed, :refunded, :voided, :denied, :expired]],
     [:pending_reason, transform_with: -> (v) { (v.is_a? String) ? v.downcase.gsub("-", "").to_sym : v }],
     [:order_id, :string],
     [:order_date, :time],

--- a/app/services/paypal_service/api/payments.rb
+++ b/app/services/paypal_service/api/payments.rb
@@ -208,9 +208,9 @@ module PaypalService::API
 
     ## GET /payments/:community_id/:transaction_id
     def get_payment(community_id, transaction_id)
-      @lookup.with_payment(community_id, transaction_id) do |payment, m_acc|
-        Result::Success.new(DataTypes.create_payment(payment))
-      end
+      Maybe(PaymentStore.get(community_id, transaction_id))
+        .map { |payment| Result::Success.new(DataTypes.create_payment(payment)) }
+        .or_else { Result::Error.new("No matching payment for community_id: #{community_id} and transaction_id: #{transaction_id}.")}
     end
 
     ## POST /payments/:community_id/:transaction_id/void


### PR DESCRIPTION
Payment should be fetched directly from store and not use lookup. Lookup will inject merchant and therefore cause unwanted functionality.