### PR TITLE
Use the native Flowdock Travis integration for build messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,13 @@ env:
     - secure: AquipD3Ru6Xyk2K/mt2jmb/kh0GiAhTpLKlOsg6EdEE4VK/JPJUdbki3K/3jfwmCXZIDVBUfKjG/jt8ui0OKGlcI0ToTu4b9U1ZJ7EuMh2MibcKWb6b5XJlfYXC34jDSM4JSOyuR0ZMi0U1hcT6CJDabs6wSGQrJFiQMRSaDyMg=
     - secure: VObS2Rnc3KgPz3uO50KiWcxXa+QXrbe0HPVVmzd5AUvJuRRvv0dPJZVrgzVLh8L1KfwFemcGz/Px9Ftt6kHqGeQktrb5QypGRgyuNJccFw0Qrqk2oTE0V8eOovixoufG9pRjPGOJMBenf6IKa3+5qBrCpCmdP2je6QHIkpbG4wk=
 notifications:
-  recipients:
-  - main@sharetribe.flowdock.com
-  - main@kassi.flowdock.com
-  - suomi@kassi.flowdock.com
+  flowdock:
+    # Main
+    - secure: FY861NHS112q8iU/meT64mfsPSr0JDx3Q4ElLdECAx+3tm6JTlKwVk35INP/pKG9n2um2LY7olDKovCtr1/FlEg9AjmGbrNSxu2ErGmhqyihj4e2qsCKYE/KioMofw1taQlnWXlOOu7ZKu3AJvauT8C4hkMGWvLtZu2ZVxhoLRM=
+    # DevTeam
+    - secure: ExDcKU91PdTOeNEmO3sewSz4AIB0kdLFK18eetuQdTGgreFxOazgsg7rLdkLSk/c51dydB9BWbD6+TASk91ZIYnN7xDBYsltSw1sd8xS04KI2OxoXj/QFDJYy1wpgjyVtoNhG2iuIlpMdela4S5Q9PwOHat/Tm5771ffc0DhfXI=
+    # Sharetribe.org Developers
+    - secure: UzPNtuYZEjujb4KJhmCyJL5nF1UPs8Z9W1Iofo+l9d9kOTAVrCo9so/b/6CXzkabU2aJ5uPmF+sQ3w/QojaXrcpnYMfO1VRZBJtTwzJYy9Bm0uKrK0JC1BE8B4zEZV8WV8AMKi36dRGnGZd6c0AWkwt6feAKND1q5H8IAbqzDNU=
 # Ensure Bundler >= 1.1, don't install rdocs, and fetch a cached bundle from S3
 before_install:
 - ./travis/before_install.sh


### PR DESCRIPTION
This will e.g. show a red/green icon in the team inbox instead of a generic email icon.