### PR TITLE
Autoreject tx 2 days after booking ends

### DIFF
--- a/app/services/marketplace_service/transaction.rb
+++ b/app/services/marketplace_service/transaction.rb
@@ -65,7 +65,7 @@ module MarketplaceService
       # - max_date_at (max date, e.g. booking ending)
       def preauth_expires_at(gateway_expires_at, max_date_at=nil)
         [gateway_expires_at,
-         Maybe(max_date_at).map {|d| (d + 1.day).to_time(:utc)}.or_else(nil)
+         Maybe(max_date_at).map {|d| (d + 2.day).to_time(:utc)}.or_else(nil)
         ].compact.min
       end
 


### PR DESCRIPTION
On some time zones 1 day buffer is too little because the server
triggers the rejection according to its own time zone. Having a 2 day
buffer makes sure we never cancel too early. It does delay the
cancellation for some people but that's better than cancelling before
the seller can accept and making marketplaces lose transactions.