### PR TITLE
Change Listing search index

### DIFF
--- a/app/indices/listing_index.rb
+++ b/app/indices/listing_index.rb
@@ -22,7 +22,7 @@ ThinkingSphinx::Index.define :listing, :with => :active_record, :delta => Thinki
   has sort_date
   has category(:id), :as => :category_id
   has listing_shape_id
-  has communities(:id), :as => :community_ids
+  has community_id
   has custom_dropdown_field_values.selected_options.id, :as => :custom_dropdown_field_options, :type => :integer, :multi => true
   has custom_checkbox_field_values.selected_options.id, :as => :custom_checkbox_field_options, :type => :integer, :multi => true
 

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -220,7 +220,7 @@ class Listing < ActiveRecord::Base
       #   with[:open] = false
       # end
 
-      with[:community_ids] = current_community.id
+      with[:community_id] = current_community.id
 
       with[:category_id] = params[:categories][:id] if params[:categories].present?
       with[:listing_shape_id] = params[:listing_shapes][:id] if params[:listing_shapes].present?

--- a/features/step_definitions/listing_steps.rb
+++ b/features/step_definitions/listing_steps.rb
@@ -67,10 +67,14 @@ end
 
 Given(/^that listing belongs to community "(.*?)"$/) do |ident|
   @listing.communities = [Community.where(ident: ident).first]
+  @listing.community_id = Community.where(ident: ident).first.id
+  @listing.save!
 end
 
 Given /^that listing is visible to members of community "([^"]*)"$/ do |ident|
   @listing.communities << Community.where(ident: ident).first
+  @listing.community_id = Community.where(ident: ident).first.id
+  @listing.save!
 end
 
 Given /^that listing has a description "(.*?)"$/ do |description|

--- a/features/support/listing_helpers.rb
+++ b/features/support/listing_helpers.rb
@@ -11,7 +11,7 @@ module ListingHelpers
       listing_shape_id: shape[:id]
     }
 
-    listing_opts = shape_opts.merge(opts).merge(communities: [community])
+    listing_opts = shape_opts.merge(opts).merge(communities: [community], community_id: community.id)
 
     @listing = FactoryGirl.create(:listing, listing_opts)
   end

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -83,6 +83,7 @@ describe ListingsController do
       :created_at => 3.days.ago,
       :sort_date => 3.days.ago,
       :author => @p1,
+      :community_id => @c1.id,
     )
     @l1.communities = [@c1]
 
@@ -97,6 +98,7 @@ describe ListingsController do
       :listing_shape_id => sell_shape[:id],
       :shape_name_tr_key => sell_shape[:name_tr_key],
       :action_button_tr_key => sell_shape[:action_button_tr_key],
+      :community_id => @c1.id,
     ).communities = [@c1]
 
     FactoryGirl.create(
@@ -108,6 +110,7 @@ describe ListingsController do
       :title => "help me",
       :created_at => 12.days.ago,
       :sort_date => 12.days.ago,
+      :community_id => @c2.id,
     ).communities = [@c2]
 
     FactoryGirl.create(
@@ -120,6 +123,7 @@ describe ListingsController do
       :open => false,
       :description => "This should be closed already,
  but nice stuff anyway",
+      :community_id => @c1.id,
     ).communities = [@c1]
 
     @l4 = FactoryGirl.create(
@@ -133,6 +137,7 @@ describe ListingsController do
       :listing_shape_id => request_shape[:id],
       :shape_name_tr_key => request_shape[:name_tr_key],
       :action_button_tr_key => request_shape[:action_button_tr_key],
+      :community_id => @c1.id,
     )
     @l4.communities = [@c1]
     @l4.save!

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -25,6 +25,7 @@ describe "CommunityMailer" do
           :created_at => 2.days.ago,
           :updates_email_at => 2.days.ago,
           :listing_shape_id => 123,
+          :community_id => @c1.id,
           :description => "<b>shiny</b> new hammer, see details at http://en.wikipedia.org/wiki/MC_Hammer")
       @l2.communities << @c1
 
@@ -74,12 +75,14 @@ describe "CommunityMailer" do
           :description => "A very nice bike",
           :created_at => 3.hours.ago,
           :listing_shape_id => 123,
+          :community_id => @c1.id,
           :author => @p1).communities = [@c1]
       @l2 = FactoryGirl.create(:listing,
           :title => "motorbike",
           :description => "fast!",
           :created_at => 1.hours.ago,
           :listing_shape_id => 123,
+          :community_id => @c2.id,
           :author => @p2).communities = [@c2]
 
       @p3 = FactoryGirl.create(:person)

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -147,6 +147,7 @@ describe Community do
         :created_at => created_at.days.ago,
         :updates_email_at => updates_email_at.days.ago,
         :listing_shape_id => 123,
+        :community_id => @community.id,
         :communities => [@community])
     end
 

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -119,7 +119,7 @@ describe Listing do
     let(:community) { FactoryGirl.create(:community, private: true) }
     let(:community2) { FactoryGirl.create(:community) }
     let(:person) { FactoryGirl.create(:person, communities: [community, community2]) }
-    let(:listing) { FactoryGirl.create(:listing, communities: [community], listing_shape_id: 123) }
+    let(:listing) { FactoryGirl.create(:listing, communities: [community], community_id: community.id, listing_shape_id: 123) }
 
     it "is not visible, if the listing doesn't belong to the given community" do
       listing.visible_to?(person, community2).should be_falsey


### PR DESCRIPTION
This pull request changes the listing search index so that it uses a single `community_id` instead of multiple community ids.

In addition, test code has been changed so that the tests pass.

All the other code is still using the `listing.communities` relation.

These are the same changes that are in PR #1412 , but I want to deploy the search index changes separately and first make sure that they work. After that, I'll continue with #1412