### PR TITLE
Upgrade AWS SDK to version 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'sass', "  ~> 3.2.9"
 gem 'rest-client', '>= 1.6.0'
 gem 'paperclip'
 gem 'delayed_paperclip'
+gem 'aws-sdk-v1'
 gem 'aws-sdk', '~> 2'
 gem "will_paginate"
 gem 'dalli'

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'sass', "  ~> 3.2.9"
 gem 'rest-client', '>= 1.6.0'
 gem 'paperclip'
 gem 'delayed_paperclip'
-gem 'aws-sdk'
+gem 'aws-sdk', '~> 2'
 gem "will_paginate"
 gem 'dalli'
 gem "memcachier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,9 @@ GEM
       jmespath (~> 1.0)
     aws-sdk-resources (2.1.12)
       aws-sdk-core (= 2.1.12)
+    aws-sdk-v1 (1.64.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
     bcrypt-ruby (3.1.2)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -508,6 +511,7 @@ DEPENDENCIES
   annotate
   asset_sync
   aws-sdk (~> 2)
+  aws-sdk-v1
   better_errors
   braintree
   cache_digests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,10 +61,12 @@ GEM
       activemodel
       fog
     ast (2.0.0)
-    aws-sdk (1.15.0)
-      json (~> 1.4)
-      nokogiri (< 1.6.0)
-      uuidtools (~> 2.1)
+    aws-sdk (2.1.12)
+      aws-sdk-resources (= 2.1.12)
+    aws-sdk-core (2.1.12)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.1.12)
+      aws-sdk-core (= 2.1.12)
     bcrypt-ruby (3.1.2)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -228,6 +230,8 @@ GEM
       term-ansicolor
       terminal-table
     innertube (1.1.0)
+    jmespath (1.0.2)
+      multi_json (~> 1.0)
     joiner (0.2.0)
       activerecord (>= 3.1.0, < 4.1.0)
     journey (1.0.4)
@@ -479,7 +483,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    uuidtools (2.1.4)
     validates_timeliness (3.0.14)
       timeliness (~> 0.3.6)
     warden (1.2.3)
@@ -504,7 +507,7 @@ DEPENDENCIES
   airbrake (~> 4.1.0)
   annotate
   asset_sync
-  aws-sdk
+  aws-sdk (~> 2)
   better_errors
   braintree
   cache_digests


### PR DESCRIPTION
Add dependency to AWS Ruby SDK version 2. We have old code that is built with v1 so we keep the v1 around. AWS SDK is designed to support having both version in parallel and has different root-namespace for classes and modules in v1 (AWS) and v2 (Aws).