### PR TITLE
Don't remove token/tx while waiting payment review

### DIFF
--- a/spec/services/paypal_service/test_merchant.rb
+++ b/spec/services/paypal_service/test_merchant.rb
@@ -171,7 +171,7 @@ module PaypalService
                 checkout_status: "not_used_in_tests",
                 billing_agreement_accepted: !billing_agreement.nil?,
                 payer: token[:email],
-                payer_id: "payer_id",
+                payer_id: token[:item_name] != "payment-not-initiated" ? "payer_id" : nil,
                 order_total: token[:order_total]
               }
 


### PR DESCRIPTION
When payment goes to payment-review state we cannot authorize the payment before the review has been passed by PayPal. Our process deletes paypal retry tokens only after the associated payment has been authorized. Before that it keeps retrying. However, we have a time limit of 1 hour after which we stop retrying and decide that the payment has failed forever. This happens when e.g. user goes to paypal to pay but closes browser window and never enters payment details. The new payment-review state in the process is an exception case that this pull request now detects and ignores the one hour token delete limit to make sure we can wait for more than 1 hour for the payment review process to complete.