### PR TITLE
Add a new 'redirect-to-domain' flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,8 +244,9 @@ class ApplicationController < ActionController::Base
 
     host = request.host
     domain = @current_community.domain
+    redirect_to_domain = @current_community.redirect_to_domain
 
-    redirect_opts = request_hash.slice(:host, :protocol, :fullpath).merge(community_domain: domain, domain_ready: domain.present?)
+    redirect_opts = request_hash.merge(community_domain: domain, redirect_to_domain: redirect_to_domain)
 
     MarketplaceRedirectUtils.needs_redirect(redirect_opts) { |redirect_url, redirect_status|
       redirect_to(redirect_url, status: redirect_status)
@@ -256,7 +257,8 @@ class ApplicationController < ActionController::Base
     @request_hash ||= {
       host: request.host,
       protocol: request.protocol,
-      fullpath: request.fullpath
+      fullpath: request.fullpath,
+      port_string: request.port_string
     }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -245,13 +245,19 @@ class ApplicationController < ActionController::Base
     host = request.host
     domain = @current_community.domain
 
-    if needs_redirect?(host, domain)
-      redirect_to "#{request.protocol}#{domain}#{request.fullpath}", status: :moved_permanently
-    end
+    redirect_opts = request_hash.slice(:host, :protocol, :fullpath).merge(community_domain: domain, domain_ready: domain.present?)
+
+    MarketplaceRedirectUtils.needs_redirect(redirect_opts) { |redirect_url, redirect_status|
+      redirect_to(redirect_url, status: redirect_status)
+    }
   end
 
-  def needs_redirect?(host, domain)
-    domain.present? && host != domain
+  def request_hash
+    @request_hash ||= {
+      host: request.host,
+      protocol: request.protocol,
+      fullpath: request.fullpath
+    }
   end
 
   def redirect_to_marketplace_ident

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -5,6 +5,7 @@
 #  id                                         :integer          not null, primary key
 #  ident                                      :string(255)
 #  domain                                     :string(255)
+#  redirect_to_domain                         :boolean          default(FALSE), not null
 #  created_at                                 :datetime
 #  updated_at                                 :datetime
 #  settings                                   :text

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -5,11 +5,13 @@ module MarketplaceRedirectUtils
   def needs_redirect(host:,
                      protocol:,
                      fullpath:,
-                     domain_ready:,
+                     port_string:,
+                     redirect_to_domain:,
                      community_domain: nil,
                      &block)
-    if community_domain.present? && domain_ready && host != community_domain
-      block.call("#{protocol}#{community_domain}#{fullpath}", :moved_permanently)
+
+    if community_domain.present? && redirect_to_domain && host != community_domain
+      block.call("#{protocol}#{community_domain}#{port_string}#{fullpath}", :moved_permanently)
     end
 
   end

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -1,0 +1,17 @@
+module MarketplaceRedirectUtils
+
+  module_function
+
+  def needs_redirect(host:,
+                     protocol:,
+                     fullpath:,
+                     domain_ready:,
+                     community_domain: nil,
+                     &block)
+    if community_domain.present? && domain_ready && host != community_domain
+      block.call("#{protocol}#{community_domain}#{fullpath}", :moved_permanently)
+    end
+
+  end
+
+end

--- a/db/migrate/20150729062045_add_redirect_to_domain_to_communities.rb
+++ b/db/migrate/20150729062045_add_redirect_to_domain_to_communities.rb
@@ -1,0 +1,5 @@
+class AddRedirectToDomainToCommunities < ActiveRecord::Migration
+  def change
+    add_column :communities, :redirect_to_domain, :boolean, after: :domain, null: false, default: false
+  end
+end

--- a/db/migrate/20150729062215_populate_redirect_to_domain.rb
+++ b/db/migrate/20150729062215_populate_redirect_to_domain.rb
@@ -1,0 +1,9 @@
+class PopulateRedirectToDomain < ActiveRecord::Migration
+  def up
+    execute("UPDATE communities SET redirect_to_domain = true WHERE domain IS NOT NULL")
+  end
+
+  def down
+    execute("UPDATE communities SET redirect_to_domain = false")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150630122552) do
+ActiveRecord::Schema.define(:version => 20150729062215) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(:version => 20150630122552) do
   create_table "communities", :force => true do |t|
     t.string   "ident"
     t.string   "domain"
+    t.boolean  "redirect_to_domain",                                       :default => false,                     :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "settings"

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -6,6 +6,7 @@
 #  id                                         :integer          not null, primary key
 #  ident                                      :string(255)
 #  domain                                     :string(255)
+#  redirect_to_domain                         :boolean          default(FALSE), not null
 #  created_at                                 :datetime
 #  updated_at                                 :datetime
 #  settings                                   :text

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe MarketplaceRedirectUtils do
+
+  def expect_redirect(opts)
+    url_and_status = MarketplaceRedirectUtils.needs_redirect(opts) { |url, status| [url, status] }
+    expect(url_and_status)
+  end
+
+  it "redirects to domain" do
+    expect_redirect(
+      host: "www.marketplace.com",
+      protocol: "https",
+      fullpath: "/listings",
+      community_domain: "www.marketplace.com",
+      domain_ready: true).to eq(nil)
+
+    expect_redirect(
+      host: "marketplace.sharetribe.com",
+      protocol: "https://",
+      domain_ready: false,
+      fullpath: "/listings").to eq(nil)
+
+    expect_redirect(
+      host: "marketplace.sharetribe.com",
+      protocol: "https://",
+      fullpath: "/listings",
+      domain_ready: true,
+      community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com/listings", :moved_permanently])
+
+    expect_redirect(
+      host: "marketplace.sharetribe.com",
+      protocol: "https://",
+      fullpath: "/listings",
+      domain_ready: false,
+      community_domain: "www.marketplace.com").to eq(nil)
+  end
+
+end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -12,28 +12,40 @@ describe MarketplaceRedirectUtils do
       host: "www.marketplace.com",
       protocol: "https",
       fullpath: "/listings",
+      port_string: "",
       community_domain: "www.marketplace.com",
-      domain_ready: true).to eq(nil)
+      redirect_to_domain: true).to eq(nil)
 
     expect_redirect(
       host: "marketplace.sharetribe.com",
       protocol: "https://",
-      domain_ready: false,
-      fullpath: "/listings").to eq(nil)
+      port_string: "",
+      fullpath: "/listings",
+      redirect_to_domain: false).to eq(nil)
 
     expect_redirect(
       host: "marketplace.sharetribe.com",
       protocol: "https://",
       fullpath: "/listings",
-      domain_ready: true,
+      port_string: "",
+      redirect_to_domain: true,
       community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com/listings", :moved_permanently])
 
     expect_redirect(
       host: "marketplace.sharetribe.com",
       protocol: "https://",
       fullpath: "/listings",
-      domain_ready: false,
+      port_string: "",
+      redirect_to_domain: false,
       community_domain: "www.marketplace.com").to eq(nil)
+
+    expect_redirect(
+      host: "marketplace.sharetribe.com",
+      protocol: "https://",
+      fullpath: "/listings",
+      port_string: ":3333",
+      redirect_to_domain: true,
+      community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com:3333/listings", :moved_permanently])
   end
 
 end


### PR DESCRIPTION
This Pull Request adds a new boolean column `redirect_to_domain` to communities table. When the column value is `true`, the user accessing the marketplace with marketplace ident in the URL (*.sharetribe.com subdomain) will be redirected to the full marketplace domain, if present. Before this change, the users were redirected to full domain always if it was present.

**Why?** Domain validation: This change is needed for SSL file verification. The SSL provider needs to be able to access the application with the full domain, thus we have to add the full domain to the database before we have a valid SSL cert. So we want to permit the access to the marketplace with the full domain, but we do not want to redirect all the traffic to the full domain because there's no valid cert yet.

**Why?** Code structure and performance: The application controller has now a big list of filters, that are dealing with redirection:

- redirect_to_marketplace_ident
- force_ssl
- redirect_deleted_marketplace
- redirect_to_marketplace_domain
- redirect_removed_locale
- redirect_locale_param

The structure of the code is pretty difficult to follow. It's hard to get a clear picture what redirects are happening and when. In addition, all this code is untested, even though it's quite critical code for our app.

In addition, multiple redirects may affect to the persieved performance. Let's take an example:

There's a marketplace with ident "boardmarket" and domain "www.boardmarket.com". A user accessed that marketplace with URL "http://www.boardmarket.sharetribe.com". How many redirects will happen (at least)?

1. Redirect http -> https
2. Redirect the ident with www to ident without www (www.boardmarket.sharetribe.com -> boardmarket.sharetribe.com)
3. Redirect to the full marketplace domain boardmarket.sharetribe.com -> www.boardmarket.com
4. And maybe some other redirects because of the selected locales etc.

So my idea was to extract the code from ApplicationController to MarketplaceRedirectUtils. It has a single method `needs_redirect` which takes all the required information to decide where the user should be redirect. That method will be fully tested. In addition, the idea is that the function returns the final redirection target in the current before filter chain and thus eliminates number of redirects happening.