### PR TITLE
Fix other party author

### DIFF
--- a/app/helpers/transaction_helper.rb
+++ b/app/helpers/transaction_helper.rb
@@ -361,11 +361,11 @@ module TransactionHelper
     end
   end
 
-  def preauthorized_status(conversation)
-    if current_user?(conversation.listing.author)
-      waiting_for_current_user_to_accept_preauthorized(conversation)
+  def preauthorized_status(transaction)
+    if current_user?(transaction.listing.author)
+      waiting_for_current_user_to_accept_preauthorized(transaction)
     else
-      waiting_for_author_to_accept_preauthorized(conversation)
+      waiting_for_author_to_accept_preauthorized(transaction)
     end
   end
 
@@ -432,19 +432,19 @@ module TransactionHelper
     ])
   end
 
-  def waiting_for_current_user_to_accept_preauthorized(conversation)
+  def waiting_for_current_user_to_accept_preauthorized(transaction)
     status_links([
       {
-        link_href: accept_preauthorized_person_message_path(@current_user, :id => conversation.id),
+        link_href: accept_preauthorized_person_message_path(@current_user, :id => transaction.id),
         link_classes: "accept_preauthorized",
         link_icon_with_text_classes: icon_for("accept_preauthorized"),
-        link_text_with_icon: link_text_with_icon(conversation, "accept_preauthorized")
+        link_text_with_icon: link_text_with_icon(transaction, "accept_preauthorized")
       },
       {
-        link_href: reject_preauthorized_person_message_path(@current_user, :id => conversation.id),
+        link_href: reject_preauthorized_person_message_path(@current_user, :id => transaction.id),
         link_classes: "reject_preauthorized",
         link_icon_with_text_classes: icon_for("reject_preauthorized"),
-        link_text_with_icon: link_text_with_icon(conversation, "reject_preauthorized")
+        link_text_with_icon: link_text_with_icon(transaction, "reject_preauthorized")
       }
     ]);
   end
@@ -509,11 +509,11 @@ module TransactionHelper
     status_info(link, icon_classes: 'ss-clock')
   end
 
-  def waiting_for_author_to_accept_preauthorized(conversation)
+  def waiting_for_author_to_accept_preauthorized(transaction)
     text = t("conversations.status.waiting_for_listing_author_to_accept_request",
       :listing_author_name => link_to(
-        conversation.other_party(@current_user).given_name_or_username,
-        conversation.other_party(@current_user)
+        transaction.author.given_name_or_username,
+        transaction.author
       )
     ).html_safe
 

--- a/app/view_utils/transaction_view_utils.rb
+++ b/app/view_utils/transaction_view_utils.rb
@@ -139,7 +139,7 @@ module TransactionViewUtils
 
     message = case state
     when "preauthorized"
-      t("conversations.message.paid", sum: humanized_money_with_symbol(payment_sum))
+      t("conversations.message.payment_preauthorized", sum: humanized_money_with_symbol(payment_sum))
     when "accepted"
       t("conversations.message.accepted_request")
     when "rejected"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -597,6 +597,7 @@ en:
       canceled_request: "canceled the request"
       canceled_offer: "canceled the offer"
       paid: "paid %{sum}"
+      payment_preauthorized: "Payment authorized: %{sum}"
     new:
       offer_message_form_title: "Offer %{listing} to %{person}"
       request_message_form_title: "Request %{listing} from %{person}"

--- a/features/conversations/booking_transaction_process.feature
+++ b/features/conversations/booking_transaction_process.feature
@@ -25,7 +25,7 @@ Feature: Booking transaction process
       And I should see payment details form for Braintree
 
      When I fill in my payment details for Braintree
-     Then I should see that I successfully paid $490
+     Then I should see that I successfully authorized payment $490
       And author "owner" should be notified about the request from starter "booker"
       And I should see that the request is waiting for seller acceptance
 

--- a/features/conversations/preauthorization.feature
+++ b/features/conversations/preauthorization.feature
@@ -26,7 +26,7 @@ Feature: Preauthorized payment
      Then I should see payment details form for Braintree
 
      When I fill in my payment details for Braintree
-     Then I should see that I successfully paid $50
+     Then I should see that I successfully authorized payment $50
       And I should see that the request is waiting for seller acceptance
 
      When I log in as "seller_jane"
@@ -51,7 +51,7 @@ Feature: Preauthorized payment
       And I should see payment details form for Braintree
 
      When I fill in my payment details for Braintree
-     Then I should see that I successfully paid $100
+     Then I should see that I successfully authorized payment $100
       And I should see that the request is waiting for seller acceptance
 
      When I log in as "seller_jane"
@@ -73,7 +73,7 @@ Feature: Preauthorized payment
      Then I should see payment details form for Braintree
 
      When I fill in my payment details for Braintree
-     Then I should see that I successfully paid $50
+     Then I should see that I successfully authorized payment $50
       And I should see that the request is waiting for seller acceptance
 
      When I log in as "seller_jane"
@@ -94,7 +94,7 @@ Feature: Preauthorized payment
      Then I should see payment details form for Braintree
 
      When I fill in my payment details for Braintree
-     Then I should see that I successfully paid $50
+     Then I should see that I successfully authorized payment $50
       And I should see that the request is waiting for seller acceptance
 
      When the seller does not respond the request within 5 days

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -255,6 +255,10 @@ Then /^I should see that I successfully paid (.*?)$/ do |amount|
   page.should have_content("paid #{amount}")
 end
 
+Then /^I should see that I successfully authorized payment (.*?)$/ do |amount|
+  page.should have_content("Payment authorized: #{amount}")
+end
+
 Then /^"(.*?)" should receive email about payment$/ do |receiver|
   email = Person.find_by_username(receiver).confirmed_notification_emails.first.address
   steps %Q{


### PR DESCRIPTION
Admin sees wrong status message in transaction

fix for:
- admin sees wrong person when payment is waiting for author to accept payment
- 'paid' status message was changed to 'payment authorized'