### PR TITLE
Remove price quantity placeholder column

### DIFF
--- a/db/migrate/20150608144130_remove_price_quantity_placeholder_column_from_listing_shapes.rb
+++ b/db/migrate/20150608144130_remove_price_quantity_placeholder_column_from_listing_shapes.rb
@@ -1,0 +1,9 @@
+class RemovePriceQuantityPlaceholderColumnFromListingShapes < ActiveRecord::Migration
+  def up
+    remove_column :listing_shapes, :price_quantity_placeholder
+  end
+
+  def down
+    add_column :listing_shapes, :price_quantity_placeholder, :string, after: :action_button_tr_key
+  end
+end


### PR DESCRIPTION
This migration removes the price_quantity_placeholder column which is not in use anymore. There's no need to hurry merging this. Let's wait and see that the code is working ok before removing the column and data in it.