### PR TITLE
Fixes Google Analytics script to use better method to drop subdomain

### DIFF
--- a/app/views/layouts/_google_analytics_script.haml
+++ b/app/views/layouts/_google_analytics_script.haml
@@ -1,9 +1,14 @@
 - if (APP_CONFIG.use_google_analytics)
+
+  - # drop first subdomain part of domain to make it easier to collect
+  - # multiple subdomains. Note: request.domain didn't work with 4 part domains.
+  - host_without_subdomain = request.host.split('.').drop(1).join(".")
+
   <script type="text/javascript">
 
   var _gaq = _gaq || [];
   = "_gaq.push(['_setAccount', '#{APP_CONFIG.google_analytics_key}']);"
-  = "_gaq.push(['_setDomainName', '.#{request.domain}']);"
+  = "_gaq.push(['_setDomainName', '.#{host_without_subdomain}']);"
   _gaq.push(
   ['_addIgnoredOrganic', 'sharetribe'],
   ['_addIgnoredOrganic', 'sharetribe.com'],
@@ -18,7 +23,7 @@
 
   - if @current_community && @current_community.google_analytics_key
     = "_gaq.push(['b._setAccount', '#{@current_community.google_analytics_key}']);"
-    = "_gaq.push(['b._setDomainName', '.#{request.domain}']);"
+    = "_gaq.push(['b._setDomainName', '.#{host_without_subdomain}']);"
     = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.name(I18n.locale).gsub("'","")}']);"
     = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.domain || @current_community.ident}']);"
     _gaq.push(


### PR DESCRIPTION
The earlier request.domain didn't work with longer TLDs (e.g. .com.br) Some clients (and we) didn't get any data to show up in GA as the domain www.something.com.br was clipped as .com.br although it should have been .something.com.br
This should fix it.