### PR TITLE
Community.full_domain takes Community.use_domain into account

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -413,7 +413,7 @@ class Community < ActiveRecord::Base
     default_host, default_port = APP_CONFIG.domain.split(':')
     port_string = options[:port] || default_port
 
-    if domain.present? # custom domain
+    if domain.present? && use_domain? # custom domain
       dom = domain
     else # just a subdomain specified
       dom = "#{self.ident}.#{default_host}"


### PR DESCRIPTION
We use community.full_domain method to construct links to our app. Emails (e.g. invitation email) contains a link that is constructed using the full_domain method. This method should take `use_domain` value into account.