### PR TITLE
Improve listings table indices for homepage

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -455,6 +455,7 @@ class Community < ActiveRecord::Base
         listings
           .currently_open
           .where("updates_email_at > ? AND updates_email_at = created_at", latest)
+          .order("updates_email_at DESC")
           .limit(additional_listings)
           .to_a
       else

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -48,13 +48,15 @@
 #
 # Indexes
 #
+#  homepage_query                      (community_id,open,sort_date)
+#  homepage_query_valid_until          (community_id,open,valid_until,sort_date)
 #  index_listings_on_category_id       (old_category_id)
 #  index_listings_on_community_id      (community_id)
 #  index_listings_on_listing_shape_id  (listing_shape_id)
-#  index_listings_on_listing_type      (listing_type_old)
 #  index_listings_on_new_category_id   (category_id)
 #  index_listings_on_open              (open)
-#  index_listings_on_share_type_id     (share_type_id)
+#  person_listings                     (community_id,author_id)
+#  updates_email_listings              (community_id,open,updates_email_at)
 #
 
 class Listing < ActiveRecord::Base

--- a/db/migrate/20150902090425_add_improved_listing_indecies.rb
+++ b/db/migrate/20150902090425_add_improved_listing_indecies.rb
@@ -1,0 +1,16 @@
+class AddImprovedListingIndecies < ActiveRecord::Migration
+  def up
+    add_index "listings", ["community_id", "open", "sort_date"], :name => "homepage_query"
+    add_index "listings", ["community_id", "open", "valid_until", "sort_date"], :name => "homepage_query_valid_until"
+    add_index "listings", ["community_id", "author_id"], :name => "person_listings"
+
+    add_index "listings", ["community_id", "open", "updates_email_at"], :name => "updates_email_listings"
+  end
+
+  def down
+    remove_index "listings", name: "homepage_query"
+    remove_index "listings", name: "homepage_query_valid_until"
+    remove_index "listings", name: "person_listings"
+    remove_index "listings", name: "updates_email_listings"
+  end
+end

--- a/db/migrate/20150902103231_remove_unused_listing_indecies.rb
+++ b/db/migrate/20150902103231_remove_unused_listing_indecies.rb
@@ -1,0 +1,11 @@
+class RemoveUnusedListingIndecies < ActiveRecord::Migration
+  def up
+    remove_index "listings", name: "index_listings_on_listing_type"
+    remove_index "listings", name: "index_listings_on_share_type_id"
+  end
+
+  def down
+    add_index "listings", ["listing_type_old"], :name => "index_listings_on_listing_type"
+    add_index "listings", ["share_type_id"], :name => "index_listings_on_share_type_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150828094836) do
+ActiveRecord::Schema.define(:version => 20150902103231) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -554,12 +554,14 @@ ActiveRecord::Schema.define(:version => 20150828094836) do
   end
 
   add_index "listings", ["category_id"], :name => "index_listings_on_new_category_id"
+  add_index "listings", ["community_id", "author_id"], :name => "person_listings"
+  add_index "listings", ["community_id", "open", "sort_date"], :name => "homepage_query"
+  add_index "listings", ["community_id", "open", "updates_email_at"], :name => "updates_email_listings"
+  add_index "listings", ["community_id", "open", "valid_until", "sort_date"], :name => "homepage_query_valid_until"
   add_index "listings", ["community_id"], :name => "index_listings_on_community_id"
   add_index "listings", ["listing_shape_id"], :name => "index_listings_on_listing_shape_id"
-  add_index "listings", ["listing_type_old"], :name => "index_listings_on_listing_type"
   add_index "listings", ["old_category_id"], :name => "index_listings_on_category_id"
   add_index "listings", ["open"], :name => "index_listings_on_open"
-  add_index "listings", ["share_type_id"], :name => "index_listings_on_share_type_id"
 
   create_table "locations", :force => true do |t|
     t.float    "latitude"

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -47,13 +47,15 @@
 #
 # Indexes
 #
+#  homepage_query                      (community_id,open,sort_date)
+#  homepage_query_valid_until          (community_id,open,valid_until,sort_date)
 #  index_listings_on_category_id       (old_category_id)
 #  index_listings_on_community_id      (community_id)
 #  index_listings_on_listing_shape_id  (listing_shape_id)
-#  index_listings_on_listing_type      (listing_type_old)
 #  index_listings_on_new_category_id   (category_id)
 #  index_listings_on_open              (open)
-#  index_listings_on_share_type_id     (share_type_id)
+#  person_listings                     (community_id,author_id)
+#  updates_email_listings              (community_id,open,updates_email_at)
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Homepage uses the following query for listings:

```sql
SELECT `listings`.* FROM `listings` WHERE `listings`.`community_id` = xxx AND (open = '1' AND (valid_until IS NULL OR valid_until > '2015-09-01 11:54:18')) ORDER BY listings.sort_date DESC LIMIT 24 OFFSET 0;
```

`EXPLAIN` tells that the indecies are not optimal:
```
mysql> EXPLAIN SELECT `listings`.* FROM `listings` WHERE `listings`.`community_id` = 6385 AND (open = '1' AND (valid_until IS NULL OR valid_until > '2015-09-01 11:54:18')) ORDER BY listings.sort_date DESC LIMIT 24 OFFSET 0;
+----+-------------+----------+-------------+-------------------------------------------------------+-------------------------------------------------------+---------+------+------+-----------------------------------------------------------------------------------------------------+
| id | select_type | table    | type        | possible_keys                                         | key                                                   | key_len | ref  | rows | Extra                                                                                               |
+----+-------------+----------+-------------+-------------------------------------------------------+-------------------------------------------------------+---------+------+------+-----------------------------------------------------------------------------------------------------+
|  1 | SIMPLE      | listings | index_merge | index_listings_on_community_id,index_listings_on_open | index_listings_on_community_id,index_listings_on_open | 4,2     | NULL |  252 | Using intersect(index_listings_on_community_id,index_listings_on_open); Using where; Using filesort |
+----+-------------+----------+-------------+-------------------------------------------------------+-------------------------------------------------------+---------+------+------+-----------------------------------------------------------------------------------------------------+
```

Siege result:
Transactions:            152 hits
Transactions:            151 hits

After applying the migration that is included in this PR, `EXPLAIN` gives us a lot nicer result:

```
mysql> EXPLAIN SELECT `listings`.* FROM `listings` WHERE `listings`.`community_id` = xxx AND (open = '1' AND (valid_until IS NULL OR valid_until > '2015-09-01 11:54:18')) ORDER BY listings.sort_date DESC LIMIT 24 OFFSET 0;
+----+-------------+----------+------+----------------+----------------+---------+-------------+------+-------------+
| id | select_type | table    | type | possible_keys  | key            | key_len | ref         | rows | Extra       |
+----+-------------+----------+------+----------------+----------------+---------+-------------+------+-------------+
|  1 | SIMPLE      | listings | ref  | homepage_query | homepage_query | 6       | const,const |  454 | Using where |
+----+-------------+----------+------+----------------+----------------+---------+-------------+------+-------------+
1 row in set (0.00 sec)
```

Siege request are slightly improved:

Siege:
Transactions:            158 hits
Transactions:            154 hits