### PR TITLE
Add "Export to CSV" option for marketplace users and transactions

### DIFF
--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -20,7 +20,7 @@ class Admin::CommunityMembershipsController < ApplicationController
         else
           @community.ident
         end
-        send_data self.class.generate_csv_for(all_memberships), filename: "#{marketplace_name}-users-#{Date.today}.csv"
+        send_data generate_csv_for(all_memberships), filename: "#{marketplace_name}-users-#{Date.today}.csv"
       end
     end
   end
@@ -59,7 +59,7 @@ class Admin::CommunityMembershipsController < ApplicationController
     render nothing: true, status: 200
   end
 
-  def self.generate_csv_for(memberships)
+  def generate_csv_for(memberships)
     CSV.generate(headers: true) do |csv|
       # first line is column names
       csv << %w{

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class Admin::CommunityMembershipsController < ApplicationController
   before_filter :ensure_is_admin
 

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -98,7 +98,7 @@ class Admin::CommunityMembershipsController < ApplicationController
           ]
           user_data.push(membership.can_post_listings) if community_requires_verification_to_post
           user.emails.each do |email|
-            csv << user_data.insert(3, email.address, !!email.confirmed_at)
+            csv << user_data.clone.insert(3, email.address, !!email.confirmed_at)
           end
         end
       end

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -71,7 +71,7 @@ class Admin::CommunityMembershipsController < ApplicationController
         email_address
         email_address_confirmed
         email_from_admins_allowed
-        number_of_listings
+        number_of_total_listings
       }
       memberships.each do |membership|
         user = membership.person

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -1,5 +1,3 @@
-require 'csv'
-
 class Admin::CommunityMembershipsController < ApplicationController
   before_filter :ensure_is_admin
 

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -78,24 +78,16 @@ class Admin::CommunityMembershipsController < ApplicationController
         email_address
         email_address_confirmed
         email_from_admins_allowed
-        number_of_total_listings
       }
       memberships.each do |membership|
         user = membership.person
-        search = {
-          author_id: user.id,
-          include_closed: true,
-          per_page: 9999 # FIXME
-        }
-        listings = ListingIndexService::API::Api.listings.search(community_id: @community.id, search: search, includes: [])
         user_data = [
           user.given_name,
           user.family_name,
           user.username,
           membership.created_at,
           membership.status,
-          user.preferences["email_from_admins"],
-          listings.data[:count]
+          user.preferences["email_from_admins"]
         ]
         user.emails.each do |email|
           csv << user_data.insert(5, email.address, !!email.confirmed_at)

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -86,18 +86,20 @@ class Admin::CommunityMembershipsController < ApplicationController
       csv << header_row
       memberships.each do |membership|
         user = membership.person
-        user_data = [
-          user.given_name,
-          user.family_name,
-          user.username,
-          membership.created_at,
-          membership.status,
-          membership.admin,
-          user.preferences["email_from_admins"]
-        ]
-        user_data.push(membership.can_post_listings) if community_requires_verification_to_post
-        user.emails.each do |email|
-          csv << user_data.insert(3, email.address, !!email.confirmed_at)
+        unless user.blank?
+          user_data = [
+            user.given_name,
+            user.family_name,
+            user.username,
+            membership.created_at,
+            membership.status,
+            membership.admin,
+            user.preferences["email_from_admins"]
+          ]
+          user_data.push(membership.can_post_listings) if community_requires_verification_to_post
+          user.emails.each do |email|
+            csv << user_data.insert(3, email.address, !!email.confirmed_at)
+          end
         end
       end
     end

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -4,15 +4,16 @@ class Admin::CommunityMembershipsController < ApplicationController
   def index
     @selected_left_navi_link = "manage_members"
     @community = @current_community
-    @memberships = CommunityMembership.where(:community_id => @current_community.id, :status => "accepted")
-                                       .includes(:person => :emails)
-                                       .paginate(:page => params[:page], :per_page => 50)
-                                       .order("#{sort_column} #{sort_direction}")
 
     respond_to do |format|
-      format.html
+      format.html do
+        @memberships = CommunityMembership.where(:community_id => @current_community.id, :status => "accepted")
+                                           .includes(:person => :emails)
+                                           .paginate(:page => params[:page], :per_page => 50)
+                                           .order("#{sort_column} #{sort_direction}")
+      end
       format.csv do
-        all_memberships = CommunityMembership.where(:community_id => @community.id)
+        @memberships = CommunityMembership.where(:community_id => @community.id)
                                               .includes(:person => :emails)
                                               .order("created_at ASC")
         marketplace_name = if @community.use_domain
@@ -20,7 +21,7 @@ class Admin::CommunityMembershipsController < ApplicationController
         else
           @community.ident
         end
-        send_data generate_csv_for(all_memberships), filename: "#{marketplace_name}-users-#{Date.today}.csv"
+        send_data generate_csv, filename: "#{marketplace_name}-users-#{Date.today}.csv"
       end
     end
   end
@@ -59,7 +60,9 @@ class Admin::CommunityMembershipsController < ApplicationController
     render nothing: true, status: 200
   end
 
-  def generate_csv_for(memberships)
+  private
+
+  def generate_csv
     CSV.generate(headers: true) do |csv|
       # first line is column names
       csv << %w{
@@ -73,14 +76,14 @@ class Admin::CommunityMembershipsController < ApplicationController
         email_from_admins_allowed
         number_of_total_listings
       }
-      memberships.each do |membership|
+      @memberships.each do |membership|
         user = membership.person
         search = {
           author_id: user.id,
           include_closed: true,
           per_page: 9999 # FIXME
         }
-        listings = ListingIndexService::API::Api.listings.search(community_id: membership.community.id, search: search, includes: [])
+        listings = ListingIndexService::API::Api.listings.search(community_id: @community.id, search: search, includes: [])
         user_data = [
           user.given_name,
           user.family_name,
@@ -96,8 +99,6 @@ class Admin::CommunityMembershipsController < ApplicationController
       end
     end
   end
-
-  private
 
   def removes_itself?(ids, current_admin_user, community)
     ids ||= []

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -52,13 +52,60 @@ class Admin::CommunityTransactionsController < ApplicationController
       pager.replace(conversations)
     end
 
-    render("index",
-      { locals: {
-        community: @current_community,
-        conversations: conversations
-      }}
-    )
+    respond_to do |format|
+      format.html do
+        render("index", {
+          locals: {
+            community: @current_community,
+            conversations: conversations
+          }
+        })
+      end
+      format.csv do
+        marketplace_name = if @current_community.use_domain
+          @current_community.domain
+        else
+          @current_community.ident
+        end
+        send_data generate_csv_for(conversations), filename: "#{marketplace_name}-transactions-#{Date.today}.csv"
+      end
+    end
   end
+
+  def generate_csv_for(conversations)
+    CSV.generate(headers: true) do |csv|
+      # first line is column names
+      csv << %w{transaction_id listing_id listing_name status sum commission started last_activity starter_username other_party_username}
+      conversations.each do |conversation|
+        csv << [
+          conversation[:id],
+          conversation[:listing][:id],
+          conversation[:listing_title] || "N/A",
+          conversation[:status],
+          conversation[:payment_total],
+          conversation[:commission_from_seller],
+          conversation[:created_at],
+          last_activity_for(conversation),
+          conversation[:starter][:username],
+          conversation[:author][:username]
+        ]
+      end
+    end
+  end
+
+  def last_activity_for(conversation)
+    last_activity_at = 0
+    if conversation[:conversation][:last_message_at].nil?
+      last_activity_at = conversation[:last_transition_at]
+    elsif conversation[:last_transition_at].nil?
+      last_activity_at = conversation[:conversation][:last_message_at]
+    else
+      last_activity_at = [conversation[:last_transition_at], conversation[:conversation][:last_message_at]].max
+    end
+    last_activity_at
+  end
+
+  helper_method :last_activity_for
 
   private
 

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -94,6 +94,8 @@ class Admin::CommunityTransactionsController < ApplicationController
         other_party_username
       }
       conversations.each do |conversation|
+        starter_username = conversation[:starter] ? conversation[:starter][:username] : "DELETED"
+        other_party_username = conversation[:author] ? conversation[:author][:username] : "DELETED"
         csv << [
           conversation[:id],
           conversation[:listing][:id],
@@ -103,8 +105,8 @@ class Admin::CommunityTransactionsController < ApplicationController
           conversation[:commission_from_seller],
           conversation[:created_at],
           conversation[:last_activity_at],
-          conversation[:starter][:username],
-          conversation[:author][:username]
+          starter_username,
+          other_party_username
         ]
       end
     end

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class Admin::CommunityTransactionsController < ApplicationController
   TransactionQuery = MarketplaceService::Transaction::Query
   before_filter :ensure_is_admin

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -47,6 +47,8 @@ class Admin::CommunityTransactionsController < ApplicationController
         transaction[:listing_url] = listing_path(id: transaction[:listing][:id])
       end
 
+      transaction[:last_activity_at] = last_activity_for(transaction)
+
       transaction.merge({author: author, starter: starter})
     end
 
@@ -87,13 +89,15 @@ class Admin::CommunityTransactionsController < ApplicationController
           conversation[:payment_total],
           conversation[:commission_from_seller],
           conversation[:created_at],
-          last_activity_for(conversation),
+          conversation[:last_activity_at],
           conversation[:starter][:username],
           conversation[:author][:username]
         ]
       end
     end
   end
+
+  private
 
   def last_activity_for(conversation)
     last_activity_at = 0
@@ -106,10 +110,6 @@ class Admin::CommunityTransactionsController < ApplicationController
     end
     last_activity_at
   end
-
-  helper_method :last_activity_for
-
-  private
 
   def simple_sort_column(sort_column)
     case sort_column

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -65,13 +65,15 @@ class Admin::CommunityTransactionsController < ApplicationController
           }
         })
       end
-      format.csv do
-        marketplace_name = if @current_community.use_domain
-          @current_community.domain
-        else
-          @current_community.ident
+      with_feature(:export_as_csv) do
+        format.csv do
+          marketplace_name = if @current_community.use_domain
+            @current_community.domain
+          else
+            @current_community.ident
+          end
+          send_data generate_csv_for(conversations), filename: "#{marketplace_name}-transactions-#{Date.today}.csv"
         end
-        send_data generate_csv_for(conversations), filename: "#{marketplace_name}-transactions-#{Date.today}.csv"
       end
     end
   end
@@ -79,7 +81,18 @@ class Admin::CommunityTransactionsController < ApplicationController
   def generate_csv_for(conversations)
     CSV.generate(headers: true) do |csv|
       # first line is column names
-      csv << %w{transaction_id listing_id listing_name status sum commission started last_activity starter_username other_party_username}
+      csv << %w{
+        transaction_id
+        listing_id
+        listing_name
+        status
+        sum
+        commission
+        started_at
+        last_activity_at
+        starter_username
+        other_party_username
+      }
       conversations.each do |conversation|
         csv << [
           conversation[:id],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,6 +70,7 @@ module ApplicationHelper
       "analytics" => "ss-analytics",
       "openbook" => "ss-openbook",
       "order_types" => "ss-cart",
+      "download" => "ss-download",
 
       # Default category & share type icons
       "offer" => "ss-share",
@@ -185,6 +186,7 @@ module ApplicationHelper
       "settings" => " icon-cog",
       "facebook" => "icon-facebook",
       "invite" => "icon-users",
+      "download" => "icon-download",
 
       "information" => "icon-info-sign",
       "alert" => "icon-warning-sign",

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -8,7 +8,8 @@ module FeatureFlagService::Store
       [:features, :mandatory, :set])
 
     FLAGS = [
-      :location_search
+      :location_search,
+      :export_as_csv
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/views/admin/community_memberships/index.haml
+++ b/app/views/admin/community_memberships/index.haml
@@ -26,6 +26,8 @@
 .left-navi-section
   %h2= t("admin.communities.manage_members.manage_members", :community_name => @community.name(I18n.locale))
 
+  #export-as-csv.right= link_to(" " + t("admin.communities.manage_members.export_as_csv"), {format: :csv}, {class: icon_class("download")})
+
   %span#admin_members_count= page_entries_info(@memberships, :model => "Person")
 
   %form

--- a/app/views/admin/community_memberships/index.haml
+++ b/app/views/admin/community_memberships/index.haml
@@ -26,7 +26,8 @@
 .left-navi-section
   %h2= t("admin.communities.manage_members.manage_members", :community_name => @community.name(I18n.locale))
 
-  #export-as-csv.right= link_to(" " + t("admin.communities.manage_members.export_as_csv"), {format: :csv}, {class: icon_class("download")})
+  - if feature_enabled?(:export_as_csv)
+    #export-as-csv.right= link_to(" " + t("admin.communities.manage_members.export_as_csv"), {format: :csv}, {class: icon_class("download")})
 
   %span#admin_members_count= page_entries_info(@memberships, :model => "Person")
 

--- a/app/views/admin/community_memberships/index.haml
+++ b/app/views/admin/community_memberships/index.haml
@@ -27,7 +27,7 @@
   %h2= t("admin.communities.manage_members.manage_members", :community_name => @community.name(I18n.locale))
 
   - if feature_enabled?(:export_as_csv)
-    #export-as-csv.right= link_to(" " + t("admin.communities.manage_members.export_as_csv"), {format: :csv}, {class: icon_class("download")})
+    #export-as-csv.right= link_to(" " + t("admin.communities.manage_members.export_all_as_csv"), {format: :csv}, {class: icon_class("download")})
 
   %span#admin_members_count= page_entries_info(@memberships, :model => "Person")
 

--- a/app/views/admin/community_transactions/index.haml
+++ b/app/views/admin/community_transactions/index.haml
@@ -9,6 +9,8 @@
 .left-navi-section
   %h2= t("admin.communities.transactions.transactions", community_name: community.name(I18n.locale))
 
+  #export-as-csv.right= link_to(" " + t("admin.communities.transactions.export_as_csv"), {per_page: 99999, format: :csv}, {class: icon_class("download")})
+
   %span#admin_transactions_count= page_entries_info(conversations, :model => "Transaction")
 
   %table#admin_transactions
@@ -32,14 +34,7 @@
               = t("admin.communities.transactions.status.#{conversation[:status]}")
           %td=conversation[:payment_total] ? humanized_money_with_symbol(conversation[:payment_total]) : ""
           %td=l(conversation[:created_at], format: :short_date)
-          - last_activity_at = 0
-          - if conversation[:conversation][:last_message_at].nil?
-            - last_activity_at = conversation[:last_transition_at]
-          - elsif conversation[:last_transition_at].nil?
-            - last_activity_at = conversation[:conversation][:last_message_at]
-          - else
-            - last_activity_at = [conversation[:last_transition_at], conversation[:conversation][:last_message_at]].max
-          %td=l(last_activity_at, format: :short_date)
+          %td=l(last_activity_for(conversation), format: :short_date)
           %td=Maybe(conversation[:starter]).map { |p| link_to_unless(p[:is_deleted], p[:display_name], p[:url]) }.or_else("")
           %td=Maybe(conversation[:author]).map { |p| link_to_unless(p[:is_deleted], p[:display_name], p[:url]) }.or_else("")
   .row

--- a/app/views/admin/community_transactions/index.haml
+++ b/app/views/admin/community_transactions/index.haml
@@ -34,7 +34,7 @@
               = t("admin.communities.transactions.status.#{conversation[:status]}")
           %td=conversation[:payment_total] ? humanized_money_with_symbol(conversation[:payment_total]) : ""
           %td=l(conversation[:created_at], format: :short_date)
-          %td=l(last_activity_for(conversation), format: :short_date)
+          %td=l(conversation[:last_activity_at], format: :short_date)
           %td=Maybe(conversation[:starter]).map { |p| link_to_unless(p[:is_deleted], p[:display_name], p[:url]) }.or_else("")
           %td=Maybe(conversation[:author]).map { |p| link_to_unless(p[:is_deleted], p[:display_name], p[:url]) }.or_else("")
   .row

--- a/app/views/admin/community_transactions/index.haml
+++ b/app/views/admin/community_transactions/index.haml
@@ -9,7 +9,8 @@
 .left-navi-section
   %h2= t("admin.communities.transactions.transactions", community_name: community.name(I18n.locale))
 
-  #export-as-csv.right= link_to(" " + t("admin.communities.transactions.export_as_csv"), {per_page: 99999, format: :csv}, {class: icon_class("download")})
+  - if feature_enabled?(:export_as_csv)
+    #export-as-csv.right= link_to(" " + t("admin.communities.transactions.export_as_csv"), {per_page: 99999, format: :csv}, {class: icon_class("download")})
 
   %span#admin_transactions_count= page_entries_info(conversations, :model => "Transaction")
 

--- a/app/views/admin/community_transactions/index.haml
+++ b/app/views/admin/community_transactions/index.haml
@@ -10,7 +10,7 @@
   %h2= t("admin.communities.transactions.transactions", community_name: community.name(I18n.locale))
 
   - if feature_enabled?(:export_as_csv)
-    #export-as-csv.right= link_to(" " + t("admin.communities.transactions.export_as_csv"), {per_page: 99999, format: :csv}, {class: icon_class("download")})
+    #export-as-csv.right= link_to(" " + t("admin.communities.transactions.export_all_as_csv"), {per_page: 99999, format: :csv}, {class: icon_class("download")})
 
   %span#admin_transactions_count= page_entries_info(conversations, :model => "Transaction")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,7 +253,7 @@ en:
         ban_user: "Ban user"
         saving_user_status: Saving...
         save_user_status_successful: Saved
-        export_as_csv: "Export as CSV"
+        export_all_as_csv: "Export all as CSV"
         save_user_status_error: "Saving failed. Please refresh the page and try again."
         ban_user_confirmation: "This removes the user from the marketplace and prevents them from accessing the site again with this account. Are you sure you want to proceed?"
         ban_me_error: "You cannot ban yourself."
@@ -292,7 +292,7 @@ en:
         url: URL
         empty: "You don't have any additional menu links"
       transactions:
-        export_as_csv: "Export as CSV"
+        export_all_as_csv: "Export all as CSV"
         transactions: "View transactions"
         headers:
           conversation: "Conversation thread"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,6 +253,7 @@ en:
         ban_user: "Ban user"
         saving_user_status: Saving...
         save_user_status_successful: Saved
+        export_as_csv: "Export as CSV"
         save_user_status_error: "Saving failed. Please refresh the page and try again."
         ban_user_confirmation: "This removes the user from the marketplace and prevents them from accessing the site again with this account. Are you sure you want to proceed?"
         ban_me_error: "You cannot ban yourself."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,7 @@ en:
         url: URL
         empty: "You don't have any additional menu links"
       transactions:
+        export_as_csv: "Export as CSV"
         transactions: "View transactions"
         headers:
           conversation: "Conversation thread"

--- a/spec/controllers/admin/csv_export_spec.rb
+++ b/spec/controllers/admin/csv_export_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Admin::CommunityMembershipsController do
+  before(:each) do
+    @community = FactoryGirl.create(:community)
+    @request.host = "#{@community.ident}.lvh.me"
+    @person = create_admin_for(@community)
+    sign_in_for_spec(@person)
+
+    FeatureFlagService::API::Api.features.enable(community_id: @community.id, features: [:export_as_csv])
+  end
+
+  describe "users CSV export" do
+    it "returns 200" do
+      get :index, {format: :csv}
+      response.status.should == 200
+    end
+
+    it "returns CSV with actual data" do
+      get :index, {format: :csv}
+      response_arr = CSV.parse(response.body)
+      user = Hash[*response_arr[0].zip(response_arr[1]).flatten]
+
+      user["first_name"].should == @person.given_name
+      user["last_name"].should == @person.family_name
+      user["email_address"].should == @person.emails.first.address
+    end
+  end
+end
+
+describe Admin::CommunityTransactionsController do
+  before(:each) do
+    @community = FactoryGirl.create(:community)
+    @person = create_admin_for(@community)
+    @listing = FactoryGirl.create(:listing, community_id: @community.id, transaction_process_id: 123, author: @person)
+    sign_in_for_spec(@person)
+    @request.host = "#{@community.ident}.lvh.me"
+    @transaction = FactoryGirl.create(:transaction, starter: @person, listing: @listing, community: @community)
+
+    FeatureFlagService::API::Api.features.enable(community_id: @community.id, features: [:export_as_csv])
+  end
+  
+  describe "transactions CSV export" do
+    it "returns 200" do
+      get :index, {format: :csv, per_page: 99999}
+      response.status.should == 200
+    end
+
+    it "returns CSV with actual data" do
+      get :index, {format: :csv, per_page: 99999}
+      response_arr = CSV.parse(response.body)
+      tx = Hash[*response_arr[0].zip(response_arr[1]).flatten]
+
+      tx["listing_id"] = @listing.id
+      tx["listing_name"] = @listing.title
+      tx["transaction_id"] = @transaction.id
+      tx["starter_username"] = @person.username
+    end
+  end
+end


### PR DESCRIPTION
Give admins the ability to export some of your marketplace's data: members and transactions.

For transactions, export the following data:

```
transaction_id, listing_id, listing_name, status, sum, commission, started_at, last_activity_at, starter_username, other_party_username
```

For users, export the following data:

```
first_name, last_name, username, email_address, email_address_confirmed, joined_at, status, is_admin, email_from_admins_allowed
```

TODO:
- [x] Export for Manage users page
- [x] Tests for users export
- [x] Export for Transactions page
- [x] Test for transactions export
- [x] Put it behind a feature flag?