### PR TITLE
Simplify Google Analytics domain name setting, by using the whole host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,8 @@ gem 'cache_digests'
 gem 'librato-rails'
 
 gem 'lograge'
+gem 'public_suffix' # Needed currently to set GA hostname right, probably not
+                    # needed anymore when GA script updated.
 
 group :staging, :production do
   gem 'newrelic_rpm', '~> 3.9.1.236'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,6 +362,7 @@ GEM
     pry-stack_explorer (0.4.9.1)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    public_suffix (1.5.1)
     pusher-client (0.4.0)
       websocket (~> 1.0.0)
     quiet_assets (1.1.0)
@@ -576,6 +577,7 @@ DEPENDENCIES
   pry-nav
   pry-rails
   pry-stack_explorer
+  public_suffix
   quiet_assets
   rabl
   rack-livereload

--- a/app/views/layouts/_google_analytics_script.haml
+++ b/app/views/layouts/_google_analytics_script.haml
@@ -1,14 +1,9 @@
 - if (APP_CONFIG.use_google_analytics)
-
-  - # drop first subdomain part of domain to make it easier to collect
-  - # multiple subdomains. Note: request.domain didn't work with 4 part domains.
-  - host_without_subdomain = request.host.split('.').drop(1).join(".")
-
   <script type="text/javascript">
 
   var _gaq = _gaq || [];
   = "_gaq.push(['_setAccount', '#{APP_CONFIG.google_analytics_key}']);"
-  = "_gaq.push(['_setDomainName', '.#{host_without_subdomain}']);"
+  = "_gaq.push(['_setDomainName', '#{request.host}']);"
   _gaq.push(
   ['_addIgnoredOrganic', 'sharetribe'],
   ['_addIgnoredOrganic', 'sharetribe.com'],
@@ -23,7 +18,7 @@
 
   - if @current_community && @current_community.google_analytics_key
     = "_gaq.push(['b._setAccount', '#{@current_community.google_analytics_key}']);"
-    = "_gaq.push(['b._setDomainName', '.#{host_without_subdomain}']);"
+    = "_gaq.push(['b._setDomainName', '#{request.host}']);"
     = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.name(I18n.locale).gsub("'","")}']);"
     = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.domain || @current_community.ident}']);"
     _gaq.push(

--- a/app/views/layouts/_google_analytics_script.haml
+++ b/app/views/layouts/_google_analytics_script.haml
@@ -3,7 +3,7 @@
 
   var _gaq = _gaq || [];
   = "_gaq.push(['_setAccount', '#{APP_CONFIG.google_analytics_key}']);"
-  = "_gaq.push(['_setDomainName', '#{request.host}']);"
+  = "_gaq.push(['_setDomainName', '.#{PublicSuffix.parse(request.host).domain}']);"
   _gaq.push(
   ['_addIgnoredOrganic', 'sharetribe'],
   ['_addIgnoredOrganic', 'sharetribe.com'],
@@ -18,7 +18,7 @@
 
   - if @current_community && @current_community.google_analytics_key
     = "_gaq.push(['b._setAccount', '#{@current_community.google_analytics_key}']);"
-    = "_gaq.push(['b._setDomainName', '#{request.host}']);"
+    = "_gaq.push(['b._setDomainName', '.#{PublicSuffix.parse(request.host).domain}']);"
     = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.name(I18n.locale).gsub("'","")}']);"
     = "_gaq.push(['b._addIgnoredOrganic', '#{@current_community.domain || @current_community.ident}']);"
     _gaq.push(


### PR DESCRIPTION
Earlier we remove the subdomain part to pool subdomains, but that's
not actively needed now, and caused trouble as the script didn't
take acocunt naked domains