### PR TITLE
Remove unused privacy

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -85,9 +85,6 @@ class HomepageController < ApplicationController
     end
 
     @listing_count = @current_community.listings.currently_open.count
-    unless @current_user
-      @private_listing_count = Listing.currently_open.private_to_community(@current_community).count
-    end
 
     filter_params[:search] = params[:q] if params[:q]
     filter_params[:include] = [:listing_images, :author, :category]

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -84,8 +84,6 @@ class HomepageController < ApplicationController
       @selected_category = category
     end
 
-    @listing_count = @current_community.listings.currently_open.count
-
     filter_params[:search] = params[:q] if params[:q]
     filter_params[:include] = [:listing_images, :author, :category]
     filter_params[:custom_dropdown_field_options] = HomepageController.dropdown_field_options_for_search(params)

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -101,7 +101,13 @@ class ListingsController < ApplicationController
   # Used to show multiple listings in one bubble
   def listing_bubble_multiple
     ids = numbers_str_to_array(params[:ids])
-    @listings = Listing.visible_to(@current_user, @current_community, ids).order("id DESC")
+
+    if @current_user || !@current_community.private?
+      @listings = @current_community.listings.where(listings: {id: ids}).order("listings.created_at DESC")
+    else
+      @listings = []
+    end
+
     if @listings.size > 0
       render :partial => "homepage/listing_bubble_multiple"
     else

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -196,10 +196,6 @@ class ListingsController < ApplicationController
       params[:listing].delete("origin_loc_attributes")
     end
 
-    # TODO REMOVE ME!
-    params[:listing][:privacy] = @current_community.private? ? "private" : "public"
-    # TODO REMOVE ME!
-
     shape = get_shape(Maybe(params)[:listing][:listing_shape_id].to_i.or_else(nil))
 
     listing_params = ListingFormViewUtils.filter(params[:listing], shape)
@@ -301,10 +297,6 @@ class ListingsController < ApplicationController
         @listing.origin_loc.delete
       end
     end
-
-    # TODO REMOVE ME!
-    params[:listing][:privacy] = @current_community.private? ? "private" : "public"
-    # TODO REMOVE ME!
 
     shape = get_shape(params[:listing][:listing_shape_id])
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -563,17 +563,15 @@ class ListingsController < ApplicationController
 
   # Ensure that only users with appropriate visibility settings can view the listing
   def ensure_authorized_to_view
-    @listing = Listing.find(params[:id])
+    # If listing is not found (in this community) the find method
+    # will throw ActiveRecord::NotFound exception, which is handled
+    # correctly in production environment (404 page)
+    @listing = @current_community.listings.find(params[:id])
 
     raise ListingDeleted if @listing.deleted?
 
     unless @listing.visible_to?(@current_user, @current_community) || (@current_user && @current_user.has_admin_rights_in?(@current_community))
-      if @listing.public?
-        # This situation occurs when the user tries to access a listing
-        # via a different community url.
-        flash[:error] = t("layouts.notifications.this_content_is_not_available_in_this_community")
-        redirect_to root and return
-      elsif @current_user
+      if @current_user
         flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
         redirect_to root and return
       else

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -190,6 +190,10 @@ class ListingsController < ApplicationController
       params[:listing].delete("origin_loc_attributes")
     end
 
+    # TODO REMOVE ME!
+    params[:listing][:privacy] = @current_community.private? ? "private" : "public"
+    # TODO REMOVE ME!
+
     shape = get_shape(Maybe(params)[:listing][:listing_shape_id].to_i.or_else(nil))
 
     listing_params = ListingFormViewUtils.filter(params[:listing], shape)
@@ -291,6 +295,10 @@ class ListingsController < ApplicationController
         @listing.origin_loc.delete
       end
     end
+
+    # TODO REMOVE ME!
+    params[:listing][:privacy] = @current_community.private? ? "private" : "public"
+    # TODO REMOVE ME!
 
     shape = get_shape(params[:listing][:listing_shape_id])
 

--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -19,10 +19,6 @@ module ListingsHelper
     "inbox_tab_#{current_tab_name.eql?(tab_name) ? 'selected' : 'unselected'}"
   end
 
-  def privacy_array
-    Listing::VALID_PRIVACY_OPTIONS.collect { |option| [t("listings.form.#{option}"), option] }
-  end
-
   def listed_listing_title(listing)
     listing_shape_name = shape_name(listing)
     # TODO remove this hotfix when we have admin ui for translations

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -4,12 +4,12 @@ require 'base64'
 module PeopleHelper
 
   def persons_listings(person, per_page=6, page=1)
+    listings_rel = @current_community.listings.where(author_id: person.id).order("created_at DESC").paginate(:per_page => per_page, :page => page)
+
     if current_user?(person) && params[:show_closed]
-      logger.info "Showing also closed"
-      person.listings.visible_to(@current_user, @current_community).order("created_at DESC").paginate(:per_page => per_page, :page => page)
+      listings_rel
     else
-      logger.info "Showing only open"
-      person.listings.currently_open.visible_to(@current_user, @current_community).order("created_at DESC").paginate(:per_page => per_page, :page => page)
+      listings_rel.currently_open
     end
   end
 

--- a/app/indices/listing_index.rb
+++ b/app/indices/listing_index.rb
@@ -22,7 +22,6 @@ ThinkingSphinx::Index.define :listing, :with => :active_record, :delta => Thinki
   has sort_date
   has category(:id), :as => :category_id
   has listing_shape_id
-  has "privacy = 'public'", :as => :visible_to_everybody, :type => :boolean
   has communities(:id), :as => :community_ids
   has custom_dropdown_field_values.selected_options.id, :as => :custom_dropdown_field_options, :type => :integer, :multi => true
   has custom_checkbox_field_values.selected_options.id, :as => :custom_checkbox_field_options, :type => :integer, :multi => true

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -447,7 +447,6 @@ class Community < ActiveRecord::Base
     selected_listings = listings
       .currently_open
       .where("updates_email_at > ? AND updates_email_at > created_at", latest)
-      .visible_to(person, self)
       .order("updates_email_at DESC")
       .to_a
 
@@ -457,7 +456,6 @@ class Community < ActiveRecord::Base
         listings
           .currently_open
           .where("updates_email_at > ? AND updates_email_at = created_at", latest)
-          .visible_to(person, self)
           .limit(additional_listings)
           .to_a
       else

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -218,9 +218,6 @@ class Listing < ActiveRecord::Base
       #   with[:open] = false
       # end
 
-      unless current_user && current_user.communities.include?(current_community)
-        with[:visible_to_everybody] = true
-      end
       with[:community_ids] = current_community.id
 
       with[:category_id] = params[:categories][:id] if params[:categories].present?

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -104,7 +104,6 @@ class Listing < ActiveRecord::Base
   scope :none, where('1 = 0')
 
   VALID_VISIBILITIES = ["this_community", "all_communities"]
-  VALID_PRIVACY_OPTIONS = ["private", "public"]
 
   before_validation :set_valid_until_time
   before_save :set_community_visibilities

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -93,9 +93,6 @@ class Listing < ActiveRecord::Base
 
   attr_accessor :current_community_id
 
-  scope :public, :conditions  => "privacy = 'public'"
-  scope :private, :conditions  => "privacy = 'private'"
-
   # Create an "empty" relationship. This is needed in search when we want to stop the search chain (NumericFields)
   # and just return empty result.
   #

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -170,7 +170,7 @@ class Listing < ActiveRecord::Base
   end
 
   def self.columns
-    super.reject { |c| c.name == "transaction_type_id" || c.name == "privacy" }
+    super.reject { |c| c.name == "transaction_type_id" }
   end
 
   def self.find_with(params, current_user=nil, current_community=nil, per_page=100, page=1)

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -161,10 +161,6 @@ class Listing < ActiveRecord::Base
     ListingVisibilityGuard.new(self, current_community, current_user).visible?
   end
 
-  def public?
-    self.privacy.eql?("public")
-  end
-
   # sets the time to midnight
   def set_valid_until_time
     if valid_until

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -23,7 +23,6 @@
 #  delta                           :boolean          default(TRUE), not null
 #  open                            :boolean          default(TRUE)
 #  share_type_old                  :string(255)
-#  privacy                         :string(255)      default("private")
 #  comments_count                  :integer          default(0)
 #  subcategory_old                 :string(255)
 #  old_category_id                 :integer
@@ -171,7 +170,7 @@ class Listing < ActiveRecord::Base
   end
 
   def self.columns
-    super.reject { |c| c.name == "transaction_type_id" }
+    super.reject { |c| c.name == "transaction_type_id" || c.name == "privacy" }
   end
 
   def self.find_with(params, current_user=nil, current_community=nil, per_page=100, page=1)

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -165,15 +165,6 @@ class Listing < ActiveRecord::Base
     self.privacy.eql?("public")
   end
 
-  # Get only listings that are restricted only to the members of the current
-  # community (or to many communities including current)
-  def self.private_to_community(community)
-    where("
-      listings.privacy = 'private'
-      AND listings.id IN (SELECT listing_id FROM communities_listings WHERE community_id = '#{community.id}')
-    ")
-  end
-
   # sets the time to midnight
   def set_valid_until_time
     if valid_until

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -145,16 +145,6 @@ class Listing < ActiveRecord::Base
     end
   end
 
-  # Filter out listings that current user cannot see
-  def self.visible_to(current_user, current_community, ids=nil)
-    id_list = ids ? ids : current_community.listings.pluck(:id)
-    if current_user && current_user.member_of?(current_community)
-      where("listings.id IN (?)", id_list)
-    else
-      where("listings.privacy = 'public' AND listings.id IN (?)", id_list)
-    end
-  end
-
   def self.currently_open(status="open")
     status = "open" if status.blank?
     case status
@@ -287,7 +277,7 @@ class Listing < ActiveRecord::Base
       query[:categories] = params[:categories] if params[:categories]
       query[:author_id] = params[:person_id] if params[:person_id]    # this is not yet used with search
       query[:id] = params[:listing_id] if params[:listing_id].present?
-      listings = joins(joined_tables).where(query).currently_open(params[:status]).visible_to(current_user, current_community).includes(params[:include]).order("listings.sort_date DESC").paginate(:per_page => per_page, :page => page)
+      listings = current_community.listings.joins(joined_tables).where(query).currently_open(params[:status]).includes(params[:include]).order("listings.sort_date DESC").paginate(:per_page => per_page, :page => page)
     end
     return listings
   end

--- a/app/services/listing_visibility_guard.rb
+++ b/app/services/listing_visibility_guard.rb
@@ -20,7 +20,7 @@ class ListingVisibilityGuard
     if user_logged_in? && user_member_of_community?
       true
     else
-      public_listing? && public_community?
+      public_community?
     end
   end
 
@@ -40,10 +40,6 @@ class ListingVisibilityGuard
 
   def user_member_of_community?
     @user.communities.include?(@community)
-  end
-
-  def public_listing?
-    @listing.privacy == "public"
   end
 
   def public_community?

--- a/app/views/listings/form/_form_content.haml
+++ b/app/views/listings/form/_form_content.haml
@@ -11,7 +11,6 @@
   = render :partial => "listings/form/googlemap", :locals => { :form => form, :run_js_immediately => run_js_immediately}
   = render :partial => "listings/form/images", :locals => { :form => form, :run_js_immediately => run_js_immediately }
   = render :partial => "listings/form/visibility", :locals => { :form => form }
-  = render :partial => "listings/form/privacy", :locals => { :form => form }
   = render :partial => "listings/form/send_button", :locals => { :form => form }
 
 = render :partial => "listings/help_texts", :collection => ["help_valid_until"], :as => :field

--- a/app/views/listings/form/_privacy.haml
+++ b/app/views/listings/form/_privacy.haml
@@ -1,7 +1,0 @@
-- if @current_community.only_public_listings
-  = form.hidden_field :privacy, :value => "public"
-- elsif @current_community.private
-  = form.hidden_field :privacy, :value => "private"
-- else
-  = form.label :privacy, t(".privacy") + "*", :class => "input"
-  = select("listing", "privacy", privacy_array, {:selected => (@listing.privacy || "public")}, { :class => "full-width" })

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -88,7 +88,7 @@
                 = t(".listing_created_at")
                 = l @listing.created_at, :format => :short_date
 
-    - if @listing.public? && !@current_community.private?
+    - if !@current_community.private?
       .row
         .col-12
           .listing-social

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1522,10 +1522,6 @@ en:
         all_communities: "All my Sharetribe marketplaces"
         this_community: "Only members of %{service_name}"
         visibility: Visibility
-      privacy:
-        privacy: Privacy
-        private: "Private (only signed-in users can see)"
-        public: "Public (visible to non-signed-in users)"
     help_texts:
       help_share_type_title: "Type of the offer or request"
       help_tags_title: Tags

--- a/features/homepage/user_views_homepage.feature
+++ b/features/homepage/user_views_homepage.feature
@@ -12,15 +12,10 @@ Feature: User views homepage
     And there is a listing with title "bike" from "kassi_testperson1" with category "Items" and with listing shape "Selling"
     And that listing is closed
     And there is a listing with title "saw" from "kassi_testperson2" with category "Items" and with listing shape "Requesting"
-    And privacy of that listing is "private"
     When I am on the homepage
     Then I should see "car spare parts"
     And I should not see "bike"
-    And I should not see "saw"
-    When I log in as "kassi_testperson1"
-    Then I should see "saw"
-    And I should see "car spare parts"
-    And I should not see "bike"
+    And I should see "saw"
 
   @javascript
   Scenario: Latest requests on the homepage
@@ -35,53 +30,6 @@ Feature: User views homepage
     And I should not see "offer item"
 
   @javascript
-  Scenario: User browses homepage with requests with visibility settings
-    Given there are following users:
-      | person |
-      | kassi_testperson1 |
-    And there is a listing with title "car spare parts" from "kassi_testperson2" with category "Items" and with listing shape "Requesting"
-    And privacy of that listing is "private"
-    And there is a listing with title "massage" from "kassi_testperson1" with category "Services" and with listing shape "Requesting"
-    And there is a listing with title "place to live" from "kassi_testperson1" with category "Spaces" and with listing shape "Requesting"
-    And visibility of that listing is "all_communities"
-    And privacy of that listing is "private"
-    And I am on the home page page
-    And I should not see "car spare parts"
-    And I should see "massage"
-    And I should not see "place to live"
-    When I log in as "kassi_testperson1"
-    Then I should see "car spare parts"
-    And I should see "massage"
-    And I should see "place to live"
-
-  @javascript
-  @subdomain2
-  Scenario: User browses homepage in a different subdomain
-    Given there are following users:
-       | person |
-       | kassi_testperson1 |
-       | kassi_testperson2 |
-    And there is a listing with title "car spare parts" from "kassi_testperson1" with category "Items" and with listing shape "Requesting"
-    And privacy of that listing is "private"
-    And that listing belongs to community "test"
-    And there is a listing with title "massage" from "kassi_testperson2" with category "Services" and with listing shape "Requesting"
-    And visibility of that listing is "all_communities"
-    And that listing belongs to community "test"
-    And there is a listing with title "saw" from "kassi_testperson2" with category "Items" and with listing shape "Requesting"
-    And visibility of that listing is "all_communities"
-    And privacy of that listing is "private"
-    And that listing belongs to community "test"
-    And that listing is visible to members of community "test2"
-    When I am on the homepage
-    Then I should not see "car spare parts"
-    And I should not see "massage"
-    And I should not see "saw"
-    When I log in as "kassi_testperson2"
-    Then I should not see "car spare parts"
-    And I should not see "massage"
-    And I should see "saw"
-
-  @javascript
   Scenario: User browses homepage when there is no content
     Given there are following users:
        | person |
@@ -94,23 +42,6 @@ Feature: User views homepage
     And I am on the homepage
     Then I should not see "No open item, service or rideshare requests."
     And I should not see "No open item, service or rideshare offers."
-
-  @javascript
-  Scenario: User browses homepage when there are only private listings. He should see blank slates
-    Given there are following users:
-      | person |
-      | kassi_testperson1 |
-    And there is a listing with title "car spare parts" from "kassi_testperson2" with category "Items" and with listing shape "Selling"
-    And privacy of that listing is "private"
-    And there is a listing with title "place to live" with category "Spaces" and with listing shape "Requesting"
-    And privacy of that listing is "private"
-    And I am on the home page page
-    And I should not see "car spare parts"
-    And I should not see "place to live"
-    When there is a listing with title "bike parts" from "kassi_testperson2" with category "Items" and with listing shape "Requesting"
-    And privacy of that listing is "private"
-    And I am on the homepage
-    Then I should not see "bike parts"
 
   @pending
   Scenario: Latest transactions on the homepage

--- a/features/listings/user_browses_listings.feature
+++ b/features/listings/user_browses_listings.feature
@@ -102,28 +102,3 @@ Feature: User browses listings
     And I should not see "saw"
     And I should not see "axe"
     And I should not see "toolbox"
-
-  @javascript @sphinx @no-transaction
-  Scenario: User browses requests with visibility settings
-    Given there are following users:
-      | person |
-      | kassi_testperson1 |
-    And there is a listing with title "car spare parts" from "kassi_testperson2" with category "Items" and with listing shape "Requesting"
-    And privacy of that listing is "private"
-    And there is a listing with title "massage" from "kassi_testperson1" with category "Services" and with listing shape "Requesting"
-    And there is a listing with title "apartment" with category "Spaces" and with listing shape "Requesting"
-    And visibility of that listing is "this_community"
-    And privacy of that listing is "private"
-    And that listing is closed
-    And the Listing indexes are processed
-
-    When I am on the home page
-    When I choose to view only listing shape "Request"
-    Then I should not see "car spare parts"
-    And I should see "massage"
-    And I should not see "apartment"
-    When I log in as "kassi_testperson1"
-    When I choose to view only listing shape "Request"
-    Then I should see "car spare parts"
-    And I should see "massage"
-    And I should not see "apartment"

--- a/features/listings/user_views_a_single_listing.feature
+++ b/features/listings/user_views_a_single_listing.feature
@@ -53,22 +53,7 @@ Feature: User views a single listing
 
   Scenario: User tries to view a listing restricted viewable to community members without logging in
     Given I am not logged in
-    And privacy of that listing is "private"
-    And I am on the home page
-    When I go to the listing page
-    Then I should see "You must sign in to view this content"
-
-  @subdomain2
-  Scenario: User tries to view a listing from another community
-    Given I am not logged in
-    And that listing belongs to community "test"
-    And I am on the home page
-    When I go to the listing page
-    Then I should see "This content is not available."
-
-  Scenario: User belongs to multiple communities, adds listing in one and sees it in another
-    Given I am not logged in
-    And privacy of that listing is "private"
+    And this community is private
     And I am on the home page
     When I go to the listing page
     Then I should see "You must sign in to view this content"

--- a/features/people/user_views_profile_page.feature
+++ b/features/people/user_views_profile_page.feature
@@ -58,31 +58,6 @@ Feature: User views profile page
     And I should see "massage"
 
   @javascript
-  Scenario: User views a profile page with listings with visibility settings
-     Given there are following users:
-       | person |
-       | kassi_testperson1 |
-       | kassi_testperson2 |
-     And there is a listing with title "car spare parts" from "kassi_testperson1" with category "Items" and with listing shape "Selling"
-     And privacy of that listing is "private"
-     And there is a listing with title "massage" from "kassi_testperson1" with category "Services" and with listing shape "Selling services"
-     And there is a listing with title "apartment" from "kassi_testperson1" with category "Spaces" and with listing shape "Requesting"
-     And that listing is closed
-     And I am on the home page
-     And I should not see "car spare parts"
-     When I follow "massage"
-     And I follow "listing-author-link"
-     And I should not see "car spare parts"
-     And I should see "massage"
-     When I log in as "kassi_testperson1"
-     And I follow "listing-author-link"
-     Then I should see "car spare parts"
-     And I should see "massage"
-     And I should not see "apartment"
-     When I follow "Show also closed"
-     Then I should see "apartment"
-
-  @javascript
   Scenario: User views feedback in a profile page
     Given there are following users:
        | person |

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -150,6 +150,11 @@ Given /^community "(.*?)" is private$/ do |community_ident|
   Community.where(ident: community_ident).first.update_attributes({:private => true})
 end
 
+Given /^this community is private$/ do
+  @current_community.private = true
+  @current_community.save!
+end
+
 Given /^community "(.*?)" has following category structure:$/ do |community, categories|
   current_community = Community.where(ident: community).first
   old_category_ids = current_community.categories.collect(&:id)

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -83,7 +83,6 @@ describe ListingsController do
       :created_at => 3.days.ago,
       :sort_date => 3.days.ago,
       :author => @p1,
-      :privacy => "public"
     )
     @l1.communities = [@c1]
 
@@ -98,7 +97,6 @@ describe ListingsController do
       :listing_shape_id => sell_shape[:id],
       :shape_name_tr_key => sell_shape[:name_tr_key],
       :action_button_tr_key => sell_shape[:action_button_tr_key],
-      :privacy => "public"
     ).communities = [@c1]
 
     FactoryGirl.create(
@@ -110,7 +108,6 @@ describe ListingsController do
       :title => "help me",
       :created_at => 12.days.ago,
       :sort_date => 12.days.ago,
-      :privacy => "public"
     ).communities = [@c2]
 
     FactoryGirl.create(
@@ -123,7 +120,6 @@ describe ListingsController do
       :open => false,
       :description => "This should be closed already,
  but nice stuff anyway",
-      :privacy => "public"
     ).communities = [@c1]
 
     @l4 = FactoryGirl.create(
@@ -137,7 +133,6 @@ describe ListingsController do
       :listing_shape_id => request_shape[:id],
       :shape_name_tr_key => request_shape[:name_tr_key],
       :action_button_tr_key => request_shape[:action_button_tr_key],
-      :privacy => "public"
     )
     @l4.communities = [@c1]
     @l4.save!

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -22,7 +22,6 @@
 #  delta                           :boolean          default(TRUE), not null
 #  open                            :boolean          default(TRUE)
 #  share_type_old                  :string(255)
-#  privacy                         :string(255)      default("private")
 #  comments_count                  :integer          default(0)
 #  subcategory_old                 :string(255)
 #  old_category_id                 :integer

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -129,21 +129,12 @@ describe Listing do
 
     it "is visible, if user is not logged in and the listing and community are public" do
       community.update_attribute(:private, false)
-      listing.update_attribute(:privacy, "public")
 
       listing.visible_to?(nil, community).should be_truthy
     end
 
-    it "is not visible, if user is not logged in but the listing is private" do
-      community.update_attribute(:private, false)
-      listing.update_attribute(:privacy, "private")
-
-      listing.visible_to?(nil, community).should be_falsey
-    end
-
     it "is not visible, if user is not logged in but the community is private" do
       community.update_attribute(:private, true)
-      listing.update_attribute(:privacy, "public")
 
       listing.visible_to?(nil, community).should be_falsey
     end


### PR DESCRIPTION
- [X] Listing contains a field called `privacy`. However, in practise, this field is not in use. We use community information to define whether the community is private or not and that info is used to define whether we should show the listing or not.

- [X] Remove `Listing.visible_to`, since it was using the `privacy` column

The `visible_to` did two things: Ensured that only listings with privacy "public" were returned if user was not logged in (useless) and that listing belonged to current community. When `visible_to` was removed it's important to make sure that the community is still the right one.

- [X] Remove unused `@listing_count`
- [X] Remove unused `@private_listing_count`
- [X] Remove tests that were testing the privacy