### PR TITLE
Disable email forwarding for SES sender addresses

### DIFF
--- a/app/services/email_service/jobs/request_email_verification.rb
+++ b/app/services/email_service/jobs/request_email_verification.rb
@@ -9,17 +9,28 @@ module EmailService::Jobs
       Maybe(AddressStore.get(community_id: community_id, id: id))
         .each do |address|
         ses_client.verify_address(email: address[:email]).on_success do
+
+          # If the address being verified for the first time...
+          if address[:verification_status] == :none
+            set_notification_topics(address[:email])
+          end
+
           AddressStore.set_verification_requested(community_id: community_id, id: id)
-          set_notification_topics(address[:email])
         end
       end
     end
 
     private
 
+    # Direct bounces and complaints to an SNS topic (configured at
+    # ses_client) and disable them from being forwarded to the sender
+    # email.
     def set_notification_topics(email)
-      ses_client.set_notification_topic(email: email, type: :bounce)
-      ses_client.set_notification_topic(email: email, type: :complaint)
+      ses_client.set_notification_topic(email: email, type: :bounce).on_success do
+        ses_client.set_notification_topic(email: email, type: :complaint).on_success do
+          ses_client.disable_email_forwarding(email: email)
+        end
+      end
     end
 
     def ses_client

--- a/app/services/email_service/ses/client.rb
+++ b/app/services/email_service/ses/client.rb
@@ -88,6 +88,28 @@ module EmailService::SES
       end
     end
 
+    def disable_email_forwarding(email:)
+      if email.blank?
+        raise ArgumentError.new("Missing mandatory value for email parameter.")
+      end
+
+      method_params = {identity: email, forwarding_enabled: false}
+
+      log_request_response(:set_identity_feedback_forwarding_enabled, method_params) do
+        begin
+          response = @ses.set_identity_feedback_forwarding_enabled(method_params)
+          if response.successful?
+            Result::Success.new()
+          else
+            Result::Error.new(response.error)
+          end
+        rescue StandardError => e
+          Result::Error.new(e)
+        end
+      end
+
+    end
+
 
     private
 


### PR DESCRIPTION
To prevent marketplace admins from unnecessarily getting all the bounces
and complaints to their sender address we instead redirect them to a SNS
topic that we handle on their behalf.