### PR TITLE
Use ListingIndexService on People#show and add SEO urls

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -6,42 +6,6 @@ class HomepageController < ApplicationController
   APP_DEFAULT_VIEW_TYPE = "grid"
   VIEW_TYPES = ["grid", "list", "map"]
 
-  ListingItem = Struct.new(
-    :id,
-    :title,
-    :category_id,
-    :latitude,
-    :longitude,
-    :author,
-    :description,
-    :listing_images,
-    :price,
-    :unit_tr_key,
-    :unit_type,
-    :quantity,
-    :shape_name_tr_key,
-    :listing_shape_id,
-    :icon_name)
-
-  Author = Struct.new(
-    :id,
-    :username,
-    :first_name,
-    :last_name,
-    :organization_name,
-    :is_organization,
-    :avatar,
-    :is_deleted,
-    :num_of_reviews)
-
-  Price = Struct.new(
-    :price_cents,
-    :currency)
-
-  ListingImage = Struct.new(
-    :thumb,
-    :small_3x2)
-
   def index
     @homepage = true
 
@@ -179,58 +143,13 @@ class HomepageController < ApplicationController
     }
 
     ListingIndexService::API::Api.listings.search(community_id: @current_community.id, search: search, includes: includes).and_then { |res|
-      listings = res[:listings].map { |l|
-        author =
-          if includes.include?(:author)
-            Author.new(
-              l[:author][:id],
-              l[:author][:username],
-              l[:author][:first_name],
-              l[:author][:last_name],
-              l[:author][:organization_name],
-              l[:author][:is_organization],
-              ListingImage.new(
-                l[:author][:avatar][:thumb]
-              ),
-              l[:author][:is_deleted],
-              l[:author][:num_of_reviews]
-            )
-          else
-            nil
-          end
-
-        listing_images =
-          if includes.include?(:listing_images)
-            l[:listing_images].map { |li|
-              ListingImage.new(li[:thumb], li[:small_3x2]) }
-          else
-            []
-          end
-
-        ListingItem.new(
-          l[:id],
-          l[:title],
-          l[:category_id],
-          l[:latitude],
-          l[:longitude],
-          author,
-          l[:description],
-          listing_images,
-          l[:price],
-          l[:unit_tr_key],
-          l[:unit_type],
-          l[:quantity],
-          l[:shape_name_tr_key],
-          l[:listing_shape_id],
-          l[:icon_name]
-        )
-      }
-
-      paginated = WillPaginate::Collection.create(params[:page] || 1, listings_per_page, res[:count]) do |pager|
-        pager.replace(listings)
-      end
-
-      Result::Success.new(paginated)
+      Result::Success.new(
+        ListingIndexViewUtils.to_struct(
+        result: res,
+        includes: includes,
+        page: search[:page],
+        per_page: search[:per_page]
+      ))
     }
   end
 

--- a/app/helpers/homepage_helper.rb
+++ b/app/helpers/homepage_helper.rb
@@ -6,22 +6,11 @@ module HomepageHelper
   end
 
   def with_first_listing_image(listing, &block)
-    if listing.listing_images.size > 0
-      first_image = listing.listing_images.first
-
-      url =
-        if first_image.respond_to?(:image_ready?)
-          if first_image.image_ready?
-            first_image.image.url(:small_3x2)
-          else
-            nil
-          end
-        else
-          first_image[:small_3x2]
-        end
-
-      block.call(url) if url
-    end
+    Maybe(listing)
+      .listing_images
+      .map { |images| images.first }[:small_3x2].each { |url|
+      block.call(url)
+    }
   end
 
   def without_listing_image(listing, &block)

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -3,16 +3,6 @@ require 'base64'
 
 module PeopleHelper
 
-  def persons_listings(person, per_page=6, page=1)
-    listings_rel = @current_community.listings.where(author_id: person.id).order("created_at DESC").paginate(:per_page => per_page, :page => page)
-
-    if current_user?(person) && params[:show_closed]
-      listings_rel
-    else
-      listings_rel.currently_open
-    end
-  end
-
   def grade_image_class(grade)
     "feedback_average_image_#{grade_number(grade).to_s}"
   end

--- a/app/services/listing_index_service/data_types.rb
+++ b/app/services/listing_index_service/data_types.rb
@@ -19,7 +19,9 @@ module ListingIndexService::DataTypes
     [:categories, :array, :optional],
     [:listing_shape_id, :fixnum, :optional],
     [:price_cents, :range, :optional],
-    [:fields, :array, default: []]
+    [:fields, :array, default: []],
+    [:author_id, :string],
+    [:include_closed, :to_bool, default: false]
   )
 
   AvatarImage = EntityUtils.define_builder(

--- a/app/services/listing_index_service/search/sphinx_adapter.rb
+++ b/app/services/listing_index_service/search/sphinx_adapter.rb
@@ -16,7 +16,7 @@ module ListingIndexService::Search
       included_models = includes.map { |m| INCLUDE_MAP[m] }
 
       if needs_db_query?(search) && needs_search?(search)
-        raise ArgumentError.new("Both DB query and search engine would be needed to full fill the search")
+        raise ArgumentError.new("Both DB query and search engine would be needed to fulfill the search")
       end
 
       result =

--- a/app/services/listing_index_service/search/sphinx_adapter.rb
+++ b/app/services/listing_index_service/search/sphinx_adapter.rb
@@ -85,7 +85,6 @@ module ListingIndexService::Search
             listing_shape_id: search[:listing_shape_id],
             price_cents: search[:price_cents],
             listing_id: numeric_search_match_listing_ids,
-            author_id: search[:author_id]
           })
 
         selection_groups = search[:fields].select { |v| v[:type] == :selection_group }

--- a/app/services/listing_index_service/search/sphinx_adapter.rb
+++ b/app/services/listing_index_service/search/sphinx_adapter.rb
@@ -15,6 +15,10 @@ module ListingIndexService::Search
     def search(community_id:, search:, includes:)
       included_models = includes.map { |m| INCLUDE_MAP[m] }
 
+      if needs_db_query?(search) && needs_search?(search)
+        raise ArgumentError.new("Both DB query and search engine would be needed to full fill the search")
+      end
+
       result =
         if needs_search?(search)
           if search_out_of_bounds?(search[:per_page], search[:page])
@@ -32,14 +36,26 @@ module ListingIndexService::Search
     private
 
     def fetch_from_db(community_id:, search:, included_models:)
-      models = Listing
-        .where(community_id: community_id)
+      where_opts = HashUtils.compact(
+        {
+          community_id: community_id,
+          author_id: search[:author_id]
+        })
+
+      query = Listing
+        .where(where_opts)
         .includes(included_models)
-        .currently_open("open")
         .order("listings.sort_date DESC")
         .paginate(per_page: search[:per_page], page: search[:page])
 
-      {count: models.total_entries, listings: models}
+      with_open =
+        if search[:include_closed]
+          query
+        else
+          query.currently_open
+        end
+
+      {count: with_open.total_entries, listings: with_open}
     end
 
     def search_with_sphinx(community_id:, search:, included_models:)
@@ -69,6 +85,7 @@ module ListingIndexService::Search
             listing_shape_id: search[:listing_shape_id],
             price_cents: search[:price_cents],
             listing_id: numeric_search_match_listing_ids,
+            author_id: search[:author_id]
           })
 
         selection_groups = search[:fields].select { |v| v[:type] == :selection_group }
@@ -183,12 +200,17 @@ module ListingIndexService::Search
       page > pages.ceil
     end
 
+    def needs_db_query?(search)
+      search[:author_id].present? || search[:include_closed] == true
+    end
+
     def needs_search?(search)
-      search[:keywords].present? ||
-        search[:listing_shape_id].present? ||
-        search[:categories].present? ||
-        search[:fields].present? ||
-        search[:price_cents].present?
+      [
+        :keywords,
+        :listing_shape_id,
+        :categories, :fields,
+        :price_cents
+      ].any? { |field| search[field].present? }
     end
 
     def selection_groups(groups)

--- a/app/view_utils/listing_index_view_utils.rb
+++ b/app/view_utils/listing_index_view_utils.rb
@@ -1,0 +1,95 @@
+module ListingIndexViewUtils
+
+  ListingItem = Struct.new(
+    :id,
+    :url,
+    :title,
+    :category_id,
+    :latitude,
+    :longitude,
+    :author,
+    :description,
+    :listing_images,
+    :price,
+    :unit_tr_key,
+    :unit_type,
+    :quantity,
+    :shape_name_tr_key,
+    :listing_shape_id,
+    :icon_name)
+
+  Author = Struct.new(
+    :id,
+    :username,
+    :first_name,
+    :last_name,
+    :organization_name,
+    :is_organization,
+    :avatar,
+    :is_deleted,
+    :num_of_reviews)
+
+  Price = Struct.new(
+    :price_cents,
+    :currency)
+
+  ListingImage = Struct.new(
+    :thumb,
+    :small_3x2)
+
+  module_function
+
+  def to_struct(result:, includes:, per_page:, page:)
+    listings = result[:listings].map { |l|
+      author =
+        if includes.include?(:author)
+          Author.new(
+            l[:author][:id],
+            l[:author][:username],
+            l[:author][:first_name],
+            l[:author][:last_name],
+            l[:author][:organization_name],
+            l[:author][:is_organization],
+            ListingImage.new(
+              l[:author][:avatar][:thumb]
+            ),
+            l[:author][:is_deleted],
+            l[:author][:num_of_reviews]
+          )
+        else
+          nil
+        end
+
+      listing_images =
+        if includes.include?(:listing_images)
+          l[:listing_images].map { |li|
+            ListingImage.new(li[:thumb], li[:small_3x2]) }
+        else
+          []
+        end
+
+      ListingItem.new(
+        l[:id],
+        l[:url],
+        l[:title],
+        l[:category_id],
+        l[:latitude],
+        l[:longitude],
+        author,
+        l[:description],
+        listing_images,
+        l[:price],
+        l[:unit_tr_key],
+        l[:unit_type],
+        l[:quantity],
+        l[:shape_name_tr_key],
+        l[:listing_shape_id],
+        l[:icon_name]
+      )
+    }
+
+    paginated = WillPaginate::Collection.create(page, per_page, result[:count]) do |pager|
+      pager.replace(listings)
+    end
+  end
+end

--- a/app/views/listings/_profile_listings.haml
+++ b/app/views/listings/_profile_listings.haml
@@ -1,9 +1,8 @@
-- listings = persons_listings(@person, limit)
 .people-fluid-thumbnail-grid-container
   .people-fluid-thumbnail-grid#profile-listings-list
     = render :partial => "people/grid_item", :collection => listings, :as => :listing
 
-- if listings.count > limit
+- if listings.total_entries > limit
   .people-load-more-listings-container
     #load-more-listings
       - if current_user?(@person) && params[:show_closed]

--- a/app/views/people/show.haml
+++ b/app/views/people/show.haml
@@ -26,11 +26,11 @@
 
     .row
       %h2.people-header
-        - if @listings.count > 0
+        - if listings.total_entries > 0
           - if current_user?(@person) && params[:show_closed]
-            = pluralize(@listings.count, t(".listing"), t(".listings"))
+            = pluralize(listings.total_entries, t(".listing"), t(".listings"))
           - else
-            = pluralize(@listings.count, t(".open_listing"), t(".open_listings"))
+            = pluralize(listings.total_entries, t(".open_listing"), t(".open_listings"))
         - else
           - if current_user?(@person) && params[:show_closed]
             = t(".no_listings")
@@ -45,11 +45,11 @@
 
     #profile-listings-list
       - limit = 6
-      = render :partial => 'listings/profile_listings', :locals => {:person => @person, :limit => limit}
+      = render :partial => 'listings/profile_listings', :locals => {person: @person, limit: limit, listings: listings}
 
     - if @current_community.follow_in_use?
       = render :partial => "followed_people", :locals => { :person => @person, :limit => 6 }
-      
+
     - if @current_community.testimonials_in_use
       #people-testimonials.listing-main
         .row


### PR DESCRIPTION
- Previous changes dropped the SEO friendly URLs (id + title). This PR will bring them back.
- People#show now uses the ListingIndexService. Because of this change now both homepage and profile page are using the same format for listings (structs). This way we can continue reusing the `grid_item.haml` that is also used in Homepage. 
- Now that ListingIndexService is used in many places, add a new ListingIndexViewUtils which takes care of transforming the ListingIndexService results (hash) to structs.
- Clean up `with_first_listing_image` helper. Now that it receives only one form of data (structs only, no models anymore) we can get rid of the smelly `respond_to`