### PR TITLE
Refactor marketplace redirects

### DIFF
--- a/app/controllers/amazon_bounces_controller.rb
+++ b/app/controllers/amazon_bounces_controller.rb
@@ -1,6 +1,6 @@
 class AmazonBouncesController < ApplicationController
   skip_before_filter :verify_authenticity_token, :only => :notification
-  skip_filter :fetch_community, :check_email_confirmation
+  skip_filter :fetch_community, :check_email_confirmation, :redirect_to_marketplace_domain
 
   before_filter :check_sns_token
 

--- a/app/controllers/amazon_bounces_controller.rb
+++ b/app/controllers/amazon_bounces_controller.rb
@@ -1,6 +1,6 @@
 class AmazonBouncesController < ApplicationController
   skip_before_filter :verify_authenticity_token, :only => :notification
-  skip_filter :fetch_community, :check_email_confirmation, :redirect_to_marketplace_domain
+  skip_filter :fetch_community, :check_email_confirmation
 
   before_filter :check_sns_token
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,6 @@ class ApplicationController < ActionController::Base
   layout 'application'
 
   before_filter :redirect_to_marketplace_ident,
-    :force_ssl,
     :check_auth_token,
     :fetch_community,
     :redirect_to_marketplace_domain,
@@ -235,10 +234,6 @@ class ApplicationController < ActionController::Base
     other = {
       no_communities: Community.count == 0,
     }
-
-    # if APP_CONFIG.always_use_ssl
-    #  redirect_to("https://#{request.host_with_port}#{request.fullpath}", status: 301) unless request.ssl? || ( request.headers["HTTP_VIA"] && request.headers["HTTP_VIA"].include?("sharetribe_proxy")) || ApplicationController.should_not_redirect_path_to_https(request.fullpath)
-    # end
 
     MarketplaceRedirectUtils.needs_redirect(
       request: request_hash,
@@ -475,13 +470,6 @@ class ApplicationController < ActionController::Base
       redirect_to path_without_auth_token
     end
 
-  end
-
-  def force_ssl
-    # If defined in the config, always redirect to https (unless already using https or coming through Sharetribe proxy)
-    if APP_CONFIG.always_use_ssl
-      redirect_to("https://#{request.host_with_port}#{request.fullpath}", status: 301) unless request.ssl? || ( request.headers["HTTP_VIA"] && request.headers["HTTP_VIA"].include?("sharetribe_proxy")) || ApplicationController.should_not_redirect_path_to_https(request.fullpath)
-    end
   end
 
   def feature_flags

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   layout 'application'
 
-  before_filter :redirect_to_marketplace_ident,
-    :check_auth_token,
+  before_filter :check_auth_token,
     :fetch_community,
     :redirect_to_marketplace_domain,
     :fetch_logged_in_user,
@@ -285,15 +284,6 @@ class ApplicationController < ActionController::Base
       {ident: ident_without_www[1]}
     else
       {domain: host}
-    end
-  end
-
-  def redirect_to_marketplace_ident
-    host = request.host
-    app_domain = URLUtils.strip_port_from_host(APP_CONFIG.domain)
-    if host.end_with?(app_domain) && host.start_with?("www.")
-      ident_without_www = host.sub(/www\./, '').chomp(".#{app_domain}")
-      return redirect_to "#{request.protocol}#{ident_without_www}.#{APP_CONFIG.domain}", status: 301
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,7 +221,7 @@ class ApplicationController < ActionController::Base
   end
 
   def community_search_status
-    @community_search_status || :no_community
+    @community_search_status || :skipped
   end
 
   # Performs redirect to correct URL, if needed.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
     :force_ssl,
     :check_auth_token,
     :fetch_logged_in_user,
+    :save_current_host_with_port,
     :fetch_community,
     :redirect_to_marketplace_domain,
     :fetch_community_membership,
@@ -222,11 +223,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Before filter to get the current community
-  def fetch_community
+  def save_current_host_with_port
     # store the host of the current request (as sometimes needed in views)
     @current_host_with_port = request.host_with_port
+  end
 
+  # Before filter to get the current community
+  def fetch_community
     fetch_community_by_strategy {
       ApplicationController.default_community_fetch_strategy(request.host)
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -243,7 +243,7 @@ class ApplicationController < ActionController::Base
     }
 
     configs = {
-      always_use_ssl: APP_CONFIG.always_use_ssl,
+      always_use_ssl: Maybe(APP_CONFIG).always_use_ssl.map { |v| v == true || v.to_s.downcase == "true" }.or_else(false), # value can be string if it comes from ENV
       app_domain: URLUtils.strip_port_from_host(APP_CONFIG.domain),
     }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -243,12 +243,13 @@ class ApplicationController < ActionController::Base
     }
 
     configs = {
-      always_use_ssl: APP_CONFIG.always_use_ssl
+      always_use_ssl: APP_CONFIG.always_use_ssl,
+      app_domain: URLUtils.strip_port_from_host(APP_CONFIG.domain),
     }
 
     other = {
       no_communities: Community.count == 0,
-      community_status: community_search_status,
+      community_search_status: community_search_status,
     }
 
     MarketplaceRouter.needs_redirect(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -285,7 +285,6 @@ class ApplicationController < ActionController::Base
       protocol: request.protocol,
       fullpath: request.fullpath,
       port_string: request.port_string,
-      is_ssl: request.ssl?,
       headers: request.headers
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,6 @@ class ApplicationController < ActionController::Base
     :check_auth_token,
     :fetch_logged_in_user,
     :fetch_community,
-    :redirect_deleted_marketplace,
     :redirect_to_marketplace_domain,
     :fetch_community_membership,
     :redirect_removed_locale,
@@ -233,20 +232,15 @@ class ApplicationController < ActionController::Base
     }
   end
 
-  def redirect_deleted_marketplace
-    if Maybe(@current_community).deleted?.or_else(false)
-      redirect_to Maybe(APP_CONFIG).community_not_found_redirect.or_else(:community_not_found)
-    end
-  end
-
   def redirect_to_marketplace_domain
     return unless @current_community
 
-    host = request.host
-    domain = @current_community.domain
-    redirect_to_domain = @current_community.redirect_to_domain
-
-    redirect_opts = request_hash.merge(community_domain: domain, redirect_to_domain: redirect_to_domain)
+    redirect_opts = request_hash.merge(
+      community_domain: @current_community.domain,
+      redirect_to_domain: @current_community.redirect_to_domain,
+      community_deleted: @current_community.deleted?,
+      community_not_found_url: Maybe(APP_CONFIG).community_not_found_redirect.or_else(:community_not_found)
+    )
 
     MarketplaceRedirectUtils.needs_redirect(redirect_opts) { |redirect_url, redirect_status|
       redirect_to(redirect_url, status: redirect_status)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -215,8 +215,9 @@ class ApplicationController < ActionController::Base
   def redirect_to_marketplace_domain
     community = Maybe(@current_community).map { |c|
       {
-        community_domain: c.domain,
-        community_deleted: c.deleted?,
+        ident: c.ident,
+        domain: c.domain,
+        deleted: c.deleted?,
         redirect_to_domain: c.redirect_to_domain?
       }
     }.or_else(nil)
@@ -504,23 +505,5 @@ class ApplicationController < ActionController::Base
   #
   def self.ensure_feature_enabled(feature_name, options = {})
     before_filter(options) { ensure_feature_enabled(feature_name) }
-  end
-
-  # Returns `true` if the path is such that the app should NOT
-  # redirect to HTTPS.
-  #
-  # Paths that should not be redirected are for example robots.txt and
-  # domain validation files.
-  #
-  def self.should_not_redirect_path_to_https(fullpath)
-    dv_regexp = /^\/[a-zA-Z0-9]+\.txt$/
-
-    (
-      # robots.txt should not be redirected
-      fullpath == "/robots.txt" ||
-
-      # matches to Domain Validation file regex, should not redirect
-      dv_regexp.match(fullpath).nil? == false
-    )
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -209,7 +209,7 @@ class ApplicationController < ActionController::Base
 
   # Before filter to get the current community
   def fetch_community
-    @current_community = find_community(community_identifiers)
+    @current_community = ApplicationController.find_community(community_identifiers)
 
     # Save :found or :not_found to community status
     # This is needed because we need to distinguish to cases
@@ -304,7 +304,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def find_community(identifiers)
+  def self.find_community(identifiers)
     by_identifier = Community.find_by_identifier(identifiers)
 
     if by_identifier

--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -1,7 +1,7 @@
 class BraintreeWebhooksController < ApplicationController
 
   skip_before_filter :verify_authenticity_token
-  skip_filter :redirect_to_marketplace_ident, :redirect_to_marketplace_domain, :check_email_confirmation
+  skip_filter :check_email_confirmation
 
   before_filter do
     unless @current_community.braintree_in_use?

--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -1,9 +1,7 @@
 class BraintreeWebhooksController < ApplicationController
 
   skip_before_filter :verify_authenticity_token
-  skip_filter :fetch_community, :redirect_to_marketplace_ident, :redirect_to_marketplace_domain, :check_email_confirmation
-
-  before_filter :fetch_community_by_params
+  skip_filter :redirect_to_marketplace_ident, :redirect_to_marketplace_domain, :check_email_confirmation
 
   before_filter do
     unless @current_community.braintree_in_use?
@@ -78,14 +76,9 @@ class BraintreeWebhooksController < ApplicationController
     render :nothing => true
   end
 
-  private
-
-  # Instead of fetching community by host (http://community.sharetribe.com),
-  # this filter fetched community by `community_id` parameter
-  # (http://sharetribe.com?community_id=id)
-  def fetch_community_by_params
-    fetch_community_by_strategy {
-      Community.find_by_id(params[:community_id])
-    }
+  # This method overrides the default behaviour defined in ApplicationController
+  # Instead of taking the ident/domain from the URL host part, take it from the community_id parameter
+  def community_identifiers
+    {id: params[:community_id]}
   end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,6 +1,5 @@
 class CommunitiesController < ApplicationController
   skip_filter :fetch_community,
-              :redirect_to_marketplace_domain,
               :cannot_access_without_joining
 
   before_filter :ensure_no_communities

--- a/app/controllers/domain_validation_controller.rb
+++ b/app/controllers/domain_validation_controller.rb
@@ -1,6 +1,6 @@
 class DomainValidationController < ApplicationController
 
-  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :redirect_to_marketplace_ident, :redirect_to_marketplace_domain, :fetch_community_membership
+  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community_membership
   skip_filter :check_email_confirmation
 
   def index

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -25,7 +25,12 @@ class ErrorsController < ActionController::Base
   private
 
   def current_community
-    @current_community ||= ApplicationController.default_community_fetch_strategy(request.host)
+    @current_community ||= ApplicationController.find_community(community_identifiers)
+  end
+
+  def community_identifiers
+    app_domain = URLUtils.strip_port_from_host(APP_CONFIG.domain)
+    ApplicationController.parse_community_identifiers_from_host(request.host, app_domain)
   end
 
   def title(status)

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -1,6 +1,6 @@
 class IntApi::MarketplacesController < ApplicationController
 
-  skip_filter :fetch_community, :redirect_to_marketplace_domain
+  skip_filter :fetch_community
 
   before_filter :set_access_control_headers
 

--- a/app/controllers/paypal_ipn_controller.rb
+++ b/app/controllers/paypal_ipn_controller.rb
@@ -3,7 +3,7 @@ class PaypalIpnController < ApplicationController
   include PaypalService::MerchantInjector
   include PaypalService::IPNInjector
 
-  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :redirect_to_marketplace_domain, :fetch_community_membership, :redirect_to_marketplace_ident
+  skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :fetch_community_membership
   skip_filter :check_email_confirmation
 
   IPNDataTypes = PaypalService::DataTypes::IPN

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -582,6 +582,29 @@ class Community < ActiveRecord::Base
     favicon.processing?
   end
 
+  # Finds a community by the given identifier(s)
+  #
+  # Communities have 3 values that can used individually to
+  # uniquely identify a community.
+  #
+  # Those are (in the order of priority):
+  #
+  # - id
+  # - ident
+  # - domain
+  #
+  def self.find_by_identifier(identifiers)
+    priority = [:id, :ident, :domain]
+
+    identifier_to_use = priority.find { |identifier| identifiers[identifier].present? }
+
+    if identifier_to_use.nil?
+      nil
+    else
+      Community.where({ identifier_to_use => identifiers[identifier_to_use]}).first
+    end
+  end
+
   private
 
   def initialize_settings

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -20,17 +20,21 @@ module MarketplaceRedirectUtils
 
     new_protocol_opt = always_use_ssl ? "https" : (protocol == "http://" ? "http" : "https")
     new_protocol_url = always_use_ssl ? "https://" : (protocol == "http://" ? "http://" : "https://")
+    protocol_needs_redirect = protocol != new_protocol_url
+    new_status = protocol_needs_redirect ? :moved_permanently : nil
 
     if !found_community
       if no_communities
-        block.call(new_community_path.merge(status: :found, protocol: new_protocol_opt))
+        block.call(new_community_path.merge(status: (new_status || :found), protocol: new_protocol_opt))
       else
-        block.call(community_not_found_url.merge(status: :found, protocol: new_protocol_opt))
+        block.call(community_not_found_url.merge(status: (new_status || :found), protocol: new_protocol_opt))
       end
     elsif community_deleted
-      block.call(community_not_found_url.merge(status: :moved_permanently, protocol: new_protocol_opt))
+      block.call(community_not_found_url.merge(status: (new_status || :moved_permanently), protocol: new_protocol_opt))
     elsif community_domain.present? && redirect_to_domain && host != community_domain
-      block.call({url: "#{new_protocol_url}#{community_domain}#{port_string}#{fullpath}", status: :moved_permanently})
+      block.call({url: "#{new_protocol_url}#{community_domain}#{port_string}#{fullpath}", status: (new_status || :moved_permanently)})
+    elsif protocol_needs_redirect
+      block.call({url: "#{new_protocol_url}#{host}#{port_string}#{fullpath}", status: new_status})
     end
 
   end

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -2,39 +2,88 @@ module MarketplaceRedirectUtils
 
   module_function
 
-  def needs_redirect(request:,
-                     community:,
-                     paths:,
-                     configs:,
-                     other:,
-                     &block)
+  def needs_redirect(request:, community:, paths:, configs:, other:, &block)
 
+    use_https = should_use_https?(request: request, community: community, configs: configs)
+
+    protocol = use_https ? "https" : (request[:protocol] == "http://" ? "http" : "https")
+    protocol_needs_redirect = request[:protocol] != "#{protocol}://"
+
+    target = redirect_target(
+      request: request,
+      community: community,
+      paths: paths,
+      configs: configs,
+      other: other,
+      protocol: protocol,
+      protocol_needs_redirect: protocol_needs_redirect
+    )
+
+    block.call(target) if target
+  end
+
+  # private
+
+  # The main "router function"
+  #
+  # Returns a hash, which contains either a url or named route
+  #
+  # Example, return hash with url:
+  #
+  # { url: "https://marketplace.sharetribe.com/listings", status :found }
+  #
+  # Example, return hash with named route:
+  #
+  # { route_name: :new_community, status: :moved_permanently, protocol: "http"}
+  #
+  def redirect_target(request:, community:, paths:, configs:, other:, protocol:, protocol_needs_redirect:)
+    target =
+      if community.nil? && other[:no_communities]
+        # Community not found, because there are no communities
+        # -> Redirect to new community page
+        paths[:new_community].merge(status: :found, protocol: protocol)
+
+      elsif community.nil? && !other[:no_communities]
+        # Community not found
+        # -> Redirect to not found
+        paths[:community_not_found].merge(status: :found, protocol: protocol)
+
+      elsif community[:deleted]
+        # Community deleted
+        # -> Redirect to not found
+        paths[:community_not_found].merge(status: :moved_permanently, protocol: protocol)
+
+      elsif community[:domain].present? && community[:redirect_to_domain] && request[:host] != community[:domain]
+        # Community has domain ready, should use it
+        # -> Redirect to community domain
+        {url: "#{protocol}://#{community[:domain]}#{request[:port_string]}#{request[:fullpath]}", status: :moved_permanently}
+
+      elsif request[:host] == "www.#{community[:ident]}.#{configs[:app_domain]}"
+        # Accessed community with ident, including www
+        # -> Redirect to ident without www
+        {url: "#{protocol}://#{community[:ident]}.#{configs[:app_domain]}#{request[:port_string]}#{request[:fullpath]}", status: :moved_permanently}
+
+      elsif protocol_needs_redirect
+        # Needs protocol redirect (to https)
+        # -> Redirect to https
+        {url: "#{protocol}://#{request[:host]}#{request[:port_string]}#{request[:fullpath]}", status: :moved_permanently}
+      else
+        # no need to redirect
+        nil
+      end
+
+    # If protocol redirect is needed, the status is always :moved_permanently
+    Maybe(target)
+      .map { |t| t.merge(status: protocol_needs_redirect ? :moved_permanently : t[:status]) }
+      .or_else(nil)
+  end
+
+  def should_use_https?(request:, configs:, community:)
     from_proxy = (request[:headers]["HTTP_VIA"] && request[:headers]["HTTP_VIA"].include?("sharetribe_proxy"))
     robots = request[:fullpath] == "/robots.txt"
     domain_verification = Maybe(community)[:domain_verification_file].map { |dv_file| request[:fullpath] == "/#{dv_file}" }.or_else(false)
-    should_use_ssl = configs[:always_use_ssl] && !from_proxy && !robots && !domain_verification
 
-    new_protocol_opt = should_use_ssl ? "https" : (request[:protocol] == "http://" ? "http" : "https")
-    new_protocol_url = should_use_ssl ? "https://" : request[:protocol]
-    protocol_needs_redirect = request[:protocol] != new_protocol_url
-    new_status = protocol_needs_redirect ? :moved_permanently : nil
-
-    if community.nil?
-      if other[:no_communities]
-        block.call(paths[:new_community].merge(status: (new_status || :found), protocol: new_protocol_opt))
-      else
-        block.call(paths[:community_not_found].merge(status: (new_status || :found), protocol: new_protocol_opt))
-      end
-    elsif community[:community_deleted]
-      block.call(paths[:community_not_found].merge(status: (new_status || :moved_permanently), protocol: new_protocol_opt))
-    elsif community[:community_domain].present? && community[:redirect_to_domain] && request[:host] != community[:community_domain]
-      block.call({url: "#{new_protocol_url}#{community[:community_domain]}#{request[:port_string]}#{request[:fullpath]}", status: (new_status || :moved_permanently)})
-    elsif request[:host] == "www.#{community[:community_ident]}.#{configs[:app_domain]}"
-      block.call({url: "#{new_protocol_url}#{community[:community_ident]}.#{configs[:app_domain]}#{request[:port_string]}#{request[:fullpath]}", status: (new_status || :moved_permanently)})
-    elsif protocol_needs_redirect
-      block.call({url: "#{new_protocol_url}#{request[:host]}#{request[:port_string]}#{request[:fullpath]}", status: new_status})
-    end
-
+    configs[:always_use_ssl] && !from_proxy && !robots && !domain_verification
   end
 
 end

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -9,10 +9,19 @@ module MarketplaceRedirectUtils
                      redirect_to_domain:,
                      community_not_found_url:,
                      community_deleted:,
+                     no_communities:,
+                     found_community:,
+                     new_community_path:,
                      community_domain: nil,
                      &block)
 
-    if community_deleted
+    if !found_community
+      if no_communities
+        block.call(new_community_path, :found)
+      else
+        block.call(community_not_found_url, :found)
+      end
+    elsif community_deleted
       block.call(community_not_found_url, :moved_permanently)
     elsif community_domain.present? && redirect_to_domain && host != community_domain
       block.call("#{protocol}#{community_domain}#{port_string}#{fullpath}", :moved_permanently)

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -3,6 +3,9 @@ module MarketplaceRedirectUtils
   module_function
 
   def needs_redirect(host:,
+                     headers:,
+                     is_ssl:,
+                     always_use_ssl:,
                      protocol:,
                      fullpath:,
                      port_string:,
@@ -15,16 +18,19 @@ module MarketplaceRedirectUtils
                      community_domain: nil,
                      &block)
 
+    new_protocol_opt = always_use_ssl ? "https" : (protocol == "http://" ? "http" : "https")
+    new_protocol_url = always_use_ssl ? "https://" : (protocol == "http://" ? "http://" : "https://")
+
     if !found_community
       if no_communities
-        block.call(new_community_path, :found)
+        block.call(new_community_path.merge(status: :found, protocol: new_protocol_opt))
       else
-        block.call(community_not_found_url, :found)
+        block.call(community_not_found_url.merge(status: :found, protocol: new_protocol_opt))
       end
     elsif community_deleted
-      block.call(community_not_found_url, :moved_permanently)
+      block.call(community_not_found_url.merge(status: :moved_permanently, protocol: new_protocol_opt))
     elsif community_domain.present? && redirect_to_domain && host != community_domain
-      block.call("#{protocol}#{community_domain}#{port_string}#{fullpath}", :moved_permanently)
+      block.call({url: "#{new_protocol_url}#{community_domain}#{port_string}#{fullpath}", status: :moved_permanently})
     end
 
   end

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -29,6 +29,8 @@ module MarketplaceRedirectUtils
       block.call(paths[:community_not_found].merge(status: (new_status || :moved_permanently), protocol: new_protocol_opt))
     elsif community[:community_domain].present? && community[:redirect_to_domain] && request[:host] != community[:community_domain]
       block.call({url: "#{new_protocol_url}#{community[:community_domain]}#{request[:port_string]}#{request[:fullpath]}", status: (new_status || :moved_permanently)})
+    elsif request[:host] == "www.#{community[:community_ident]}.#{configs[:app_domain]}"
+      block.call({url: "#{new_protocol_url}#{community[:community_ident]}.#{configs[:app_domain]}#{request[:port_string]}#{request[:fullpath]}", status: (new_status || :moved_permanently)})
     elsif protocol_needs_redirect
       block.call({url: "#{new_protocol_url}#{request[:host]}#{request[:port_string]}#{request[:fullpath]}", status: new_status})
     end

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -7,10 +7,14 @@ module MarketplaceRedirectUtils
                      fullpath:,
                      port_string:,
                      redirect_to_domain:,
+                     community_not_found_url:,
+                     community_deleted:,
                      community_domain: nil,
                      &block)
 
-    if community_domain.present? && redirect_to_domain && host != community_domain
+    if community_deleted
+      block.call(community_not_found_url, :moved_permanently)
+    elsif community_domain.present? && redirect_to_domain && host != community_domain
       block.call("#{protocol}#{community_domain}#{port_string}#{fullpath}", :moved_permanently)
     end
 

--- a/app/utils/marketplace_redirect_utils.rb
+++ b/app/utils/marketplace_redirect_utils.rb
@@ -2,39 +2,30 @@ module MarketplaceRedirectUtils
 
   module_function
 
-  def needs_redirect(host:,
-                     headers:,
-                     is_ssl:,
-                     always_use_ssl:,
-                     protocol:,
-                     fullpath:,
-                     port_string:,
-                     redirect_to_domain:,
-                     community_not_found_url:,
-                     community_deleted:,
-                     no_communities:,
-                     found_community:,
-                     new_community_path:,
-                     community_domain: nil,
+  def needs_redirect(request:,
+                     community:,
+                     paths:,
+                     configs:,
+                     other:,
                      &block)
 
-    new_protocol_opt = always_use_ssl ? "https" : (protocol == "http://" ? "http" : "https")
-    new_protocol_url = always_use_ssl ? "https://" : (protocol == "http://" ? "http://" : "https://")
-    protocol_needs_redirect = protocol != new_protocol_url
+    new_protocol_opt = configs[:always_use_ssl] ? "https" : (request[:protocol] == "http://" ? "http" : "https")
+    new_protocol_url = configs[:always_use_ssl] ? "https://" : (request[:protocol] == "http://" ? "http://" : "https://")
+    protocol_needs_redirect = request[:protocol] != new_protocol_url
     new_status = protocol_needs_redirect ? :moved_permanently : nil
 
-    if !found_community
-      if no_communities
-        block.call(new_community_path.merge(status: (new_status || :found), protocol: new_protocol_opt))
+    if community.nil?
+      if other[:no_communities]
+        block.call(paths[:new_community].merge(status: (new_status || :found), protocol: new_protocol_opt))
       else
-        block.call(community_not_found_url.merge(status: (new_status || :found), protocol: new_protocol_opt))
+        block.call(paths[:community_not_found].merge(status: (new_status || :found), protocol: new_protocol_opt))
       end
-    elsif community_deleted
-      block.call(community_not_found_url.merge(status: (new_status || :moved_permanently), protocol: new_protocol_opt))
-    elsif community_domain.present? && redirect_to_domain && host != community_domain
-      block.call({url: "#{new_protocol_url}#{community_domain}#{port_string}#{fullpath}", status: (new_status || :moved_permanently)})
+    elsif community[:community_deleted]
+      block.call(paths[:community_not_found].merge(status: (new_status || :moved_permanently), protocol: new_protocol_opt))
+    elsif community[:community_domain].present? && community[:redirect_to_domain] && request[:host] != community[:community_domain]
+      block.call({url: "#{new_protocol_url}#{community[:community_domain]}#{request[:port_string]}#{request[:fullpath]}", status: (new_status || :moved_permanently)})
     elsif protocol_needs_redirect
-      block.call({url: "#{new_protocol_url}#{host}#{port_string}#{fullpath}", status: new_status})
+      block.call({url: "#{new_protocol_url}#{request[:host]}#{request[:port_string]}#{request[:fullpath]}", status: new_status})
     end
 
   end

--- a/app/utils/marketplace_router.rb
+++ b/app/utils/marketplace_router.rb
@@ -1,4 +1,4 @@
-module MarketplaceRedirectUtils
+module MarketplaceRouter
 
   module_function
 
@@ -38,12 +38,12 @@ module MarketplaceRedirectUtils
   #
   def redirect_target(request:, community:, paths:, configs:, other:, protocol:, protocol_needs_redirect:)
     target =
-      if community.nil? && other[:no_communities]
+      if other[:community_search_status] == :not_found && other[:no_communities]
         # Community not found, because there are no communities
         # -> Redirect to new community page
         paths[:new_community].merge(status: :found, protocol: protocol)
 
-      elsif community.nil? && !other[:no_communities]
+      elsif other[:community_search_status] == :not_found && !other[:no_communities]
         # Community not found
         # -> Redirect to not found
         paths[:community_not_found].merge(status: :found, protocol: protocol)

--- a/lib/mercury/authentication.rb
+++ b/lib/mercury/authentication.rb
@@ -3,8 +3,13 @@ module Mercury
 
     def can_edit?
       @current_user = current_person
-      @current_community = ApplicationController.default_community_fetch_strategy(request.host)
+      @current_community = ApplicationController.find_community(community_identifiers)
       @current_user && @current_community && @current_user.has_admin_rights_in?(@current_community)
+    end
+
+    def community_identifiers
+      app_domain = URLUtils.strip_port_from_host(APP_CONFIG.domain)
+      ApplicationController.parse_community_identifiers_from_host(request.host, app_domain)
     end
 
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -129,32 +129,6 @@ describe ApplicationController do
     end
   end
 
-  describe "should force ssl for path" do
-
-    def expect_redirect(path, should_not_redirect)
-      expect(ApplicationController.should_not_redirect_path_to_https(path))
-        .to eq(should_not_redirect)
-    end
-
-    def should_redirect(path)
-      expect_redirect(path, false)
-    end
-
-    def should_not_redirect(path)
-      expect_redirect(path, true)
-    end
-
-    it "returns true if should redirect" do
-      should_not_redirect("/robots.txt")
-      should_not_redirect("/ABCDEF1234567890.txt")
-      should_redirect("/.txt")
-      should_redirect("/txt")
-      should_redirect("/ABCDEF1234567890")
-      should_redirect("/subfolder/ABCDEF1234567890.txt")
-      should_redirect("/ABCDEF1234567890.txt_backup")
-    end
-  end
-
   describe "#parse_community_identifiers_from_request" do
     it "parses ident from host" do
       expect(ApplicationController.parse_community_identifiers_from_host("market.sharetribe.com", "sharetribe.com")).to eq({ident: "market"})

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -154,4 +154,18 @@ describe ApplicationController do
       should_redirect("/ABCDEF1234567890.txt_backup")
     end
   end
+
+  describe "#parse_community_identifiers_from_request" do
+    it "parses ident from host" do
+      expect(ApplicationController.parse_community_identifiers_from_host("market.sharetribe.com", "sharetribe.com")).to eq({ident: "market"})
+    end
+
+    it "parses ident (with www) from host" do
+      expect(ApplicationController.parse_community_identifiers_from_host("www.market.sharetribe.com", "sharetribe.com")).to eq({ident: "market"})
+    end
+
+    it "parses domain from host" do
+      expect(ApplicationController.parse_community_identifiers_from_host("www.market.com", "sharetribe.com")).to eq({domain: "www.market.com"})
+    end
+  end
 end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -15,13 +15,15 @@ describe MarketplaceRedirectUtils do
       community_deleted: false,
       community_domain: "www.marketplace.com",
       domain_verification_file: nil,
+      community_ident: "marketplace",
     }
     default_paths = {
       community_not_found: {route_name: :not_found},
       new_community: {route_name: :new_community},
     }
     default_configs = {
-      always_use_ssl: true
+      always_use_ssl: true,
+      app_domain: "sharetribe.com"
     }
     default_other = {
       no_communities: false
@@ -197,6 +199,32 @@ describe MarketplaceRedirectUtils do
                         domain_verification_file: "1234567890ABCDEF.txt"
                       }
                       ).to eq(nil)
+    end
+
+    it "redirects to marketplace ident without www" do
+      expect_redirect(request: {
+                        host: "www.marketplace.sharetribe.com",
+                      },
+                      community: {
+                        community_ident: "marketplace",
+                        community_domain: nil,
+                      },
+                      configs: {
+                        app_domain: "sharetribe.com"
+                      }
+                     ).to eq(:url=>"https://marketplace.sharetribe.com/listings", :status=>:moved_permanently)
+    end
+
+    it "redirects to marketplace domain if available" do
+      expect_redirect(request: {
+                        host: "www.marketplace.sharetribe.com",
+                      },
+                      community: {
+                        community_ident: "marketplace",
+                        community_domain: "www.marketplace.com",
+                        redirect_to_domain: true
+                      }
+                     ).to eq(:url=>"https://www.marketplace.com/listings", :status=>:moved_permanently)
     end
   end
 end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -2,244 +2,151 @@ require 'spec_helper'
 
 describe MarketplaceRedirectUtils do
 
-  def expect_redirect(opts)
-    result = MarketplaceRedirectUtils.needs_redirect(opts) { |x| x }
+  def expect_redirect(request: {}, community: {}, paths: {}, other: {}, configs: {})
+    default_request = {
+      host: "marketplace.sharetribe.com",
+      protocol: "https://",
+      fullpath: "/listings",
+      port_string: "",
+      headers: {}
+    }
+    default_community = {
+      redirect_to_domain: true,
+      community_deleted: false,
+      community_domain: "www.marketplace.com",
+    }
+    default_paths = {
+      community_not_found: {route_name: :not_found},
+      new_community: {route_name: :new_community},
+    }
+    default_configs = {
+      always_use_ssl: true
+    }
+    default_other = {
+      no_communities: false
+    }
+
+    result = MarketplaceRedirectUtils.needs_redirect(
+      request: default_request.merge(request),
+      community: community.nil? ? nil : default_community.merge(community),
+      paths: default_paths.merge(paths),
+      configs: default_configs.merge(configs),
+      other: other
+    ) { |x| x }
+
     expect(result)
   end
 
   describe "#needs_redirect" do
 
     it "does not redirect to full domain if the host is already the full domain" do
-      expect_redirect(
-        host: "www.marketplace.com",
-        protocol: "https://",
-        always_use_ssl: true,
-        fullpath: "/listings",
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        community_domain: "www.marketplace.com",
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        found_community: true,
-        no_communities: false,
-        new_community_path: {route_name: :new_community},
-        redirect_to_domain: true).to eq(nil)
+      expect_redirect(request: {
+                        host: "www.marketplace.com",
+                      }).to eq(nil)
     end
 
     it "does not redirect to full domain if full domain is not provided" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        always_use_ssl: true,
-        port_string: "",
-        fullpath: "/listings",
-        headers: {},
-        is_ssl: true,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        found_community: true,
-        no_communities: false,
-        new_community_path: {route_name: :new_community},
-        redirect_to_domain: false).to eq(nil)
+      expect_redirect(community: {
+                        community_deleted: false,
+                        redirect_to_domain: false,
+                      }).to eq(nil)
     end
 
     it "redirects to full domain, if marketplace is accessed with the subdomain (ident) and full domain is provided and redirect_to_domain is true" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        fullpath: "/listings",
-        always_use_ssl: true,
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: true,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        found_community: true,
-        no_communities: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: "www.marketplace.com").to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
+      expect_redirect(community: {
+                        redirect_to_domain: true,
+                        community_deleted: false,
+                        community_domain: "www.marketplace.com",
+                      }).to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
     end
 
     it "does not redirect if redirect_to_domain is false" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        always_use_ssl: true,
-        fullpath: "/listings",
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: false,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        found_community: true,
-        no_communities: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: "www.marketplace.com").to eq(nil)
+      expect_redirect(community: {
+                        community_deleted: false,
+                        community_domain: "www.marketplace.com",
+                        redirect_to_domain: false,
+                      }).to eq(nil)
     end
 
     it "includes port" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        fullpath: "/listings",
-        always_use_ssl: true,
-        port_string: ":3333",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: true,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        found_community: true,
-        no_communities: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: "www.marketplace.com").to eq(url: "https://www.marketplace.com:3333/listings", status: :moved_permanently)
+      expect_redirect(request: {
+                        port_string: ":3333",
+                      },
+                      community: {
+                        community_domain: "www.marketplace.com",
+                        community_deleted: false,
+                        redirect_to_domain: true,
+                      }).to eq(url: "https://www.marketplace.com:3333/listings", status: :moved_permanently)
     end
 
     it "redirects deleted marketplaces" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        always_use_ssl: true,
-        fullpath: "/listings",
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: true,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: true,
-        found_community: true,
-        no_communities: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: "www.marketplace.com").to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
+      expect_redirect(community: {
+                        community_domain: "www.marketplace.com",
+                        community_deleted: true,
+                        redirect_to_domain: true,
+                      }).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
 
     it "redirects deleted marketplaces" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        always_use_ssl: true,
-        fullpath: "/listings",
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: true,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: true,
-        found_community: true,
-        no_communities: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: "www.marketplace.com").to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
+      expect_redirect(community: {
+                        community_domain: "www.marketplace.com",
+                        community_deleted: true,
+                        redirect_to_domain: true,
+                      }).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
 
     it "redirects to community not found if community was not found and some communities do exist" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        always_use_ssl: true,
-        fullpath: "/listings",
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: nil,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: nil,
-        no_communities: false,
-        found_community: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: nil).to eq(route_name: :not_found, status: :found, protocol: "https")
+      expect_redirect(community: nil).to eq(route_name: :not_found, status: :found, protocol: "https")
     end
 
     it "redirects to community not found if community was not found and some communities do exist" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "https://",
-        always_use_ssl: true,
-        fullpath: "/listings",
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: nil,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: nil,
-        no_communities: true,
-        found_community: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: nil).to eq(route_name: :new_community, status: :found, protocol: "https")
+      expect_redirect(community: nil,
+                      other: {
+                        no_communities: true,
+                      }).to eq(route_name: :new_community, status: :found, protocol: "https")
     end
 
     it "redirects to https if always_use_ssl configuration is set true" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        headers: {},
-        is_ssl: false,
-        always_use_ssl: true,
-        protocol: "http://",
-        fullpath: "/listings",
-        port_string: "",
-        redirect_to_domain: true,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        no_communities: false,
-        found_community: true,
-        new_community_path: {route_name: :new_community},
-        community_domain: "www.marketplace.com").to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
+      expect_redirect(request: {
+                        protocol: "http://",
+                      },
+                      community: {
+                        community_domain: "www.marketplace.com",
+                        community_deleted: false,
+                        redirect_to_domain: true,
+                      }).to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
     end
 
     it "redirects to https even if there's no other reason to do redirect" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        headers: {},
-        is_ssl: false,
-        always_use_ssl: true,
-        protocol: "http://",
-        fullpath: "/listings",
-        port_string: "",
-        redirect_to_domain: false,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        no_communities: false,
-        found_community: true,
-        new_community_path: {route_name: :new_community},
-        community_domain: nil).to eq(url: "https://marketplace.sharetribe.com/listings", status: :moved_permanently)
+      expect_redirect(request: {
+                        protocol: "http://",
+                      },
+                      community: {
+                        community_domain: nil,
+                        community_deleted: false,
+                        redirect_to_domain: false,
+                      }).to eq(url: "https://marketplace.sharetribe.com/listings", status: :moved_permanently)
     end
 
     it "redirects to protocol in use if always_use_ssl configuration is set false" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        headers: {},
-        is_ssl: false,
-        always_use_ssl: false,
-        protocol: "http://",
-        fullpath: "/listings",
-        port_string: "",
-        redirect_to_domain: true,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: false,
-        no_communities: false,
-        found_community: true,
-        new_community_path: {route_name: :new_community},
-        community_domain: "www.marketplace.com").to eq(url: "http://www.marketplace.com/listings", status: :moved_permanently)
+      expect_redirect(request: {
+                        protocol: "http://",
+                      },
+                      community: {
+                        community_domain: "www.marketplace.com",
+                        community_deleted: false,
+                        redirect_to_domain: true,
+                      },
+                      configs: {
+                        always_use_ssl: false,
+                      }).to eq(url: "http://www.marketplace.com/listings", status: :moved_permanently)
     end
 
     it "redirects with moved permanently if the protocol needs redirect even if it would otherwise used found status" do
-      expect_redirect(
-        host: "marketplace.sharetribe.com",
-        protocol: "http://",
-        always_use_ssl: true,
-        fullpath: "/listings",
-        port_string: "",
-        headers: {},
-        is_ssl: true,
-        redirect_to_domain: nil,
-        community_not_found_url: {route_name: :not_found},
-        community_deleted: nil,
-        no_communities: false,
-        found_community: false,
-        new_community_path: {route_name: :new_community},
-        community_domain: nil).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
+      expect_redirect(community: nil,
+                      request: {
+                        protocol: "http://",
+                      }).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
   end
 end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe MarketplaceRedirectUtils do
 
   def expect_redirect(opts)
-    url_and_status = MarketplaceRedirectUtils.needs_redirect(opts) { |url, status| [url, status] }
-    expect(url_and_status)
+    result = MarketplaceRedirectUtils.needs_redirect(opts) { |x| x }
+    expect(result)
   end
 
   describe "#needs_redirect" do
@@ -13,14 +13,17 @@ describe MarketplaceRedirectUtils do
       expect_redirect(
         host: "www.marketplace.com",
         protocol: "https",
+        always_use_ssl: true,
         fullpath: "/listings",
         port_string: "",
+        headers: {},
+        is_ssl: true,
         community_domain: "www.marketplace.com",
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: false,
         found_community: true,
         no_communities: false,
-        new_community_path: :new_community,
+        new_community_path: {route_name: :new_community},
         redirect_to_domain: true).to eq(nil)
     end
 
@@ -28,13 +31,16 @@ describe MarketplaceRedirectUtils do
       expect_redirect(
         host: "marketplace.sharetribe.com",
         protocol: "https://",
+        always_use_ssl: true,
         port_string: "",
         fullpath: "/listings",
-        community_not_found_url: :not_found,
+        headers: {},
+        is_ssl: true,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: false,
         found_community: true,
         no_communities: false,
-        new_community_path: :new_community,
+        new_community_path: {route_name: :new_community},
         redirect_to_domain: false).to eq(nil)
     end
 
@@ -43,28 +49,34 @@ describe MarketplaceRedirectUtils do
         host: "marketplace.sharetribe.com",
         protocol: "https://",
         fullpath: "/listings",
+        always_use_ssl: true,
         port_string: "",
+        headers: {},
+        is_ssl: true,
         redirect_to_domain: true,
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: false,
         found_community: true,
         no_communities: false,
-        new_community_path: :new_community,
-        community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com/listings", :moved_permanently])
+        new_community_path: {route_name: :new_community},
+        community_domain: "www.marketplace.com").to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
     end
 
     it "does not redirect if redirect_to_domain is false" do
       expect_redirect(
         host: "marketplace.sharetribe.com",
         protocol: "https://",
+        always_use_ssl: true,
         fullpath: "/listings",
         port_string: "",
+        headers: {},
+        is_ssl: true,
         redirect_to_domain: false,
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: false,
         found_community: true,
         no_communities: false,
-        new_community_path: :new_community,
+        new_community_path: {route_name: :new_community},
         community_domain: "www.marketplace.com").to eq(nil)
     end
 
@@ -73,74 +85,125 @@ describe MarketplaceRedirectUtils do
         host: "marketplace.sharetribe.com",
         protocol: "https://",
         fullpath: "/listings",
+        always_use_ssl: true,
         port_string: ":3333",
+        headers: {},
+        is_ssl: true,
         redirect_to_domain: true,
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: false,
         found_community: true,
         no_communities: false,
-        new_community_path: :new_community,
-        community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com:3333/listings", :moved_permanently])
+        new_community_path: {route_name: :new_community},
+        community_domain: "www.marketplace.com").to eq(url: "https://www.marketplace.com:3333/listings", status: :moved_permanently)
     end
 
     it "redirects deleted marketplaces" do
       expect_redirect(
         host: "marketplace.sharetribe.com",
         protocol: "https://",
+        always_use_ssl: true,
         fullpath: "/listings",
         port_string: "",
+        headers: {},
+        is_ssl: true,
         redirect_to_domain: true,
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: true,
         found_community: true,
         no_communities: false,
-        new_community_path: :new_community,
-        community_domain: "www.marketplace.com").to eq([:not_found, :moved_permanently])
+        new_community_path: {route_name: :new_community},
+        community_domain: "www.marketplace.com").to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
 
     it "redirects deleted marketplaces" do
       expect_redirect(
         host: "marketplace.sharetribe.com",
         protocol: "https://",
+        always_use_ssl: true,
         fullpath: "/listings",
         port_string: "",
+        headers: {},
+        is_ssl: true,
         redirect_to_domain: true,
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: true,
         found_community: true,
         no_communities: false,
-        new_community_path: :new_community,
-        community_domain: "www.marketplace.com").to eq([:not_found, :moved_permanently])
+        new_community_path: {route_name: :new_community},
+        community_domain: "www.marketplace.com").to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
 
     it "redirects to community not found if community was not found and some communities do exist" do
       expect_redirect(
         host: "marketplace.sharetribe.com",
         protocol: "https://",
+        always_use_ssl: true,
         fullpath: "/listings",
         port_string: "",
+        headers: {},
+        is_ssl: true,
         redirect_to_domain: nil,
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: nil,
         no_communities: false,
         found_community: false,
-        new_community_path: :new_community,
-        community_domain: nil).to eq([:not_found, :found])
+        new_community_path: {route_name: :new_community},
+        community_domain: nil).to eq(route_name: :not_found, status: :found, protocol: "https")
     end
 
     it "redirects to community not found if community was not found and some communities do exist" do
       expect_redirect(
         host: "marketplace.sharetribe.com",
         protocol: "https://",
+        always_use_ssl: true,
         fullpath: "/listings",
         port_string: "",
+        headers: {},
+        is_ssl: true,
         redirect_to_domain: nil,
-        community_not_found_url: :not_found,
+        community_not_found_url: {route_name: :not_found},
         community_deleted: nil,
         no_communities: true,
         found_community: false,
-        new_community_path: :new_community,
-        community_domain: nil).to eq([:new_community, :found])
+        new_community_path: {route_name: :new_community},
+        community_domain: nil).to eq(route_name: :new_community, status: :found, protocol: "https")
+    end
+
+    it "redirects to https if always_use_ssl configuration is set true" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        headers: {},
+        is_ssl: false,
+        always_use_ssl: true,
+        protocol: "http://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: true,
+        community_not_found_url: {route_name: :not_found},
+        community_deleted: false,
+        no_communities: false,
+        found_community: true,
+        new_community_path: {route_name: :new_community},
+        community_domain: "www.marketplace.com").to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
+    end
+
+    it "redirects to protocol in use if always_use_ssl configuration is set false" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        headers: {},
+        is_ssl: false,
+        always_use_ssl: false,
+        protocol: "http://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: true,
+        community_not_found_url: {route_name: :not_found},
+        community_deleted: false,
+        no_communities: false,
+        found_community: true,
+        new_community_path: {route_name: :new_community},
+        community_domain: "www.marketplace.com").to eq(url: "http://www.marketplace.com/listings", status: :moved_permanently)
     end
   end
 end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -12,10 +12,10 @@ describe MarketplaceRedirectUtils do
     }
     default_community = {
       redirect_to_domain: true,
-      community_deleted: false,
-      community_domain: "www.marketplace.com",
+      deleted: false,
+      domain: "www.marketplace.com",
       domain_verification_file: nil,
-      community_ident: "marketplace",
+      ident: "marketplace",
     }
     default_paths = {
       community_not_found: {route_name: :not_found},
@@ -29,15 +29,16 @@ describe MarketplaceRedirectUtils do
       no_communities: false
     }
 
+    called = false
     result = MarketplaceRedirectUtils.needs_redirect(
       request: default_request.merge(request),
       community: community.nil? ? nil : default_community.merge(community),
       paths: default_paths.merge(paths),
       configs: default_configs.merge(configs),
       other: other
-    ) { |x| x }
+    ) { |x| called = true; x }
 
-    expect(result)
+    expect(called ? result : nil)
   end
 
   describe "#needs_redirect" do
@@ -50,7 +51,7 @@ describe MarketplaceRedirectUtils do
 
     it "does not redirect to full domain if full domain is not provided" do
       expect_redirect(community: {
-                        community_deleted: false,
+                        deleted: false,
                         redirect_to_domain: false,
                       }).to eq(nil)
     end
@@ -58,15 +59,15 @@ describe MarketplaceRedirectUtils do
     it "redirects to full domain, if marketplace is accessed with the subdomain (ident) and full domain is provided and redirect_to_domain is true" do
       expect_redirect(community: {
                         redirect_to_domain: true,
-                        community_deleted: false,
-                        community_domain: "www.marketplace.com",
+                        deleted: false,
+                        domain: "www.marketplace.com",
                       }).to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
     end
 
     it "does not redirect if redirect_to_domain is false" do
       expect_redirect(community: {
-                        community_deleted: false,
-                        community_domain: "www.marketplace.com",
+                        deleted: false,
+                        domain: "www.marketplace.com",
                         redirect_to_domain: false,
                       }).to eq(nil)
     end
@@ -76,24 +77,24 @@ describe MarketplaceRedirectUtils do
                         port_string: ":3333",
                       },
                       community: {
-                        community_domain: "www.marketplace.com",
-                        community_deleted: false,
+                        domain: "www.marketplace.com",
+                        deleted: false,
                         redirect_to_domain: true,
                       }).to eq(url: "https://www.marketplace.com:3333/listings", status: :moved_permanently)
     end
 
     it "redirects deleted marketplaces" do
       expect_redirect(community: {
-                        community_domain: "www.marketplace.com",
-                        community_deleted: true,
+                        domain: "www.marketplace.com",
+                        deleted: true,
                         redirect_to_domain: true,
                       }).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
 
     it "redirects deleted marketplaces" do
       expect_redirect(community: {
-                        community_domain: "www.marketplace.com",
-                        community_deleted: true,
+                        domain: "www.marketplace.com",
+                        deleted: true,
                         redirect_to_domain: true,
                       }).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
@@ -114,8 +115,8 @@ describe MarketplaceRedirectUtils do
                         protocol: "http://",
                       },
                       community: {
-                        community_domain: "www.marketplace.com",
-                        community_deleted: false,
+                        domain: "www.marketplace.com",
+                        deleted: false,
                         redirect_to_domain: true,
                       }).to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
     end
@@ -125,8 +126,8 @@ describe MarketplaceRedirectUtils do
                         protocol: "http://",
                       },
                       community: {
-                        community_domain: nil,
-                        community_deleted: false,
+                        domain: nil,
+                        deleted: false,
                         redirect_to_domain: false,
                       }).to eq(url: "https://marketplace.sharetribe.com/listings", status: :moved_permanently)
     end
@@ -136,8 +137,8 @@ describe MarketplaceRedirectUtils do
                         protocol: "http://",
                       },
                       community: {
-                        community_domain: "www.marketplace.com",
-                        community_deleted: false,
+                        domain: "www.marketplace.com",
+                        deleted: false,
                         redirect_to_domain: true,
                       },
                       configs: {
@@ -206,8 +207,8 @@ describe MarketplaceRedirectUtils do
                         host: "www.marketplace.sharetribe.com",
                       },
                       community: {
-                        community_ident: "marketplace",
-                        community_domain: nil,
+                        ident: "marketplace",
+                        domain: nil,
                       },
                       configs: {
                         app_domain: "sharetribe.com"
@@ -220,8 +221,8 @@ describe MarketplaceRedirectUtils do
                         host: "www.marketplace.sharetribe.com",
                       },
                       community: {
-                        community_ident: "marketplace",
-                        community_domain: "www.marketplace.com",
+                        ident: "marketplace",
+                        domain: "www.marketplace.com",
                         redirect_to_domain: true
                       }
                      ).to eq(:url=>"https://www.marketplace.com/listings", :status=>:moved_permanently)

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -12,7 +12,7 @@ describe MarketplaceRedirectUtils do
     it "does not redirect to full domain if the host is already the full domain" do
       expect_redirect(
         host: "www.marketplace.com",
-        protocol: "https",
+        protocol: "https://",
         always_use_ssl: true,
         fullpath: "/listings",
         port_string: "",
@@ -188,6 +188,24 @@ describe MarketplaceRedirectUtils do
         community_domain: "www.marketplace.com").to eq(url: "https://www.marketplace.com/listings", status: :moved_permanently)
     end
 
+    it "redirects to https even if there's no other reason to do redirect" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        headers: {},
+        is_ssl: false,
+        always_use_ssl: true,
+        protocol: "http://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: false,
+        community_not_found_url: {route_name: :not_found},
+        community_deleted: false,
+        no_communities: false,
+        found_community: true,
+        new_community_path: {route_name: :new_community},
+        community_domain: nil).to eq(url: "https://marketplace.sharetribe.com/listings", status: :moved_permanently)
+    end
+
     it "redirects to protocol in use if always_use_ssl configuration is set false" do
       expect_redirect(
         host: "marketplace.sharetribe.com",
@@ -204,6 +222,24 @@ describe MarketplaceRedirectUtils do
         found_community: true,
         new_community_path: {route_name: :new_community},
         community_domain: "www.marketplace.com").to eq(url: "http://www.marketplace.com/listings", status: :moved_permanently)
+    end
+
+    it "redirects with moved permanently if the protocol needs redirect even if it would otherwise used found status" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "http://",
+        always_use_ssl: true,
+        fullpath: "/listings",
+        port_string: "",
+        headers: {},
+        is_ssl: true,
+        redirect_to_domain: nil,
+        community_not_found_url: {route_name: :not_found},
+        community_deleted: nil,
+        no_communities: false,
+        found_community: false,
+        new_community_path: {route_name: :new_community},
+        community_domain: nil).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
   end
 end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -18,6 +18,9 @@ describe MarketplaceRedirectUtils do
         community_domain: "www.marketplace.com",
         community_not_found_url: :not_found,
         community_deleted: false,
+        found_community: true,
+        no_communities: false,
+        new_community_path: :new_community,
         redirect_to_domain: true).to eq(nil)
     end
 
@@ -29,6 +32,9 @@ describe MarketplaceRedirectUtils do
         fullpath: "/listings",
         community_not_found_url: :not_found,
         community_deleted: false,
+        found_community: true,
+        no_communities: false,
+        new_community_path: :new_community,
         redirect_to_domain: false).to eq(nil)
     end
 
@@ -41,6 +47,9 @@ describe MarketplaceRedirectUtils do
         redirect_to_domain: true,
         community_not_found_url: :not_found,
         community_deleted: false,
+        found_community: true,
+        no_communities: false,
+        new_community_path: :new_community,
         community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com/listings", :moved_permanently])
     end
 
@@ -53,6 +62,9 @@ describe MarketplaceRedirectUtils do
         redirect_to_domain: false,
         community_not_found_url: :not_found,
         community_deleted: false,
+        found_community: true,
+        no_communities: false,
+        new_community_path: :new_community,
         community_domain: "www.marketplace.com").to eq(nil)
     end
 
@@ -65,6 +77,9 @@ describe MarketplaceRedirectUtils do
         redirect_to_domain: true,
         community_not_found_url: :not_found,
         community_deleted: false,
+        found_community: true,
+        no_communities: false,
+        new_community_path: :new_community,
         community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com:3333/listings", :moved_permanently])
     end
 
@@ -77,7 +92,55 @@ describe MarketplaceRedirectUtils do
         redirect_to_domain: true,
         community_not_found_url: :not_found,
         community_deleted: true,
+        found_community: true,
+        no_communities: false,
+        new_community_path: :new_community,
         community_domain: "www.marketplace.com").to eq([:not_found, :moved_permanently])
+    end
+
+    it "redirects deleted marketplaces" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: true,
+        community_not_found_url: :not_found,
+        community_deleted: true,
+        found_community: true,
+        no_communities: false,
+        new_community_path: :new_community,
+        community_domain: "www.marketplace.com").to eq([:not_found, :moved_permanently])
+    end
+
+    it "redirects to community not found if community was not found and some communities do exist" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: nil,
+        community_not_found_url: :not_found,
+        community_deleted: nil,
+        no_communities: false,
+        found_community: false,
+        new_community_path: :new_community,
+        community_domain: nil).to eq([:not_found, :found])
+    end
+
+    it "redirects to community not found if community was not found and some communities do exist" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: nil,
+        community_not_found_url: :not_found,
+        community_deleted: nil,
+        no_communities: true,
+        found_community: false,
+        new_community_path: :new_community,
+        community_domain: nil).to eq([:new_community, :found])
     end
   end
 end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -16,6 +16,8 @@ describe MarketplaceRedirectUtils do
         fullpath: "/listings",
         port_string: "",
         community_domain: "www.marketplace.com",
+        community_not_found_url: :not_found,
+        community_deleted: false,
         redirect_to_domain: true).to eq(nil)
     end
 
@@ -25,6 +27,8 @@ describe MarketplaceRedirectUtils do
         protocol: "https://",
         port_string: "",
         fullpath: "/listings",
+        community_not_found_url: :not_found,
+        community_deleted: false,
         redirect_to_domain: false).to eq(nil)
     end
 
@@ -35,6 +39,8 @@ describe MarketplaceRedirectUtils do
         fullpath: "/listings",
         port_string: "",
         redirect_to_domain: true,
+        community_not_found_url: :not_found,
+        community_deleted: false,
         community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com/listings", :moved_permanently])
     end
 
@@ -45,6 +51,8 @@ describe MarketplaceRedirectUtils do
         fullpath: "/listings",
         port_string: "",
         redirect_to_domain: false,
+        community_not_found_url: :not_found,
+        community_deleted: false,
         community_domain: "www.marketplace.com").to eq(nil)
     end
 
@@ -55,7 +63,21 @@ describe MarketplaceRedirectUtils do
         fullpath: "/listings",
         port_string: ":3333",
         redirect_to_domain: true,
+        community_not_found_url: :not_found,
+        community_deleted: false,
         community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com:3333/listings", :moved_permanently])
+    end
+
+    it "redirects deleted marketplaces" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: true,
+        community_not_found_url: :not_found,
+        community_deleted: true,
+        community_domain: "www.marketplace.com").to eq([:not_found, :moved_permanently])
     end
   end
 end

--- a/spec/utils/marketplace_redirect_utils_spec.rb
+++ b/spec/utils/marketplace_redirect_utils_spec.rb
@@ -7,45 +7,55 @@ describe MarketplaceRedirectUtils do
     expect(url_and_status)
   end
 
-  it "redirects to domain" do
-    expect_redirect(
-      host: "www.marketplace.com",
-      protocol: "https",
-      fullpath: "/listings",
-      port_string: "",
-      community_domain: "www.marketplace.com",
-      redirect_to_domain: true).to eq(nil)
+  describe "#needs_redirect" do
 
-    expect_redirect(
-      host: "marketplace.sharetribe.com",
-      protocol: "https://",
-      port_string: "",
-      fullpath: "/listings",
-      redirect_to_domain: false).to eq(nil)
+    it "does not redirect to full domain if the host is already the full domain" do
+      expect_redirect(
+        host: "www.marketplace.com",
+        protocol: "https",
+        fullpath: "/listings",
+        port_string: "",
+        community_domain: "www.marketplace.com",
+        redirect_to_domain: true).to eq(nil)
+    end
 
-    expect_redirect(
-      host: "marketplace.sharetribe.com",
-      protocol: "https://",
-      fullpath: "/listings",
-      port_string: "",
-      redirect_to_domain: true,
-      community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com/listings", :moved_permanently])
+    it "does not redirect to full domain if full domain is not provided" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        port_string: "",
+        fullpath: "/listings",
+        redirect_to_domain: false).to eq(nil)
+    end
 
-    expect_redirect(
-      host: "marketplace.sharetribe.com",
-      protocol: "https://",
-      fullpath: "/listings",
-      port_string: "",
-      redirect_to_domain: false,
-      community_domain: "www.marketplace.com").to eq(nil)
+    it "redirects to full domain, if marketplace is accessed with the subdomain (ident) and full domain is provided and redirect_to_domain is true" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: true,
+        community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com/listings", :moved_permanently])
+    end
 
-    expect_redirect(
-      host: "marketplace.sharetribe.com",
-      protocol: "https://",
-      fullpath: "/listings",
-      port_string: ":3333",
-      redirect_to_domain: true,
-      community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com:3333/listings", :moved_permanently])
+    it "does not redirect if redirect_to_domain is false" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        fullpath: "/listings",
+        port_string: "",
+        redirect_to_domain: false,
+        community_domain: "www.marketplace.com").to eq(nil)
+    end
+
+    it "includes port" do
+      expect_redirect(
+        host: "marketplace.sharetribe.com",
+        protocol: "https://",
+        fullpath: "/listings",
+        port_string: ":3333",
+        redirect_to_domain: true,
+        community_domain: "www.marketplace.com").to eq(["https://www.marketplace.com:3333/listings", :moved_permanently])
+    end
   end
-
 end

--- a/spec/utils/marketplace_router_spec.rb
+++ b/spec/utils/marketplace_router_spec.rb
@@ -36,7 +36,7 @@ describe MarketplaceRouter do
       community: community.nil? ? nil : default_community.merge(community),
       paths: default_paths.merge(paths),
       configs: default_configs.merge(configs),
-      other: other
+      other: default_other.merge(other)
     ) { |x| called = true; x }
 
     expect(called ? result : nil)


### PR DESCRIPTION
Add a `MarketplaceRedirectionUtils`, which takes a care of the redirections needed to perform.

Following redirections are done:

1. If community is not found and there are no communities in the whole platform, redirect to new community form (this is mostly for new open source installations and local development)
2. If community is not found, redirect to not found page, or to url from configurations (sharetribe.com)
3. If community is deleted, redirect to not found page, or to url from configurations (sharetribe.com)
4. If community is accessed with ident, but the community has domain which is ready, redirect to domain
5. If community is accessed with subdomain but it includes "www.", redirect to subdomain without "www"
6. If http is used and `always_use_ssl` is set to true, redirect to https (except if it's robots.txt, or domain validation file, or if the request comes from proxy)

One goal of this Pull Request is to reduce the amount of redirects by doing all the necessary redirects at once. Here's a good SO answer how to debug redirects with Chrome: http://stackoverflow.com/questions/10987453/how-to-use-chromes-network-debugger-with-redirects

For example, if I try to access "Larun tori" marketplace (a marketplace previously run by Sharetribe, but currently deleted) we can see quite a many redirects happening:

![screen shot 2015-07-31 at 10 01 45](https://cloud.githubusercontent.com/assets/429876/9002346/743da5e2-376b-11e5-9bf8-ae2b77d3a133.png)

1. Redirect from http://www.lauttasaari.sharetribe.com to http://lauttasaari.sharetribe.com
2. Redirect from http://lauttasaari.sharetribe.com to https://lauttasaari.sharetribe.com
3. Redirect from https://lauttasaari.sharetribe.com to www.sharetribe.com (because the marketplace is deleted)

And as you can see from the waterfall chart, there redirects do take some time.