### PR TITLE
Remove communities from listings

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -2,6 +2,11 @@
 class ListingsController < ApplicationController
   class ListingDeleted < StandardError; end
 
+  # TODO Remove me soon
+  # Gives us access to communities_listings join table
+  class CommunitiesListing < ActiveRecord::Base; end
+  # TODO Remove me soon
+
   include PeopleHelper
 
   # Skip auth token check as current jQuery doesn't provide it automatically
@@ -225,6 +230,9 @@ class ListingsController < ApplicationController
     @listing.author = @current_user
 
     if @listing.save
+      # TODO Remove this soon
+      CommunitiesListing.create!(community_id: @current_community.id, listing_id: @listing.id)
+
       upsert_field_values!(@listing, params[:custom_fields])
 
       listing_image_ids = params[:listing_images].collect { |h| h[:id] }.select { |id| id.present? }

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -222,7 +222,6 @@ class ListingsController < ApplicationController
         transaction_process_id: shape[:transaction_process_id],
         shape_name_tr_key: shape[:name_tr_key],
         action_button_tr_key: shape[:action_button_tr_key],
-        current_community_id: @current_community.id
     ).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
     @listing = Listing.new(listing_params)
@@ -330,7 +329,6 @@ class ListingsController < ApplicationController
       transaction_process_id: shape[:transaction_process_id],
       shape_name_tr_key: shape[:name_tr_key],
       action_button_tr_key: shape[:action_button_tr_key],
-      current_community_id: @current_community.id,
       last_modified: DateTime.now
     ).merge(open_params).merge(unit_to_listing_opts(m_unit)).except(:unit)
 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -124,7 +124,7 @@ class Community < ActiveRecord::Base
   has_many :transactions
   has_many :payments
 
-  has_and_belongs_to_many :listings
+  has_many :listings
 
   has_one :marketplace_settings, dependent: :destroy
   has_one :payment_gateway, :dependent => :destroy

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -15,7 +15,6 @@
 #  updated_at                      :datetime
 #  last_modified                   :datetime
 #  sort_date                       :datetime
-#  visibility                      :string(255)      default("this_community")
 #  listing_type_old                :string(255)
 #  description                     :text
 #  origin                          :string(255)
@@ -98,8 +97,6 @@ class Listing < ActiveRecord::Base
   # http://stackoverflow.com/questions/4877931/how-to-return-an-empty-activerecord-relation
   scope :none, where('1 = 0')
 
-  VALID_VISIBILITIES = ["this_community", "all_communities"]
-
   before_validation :set_valid_until_time
 
   validates_presence_of :author_id
@@ -123,7 +120,6 @@ class Listing < ActiveRecord::Base
     self.description = description.gsub("\r\n","\n") if self.description
   end
   validates_length_of :description, :maximum => 5000, :allow_nil => true
-  validates_inclusion_of :visibility, :in => VALID_VISIBILITIES
   validates_presence_of :category
   validates_inclusion_of :valid_until, :allow_nil => :true, :in => DateTime.now..DateTime.now + 7.months
   validates_numericality_of :price_cents, :only_integer => true, :greater_than_or_equal_to => 0, :message => "price must be numeric", :allow_nil => true
@@ -157,7 +153,7 @@ class Listing < ActiveRecord::Base
   end
 
   def self.columns
-    super.reject { |c| c.name == "transaction_type_id" }
+    super.reject { |c| c.name == "transaction_type_id" || c.name == "visibility"}
   end
 
   def self.find_with(params, current_user=nil, current_community=nil, per_page=100, page=1)

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -91,8 +91,6 @@ class Listing < ActiveRecord::Base
   monetize :shipping_price_cents, allow_nil: true, with_model_currency: :currency
   monetize :shipping_price_additional_cents, allow_nil: true, with_model_currency: :currency
 
-  attr_accessor :current_community_id
-
   # Create an "empty" relationship. This is needed in search when we want to stop the search chain (NumericFields)
   # and just return empty result.
   #

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -83,7 +83,6 @@ class Listing < ActiveRecord::Base
   has_one :destination_loc, :class_name => "Location", :conditions => ['location_type = ?', 'destination_loc'], :dependent => :destroy
   accepts_nested_attributes_for :origin_loc, :destination_loc
 
-  has_and_belongs_to_many :communities
   has_and_belongs_to_many :followers, :class_name => "Person", :join_table => "listing_followers"
 
   belongs_to :category
@@ -104,7 +103,6 @@ class Listing < ActiveRecord::Base
   VALID_VISIBILITIES = ["this_community", "all_communities"]
 
   before_validation :set_valid_until_time
-  before_save :set_community_visibilities
 
   validates_presence_of :author_id
   validates_length_of :title, :in => 2..60, :allow_nil => false
@@ -131,17 +129,6 @@ class Listing < ActiveRecord::Base
   validates_presence_of :category
   validates_inclusion_of :valid_until, :allow_nil => :true, :in => DateTime.now..DateTime.now + 7.months
   validates_numericality_of :price_cents, :only_integer => true, :greater_than_or_equal_to => 0, :message => "price must be numeric", :allow_nil => true
-
-  def set_community_visibilities
-    if current_community_id
-      communities.clear
-      if visibility.eql?("this_community")
-        communities << Community.find(current_community_id)
-      else
-        author.communities.each { |c| communities << c }
-      end
-    end
-  end
 
   def self.currently_open(status="open")
     status = "open" if status.blank?

--- a/app/services/listing_service/store/listing.rb
+++ b/app/services/listing_service/store/listing.rb
@@ -18,8 +18,7 @@ module ListingService::Store::Listing
   # query params
   def where_models(community_id, query)
     ar_query = ListingModel
-      .joins(:communities)
-      .where(communities: {id: community_id})
+      .where(community_id: community_id)
 
     ar_query =
       if query[:open] == true

--- a/app/services/listing_visibility_guard.rb
+++ b/app/services/listing_visibility_guard.rb
@@ -31,7 +31,7 @@ class ListingVisibilityGuard
   end
 
   def listing_belongs_to_community?
-    @community && @listing.communities.include?(@community)
+    @community && @listing.community_id == @community.id
   end
 
   def user_logged_in?

--- a/app/view_utils/paypal_helper.rb
+++ b/app/view_utils/paypal_helper.rb
@@ -96,9 +96,8 @@ module PaypalHelper
       false
     else
       listing_count = Listing
-                      .includes(:communities)
                       .where(
-                        communities: { id: community_id },
+                        community_id: community_id,
                         author_id: user_id,
                         open: true,
                         transaction_process_id: payment_process_ids)

--- a/app/views/listings/form/_form_content.haml
+++ b/app/views/listings/form/_form_content.haml
@@ -10,7 +10,6 @@
   = render :partial => "listings/form/origin", :locals => { :form => form, :origin_loc => @listing.origin_loc }
   = render :partial => "listings/form/googlemap", :locals => { :form => form, :run_js_immediately => run_js_immediately}
   = render :partial => "listings/form/images", :locals => { :form => form, :run_js_immediately => run_js_immediately }
-  = render :partial => "listings/form/visibility", :locals => { :form => form }
   = render :partial => "listings/form/send_button", :locals => { :form => form }
 
 = render :partial => "listings/help_texts", :collection => ["help_valid_until"], :as => :field

--- a/app/views/listings/form/_visibility.haml
+++ b/app/views/listings/form/_visibility.haml
@@ -1,1 +1,0 @@
-= form.hidden_field :visibility, :value => "this_community"

--- a/app/views/listings/index.atom.builder
+++ b/app/views/listings/index.atom.builder
@@ -44,7 +44,6 @@ atom_feed :language => 'en-US', 'xmlns:georss' => 'http://www.georss.org/georss'
 
 
       entry.st :comment_count, listing.comments_count
-      entry.st :visibility, listing.visibility
     end
   end
 end

--- a/app/views/people/_testimonial.haml
+++ b/app/views/people/_testimonial.haml
@@ -9,10 +9,7 @@
     .testimonial-author
       = link_to_unless testimonial.author.deleted?, PersonViewUtils.person_display_name(testimonial.author, @current_community), testimonial.author
       = t("testimonials.testimonial.about_listing")
-      - if listing.visibility.eql?("disabled")
-        &ldquo;#{listing.title}&rdquo;
-      - else
-        = link_to listing.title, listing
+      = link_to listing.title, listing
       = time_ago(testimonial.created_at) + "."
   .testimonial-icon{:class => testimonial.grade > 0.25 ? 'positive' : 'negative'}
     - if testimonial.grade > 0.25

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1516,10 +1516,6 @@ en:
         valid_until: "Expiration date"
       valid_until_radio_buttons:
         for_the_time_being: "For the time being"
-      visibility:
-        all_communities: "All my Sharetribe marketplaces"
-        this_community: "Only members of %{service_name}"
-        visibility: Visibility
       privacy:
         privacy: Privacy
         private: "Private (only signed-in users can see)"

--- a/features/listings/user_creates_a_new_listing.feature
+++ b/features/listings/user_creates_a_new_listing.feature
@@ -71,7 +71,6 @@ Feature: User creates a new listing
       | person |
       | kassi_testperson3 |
     And there is a listing with title "Hammer" from "kassi_testperson3" with category "Items" and with listing shape "Requesting"
-    And visibility of that listing is "all_communities"
     And I am on the homepage
     Then I should see "Hammer"
     When I move to community "test2"

--- a/features/step_definitions/listing_steps.rb
+++ b/features/step_definitions/listing_steps.rb
@@ -66,13 +66,11 @@ Given /^privacy of that listing is "([^"]*)"$/ do |privacy|
 end
 
 Given(/^that listing belongs to community "(.*?)"$/) do |ident|
-  @listing.communities = [Community.where(ident: ident).first]
   @listing.community_id = Community.where(ident: ident).first.id
   @listing.save!
 end
 
 Given /^that listing is visible to members of community "([^"]*)"$/ do |ident|
-  @listing.communities << Community.where(ident: ident).first
   @listing.community_id = Community.where(ident: ident).first.id
   @listing.save!
 end

--- a/features/step_definitions/listing_steps.rb
+++ b/features/step_definitions/listing_steps.rb
@@ -57,10 +57,6 @@ When(/^I set search range for numeric filter "(.*?)" between "(.*?)" and "(.*?)"
   }
 end
 
-Given /^visibility of that listing is "([^"]*)"$/ do |visibility|
-  @listing.update_attribute(:visibility, visibility)
-end
-
 Given /^privacy of that listing is "([^"]*)"$/ do |privacy|
   @listing.update_attribute(:privacy, privacy)
 end

--- a/features/support/listing_helpers.rb
+++ b/features/support/listing_helpers.rb
@@ -11,7 +11,7 @@ module ListingHelpers
       listing_shape_id: shape[:id]
     }
 
-    listing_opts = shape_opts.merge(opts).merge(communities: [community], community_id: community.id)
+    listing_opts = shape_opts.merge(opts).merge(community_id: community.id)
 
     @listing = FactoryGirl.create(:listing, listing_opts)
   end

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -85,7 +85,6 @@ describe ListingsController do
       :author => @p1,
       :community_id => @c1.id,
     )
-    @l1.communities = [@c1]
 
     FactoryGirl.create(
       :listing,
@@ -99,7 +98,7 @@ describe ListingsController do
       :shape_name_tr_key => sell_shape[:name_tr_key],
       :action_button_tr_key => sell_shape[:action_button_tr_key],
       :community_id => @c1.id,
-    ).communities = [@c1]
+    )
 
     FactoryGirl.create(
       :listing,
@@ -111,7 +110,7 @@ describe ListingsController do
       :created_at => 12.days.ago,
       :sort_date => 12.days.ago,
       :community_id => @c2.id,
-    ).communities = [@c2]
+    )
 
     FactoryGirl.create(
       :listing,
@@ -124,7 +123,7 @@ describe ListingsController do
       :description => "This should be closed already,
  but nice stuff anyway",
       :community_id => @c1.id,
-    ).communities = [@c1]
+    )
 
     @l4 = FactoryGirl.create(
       :listing,
@@ -139,7 +138,6 @@ describe ListingsController do
       :action_button_tr_key => request_shape[:action_button_tr_key],
       :community_id => @c1.id,
     )
-    @l4.communities = [@c1]
     @l4.save!
     @l4.update_attribute(:valid_until, 2.days.ago)
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -104,7 +104,6 @@ FactoryGirl.define do
     category { TestHelpers::find_or_build_category("item") }
     valid_until 3.months.from_now
     times_viewed 0
-    visibility "this_community"
     privacy "public"
     listing_shape_id 123
     price Money.new(20, "USD")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -108,9 +108,6 @@ FactoryGirl.define do
     privacy "public"
     listing_shape_id 123
     price Money.new(20, "USD")
-    has_many :communities do |listing|
-      FactoryGirl.build(:community)
-    end
   end
 
   factory :transaction do

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -27,7 +27,6 @@ describe "CommunityMailer" do
           :listing_shape_id => 123,
           :community_id => @c1.id,
           :description => "<b>shiny</b> new hammer, see details at http://en.wikipedia.org/wiki/MC_Hammer")
-      @l2.communities << @c1
 
       @email = CommunityMailer.community_updates(
         @p1,
@@ -76,14 +75,14 @@ describe "CommunityMailer" do
           :created_at => 3.hours.ago,
           :listing_shape_id => 123,
           :community_id => @c1.id,
-          :author => @p1).communities = [@c1]
+          :author => @p1)
       @l2 = FactoryGirl.create(:listing,
           :title => "motorbike",
           :description => "fast!",
           :created_at => 1.hours.ago,
           :listing_shape_id => 123,
           :community_id => @c2.id,
-          :author => @p2).communities = [@c2]
+          :author => @p2)
 
       @p3 = FactoryGirl.create(:person)
       @p3.communities << @c1

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -201,9 +201,9 @@ describe PersonMailer do
   describe "#new_listing_by_followed_person" do
 
     before do
-      @listing = FactoryGirl.create(:listing, listing_shape_id: 123)
+      @community = FactoryGirl.create(:community)
+      @listing = FactoryGirl.create(:listing, listing_shape_id: 123, community_id: @community.id)
       @recipient = FactoryGirl.create(:person)
-      @community = @listing.communities.last
     end
 
     it "should notify of a new listing" do

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -147,8 +147,7 @@ describe Community do
         :created_at => created_at.days.ago,
         :updates_email_at => updates_email_at.days.ago,
         :listing_shape_id => 123,
-        :community_id => @community.id,
-        :communities => [@community])
+        :community_id => @community.id)
     end
 
     before(:each) do

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -14,7 +14,6 @@
 #  updated_at                      :datetime
 #  last_modified                   :datetime
 #  sort_date                       :datetime
-#  visibility                      :string(255)      default("this_community")
 #  listing_type_old                :string(255)
 #  description                     :text
 #  origin                          :string(255)

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -119,7 +119,7 @@ describe Listing do
     let(:community) { FactoryGirl.create(:community, private: true) }
     let(:community2) { FactoryGirl.create(:community) }
     let(:person) { FactoryGirl.create(:person, communities: [community, community2]) }
-    let(:listing) { FactoryGirl.create(:listing, communities: [community], community_id: community.id, listing_shape_id: 123) }
+    let(:listing) { FactoryGirl.create(:listing, community_id: community.id, listing_shape_id: 123) }
 
     it "is not visible, if the listing doesn't belong to the given community" do
       listing.visible_to?(person, community2).should be_falsey

--- a/spec/services/listing_service/api/listings_spec.rb
+++ b/spec/services/listing_service/api/listings_spec.rb
@@ -12,7 +12,7 @@ describe ListingService::API::Listings do
 
   def create_listing(community, opts = {})
     # TODO We should not use models directly like this
-    FactoryGirl.create(:listing, opts.merge(communities: [community]))
+    FactoryGirl.create(:listing, opts.merge(community_id: community.id))
   end
 
   before(:each) do


### PR DESCRIPTION
- Use `listing.community_id`
- Do not use `listing.communities`
- However, save entries to `communities_listings` table, in case this doesn't work and we need to rollback. (So ignore the `TODO Remove this soon` comments. They are there on purpose.)