### PR TITLE
Paypal fee link

### DIFF
--- a/app/controllers/accept_preauthorized_conversations_controller.rb
+++ b/app/controllers/accept_preauthorized_conversations_controller.rb
@@ -143,6 +143,7 @@ class AcceptPreauthorizedConversationsController < ApplicationController
     transaction_conversation = MarketplaceService::Transaction::Query.transaction(@listing_conversation.id)
     result = TransactionService::Transaction.get(community_id: @current_community.id, transaction_id: @listing_conversation.id)
     transaction = result[:data]
+    community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
 
     render "accept", locals: {
       payment_gateway: :paypal,
@@ -160,7 +161,8 @@ class AcceptPreauthorizedConversationsController < ApplicationController
         person_id: @current_user.id,
         id: @listing_conversation.id
       ),
-      preselected_action: preselected_action
+      preselected_action: preselected_action,
+      paypal_fees_url: PaypalHelper.fee_link(community_country_code)
     }
   end
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -452,6 +452,8 @@ class ListingsController < ApplicationController
           0
         end
 
+      community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
+
       commission(@current_community, process).merge({
         shape: shape,
         unit_options: unit_options,
@@ -459,7 +461,8 @@ class ListingsController < ApplicationController
         shipping_enabled: @listing.require_shipping_address?,
         pickup_enabled: @listing.pickup_enabled?,
         shipping_price_additional: shipping_price_additional,
-        always_show_additional_shipping_price: shape[:units].length == 1 && shape[:units].first[:kind] == :quantity
+        always_show_additional_shipping_price: shape[:units].length == 1 && shape[:units].first[:kind] == :quantity,
+        paypal_fees_url: PaypalHelper.fee_link(community_country_code)
       })
     else
       nil

--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -71,6 +71,7 @@ class PaypalAccountsController < ApplicationController
       minimum_commission: Money.new(payment_settings[:minimum_transaction_fee_cents], community_currency),
       commission_type: payment_settings[:commission_type],
       currency: community_currency,
+      paypal_fees_url: PaypalHelper.fee_link(community_country_code),
       create_url: "https://www.paypal.com/#{community_country_code}/signup/account",
       upgrade_url: "https://www.paypal.com/#{community_country_code}/upgrade"
     })

--- a/app/view_utils/paypal_helper.rb
+++ b/app/view_utils/paypal_helper.rb
@@ -1,11 +1,14 @@
 module PaypalHelper
 
+  # List all the contries that have the new fee page available
+  SHOW_NEW_FEE_PAGE = ["us", "de", "br"].to_set
+
   # List all the contries that have the popup URL available
   SHOW_POPUP_COUNTRIES = ["us", "de"].to_set
 
   # List all the countries that should use the home URL, because popup is not available
   # (and default English popup is not good)
-  SHOW_HOMEPAGE_COUNTRIES = ["br"]
+  SHOW_HOMEPAGE_COUNTRIES = ["br"].to_set
 
   TxApi = TransactionService::API::Api
 
@@ -46,6 +49,14 @@ module PaypalHelper
 
   def account_prepared_for_community?(community_id)
     account_prepared?(community_id: community_id)
+  end
+
+  def fee_link(country_code)
+    if SHOW_NEW_FEE_PAGE.include?(country_code)
+      "https://www.paypal.com/#{country_code}/webapps/mpp/paypal-fees"
+    else
+      "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside"
+    end
   end
 
   def popup_link(country_code)

--- a/app/views/accept_preauthorized_conversations/accept.haml
+++ b/app/views/accept_preauthorized_conversations/accept.haml
@@ -98,7 +98,7 @@
       = render layout: "layouts/lightbox", locals: { id: "paypal_fee_info_content"} do
         %h2= t("common.paypal_fee_info.title")
         - text_with_line_breaks_html_safe do
-          - link_to_paypal = link_to(t("common.paypal_fee_info.link_to_paypal_text"), "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside")
+          - link_to_paypal = link_to(t("common.paypal_fee_info.link_to_paypal_text"), paypal_fees_url)
           = t("common.paypal_fee_info.body_text", link_to_paypal: link_to_paypal).html_safe
 
       - content_for :extra_javascript do

--- a/app/views/listings/form/_form_content.haml
+++ b/app/views/listings/form/_form_content.haml
@@ -2,7 +2,7 @@
 
 = form_for @listing, :html => {:multipart => true} do |form|
   = render :partial => "listings/form/title", :locals => { :form => form }
-  = render :partial => "listings/form/price", :locals => { :form => form, :seller_commission_in_use => seller_commission_in_use, :payment_gateway => payment_gateway, :run_js_immediately => run_js_immediately, :minimum_commission => minimum_commission, commission_from_seller: commission_from_seller, shape: shape, unit_options: unit_options, shipping_price_additional: shipping_price_additional }
+  = render :partial => "listings/form/price", :locals => { :form => form, :seller_commission_in_use => seller_commission_in_use, :payment_gateway => payment_gateway, :run_js_immediately => run_js_immediately, :minimum_commission => minimum_commission, commission_from_seller: commission_from_seller, shape: shape, unit_options: unit_options, shipping_price_additional: shipping_price_additional, paypal_fees_url: paypal_fees_url }
   = render partial: "listings/form/shipping", locals: { form: form, shape: shape, always_show_additional_shipping_price: always_show_additional_shipping_price, shipping_enabled: shipping_enabled, pickup_enabled: pickup_enabled, shipping_price: shipping_price, shipping_price_additional: shipping_price_additional }
   = render :partial => "listings/form/description", :locals => { :form => form }
   = render :partial => "listings/form/custom_fields", :locals => { :form => form, :listing => @listing, :custom_fields => @custom_field_questions }

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -54,7 +54,7 @@
   = render layout: "layouts/lightbox", locals: { id: "paypal_fee_info_content"} do
     %h2= t("common.paypal_fee_info.title")
     - text_with_line_breaks_html_safe do
-      - link_to_paypal = link_to(t("common.paypal_fee_info.link_to_paypal_text"), "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside")
+      - link_to_paypal = link_to(t("common.paypal_fee_info.link_to_paypal_text"), paypal_fees_url)
       - if shape[:shipping_enabled]
         = t("common.paypal_fee_info.body_with_shipping_text", link_to_paypal: link_to_paypal).html_safe
       - else

--- a/app/views/paypal_accounts/_ask_paypal_billing_agreement.haml
+++ b/app/views/paypal_accounts/_ask_paypal_billing_agreement.haml
@@ -32,7 +32,7 @@
   = render layout: "layouts/lightbox", locals: { id: "paypal_fee_info_content"} do
     %h2= t("common.paypal_fee_info.title")
     - text_with_line_breaks_html_safe do
-      - link_to_paypal = link_to(t("common.paypal_fee_info.link_to_paypal_text"), "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside")
+      - link_to_paypal = link_to(t("common.paypal_fee_info.link_to_paypal_text"), paypal_fees_url)
       = t("common.paypal_fee_info.body_text", link_to_paypal: link_to_paypal).html_safe
 
   - content_for :extra_javascript do

--- a/app/views/paypal_accounts/new.haml
+++ b/app/views/paypal_accounts/new.haml
@@ -18,7 +18,7 @@
 
     - if paypal_account_state == :verified
       = form_for paypal_account_form, :url => billing_agreement_action, method: "get", :html => { :id => "paypal_account_form"} do |form|
-        = render :partial => "ask_paypal_billing_agreement", locals: {paypal_account_email: paypal_account_email, form: form, change_url: change_url, commission_type: commission_type, commission_from_seller: commission_from_seller, minimum_commission: minimum_commission}
+        = render :partial => "ask_paypal_billing_agreement", locals: {paypal_account_email: paypal_account_email, form: form, change_url: change_url, commission_type: commission_type, commission_from_seller: commission_from_seller, minimum_commission: minimum_commission, paypal_fees_url: paypal_fees_url}
     - else
       = form_for paypal_account_form, :url => order_permission_action, method: "get", :html => { :id => "paypal_account_form"} do |form|
         - title = t("paypal_accounts.new.paypal_account_email")

--- a/app/views/paypal_service/success.haml
+++ b/app/views/paypal_service/success.haml
@@ -11,4 +11,5 @@
       = t("paypal.wait_while_loading").html_safe
     %p.paypal-loading-desc
       = t("paypal.chatting_with_paypal").html_safe
-    %img.spinner(src="https://s3.amazonaws.com/sharetribe/assets/ajax-loader-grey.gif")
+    %p.paypal-loading-spinner
+      %img.spinner(src="https://s3.amazonaws.com/sharetribe/assets/ajax-loader-grey.gif")


### PR DESCRIPTION
1. Add country specific links to PayPal fee page. Whitelist countries that should use the new fee page. Use the old page for others.
2) Fix the PayPal spinner padding:

Before:
![screen shot 2015-10-05 at 11 35 02](https://cloud.githubusercontent.com/assets/429876/10276051/6303c022-6b55-11e5-8d8e-0218d3b37eb6.png)

After:
![screen shot 2015-10-05 at 11 35 21](https://cloud.githubusercontent.com/assets/429876/10276050/62ffb00e-6b55-11e5-8df0-4b297f64021b.png)
