### PR TITLE
Always show sum and status

### DIFF
--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -54,7 +54,6 @@ class Admin::CommunityTransactionsController < ApplicationController
 
     render("index",
       { locals: {
-        show_status_and_sum: @current_community.payments_in_use?,
         community: @current_community,
         conversations: conversations
       }}

--- a/app/views/admin/community_transactions/index.haml
+++ b/app/views/admin/community_transactions/index.haml
@@ -15,9 +15,8 @@
     %thead
       %tr
         %th= render partial: "layouts/sort_link", locals: { column: "listing", direction: sort_link_direction("listing"), title: t("admin.communities.transactions.headers.listing") }
-        - if show_status_and_sum
-          %th=t("admin.communities.transactions.headers.status")
-          %th=t("admin.communities.transactions.headers.sum")
+        %th=t("admin.communities.transactions.headers.status")
+        %th=t("admin.communities.transactions.headers.sum")
         %th= render partial: "layouts/sort_link", locals: { column: "started", direction: sort_link_direction("started"), title: t("admin.communities.transactions.headers.started") }
         %th= render partial: "layouts/sort_link", locals: { column: "last_activity", direction: sort_link_direction("last_activity"), title: t("admin.communities.transactions.headers.last_activity") }
         %th=t("admin.communities.transactions.headers.initiated_by")
@@ -28,14 +27,13 @@
         %tr
           - listing_title = conversation[:listing_title] || t("admin.communities.transactions.not_available")
           %td=Maybe(conversation[:listing]).map { |listing| link_to_unless(listing[:deleted], listing_title, conversation[:listing_url]) }.or_else(listing_title)
-          - if show_status_and_sum
-            %td
-              - if feature_enabled?(:admin_conversations)
-                = link_to person_transaction_path(person_id: @current_user.id, id: conversation[:id]) do
-                  = t("admin.communities.transactions.status.#{conversation[:status]}")
-              - else
+          %td
+            - if feature_enabled?(:admin_conversations)
+              = link_to person_transaction_path(person_id: @current_user.id, id: conversation[:id]) do
                 = t("admin.communities.transactions.status.#{conversation[:status]}")
-            %td=conversation[:payment_total] ? humanized_money_with_symbol(conversation[:payment_total]) : ""
+            - else
+              = t("admin.communities.transactions.status.#{conversation[:status]}")
+          %td=conversation[:payment_total] ? humanized_money_with_symbol(conversation[:payment_total]) : ""
           %td=l(conversation[:created_at], format: :short_date)
           - last_activity_at = 0
           - if conversation[:conversation][:last_message_at].nil?


### PR DESCRIPTION
**Background:** In the past we made a design decision that we do not show the "Status" and "Sum" columns in the admin transaction view (see the screenshot) if the marketplace doesn't use payments (i.e. doesn't have any payment gateway configured). However, we lately added a feature for marketplace admins to see the conversation happening in the marketplace. The "Status" column link is how the admins can access the conversations. The problem is that the marketplaces without payments can't access the conversation, because the link is not visible.

![screen shot 2015-06-29 at 11 21 30](https://cloud.githubusercontent.com/assets/429876/8403957/fc973dbe-1e51-11e5-8d74-6ee82048cd90.png)

**This Pull Request** removes the `if` clause that hided the "Status" and "Sum". I see three benefits:

- Now marketplaces without payments can access conversations
- Reduces "product" complexity (hard to explain, but I mean that the product it self is less complex, when all admins see the same thing, regardless of their settings.)
- Currently, with Order Types, it's not so easy to define if the marketplace has payments enabled or not. The marketplace may have PayPal configured, but no order type is using online payments. In addition, there might be transactions that were using payments before admin decided to remove online payments.