### PR TITLE
Do not delete CommunityMembership when user is deleted

### DIFF
--- a/app/models/community_membership.rb
+++ b/app/models/community_membership.rb
@@ -22,7 +22,7 @@
 
 class CommunityMembership < ActiveRecord::Base
 
-  VALID_STATUSES = ["accepted", "pending_email_confirmation", "banned"]
+  VALID_STATUSES = ["accepted", "pending_email_confirmation", "banned", "deleted_user"]
 
   belongs_to :person
   belongs_to :community, :counter_cache => :members_count

--- a/app/services/user_service/api/users.rb
+++ b/app/services/user_service/api/users.rb
@@ -64,6 +64,10 @@ module UserService::API
           phone_number: nil,
           description: nil,
           facebook_id: nil,
+          # To ensure user can not log in anymore we have to:
+          #
+          # 1. Delete the password (Devise rejects login attempts if the password is empty)
+          # 2. Remove the emails (So that use can not reset the password)
           encrypted_password: "",
           deleted: true # Flag deleted
         )

--- a/app/services/user_service/api/users.rb
+++ b/app/services/user_service/api/users.rb
@@ -86,7 +86,7 @@ module UserService::API
         person.inverse_follower_relationships.destroy_all
 
         # Delete memberships
-        person.community_memberships.destroy_all
+        person.community_memberships.update_all(status: "deleted_user")
 
         # Delte auth tokens
         person.auth_tokens.destroy_all

--- a/spec/services/user_service/users_spec.rb
+++ b/spec/services/user_service/users_spec.rb
@@ -94,7 +94,7 @@ describe UserService::API::Users do
       expect(deleted_user.given_name).to be_nil
       expect(deleted_user.family_name).to be_nil
       expect(deleted_user.emails).to be_empty
-      expect(deleted_user.community_memberships).to be_empty
+      expect(deleted_user.community_memberships.map(&:status).all? { |status| status == "deleted_user" }).to eq(true)
       expect(deleted_user.braintree_account).to be_nil
       expect(deleted_user.checkout_account).to be_nil
       expect(deleted_user.auth_tokens).to be_empty


### PR DESCRIPTION
**Background:** The data export script uses community_memberships table to define which users to export. When a user deletes his or her account also the membership is deleted. Thus, the export script doesn't know that this user once belonged to the community.

Now when another user who has had interaction with the deleted user goes to transaction view, the view breaks because the export script wasn't able to copy the deleted user.

**Steps:**

Prerequisite: Two existing users (Joe and Paul)

1. Log in as Joe
1. Send a message to Paul
1. Delete own (Joe's) account
1. Run the data export script and setup new marketplace from the data dump (i.e. run the script locally and change your database.yml to use `dump` database)
1. Log in as Paul (after resetting the password)
1. Go to inbox and transaction view to see the message from Paul

Expected: Paul sees conversation with "Removed user"

Actual: Site breaks

**Solution:** This pull request changes the behaviour so that the memberhips is not deleted when user deletes his or her account. Instead, the state is changed to "deleted_user".