### PR TITLE
When trying to access a closed listing, tell the user it's closed

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -571,7 +571,11 @@ class ListingsController < ApplicationController
 
     unless @listing.visible_to?(@current_user, @current_community) || (@current_user && @current_user.has_admin_rights_in?(@current_community))
       if @current_user
-        flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
+        if @listing.closed?
+          flash[:error] = t("layouts.notifications.listing_closed")
+        else
+          flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
+        end
         redirect_to root and return
       else
         session[:return_to] = request.fullpath

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1355,6 +1355,7 @@ en:
       you_are_not_allowed_to_give_feedback_on_this_transaction: "You are not authorized to give feedback on this event"
       you_are_not_authorized_to_do_this: "You are not authorized to do this"
       you_are_not_authorized_to_view_this_content: "You are not authorized to view this content"
+      listing_closed: "This listing has been closed"
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       you_cannot_reply_to_a_closed_offer: "You cannot reply to a closed offer"
       you_cannot_reply_to_a_closed_request: "You cannot reply to a closed request"


### PR DESCRIPTION
Users used to see a generic "not authorized to view this content" error. Replace it with "This listing has been closed" if that's the case.