### PR TITLE
SEO friendly listing URLs

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -8,6 +8,7 @@ class HomepageController < ApplicationController
 
   ListingItem = Struct.new(
     :id,
+    :url,
     :title,
     :category_id,
     :latitude,
@@ -209,6 +210,7 @@ class HomepageController < ApplicationController
 
         ListingItem.new(
           l[:id],
+          l[:url],
           l[:title],
           l[:category_id],
           l[:latitude],

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -1,10 +1,10 @@
 - frontpage_fragment_cache("list_item", listing) do
   .home-list-item
     - if listing.listing_images.size > 0
-      = link_to listing_path(listing.id), :class => "home-list-image-container-desktop" do
+      = link_to listing_path(listing.url), :class => "home-list-image-container-desktop" do
         = image_tag listing.listing_images.first[:small_3x2], {:alt => listed_listing_title(listing), :class => "home-list-image"}
     - if listing.listing_images.size > 0
-      = link_to listing_path(listing.id), :class => "home-list-image-container-mobile" do
+      = link_to listing_path(listing.url), :class => "home-list-image-container-mobile" do
         = image_tag listing.listing_images.first[:thumb], {:alt => listed_listing_title(listing), :class => "home-list-image"}
     .home-list-details-right
       .home-list-price
@@ -26,7 +26,7 @@
 
     %div{:class => (listing.listing_images.size > 0 ? "home-list-details-with-image" : "")}
       %h2.home-list-title
-        = link_to listing_path(listing.id) do
+        = link_to listing_path(listing.url) do
           = listing.title
           - if @current_community.show_category_in_listing_list
             %a.home-share-type-link{:href => root_path(:transaction_type => shape_name_map[listing.listing_shape_id], :view => :list)}

--- a/app/views/layouts/_grid_item_listing_image.haml
+++ b/app/views/layouts/_grid_item_listing_image.haml
@@ -7,7 +7,7 @@
   - Listing price
   - Adds `modifier_class` which can be used for view specific fine tunings
 
-= link_to(listing_path(listing.id), :class => "#{modifier_class} fluid-thumbnail-grid-image-item-link") do
+= link_to(listing_path(listing.url), :class => "#{modifier_class} fluid-thumbnail-grid-image-item-link") do
   .fluid-thumbnail-grid-image-image-container{:class => "#{modifier_class}"}
     - with_first_listing_image(listing) do |first_image_url|
       = image_tag first_image_url, {:alt => listed_listing_title(listing), :class => "#{modifier_class} fluid-thumbnail-grid-image-image"}


### PR DESCRIPTION
The latest changes to the listing rendering removed the SEO friendly URLs to listings. This PR will bring them back.