### PR TITLE
Usability improvement test: Separate link for PayPal help popup

### DIFF
--- a/app/assets/stylesheets/views/_listings.css.scss
+++ b/app/assets/stylesheets/views/_listings.css.scss
@@ -198,3 +198,7 @@ $listing-author-avatar-height: 108;
   width: 20px;
   color: $link;
 }
+
+.listings-how-paypal-works-link {
+  font-size: em(14);
+}

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -8,7 +8,8 @@ module FeatureFlagService::Store
       [:features, :mandatory, :set])
 
     FLAGS = [
-      :location_search
+      :location_search,
+      :how_paypal_works_text_link
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/views/listing_conversations/_paypal_payment_methods.haml
+++ b/app/views/listing_conversations/_paypal_payment_methods.haml
@@ -1,6 +1,22 @@
 - how_paypal_works_link = "https://www.paypal.com/webapps/mpp/paypal-popup"
-%a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
+
+- content_for(:paypal_credit_card_icons) do
   = image_tag "https://www.paypalobjects.com/webstatic/en_US/i/buttons/cc-badges-ppmcvdam.png", style: "max-width: 100%"
+
+
+- if feature_enabled?(:how_paypal_works_text_link)
+  = content_for(:paypal_credit_card_icons)
+
+%a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
+
+  - if feature_enabled?(:how_paypal_works_text_link)
+    %br/
+    %span.listings-how-paypal-works-link
+      = t("listings.listing_actions.learn_more_how_paypal_works")
+
+  - else
+    = content_for(:paypal_credit_card_icons)
+
   - content_for :extra_javascript do
     :javascript
       $("#how-paypal-works-popup-link").click(function() {

--- a/app/views/listing_conversations/_paypal_payment_methods.haml
+++ b/app/views/listing_conversations/_paypal_payment_methods.haml
@@ -12,7 +12,7 @@
   - if feature_enabled?(:how_paypal_works_text_link)
     %br/
     %span.listings-how-paypal-works-link
-      = t("listings.listing_actions.learn_more_how_paypal_works")
+      = t("listings.listing_actions.payment_help")
 
   - else
     = content_for(:paypal_credit_card_icons)

--- a/app/views/listing_conversations/_paypal_payment_methods.haml
+++ b/app/views/listing_conversations/_paypal_payment_methods.haml
@@ -3,27 +3,24 @@
 - content_for(:paypal_credit_card_icons) do
   = image_tag "https://www.paypalobjects.com/webstatic/en_US/i/buttons/cc-badges-ppmcvdam.png", style: "max-width: 100%"
 
-
 - if feature_enabled?(:how_paypal_works_text_link)
   = content_for(:paypal_credit_card_icons)
-
-%a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
-
-  - if feature_enabled?(:how_paypal_works_text_link)
-    %br/
+  %br/
+  %a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
     %span.listings-how-paypal-works-link
       = t("listings.listing_actions.payment_help")
 
-  - else
+- else
+  %a#how-paypal-works-popup-link{title: t("listings.listing_actions.how_paypal_works"), href: how_paypal_works_link}
     = content_for(:paypal_credit_card_icons)
 
-  - content_for :extra_javascript do
-    :javascript
-      $("#how-paypal-works-popup-link").click(function() {
-        window.open(
-          '#{how_paypal_works_link}',
-          'WIPaypal',
-          'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700'
-        );
-        return false;
-      });
+- content_for :extra_javascript do
+  :javascript
+    $("#how-paypal-works-popup-link").click(function() {
+      window.open(
+        '#{how_paypal_works_link}',
+        'WIPaypal',
+        'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700'
+      );
+      return false;
+    });

--- a/config/locales/unreleased_features/en.yml
+++ b/config/locales/unreleased_features/en.yml
@@ -1,4 +1,4 @@
 en:
   listings:
     listing_actions:
-      learn_more_how_paypal_works: Learn more how PayPal works
+      payment_help: Payment help

--- a/config/locales/unreleased_features/en.yml
+++ b/config/locales/unreleased_features/en.yml
@@ -1,1 +1,4 @@
 en:
+  listings:
+    listing_actions:
+      learn_more_how_paypal_works: Learn more how PayPal works


### PR DESCRIPTION
Some people have reported that it's confusing that pressing the credit card icons open a new PayPal popup, which actually is only a help popup, not for the payment.

This Pull Request adds a separate link text under the credit card icons that will open the popup. The link is removed from the credit card icons.

The feature is behind feature flag, so that we can test it first in one marketplace.

Before:

<img width="347" alt="screen shot 2015-09-18 at 09 17 46" src="https://cloud.githubusercontent.com/assets/429876/9953144/c92786f8-5de6-11e5-8dc6-eebe1f95de33.png">

After:

<img width="338" alt="screen shot 2015-09-18 at 09 16 12" src="https://cloud.githubusercontent.com/assets/429876/9953149/d2b3a62a-5de6-11e5-8da0-ba91a4020b92.png">
