### PR TITLE
Handle paypal payment review state for payments

### DIFF
--- a/app/controllers/paypal_service/checkout_orders_controller.rb
+++ b/app/controllers/paypal_service/checkout_orders_controller.rb
@@ -53,6 +53,9 @@ class PaypalService::CheckoutOrdersController < ApplicationController
     else
       if response_data[:paypal_error_code] == "10486"
         redirect_to response_data[:redirect_url]
+      elsif response_data[:error_code] == :"payment-review"
+        flash[:warning] = t("error_messages.paypal.pending_review_error")
+        redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)
       else
         flash[:error] = t("error_messages.paypal.generic_error")
         redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)

--- a/app/services/paypal_service/api/lookup.rb
+++ b/app/services/paypal_service/api/lookup.rb
@@ -68,7 +68,7 @@ module PaypalService::API
       end
 
       if (!payment_in_accepted_state?(payment, accepted_states))
-        return log_and_return(Result::Error.new("Payment was not in accepted precondition state for the requested operation. Expected one of: #{accepted_states}, was: :#{payment[:payment_status]}, :#{payment[:pending_reason]}"))
+        return log_and_return(Result::Error.new("Payment was not in accepted precondition state for the requested operation. Expected one of: #{accepted_states}, was: :[#{payment[:payment_status]}, :#{payment[:pending_reason]}]"))
       end
 
       m_acc = AccountStore.get(person_id: payment[:merchant_id], community_id: cid, payer_id: payment[:receiver_id])

--- a/app/services/paypal_service/api/payments.rb
+++ b/app/services/paypal_service/api/payments.rb
@@ -150,7 +150,8 @@ module PaypalService::API
 
     def ensure_payment_authorized(community_id, payment_entity)
       if payment_entity[:pending_reason] == :"payment-review"
-        Result::Error.new("Cannot complete authorization because the payment is pending for manual review by PayPal.", {error_code: :"payment-review"})
+        Result::Error.new("Cannot complete authorization because the payment is pending for manual review by PayPal.",
+                          { error_code: :"payment-review", payment: payment_entity })
       elsif payment_entity[:pending_reason] != :authorization
         authorize_payment(community_id, payment_entity)
       else

--- a/app/services/paypal_service/api/payments.rb
+++ b/app/services/paypal_service/api/payments.rb
@@ -149,7 +149,9 @@ module PaypalService::API
     end
 
     def ensure_payment_authorized(community_id, payment_entity)
-      if payment_entity[:pending_reason] != :authorization
+      if payment_entity[:pending_reason] == :"payment-review"
+        Result::Error.new("Cannot complete authorization because the payment is pending for manual review by PayPal.", {error_code: :"payment-review"})
+      elsif payment_entity[:pending_reason] != :authorization
         authorize_payment(community_id, payment_entity)
       else
         Result::Success.new(payment_entity)

--- a/app/services/paypal_service/store/paypal_payment.rb
+++ b/app/services/paypal_service/store/paypal_payment.rb
@@ -205,6 +205,7 @@ module PaypalService::Store::PaypalPayment
 
   STATES = {
     order: [:pending, :order],
+    payment_review: [:pending, :"payment-review"],
     authorized: [:pending, :authorization],
     expired: [:expired, :none],
     pending_ext: [:pending, :ext],
@@ -213,15 +214,16 @@ module PaypalService::Store::PaypalPayment
     denied: [:denied, :none]
   }
 
-  INTERNAL_REASONS = [:none, :authorization, :order]
+  INTERNAL_REASONS = [:none, :authorization, :order, :"payment-review"]
 
   STATE_HIERARCHY = {
     order: 0,
-    authorized: 1,
-    expired: 2,
-    voided: 2,
-    pending_ext: 2,
-    completed: 3,
+    payment_review: 1,
+    authorized: 2,
+    expired: 3,
+    voided: 3,
+    pending_ext: 3,
+    completed: 4,
     denied: 4,
   }
 

--- a/app/services/transaction_service/gateway/paypal_adapter.rb
+++ b/app/services/transaction_service/gateway/paypal_adapter.rb
@@ -35,7 +35,7 @@ module TransactionService::Gateway
         async: prefer_async)
 
       if !result[:success]
-        return SyncCompletion.new(Result::Error.new(result[:error_msg]))
+        return SyncCompletion.new(result)
       end
 
       if prefer_async

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -978,7 +978,7 @@ en:
     transaction_agreement:
       required_error: "You need to accept the agreement"
     paypal:
-      pending_review_error: "The payment was submitted but was flagged by PayPal for requiring a review. When the review is done the payment will be automatically marked as authorized."
+      pending_review_error: "The payment was submitted but was flagged by PayPal as 'requiring a review'. When the review is done, the payment will be automatically authorized."
       generic_error: "An error occured during the payment process. Could not finalize your PayPal payment."
       cancel_error: "An error occured during cancellation. Could not finalize cancel."
       accept_authorization_error: "An error occured while trying to accept preauthorized Paypal payment. Please, try again."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -978,6 +978,7 @@ en:
     transaction_agreement:
       required_error: "You need to accept the agreement"
     paypal:
+      pending_review_error: "The payment was submitted but was flagged by PayPal for requiring a review. When the review is done the payment will be automatically marked as authorized."
       generic_error: "An error occured during the payment process. Could not finalize your PayPal payment."
       cancel_error: "An error occured during cancellation. Could not finalize cancel."
       accept_authorization_error: "An error occured while trying to accept preauthorized Paypal payment. Please, try again."

--- a/spec/services/paypal_service/api/payments_spec.rb
+++ b/spec/services/paypal_service/api/payments_spec.rb
@@ -180,6 +180,17 @@ describe PaypalService::API::Payments do
       expect(payment_res[:data][:authorization_total]).to eq(@req_info_auth[:order_total])
     end
 
+    it "returns error with parseable error_code when payment needs review" do
+      token = @payments.request(@cid, @req_info_auth.merge({item_name: "require-payment-review"}))[:data]
+
+      payment_res = @payments.create(@cid, token[:token])
+
+      payment = PaymentStore.get(@cid, @tx_id)
+      expect(payment_res.success).to eq(false)
+      expect(payment_res.data[:error_code]).to eq(:"payment-review")
+      expect(payment[:pending_reason]).to eq(:"payment-review")
+    end
+
     it "triggers payment_created event followed by payment_updated" do
       token = @payments.request(@cid, @req_info)[:data]
       payment_res = @payments.create(@cid, token[:token])

--- a/spec/services/paypal_service/ipn_spec.rb
+++ b/spec/services/paypal_service/ipn_spec.rb
@@ -232,6 +232,17 @@ describe PaypalService::IPN do
       expect(@events.received_events[:payment_updated].length).to eq 1
     end
 
+    it "should handle authorization when payment in payment-review state" do
+      PaypalPayment.where(authorization_id: @authorization[:authorization_id])
+        .first
+        .update_attribute(:pending_reason, "payment-review")
+
+      @ipn_service.handle_msg(@auth_created_no_order_msg)
+      payment = PaypalPayment.where(authorization_id: @authorization[:authorization_id]).first
+      expect(payment.payment_status).to eql "pending"
+      expect(payment.pending_reason).to eql "authorization"
+    end
+
     it "should handle authorization without order" do
       @ipn_service.handle_msg(@auth_created_no_order_msg)
 

--- a/spec/services/paypal_service/test_merchant.rb
+++ b/spec/services/paypal_service/test_merchant.rb
@@ -59,10 +59,13 @@ module PaypalService
     end
 
     def create_and_save_auth_payment(token)
+      # Allows test calls to inject payment-review response status
+      require_payment_review = token[:item_name] == "require-payment-review"
+
       payment = {
         authorization_date: Time.now,
         payment_status: "pending",
-        pending_reason: "authorization",
+        pending_reason: require_payment_review ? "payment-review" : "authorization",
         authorization_id: SecureRandom.uuid,
         authorization_total: token[:order_total],
         receiver_id: token[:receiver_id]

--- a/spec/services/transaction_service/paypal_events_spec.rb
+++ b/spec/services/transaction_service/paypal_events_spec.rb
@@ -129,6 +129,30 @@ describe TransactionService::PaypalEvents do
     end
   end
 
+  context "#payment_updated - initiated => payment-review" do
+    before(:each) do
+      @payment_review_payment = PaymentStore.create(@cid, @transaction_with_msg.id, {
+          payer_id: "sduyfsudf",
+          receiver_id: "98ysdf98ysdf",
+          merchant_id: "asdfasdf",
+          pending_reason: "payment-review",
+          order_id: SecureRandom.uuid,
+          order_date: Time.now,
+          order_total: Money.new(22000, "EUR"),
+          authorization_id: SecureRandom.uuid,
+          authorization_date: Time.now,
+          authorization_total: Money.new(22000, "EUR"),
+        })
+    end
+
+    it "keeps transaction in initiated state" do
+      TransactionService::PaypalEvents.payment_updated(:success, @payment_review_payment)
+
+      tx = MarketplaceService::Transaction::Query.transaction(@transaction_with_msg.id)
+      expect(tx[:status]).to eq("initiated")
+    end
+  end
+
   context "#payment_updated - initiated => authorized" do
     before(:each) do
       @authorized_payment = PaymentStore.create(@cid, @transaction_with_msg.id, {


### PR DESCRIPTION
We detected a new payment state coming from PayPal, payment-review. This happens before an authorization for a payment goes through. So far it seems this state if very rare so we only implement minimal handling for it by:

1. We detect the state from PayPal response and show a warning message to seller saying that payment has been submitted but it only will go through once PayPal approves it.
2. We keep the transaction in initiated state. This means it will not be visible in buyers or sellers inbox and no emails are sent about it at this stage.
3. When PayPal approves the payment we get an IPN message that payment has now been authorized. This PR also makes sure we handle it properly and allow payment to transition from payment-review to authorized. This causes transaction to transition from initiated to preauthorized and from there on the flow continues normally.

What the buyer sees when this happens:

![screen shot 2015-07-03 at 15 46 43](https://cloud.githubusercontent.com/assets/271845/8499366/ad14f26c-219a-11e5-8495-2e6db4ff2a28.png)

