### PR TITLE
Remove unused `only_public_listings` column.

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -267,7 +267,7 @@ class Community < ActiveRecord::Base
   attr_accessor :terms
 
   def self.columns
-    super.reject { |c| ["redirect_to_domain", "custom_email_from_address"].include?(c.name) }
+    super.reject { |c| ["only_public_listings"].include?(c.name) }
   end
 
   def name(locale)

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -52,7 +52,6 @@
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text
 #  facebook_connect_enabled                   :boolean          default(TRUE)
-#  only_public_listings                       :boolean          default(TRUE)
 #  vat                                        :integer
 #  commission_from_seller                     :integer
 #  minimum_price_cents                        :integer

--- a/db/migrate/20150828094836_remove_only_public_listings_from_communities.rb
+++ b/db/migrate/20150828094836_remove_only_public_listings_from_communities.rb
@@ -1,0 +1,9 @@
+class RemoveOnlyPublicListingsFromCommunities < ActiveRecord::Migration
+  def up
+    remove_column :communities, :only_public_listings
+  end
+
+  def down
+    add_column :communities, :only_public_listings, :boolean, default: true, after: :facebook_connect_enabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150825122606) do
+ActiveRecord::Schema.define(:version => 20150828094836) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -173,7 +173,6 @@ ActiveRecord::Schema.define(:version => 20150825122606) do
     t.string   "service_logo_style",                                       :default => "full-logo"
     t.text     "available_currencies"
     t.boolean  "facebook_connect_enabled",                                 :default => true
-    t.boolean  "only_public_listings",                                     :default => true
     t.integer  "vat"
     t.integer  "commission_from_seller"
     t.integer  "minimum_price_cents"

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -53,7 +53,6 @@
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text
 #  facebook_connect_enabled                   :boolean          default(TRUE)
-#  only_public_listings                       :boolean          default(TRUE)
 #  vat                                        :integer
 #  commission_from_seller                     :integer
 #  minimum_price_cents                        :integer


### PR DESCRIPTION
- `communities.public` is the column that defines whether the community is public or not