### PR TITLE
Show price unit in mobile

### DIFF
--- a/app/assets/stylesheets/views/_home.css.scss
+++ b/app/assets/stylesheets/views/_home.css.scss
@@ -281,18 +281,9 @@ $home-list-avatar-padding: lines(0.25);
 
 .home-list-price-mobile {
   position: absolute;
-  font-size: 24px;
-
-  & > .smaller {
-    font-size: 18px;
-  }
-
   bottom: lines(0.25, 24);
   @include media(large-mobile) {
-    font-size: 36px;
-    & > .smaller {
-      font-size: 24px;
-    }
+    text-align: right;
     right: 0;
     padding-top: 10px;
     bottom: lines(0.5, 36);
@@ -305,8 +296,21 @@ $home-list-avatar-padding: lines(0.25);
   }
 }
 
+.home-list-price-value-mobile {
+  font-size: 24px;
+  & > .smaller {
+    font-size: 18px;
+  }
+  @include media(large-mobile) {
+    font-size: 36px;
+    & > .smaller {
+      font-size: 24px;
+    }
+  }
+}
+
 .home-list-price-mobile-with-listing-image {
-  left: lines(3.5, 24);
+  left: 84px;
 
   @include media(large-mobile) {
     left: auto;

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -48,7 +48,16 @@
 
     .home-list-price-mobile{:class => (listing.listing_images.size > 0 ? "home-list-price-mobile-with-listing-image" : "home-list-price-mobile-without-listing-image")}
       - if listing.price
-        = humanized_money_with_symbol(listing.price).upcase
+        .home-list-price-value-mobile
+          = humanized_money_with_symbol(listing.price).upcase
+        - price_text = nil
+        - if listing.quantity.present?
+          - price_text = t("listings.form.price.per") + " " + listing.quantity
+        - elsif listing.unit_type
+          - price_text = price_quantity_per_unit(listing)
+        - if price_text.present?
+          .home-list-price-quantity{:title => price_text}
+            = price_text
       - else
         %span.smaller
           = shape_name(listing)


### PR DESCRIPTION
Earlier we haven't shown pricing unit in front page list view on <1008 px wide windows. We should.

Before:
![Before:](https://cloud.githubusercontent.com/assets/432030/10192910/642cf3d6-6788-11e5-94aa-0fd3d66343f9.png)

After:
![After:](https://cloud.githubusercontent.com/assets/432030/10192917/6e75fe46-6788-11e5-964c-59042d36dd92.png)
