### PR TITLE
Fix bug in PayPal payment-review state

### DIFF
--- a/app/services/paypal_service/data_types/ipn.rb
+++ b/app/services/paypal_service/data_types/ipn.rb
@@ -269,7 +269,7 @@ module PaypalService
 
         create_payment_review(
           p.merge({
-              authorization_total: to_money(p[:mc_gross_1], p[:mc_currency]),
+              authorization_total: to_money(p[:mc_gross], p[:mc_currency]),
               pending_reason: "payment-review"})) # Normalize the pending reason, it comes as either "paymentreview" or "payment-review"
 
       end

--- a/app/services/paypal_service/data_types/ipn.rb
+++ b/app/services/paypal_service/data_types/ipn.rb
@@ -26,6 +26,21 @@ module PaypalService
         [:order_total, :money, :mandatory]
       )
 
+      PaymentReview = EntityUtils.define_builder(
+        [:type, const_value: :payment_review],
+        [:authorization_date, :mandatory, str_to_time: "%H:%M:%S %b %e, %Y %Z"],
+        [:authorization_expires_date, :mandatory, str_to_time: "%H:%M:%S %b %e, %Y %Z"],
+        [:authorization_id, :string, :mandatory],
+        [:payer_email, :string],
+        [:payer_id, :string, :mandatory],
+        [:receiver_email, :string, :mandatory],
+        [:receiver_id, :string, :mandatory],
+        [:payment_status, :string, :mandatory],
+        [:pending_reason, :string],
+        [:receipt_id, :string],
+        [:authorization_total, :money, :mandatory]
+      )
+
       AuthorizationCreated = EntityUtils.define_builder(
         [:type, const_value: :authorization_created],
         [:authorization_date, :mandatory, str_to_time: "%H:%M:%S %b %e, %Y %Z"],
@@ -146,6 +161,7 @@ module PaypalService
       module_function
 
       def create_order_created(opts); OrderCreated.call(opts) end
+      def create_payment_review(opts); PaymentReview.call(opts) end
       def create_authorization_created(opts); AuthorizationCreated.call(opts) end
       def create_authorization_expired(opts); AuthorizationExpired.call(opts) end
       def create_payment_completed(opts); PaymentCompleted.call(opts) end
@@ -164,6 +180,8 @@ module PaypalService
         case type
         when :order_created
           to_order_created(p)
+        when :payment_review
+          to_payment_review(p)
         when :authorization_created
           to_authorization_created(p)
         when :authorization_expired
@@ -202,6 +220,8 @@ module PaypalService
           return :billing_agreement_created
         elsif status == "pending" && reason == "order"
           return :order_created
+        elsif status == "pending" && (reason == "paymentreview" || reason == "payment-review")
+          return :payment_review
         elsif status == "pending" && reason == "authorization"
           return :authorization_created
         elsif status == "expired"
@@ -237,6 +257,22 @@ module PaypalService
         create_order_created(p.merge({order_total: to_money(p[:mc_gross], p[:mc_currency])}))
       end
       private_class_method :to_order_created
+
+      def to_payment_review(params)
+        p = HashUtils.rename_keys(
+          {
+            txn_id: :authorization_id,
+            payment_date: :authorization_date,
+            auth_exp: :authorization_expires_date
+          },
+          params)
+
+        create_payment_review(
+          p.merge({
+              authorization_total: to_money(p[:mc_gross_1], p[:mc_currency]),
+              pending_reason: "payment-review"})) # Normalize the pending reason, it comes as either "paymentreview" or "payment-review"
+
+      end
 
       def to_authorization_created(params)
         p = HashUtils.rename_keys(

--- a/app/services/paypal_service/ipn.rb
+++ b/app/services/paypal_service/ipn.rb
@@ -9,6 +9,7 @@ module PaypalService
 
     PAYMENT_ROW_UPDATE_TYPES = [
       :order_created,
+      :payment_review,
       :authorization_created,
       :authorization_expired,
       :payment_completed,

--- a/app/services/paypal_service/store/paypal_payment.rb
+++ b/app/services/paypal_service/store/paypal_payment.rb
@@ -185,8 +185,10 @@ module PaypalService::Store::PaypalPayment
       :none
     elsif(reason.is_a? Symbol)
       reason
+    elsif(reason == "payment-review") # Canonical version of payment-review status is with dash
+      reason.downcase.to_sym
     else
-      reason.downcase.gsub(/[-_]/, "").to_sym
+      reason.downcase.gsub(/[-_]/, "").to_sym # Normalize dashes and underscores away
     end
   end
 

--- a/spec/services/paypal_service/api/payments_spec.rb
+++ b/spec/services/paypal_service/api/payments_spec.rb
@@ -484,7 +484,7 @@ describe PaypalService::API::Payments do
 
   context "#retry_and_clean_tokens" do
     it "retries payment and completes if payment now authorized" do
-      token = @payments.request(@cid, @req_info)[:data]
+      @payments.request(@cid, @req_info)[:data]
 
       @payments.retry_and_clean_tokens(1.hour.ago)
 
@@ -495,7 +495,7 @@ describe PaypalService::API::Payments do
     end
 
     it "leaves token in place if op fails but clean time limit not reached" do
-      token = @payments.request(@cid, @req_info.merge({item_name: "payment-not-initiated"}))[:data]
+      @payments.request(@cid, @req_info.merge({item_name: "payment-not-initiated"}))[:data]
 
       @payments.retry_and_clean_tokens(1.hour.ago)
 
@@ -504,7 +504,7 @@ describe PaypalService::API::Payments do
     end
 
     it "removes token if op fails and clean time limit reached" do
-      token = @payments.request(@cid, @req_info.merge({item_name: "payment-not-initiated"}))[:data]
+      @payments.request(@cid, @req_info.merge({item_name: "payment-not-initiated"}))[:data]
 
       @payments.retry_and_clean_tokens(1.hour.from_now)
 
@@ -513,7 +513,7 @@ describe PaypalService::API::Payments do
     end
 
     it "doesn't remove token when op fails, clean time limit reached but payment in :payment-review state" do
-      token = @payments.request(@cid, @req_info_auth.merge({item_name: "require-payment-review"}))[:data]
+      @payments.request(@cid, @req_info_auth.merge({item_name: "require-payment-review"}))[:data]
 
       @payments.retry_and_clean_tokens(1.hour.from_now)
 

--- a/spec/services/paypal_service/data_types/ipn_spec.rb
+++ b/spec/services/paypal_service/data_types/ipn_spec.rb
@@ -59,6 +59,61 @@ describe PaypalService::DataTypes::IPN do
     "ipn_track_id"=>"d9520dcb18f6"
   }
 
+  payment_review = {
+    mc_gross: "15410.35",
+    invoice: "3876-81783-payment",
+    auth_exp: "11:20:48 Sep 28, 2015 PDT",
+    protection_eligibility: "Ineligible",
+    address_status: "confirmed",
+    item_number1: "",
+    payer_id: "MGGGS735KYJBJ",
+    tax: "0.00",
+    address_street: "14027 caminito vistana",
+    payment_date: "11:20:48 Aug 29, 2015 PDT",
+    payment_status: "Pending",
+    charset: "windows-1252",
+    address_zip: "92130",
+    mc_shipping: "59.95",
+    mc_handling: "0.00",
+    first_name: "James",
+    transaction_entity: "auth",
+    address_country_code: "US",
+    address_name: "James parker",
+    notify_version: "3.8",
+    custom: "",
+    payer_status: "unverified",
+    address_country: "United States",
+    num_cart_items: "1",
+    mc_handling1: "0.00",
+    address_city: "san diego",
+    verify_sign: "AZM038rWDSJ1dQw5ivqZtXm6LwBAAH5-bdfWUdc.afN69knyHl1DzW.n",
+    payer_email: "jparkerc@aol.com",
+    mc_shipping1: "0.00",
+    tax1: "0.00",
+    parent_txn_id: "",
+    txn_id: "1LK038829V247181R",
+    payment_type: "instant",
+    remaining_settle: "10",
+    auth_id: "1LK038829V247181R",
+    last_name: "parker",
+    address_state: "CA",
+    item_name1: "TIGER TURF Diamond Pro 80 oz. BEST PRODUCT",
+    receiver_email: "projectnewgreen@gmail.com",
+    auth_amount: "15410.35",
+    quantity1: "4160",
+    receiver_id: "QL2DC7NDULU9U",
+    pending_reason: "paymentreview",
+    txn_type: "cart",
+    mc_gross_1: "15350.40",
+    mc_currency: "USD",
+    residence_country: "US",
+    receipt_id: "1546-0244-6643-5772",
+    transaction_subject: "",
+    payment_gross: "15410.35",
+    auth_status: "Pending",
+    ipn_track_id: "73c905ac220b8"
+  }
+
   auth_created = {
     "mc_gross"=>"1.20",
     "auth_exp"=>"23:50:00 Oct 03, 2014 PDT",
@@ -713,6 +768,7 @@ describe PaypalService::DataTypes::IPN do
       [billing_agreement_created, :billing_agreement_created],
       [payment_refunded, :payment_refunded],
       [order_created, :order_created],
+      [payment_review, :payment_review],
       [auth_created, :authorization_created],
       [auth_created_no_order, :authorization_created],
       [payment_completed, :payment_completed],
@@ -748,5 +804,11 @@ describe PaypalService::DataTypes::IPN do
     ipn_msg = PaypalService::DataTypes::IPN.from_params(authorization_expired_no_order)
 
     expect(ipn_msg[:order_id]).to be_nil
+  end
+
+  it "#from_params - normalizes pending reason status for payment-review" do
+    ipn_msg = PaypalService::DataTypes::IPN.from_params(payment_review)
+
+    expect(ipn_msg[:pending_reason]).to eq("payment-review")
   end
 end


### PR DESCRIPTION
Fixes two bugs in PayPal logic:
1. Add missing handling for PayPal payment-review IPN message. This is in practise a no-op message since we already know the payment state from synchronous response but previously it was handled incorrectly as pending ext message causing state to be overridden in DB.
2. Ensure that throughout the chain we use canonical storing for pending reason "payment-review", (with the dash). IPN messages send the information without dash but synchronous responses return it with dash.

Together these two bugs led to transactions been marked deleted when they should have been in payment-review state that normally prevents deleting the tokens. It also led to state change to authorized been ignored, i.e. when payment review passes we didn't notice.