### PR TITLE
Revert the reverting of tx-deleted-flag

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -29,13 +29,16 @@
 #  payment_process                   :string(31)       default("none")
 #  delivery_method                   :string(31)       default("none")
 #  shipping_price_cents              :integer
+#  deleted                           :boolean          default(FALSE)
 #
 # Indexes
 #
 #  index_transactions_on_community_id        (community_id)
 #  index_transactions_on_conversation_id     (conversation_id)
+#  index_transactions_on_deleted             (deleted)
 #  index_transactions_on_last_transition_at  (last_transition_at)
 #  index_transactions_on_listing_id          (listing_id)
+#  transactions_on_cid_and_deleted           (community_id,deleted)
 #
 
 class Transaction < ActiveRecord::Base
@@ -59,7 +62,7 @@ class Transaction < ActiveRecord::Base
     :unit_tr_key,
     :unit_selector_tr_key,
     :shipping_price,
-    :delivery_method,
+    :delivery_method
   )
 
   attr_accessor :contract_agreed

--- a/app/services/marketplace_service/inbox.rb
+++ b/app/services/marketplace_service/inbox.rb
@@ -251,10 +251,11 @@ module MarketplaceService
           WHERE conversations.community_id = #{params[:community_id]}
           AND conversations.id IN (#{params[:conversation_ids].join(',')})
 
-          # Ignore initiated
+          # Ignore initiated and deleted
           AND (
             transactions.id IS NULL
-            OR transactions.current_state != 'initiated'
+            OR (transactions.current_state != 'initiated'
+                AND transactions.deleted = 0)
           )
 
           # This is a bit complicated logic that is now moved from app to SQL.
@@ -335,10 +336,11 @@ module MarketplaceService
           WHERE conversations.community_id = #{params[:community_id]}
           AND conversations.id IN (#{params[:conversation_ids].join(',')})
 
-          # Ignore initiated
+          # Ignore initiated and deleted
           AND (
             transactions.id IS NULL
-            OR transactions.current_state != 'initiated'
+            OR (transactions.current_state != 'initiated'
+                AND transactions.deleted = 0)
           )
 
           # Order by 'last_activity_at', that is last message or last transition
@@ -360,12 +362,12 @@ module MarketplaceService
           WHERE conversations.community_id = #{params[:community_id]}
           AND conversations.id IN (#{params[:conversation_ids].join(',')})
 
-          # Ignore initiated
+          # Ignore initiated and deleted
           AND (
             transactions.id IS NULL
-            OR transactions.current_state != 'initiated'
+            OR (transactions.current_state != 'initiated'
+                AND transactions.deleted = 0)
           )
-
         "
       }
     end

--- a/app/services/marketplace_service/transaction.rb
+++ b/app/services/marketplace_service/transaction.rb
@@ -196,15 +196,18 @@ module MarketplaceService
 
       def transition_to(transaction_id, new_status, metadata = nil)
         new_status = new_status.to_sym
-        transaction = TransactionModel.find(transaction_id)
-        old_status = transaction.current_state.to_sym if transaction.current_state.present?
 
-        transaction_entity = Entity.transaction(transaction)
-        payment_type = transaction.payment_gateway.to_sym
+        if Query.can_transition_to?(transaction_id, new_status)
+          transaction = TransactionModel.where(id: transaction_id, deleted: false).first
+          old_status = transaction.current_state.to_sym if transaction.current_state.present?
 
-        Events.handle_transition(transaction_entity, payment_type, old_status, new_status)
+          transaction_entity = Entity.transaction(transaction)
+          payment_type = transaction.payment_gateway.to_sym
 
-        Entity.transaction(save_transition(transaction, new_status, metadata))
+          Events.handle_transition(transaction_entity, payment_type, old_status, new_status)
+
+          Entity.transaction(save_transition(transaction, new_status, metadata))
+        end
       end
 
       def save_transition(transaction, new_status, metadata = nil)
@@ -231,14 +234,14 @@ module MarketplaceService
       module_function
 
       def transaction(transaction_id)
-        Maybe(TransactionModel.where(id: transaction_id).first)
+        Maybe(TransactionModel.where(id: transaction_id, deleted: false).first)
           .map { |m| Entity.transaction(m) }
           .or_else(nil)
       end
 
       def transaction_with_conversation(transaction_id:, person_id: nil, community_id:)
         rel = TransactionModel.joins(:listing)
-          .where(id: transaction_id)
+          .where(id: transaction_id, deleted: false)
           .where(community_id: community_id)
           .includes(:booking)
 
@@ -256,7 +259,7 @@ module MarketplaceService
 
       def transactions_for_community_sorted_by_column(community_id, sort_column, sort_direction, limit, offset)
         transactions = TransactionModel
-          .where(:community_id => community_id)
+          .where(community_id: community_id, deleted: false)
           .includes(:listing)
           .limit(limit)
           .offset(offset)
@@ -277,13 +280,15 @@ module MarketplaceService
       end
 
       def transactions_count_for_community(community_id)
-        TransactionModel.where(:community_id => community_id).count
+        TransactionModel.where(community_id: community_id, deleted: false).count
       end
 
       def can_transition_to?(transaction_id, new_status)
-        transaction = TransactionModel.find(transaction_id)
-        state_machine = TransactionProcessStateMachine.new(transaction, transition_class: TransactionTransition)
-        state_machine.can_transition_to?(new_status)
+        transaction = TransactionModel.where(id: transaction_id, deleted: false).first
+        if transaction
+          state_machine = TransactionProcessStateMachine.new(transaction, transition_class: TransactionTransition)
+          state_machine.can_transition_to?(new_status)
+        end
       end
 
       # TODO Consider removing to inbox service, since this is more like inbox than transaction stuff.
@@ -294,7 +299,7 @@ module MarketplaceService
           # Get 'last_transition_at'
           # (this is done by joining the transitions table to itself where created_at < created_at OR sort_key < sort_key, if created_at equals)
           LEFT JOIN conversations ON transactions.conversation_id = conversations.id
-          WHERE transactions.community_id = #{community_id}
+          WHERE transactions.community_id = #{community_id} AND transactions.deleted = 0
           ORDER BY
             GREATEST(COALESCE(transactions.last_transition_at, 0),
               COALESCE(conversations.last_message_at, 0)) #{sort_direction}

--- a/app/services/transaction_service/paypal_events.rb
+++ b/app/services/transaction_service/paypal_events.rb
@@ -1,6 +1,5 @@
 module TransactionService::PaypalEvents
 
-  TransactionModel = ::Transaction
   TransactionStore = TransactionService::Store::Transaction
   module_function
 
@@ -122,11 +121,8 @@ module TransactionService::PaypalEvents
   end
 
   def delete_transaction(cid:, tx_id:)
-    tx = TransactionModel.where(community_id: cid, id: tx_id, current_state: "initiated").first
-
-    if tx
-      tx.conversation.destroy
-      tx.destroy
+    if TransactionStore.get_in_community(community_id: cid, transaction_id: tx_id)
+      TransactionStore.delete(community_id: cid, transaction_id: tx_id)
     end
   end
 

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -53,13 +53,16 @@ module TransactionService::Transaction
   # Deprecated
   def query(transaction_id)
     ActiveSupport::Deprecation.warn("TransactionService::Transaction.query: this is deprecated and will be removed in the near future.")
-    tx = TxStore.get(transaction_id)
-    to_tx_response(tx)
+
+    Maybe(TxStore.get(transaction_id))
+      .map { |tx| to_tx_response(tx) }
+      .or_else(nil)
   end
 
   def get(community_id:, transaction_id:)
-    tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
-    Result::Success.new(to_tx_response(tx))
+    Maybe(TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id))
+      .map { |tx|  Result::Success.new(to_tx_response(tx)) }
+      .or_else(Result::Error.new("No tx for community_id: #{community_id} and transaction_id: #{transaction_id}"))
   end
 
   def has_unfinished_transactions(person_id)

--- a/db/migrate/20150630082932_add_deleted_flag_to_transaction.rb
+++ b/db/migrate/20150630082932_add_deleted_flag_to_transaction.rb
@@ -1,0 +1,5 @@
+class AddDeletedFlagToTransaction < ActiveRecord::Migration
+  def change
+    add_column :transactions, :deleted, :boolean, default: false, after: :shipping_price_cents
+  end
+end

--- a/db/migrate/20150630122552_add_index_on_transactions_deleted.rb
+++ b/db/migrate/20150630122552_add_index_on_transactions_deleted.rb
@@ -1,0 +1,11 @@
+class AddIndexOnTransactionsDeleted < ActiveRecord::Migration
+  def up
+    add_index :transactions, [:community_id, :deleted], name: "transactions_on_cid_and_deleted"
+    add_index :transactions, :deleted
+  end
+
+  def down
+    remove_index :transactions, :deleted
+    remove_index :transactions, name: "transactions_on_cid_and_deleted"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150622080657) do
+ActiveRecord::Schema.define(:version => 20150630122552) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -960,10 +960,13 @@ ActiveRecord::Schema.define(:version => 20150622080657) do
     t.string   "payment_process",                   :limit => 31, :default => "none"
     t.string   "delivery_method",                   :limit => 31, :default => "none"
     t.integer  "shipping_price_cents"
+    t.boolean  "deleted",                                         :default => false
   end
 
+  add_index "transactions", ["community_id", "deleted"], :name => "transactions_on_cid_and_deleted"
   add_index "transactions", ["community_id"], :name => "index_transactions_on_community_id"
   add_index "transactions", ["conversation_id"], :name => "index_transactions_on_conversation_id"
+  add_index "transactions", ["deleted"], :name => "index_transactions_on_deleted"
   add_index "transactions", ["last_transition_at"], :name => "index_transactions_on_last_transition_at"
   add_index "transactions", ["listing_id"], :name => "index_transactions_on_listing_id"
 

--- a/spec/services/transaction_service/paypal_events_spec.rb
+++ b/spec/services/transaction_service/paypal_events_spec.rb
@@ -112,15 +112,13 @@ describe TransactionService::PaypalEvents do
 
 
   context "#request_cancelled" do
-    it "removes transaction associated with the cancelled token" do
+    it "marks the transaction associated with the cancelled token as deleted" do
       TransactionService::PaypalEvents.request_cancelled(:success, @token_no_msg)
       TransactionService::PaypalEvents.request_cancelled(:success, @token_with_msg)
 
-      # Both transactions are deleted
-      expect(TransactionModel.count).to eq(0)
-      # and so are the conversations
-      expect(Conversation.where(id: @conversation_no_msg).first).to be_nil
-      expect(Conversation.where(id: @conversation_with_msg).first).to be_nil
+      # Both transactions are there but marked as deleted
+      expect(TransactionModel.count).to eq(2)
+      expect(TransactionModel.all.map(&:deleted)).to eq([true, true])
     end
 
     it "calling with token that doesn't match a transaction is a no-op" do
@@ -198,11 +196,9 @@ describe TransactionService::PaypalEvents do
       TransactionService::PaypalEvents.payment_updated(:success, @voided_payment_no_msg)
       TransactionService::PaypalEvents.payment_updated(:success, @voided_payment_with_msg)
 
-      # Both transactions are deleted
-      expect(TransactionModel.count).to eq(0)
-      # and so are the conversations
-      expect(Conversation.where(id: @conversation_no_msg).first).to be_nil
-      expect(Conversation.where(id: @conversation_with_msg).first).to be_nil
+      # Both transactions are there but marked as deleted
+      expect(TransactionModel.count).to eq(2)
+      expect(TransactionModel.all.map(&:deleted)).to eq([true, true])
     end
 
     it "is safe to call for non-existent transaction" do

--- a/spec/services/transaction_service/store/transaction_spec.rb
+++ b/spec/services/transaction_service/store/transaction_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe TransactionService::Store::Transaction do
+
+  PaypalAccountModel = ::PaypalAccount
+  TransactionStore = TransactionService::Store::Transaction
+  TransactionModel = ::Transaction
+
+  before(:each) do
+    @cid = 3
+    @payer = FactoryGirl.create(:payer)
+    @listing = FactoryGirl.create(:listing,
+                                  price: Money.new(45000, "EUR"),
+                                  listing_shape_id: 123, # This is not used, but needed because the Entity value is mandatory
+                                  transaction_process_id: 123) # This is not used, but needed because the Entity value is mandatory
+
+    @paypal_account = PaypalAccountModel.create(person_id: @listing.author, community_id: @cid, email: "author@sharetribe.com", payer_id: "abcdabcd")
+
+    @transaction_info = {
+      payment_process: :preauthorize,
+      payment_gateway: :paypal,
+      community_id: @cid,
+      starter_id: @payer.id,
+      listing_id: @listing.id,
+      listing_title: @listing.title,
+      unit_price: @listing.price,
+      listing_author_id: @listing.author_id,
+      listing_quantity: 1,
+      automatic_confirmation_after_days: 3,
+      commission_from_seller: 10,
+      minimum_commission: Money.new(20, "EUR")
+    }
+  end
+
+  context "#create" do
+    it "creates transactions with deleted set to false" do
+      tx = TransactionStore.create(@transaction_info)
+
+      expect(tx).not_to be_nil
+      expect(TransactionModel.first.deleted).to eq(false)
+      expect(TransactionStore.get(tx[:id])).not_to be_nil
+    end
+  end
+
+  context "#delete" do
+    it "sets deleted flag for the given transaction_id" do
+      tx = TransactionStore.create(@transaction_info)
+      TransactionStore.delete(community_id: tx[:community_id], transaction_id: tx[:id])
+      expect(TransactionModel.first.deleted).to eq(true)
+    end
+
+    it "deleted transaction are not returned by get" do
+      tx = TransactionStore.create(@transaction_info)
+      TransactionStore.delete(community_id: tx[:community_id], transaction_id: tx[:id])
+      expect(TransactionStore.get(tx[:id])).to be_nil
+    end
+
+    it "deleted transaction are not returned by get_in_community" do
+      tx = TransactionStore.create(@transaction_info)
+      TransactionStore.delete(community_id: tx[:community_id], transaction_id: tx[:id])
+      expect(TransactionStore.get_in_community(community_id: tx[:community_id], transaction_id: tx[:id])).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This reverts the revert of tx-deleted-flag branch. Rolling to production seemed to cause performance issues but today further testing the code in comparison to existing code I haven't yet found any possible cause nor been able to reproduce the results. This is an attempt to go to master again with the same code and test it again in production like environment to see if yesterday's problem was a temporary effect.