### PR TITLE
Don't make transaction agreement mandatory on disabled locales.

### DIFF
--- a/app/assets/javascripts/admin/community_customizations.js
+++ b/app/assets/javascripts/admin/community_customizations.js
@@ -1,22 +1,9 @@
 window.ST = window.ST || {};
 
 (function(module) {
+
   var initializeTransactionAgreementFields = function() {
-    var checkbox = $('#community_transaction_agreement_checkbox');
-    var modalFields = $('.transaction-agreement-modal');
-    var checked = checkbox.is(':checked');
-
-    modalFields
-      .prop("disabled", !checked)
-      .toggleClass('required', checked)
-      .toggleClass('disabled', !checked);
-
-    checkbox.click(function() {
-      modalFields
-        .prop("disabled", !this.checked)
-        .toggleClass('required', this.checked)
-        .toggleClass('disabled', !this.checked);
-    });
+    $('#community_transaction_agreement_checkbox').click(updateFieldModality);
   };
 
   var initializeCustomizationFormValidation = function () {
@@ -30,6 +17,37 @@ window.ST = window.ST || {};
         }
       }
     });
+  };
+
+  var updateFieldStatus = function($field, enabled) {
+    $field
+      .prop('disabled', !enabled)
+      .toggleClass('disabled', !enabled)
+      .toggleClass('required', enabled);
+  };
+
+  var updateFieldModality = function() {
+    var txAgreementEnabled = $('#community_transaction_agreement_checkbox').is(':checked');
+    var modalFields = $('input.transaction-agreement-modal, textarea.transaction-agreement-modal');
+    
+    updateFieldStatus(modalFields, false);
+
+    if (txAgreementEnabled) {
+      modalFields.filter(function(){
+        return $(this).data("locale-enabled") === true;
+      }).each(function(index, field){
+        updateFieldStatus($(field), true);
+      });
+    }
+  };
+
+  module.updateLocales = function(locales) {
+    var modalFields = $('input.transaction-agreement-modal, textarea.transaction-agreement-modal');
+    modalFields.data("locale-enabled", false);
+    $(locales).each(function(index, locale){
+      modalFields.filter("[name*='["+locale+"]']").data("locale-enabled", true);
+    });
+    updateFieldModality();
   };
 
   module.initializeCommunityCustomizations = function () {

--- a/app/views/admin/community_customizations/_locale_selection.haml
+++ b/app/views/admin/community_customizations/_locale_selection.haml
@@ -5,10 +5,12 @@
   - if unofficial_locales.blank?
     - content_for :extra_javascript do
       :javascript
+        ST.updateLocales(#{enabled_locale_keys.to_json.html_safe});
         var selectize = $('#locale-selection').selectize({plugins: ['remove_button'], items: #{enabled_locale_keys.to_json.html_safe}})[0].selectize;
         selectize.on("change", function(value) {
           defaultLanguage = value ? selectize.options[value[0]].text.trim() : "-";
           $(".selected-default-language-name").text(defaultLanguage);
+          ST.updateLocales(value);
           $('#edit_community').valid();
         });
     = render :partial => "layouts/info_text", :locals => { :text => t("admin.communities.edit_details.enabled_languages_description") }


### PR DESCRIPTION
When removing locales with the new locale admin UI, custom transaction agreement texts were still mandatory to fill. This caused user issues.