### PR TITLE
Mark transactions deleted instead of removing them

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -29,6 +29,7 @@
 #  payment_process                   :string(31)       default("none")
 #  delivery_method                   :string(31)       default("none")
 #  shipping_price_cents              :integer
+#  deleted                           :boolean          default(FALSE)
 #
 # Indexes
 #
@@ -59,7 +60,7 @@ class Transaction < ActiveRecord::Base
     :unit_tr_key,
     :unit_selector_tr_key,
     :shipping_price,
-    :delivery_method,
+    :delivery_method
   )
 
   attr_accessor :contract_agreed

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -35,8 +35,10 @@
 #
 #  index_transactions_on_community_id        (community_id)
 #  index_transactions_on_conversation_id     (conversation_id)
+#  index_transactions_on_deleted             (deleted)
 #  index_transactions_on_last_transition_at  (last_transition_at)
 #  index_transactions_on_listing_id          (listing_id)
+#  transactions_on_cid_and_deleted           (community_id,deleted)
 #
 
 class Transaction < ActiveRecord::Base

--- a/app/services/marketplace_service/inbox.rb
+++ b/app/services/marketplace_service/inbox.rb
@@ -251,10 +251,11 @@ module MarketplaceService
           WHERE conversations.community_id = #{params[:community_id]}
           AND conversations.id IN (#{params[:conversation_ids].join(',')})
 
-          # Ignore initiated
+          # Ignore initiated and deleted
           AND (
             transactions.id IS NULL
-            OR transactions.current_state != 'initiated'
+            OR (transactions.current_state != 'initiated'
+                AND transactions.deleted = 0)
           )
 
           # This is a bit complicated logic that is now moved from app to SQL.
@@ -335,10 +336,11 @@ module MarketplaceService
           WHERE conversations.community_id = #{params[:community_id]}
           AND conversations.id IN (#{params[:conversation_ids].join(',')})
 
-          # Ignore initiated
+          # Ignore initiated and deleted
           AND (
             transactions.id IS NULL
-            OR transactions.current_state != 'initiated'
+            OR (transactions.current_state != 'initiated'
+                AND transactions.deleted = 0)
           )
 
           # Order by 'last_activity_at', that is last message or last transition
@@ -360,12 +362,12 @@ module MarketplaceService
           WHERE conversations.community_id = #{params[:community_id]}
           AND conversations.id IN (#{params[:conversation_ids].join(',')})
 
-          # Ignore initiated
+          # Ignore initiated and deleted
           AND (
             transactions.id IS NULL
-            OR transactions.current_state != 'initiated'
+            OR (transactions.current_state != 'initiated'
+                AND transactions.deleted = 0)
           )
-
         "
       }
     end

--- a/app/services/transaction_service/paypal_events.rb
+++ b/app/services/transaction_service/paypal_events.rb
@@ -1,6 +1,5 @@
 module TransactionService::PaypalEvents
 
-  TransactionModel = ::Transaction
   TransactionStore = TransactionService::Store::Transaction
   module_function
 
@@ -122,11 +121,8 @@ module TransactionService::PaypalEvents
   end
 
   def delete_transaction(cid:, tx_id:)
-    tx = TransactionModel.where(community_id: cid, id: tx_id, current_state: "initiated").first
-
-    if tx
-      tx.conversation.destroy
-      tx.destroy
+    if TransactionStore.get_in_community(community_id: cid, transaction_id: tx_id)
+      TransactionStore.delete(community_id: cid, transaction_id: tx_id)
     end
   end
 

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -53,13 +53,16 @@ module TransactionService::Transaction
   # Deprecated
   def query(transaction_id)
     ActiveSupport::Deprecation.warn("TransactionService::Transaction.query: this is deprecated and will be removed in the near future.")
-    tx = TxStore.get(transaction_id)
-    to_tx_response(tx)
+
+    Maybe(TxStore.get(transaction_id))
+      .map { |tx| to_tx_response(tx) }
+      .or_else(nil)
   end
 
   def get(community_id:, transaction_id:)
-    tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
-    Result::Success.new(to_tx_response(tx))
+    Maybe(TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id))
+      .map { |tx|  Result::Success.new(to_tx_response(tx)) }
+      .or_else(Result::Error.new("No tx for community_id: #{community_id} and transaction_id: #{transaction_id}"))
   end
 
   def has_unfinished_transactions(person_id)

--- a/db/migrate/20150630082932_add_deleted_flag_to_transaction.rb
+++ b/db/migrate/20150630082932_add_deleted_flag_to_transaction.rb
@@ -1,0 +1,5 @@
+class AddDeletedFlagToTransaction < ActiveRecord::Migration
+  def change
+    add_column :transactions, :deleted, :boolean, default: false, after: :shipping_price_cents
+  end
+end

--- a/db/migrate/20150630122552_add_index_on_transactions_deleted.rb
+++ b/db/migrate/20150630122552_add_index_on_transactions_deleted.rb
@@ -1,0 +1,11 @@
+class AddIndexOnTransactionsDeleted < ActiveRecord::Migration
+  def up
+    add_index :transactions, [:community_id, :deleted], name: "transactions_on_cid_and_deleted"
+    add_index :transactions, :deleted
+  end
+
+  def down
+    remove_index :transactions, :deleted
+    remove_index :transactions, name: "transactions_on_cid_and_deleted"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150622080657) do
+ActiveRecord::Schema.define(:version => 20150630082932) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -961,6 +961,7 @@ ActiveRecord::Schema.define(:version => 20150622080657) do
     t.string   "payment_process",                   :limit => 31, :default => "none"
     t.string   "delivery_method",                   :limit => 31, :default => "none"
     t.integer  "shipping_price_cents"
+    t.boolean  "deleted",                                         :default => false
   end
 
   add_index "transactions", ["community_id"], :name => "index_transactions_on_community_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150630082932) do
+ActiveRecord::Schema.define(:version => 20150630122552) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -964,8 +964,10 @@ ActiveRecord::Schema.define(:version => 20150630082932) do
     t.boolean  "deleted",                                         :default => false
   end
 
+  add_index "transactions", ["community_id", "deleted"], :name => "transactions_on_cid_and_deleted"
   add_index "transactions", ["community_id"], :name => "index_transactions_on_community_id"
   add_index "transactions", ["conversation_id"], :name => "index_transactions_on_conversation_id"
+  add_index "transactions", ["deleted"], :name => "index_transactions_on_deleted"
   add_index "transactions", ["last_transition_at"], :name => "index_transactions_on_last_transition_at"
   add_index "transactions", ["listing_id"], :name => "index_transactions_on_listing_id"
 

--- a/spec/services/transaction_service/paypal_events_spec.rb
+++ b/spec/services/transaction_service/paypal_events_spec.rb
@@ -112,15 +112,13 @@ describe TransactionService::PaypalEvents do
 
 
   context "#request_cancelled" do
-    it "removes transaction associated with the cancelled token" do
+    it "marks the transaction associated with the cancelled token as deleted" do
       TransactionService::PaypalEvents.request_cancelled(:success, @token_no_msg)
       TransactionService::PaypalEvents.request_cancelled(:success, @token_with_msg)
 
-      # Both transactions are deleted
-      expect(TransactionModel.count).to eq(0)
-      # and so are the conversations
-      expect(Conversation.where(id: @conversation_no_msg).first).to be_nil
-      expect(Conversation.where(id: @conversation_with_msg).first).to be_nil
+      # Both transactions are there but marked as deleted
+      expect(TransactionModel.count).to eq(2)
+      expect(TransacctionModel.all.map(&:deleted)).to eq([true, true])
     end
 
     it "calling with token that doesn't match a transaction is a no-op" do

--- a/spec/services/transaction_service/paypal_events_spec.rb
+++ b/spec/services/transaction_service/paypal_events_spec.rb
@@ -118,7 +118,7 @@ describe TransactionService::PaypalEvents do
 
       # Both transactions are there but marked as deleted
       expect(TransactionModel.count).to eq(2)
-      expect(TransacctionModel.all.map(&:deleted)).to eq([true, true])
+      expect(TransactionModel.all.map(&:deleted)).to eq([true, true])
     end
 
     it "calling with token that doesn't match a transaction is a no-op" do
@@ -196,11 +196,9 @@ describe TransactionService::PaypalEvents do
       TransactionService::PaypalEvents.payment_updated(:success, @voided_payment_no_msg)
       TransactionService::PaypalEvents.payment_updated(:success, @voided_payment_with_msg)
 
-      # Both transactions are deleted
-      expect(TransactionModel.count).to eq(0)
-      # and so are the conversations
-      expect(Conversation.where(id: @conversation_no_msg).first).to be_nil
-      expect(Conversation.where(id: @conversation_with_msg).first).to be_nil
+      # Both transactions are there but marked as deleted
+      expect(TransactionModel.count).to eq(2)
+      expect(TransactionModel.all.map(&:deleted)).to eq([true, true])
     end
 
     it "is safe to call for non-existent transaction" do

--- a/spec/services/transaction_service/store/transaction_spec.rb
+++ b/spec/services/transaction_service/store/transaction_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe TransactionService::Store::Transaction do
+
+  PaypalAccountModel = ::PaypalAccount
+  TransactionStore = TransactionService::Store::Transaction
+  TransactionModel = ::Transaction
+
+  before(:each) do
+    @cid = 3
+    @payer = FactoryGirl.create(:payer)
+    @listing = FactoryGirl.create(:listing,
+                                  price: Money.new(45000, "EUR"),
+                                  listing_shape_id: 123, # This is not used, but needed because the Entity value is mandatory
+                                  transaction_process_id: 123) # This is not used, but needed because the Entity value is mandatory
+
+    @paypal_account = PaypalAccountModel.create(person_id: @listing.author, community_id: @cid, email: "author@sharetribe.com", payer_id: "abcdabcd")
+
+    @transaction_info = {
+      payment_process: :preauthorize,
+      payment_gateway: :paypal,
+      community_id: @cid,
+      starter_id: @payer.id,
+      listing_id: @listing.id,
+      listing_title: @listing.title,
+      unit_price: @listing.price,
+      listing_author_id: @listing.author_id,
+      listing_quantity: 1,
+      automatic_confirmation_after_days: 3,
+      commission_from_seller: 10,
+      minimum_commission: Money.new(20, "EUR")
+    }
+  end
+
+  context "#create" do
+    it "creates transactions with deleted set to false" do
+      tx = TransactionStore.create(@transaction_info)
+
+      expect(tx).not_to be_nil
+      expect(TransactionModel.first.deleted).to eq(false)
+      expect(TransactionStore.get(tx[:id])).not_to be_nil
+    end
+  end
+
+  context "#delete" do
+    it "sets deleted flag for the given transaction_id" do
+      tx = TransactionStore.create(@transaction_info)
+      TransactionStore.delete(community_id: tx[:community_id], transaction_id: tx[:id])
+      expect(TransactionModel.first.deleted).to eq(true)
+    end
+
+    it "deleted transaction are not returned by get" do
+      tx = TransactionStore.create(@transaction_info)
+      TransactionStore.delete(community_id: tx[:community_id], transaction_id: tx[:id])
+      expect(TransactionStore.get(tx[:id])).to be_nil
+    end
+
+    it "deleted transaction are not returned by get_in_community" do
+      tx = TransactionStore.create(@transaction_info)
+      TransactionStore.delete(community_id: tx[:community_id], transaction_id: tx[:id])
+      expect(TransactionStore.get_in_community(community_id: tx[:community_id], transaction_id: tx[:id])).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
We stop permanently deleting transactions and instead introduce a flag, deleted, to differentiate between initiated and deleted transactions.

This PR stops us from losing data permanently. This has bitten us already several times when there's some unexpected behavior in the middle of the payment process. This won't solve those issues but leaves the data in place so we can manually detect what was going on and have a way to bring back the transaction in case of failure.

This affects multiple places and I've tried to cover them all. Luckily we have pretty good tests to cover the payment flow and messages. I'm still slightly concerned about touching the huge inbox SQL queries from perf POV. Locally everything seemed to be in order so need to just test in production and be ready to rollback in case of any issues.