### PR TITLE
Update PayPal signup link

### DIFF
--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -64,7 +64,7 @@ class Admin::PaypalPreferencesController < ApplicationController
         min_commission_percentage: MIN_COMMISSION_PERCENTAGE,
         max_commission_percentage: MAX_COMMISSION_PERCENTAGE,
         currency: currency,
-        create_url: "https://www.paypal.com/#{community_country_code}/signup",
+        create_url: "https://www.paypal.com/#{community_country_code}/signup/account",
         upgrade_url: "https://www.paypal.com/#{community_country_code}/upgrade",
         display_knowledge_base_articles: APP_CONFIG.display_knowledge_base_articles,
         knowledge_base_url: APP_CONFIG.knowledge_base_url

--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -71,7 +71,7 @@ class PaypalAccountsController < ApplicationController
       minimum_commission: Money.new(payment_settings[:minimum_transaction_fee_cents], community_currency),
       commission_type: payment_settings[:commission_type],
       currency: community_currency,
-      create_url: "https://www.paypal.com/#{community_country_code}/signup",
+      create_url: "https://www.paypal.com/#{community_country_code}/signup/account",
       upgrade_url: "https://www.paypal.com/#{community_country_code}/upgrade"
     })
   end


### PR DESCRIPTION
Old link doesn't work and user ends up to 
https://www.paypal.com/webapps/mpp/get-started 
(with US locale)
