### PR TITLE
Prevent people from getting directed to sharetribe.com

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
   layout 'application'
 
   before_filter :force_ssl,
+    :redirect_to_marketplace_ident,
     :check_auth_token,
     :fetch_logged_in_user,
     :fetch_community,
@@ -251,6 +252,15 @@ class ApplicationController < ActionController::Base
 
   def needs_redirect?(host, domain)
     domain.present? && host != domain
+  end
+
+  def redirect_to_marketplace_ident
+    host = request.host
+    app_domain = URLUtils.strip_port_from_host(APP_CONFIG.domain)
+    if host.end_with?(app_domain) && host.start_with?("www.")
+      ident_without_www = host.sub(/www\./, '').chomp(".#{app_domain}")
+      return redirect_to "#{request.protocol}#{ident_without_www}.#{APP_CONFIG.domain}", status: 301
+    end
   end
 
   # Fetch community

--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -1,7 +1,7 @@
 class BraintreeWebhooksController < ApplicationController
 
   skip_before_filter :verify_authenticity_token
-  skip_filter :fetch_community, :redirect_to_marketplace_domain, :check_email_confirmation
+  skip_filter :fetch_community, :redirect_to_marketplace_ident, :redirect_to_marketplace_domain, :check_email_confirmation
 
   before_filter :fetch_community_by_params
 

--- a/app/controllers/domain_validation_controller.rb
+++ b/app/controllers/domain_validation_controller.rb
@@ -1,6 +1,6 @@
 class DomainValidationController < ApplicationController
 
-  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :redirect_to_marketplace_domain, :fetch_community_membership
+  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :redirect_to_marketplace_ident, :redirect_to_marketplace_domain, :fetch_community_membership
   skip_filter :check_email_confirmation
 
   def index

--- a/app/controllers/paypal_ipn_controller.rb
+++ b/app/controllers/paypal_ipn_controller.rb
@@ -3,7 +3,7 @@ class PaypalIpnController < ApplicationController
   include PaypalService::MerchantInjector
   include PaypalService::IPNInjector
 
-  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :redirect_to_marketplace_domain, :fetch_community_membership
+  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :redirect_to_marketplace_domain, :fetch_community_membership, :redirect_to_marketplace_ident
   skip_filter :check_email_confirmation
 
   IPNDataTypes = PaypalService::DataTypes::IPN


### PR DESCRIPTION
Now people are redirected to sharetribe.com if they mistakenly enter an address like `www.ident.sharetribe.com` instead of `ident.sharetribe.com`. They will also receive a certificate error in that case. This is a simple fix for that.