### PR TITLE
Don't expire OS installation marketplaces

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -23,8 +23,9 @@ class CommunitiesController < ApplicationController
                         :marketplace_type,
                         :marketplace_country,
                         :marketplace_language)
-                 .merge(plan_level: CommunityPlan::SCALE_PLAN)
-                 .merge(payment_process: :none)
+        .merge(plan_level: CommunityPlan::SCALE_PLAN,
+               expires_at: :never,
+               payment_process: :none)
       )
 
       user = UserService::API::Users.create_user_with_membership({

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -65,7 +65,8 @@ module MarketplaceService::API
       shape = Helper.create_listing_shape!(community, p[:marketplace_type], payment_process)
 
       plan_level = p[:plan_level].or_else(CommunityPlan::FREE_PLAN)
-      Helper.create_community_plan!(community, {plan_level: plan_level});
+      expires_at = p[:expires_at].or_else(DateTime.now.change({ hour: 9, min: 0, sec: 0 }) + 31.days)
+      Helper.create_community_plan!(community, {plan_level: plan_level, expires_at: expires_at});
 
       return from_model(community)
     end
@@ -176,8 +177,8 @@ module MarketplaceService::API
       def create_community_plan!(community, options={})
         CommunityPlan.create({
           community_id: community.id,
-          plan_level:   Maybe(options[:plan_level]).or_else(0),
-          expires_at:   Maybe(options[:expires_at]).or_else(DateTime.now.change({ hour: 9, min: 0, sec: 0 }) + 31.days)
+          plan_level: options[:plan_level],
+          expires_at: options[:expires_at] == :never ? nil : options[:expires_at]
         })
       end
 


### PR DESCRIPTION
When the DB is empty (fresh OS installation) we trigger a form for creating the first marketplace. Currently filling the form creates a marketplace plan with expires_at time set to 31 days from now. This is the default behavior for trial marketplaces but not desired with OS installations. This PR adds a possibility to override the default behavior and never expire a marketplace and then uses this new behavior in OS marketplace creation form.