### PR TITLE
Implement a Logger (a Rails.logger wrapper)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -166,6 +166,8 @@ class ApplicationController < ActionController::Base
   def fetch_logged_in_user
     if person_signed_in?
       @current_user = current_person
+      logger.user_id = @current_user.id
+      logger.username = @current_user.username
     end
   end
 
@@ -211,6 +213,9 @@ class ApplicationController < ActionController::Base
   # Before filter to get the current community
   def fetch_community
     @current_community = ApplicationController.find_community(community_identifiers)
+
+    logger.community_id = @current_community.id
+    logger.community_ident = @current_community.ident
 
     # Save :found or :not_found to community status
     # This is needed because we need to distinguish to cases
@@ -503,6 +508,10 @@ class ApplicationController < ActionController::Base
   end
 
   helper_method :fetch_feature_flags # Make this method available for FeatureFlagHelper
+
+  def logger
+    @logger ||= SharetribeLogger.new
+  end
 
   # Fetch temporary flags from params and session
   def self.fetch_temp_flags(is_admin, params, session)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -214,8 +214,9 @@ class ApplicationController < ActionController::Base
   def fetch_community
     @current_community = ApplicationController.find_community(community_identifiers)
 
-    logger.community_id = @current_community.id
-    logger.community_ident = @current_community.ident
+    m_community = Maybe(@current_community)
+    logger.community_id = m_community.id
+    logger.community_ident = m_community.ident
 
     # Save :found or :not_found to community status
     # This is needed because we need to distinguish to cases
@@ -510,7 +511,12 @@ class ApplicationController < ActionController::Base
   helper_method :fetch_feature_flags # Make this method available for FeatureFlagHelper
 
   def logger
-    @logger ||= SharetribeLogger.new
+    if @logger.nil?
+      @logger = SharetribeLogger.new
+      @logger.request_uuid = request.uuid
+    end
+
+    @logger
   end
 
   # Fetch temporary flags from params and session

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -166,8 +166,7 @@ class ApplicationController < ActionController::Base
   def fetch_logged_in_user
     if person_signed_in?
       @current_user = current_person
-      logger.user_id = @current_user.id
-      logger.username = @current_user.username
+      setup_logger!(user_id: @current_user.id, username: @current_user.username)
     end
   end
 
@@ -215,8 +214,7 @@ class ApplicationController < ActionController::Base
     @current_community = ApplicationController.find_community(community_identifiers)
 
     m_community = Maybe(@current_community)
-    logger.community_id = m_community.id
-    logger.community_ident = m_community.ident
+    setup_logger!(marketplace_id: m_community.id.or_else(nil), marketplace_ident: m_community.ident.or_else(nil))
 
     # Save :found or :not_found to community status
     # This is needed because we need to distinguish to cases
@@ -416,7 +414,7 @@ class ApplicationController < ActionController::Base
     payload[:host] = request.host
     payload[:community_id] = Maybe(@current_community).id.or_else("")
     payload[:current_user_id] = Maybe(@current_user).id.or_else("")
-    payload[:request_uuid] = request.env["HTTP_X_REQUEST_ID"]
+    payload[:request_uuid] = request.uuid
   end
 
   def date_equals?(date, comp)
@@ -512,11 +510,16 @@ class ApplicationController < ActionController::Base
 
   def logger
     if @logger.nil?
-      @logger = SharetribeLogger.new
-      @logger.request_uuid = request.uuid
+      metadata = [:marketplace_id, :marketplace_ident, :user_id, :username, :request_uuid]
+      @logger = SharetribeLogger.new(:controller, metadata)
+      @logger.add_metadata(request_uuid: request.uuid)
     end
 
     @logger
+  end
+
+  def setup_logger!(metadata)
+    logger.add_metadata(metadata)
   end
 
   # Fetch temporary flags from params and session

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -256,12 +256,7 @@ class ListingsController < ApplicationController
           if params[:listing_images]
             params[:listing_images].collect { |h| h[:id] }.select { |id| id.present? }
           else
-            Rails.logger.error({tag: :error,
-                                free: "Listing images array is missing",
-                                structured: {params: params,
-                                             community_id: @current_community.id,
-                                             current_user: @current_user.id},
-                                request_id: request.uuid}.to_json)
+            logger.error("Listing images array is missing", nil, {params: params})
             []
           end
 
@@ -278,7 +273,7 @@ class ListingsController < ApplicationController
         ).html_safe
         redirect_to @listing, status: 303 and return
       else
-        Rails.logger.error "Errors in creating listing: #{@listing.errors.full_messages.inspect}"
+        logger.error("Errors in creating listing: #{@listing.errors.full_messages.inspect}")
         flash[:error] = t(
           "layouts.notifications.listing_could_not_be_saved",
           :contact_admin_link => view_context.link_to(t("layouts.notifications.contact_admin_link_text"), new_user_feedback_path, :class => "flash-error-link")
@@ -371,7 +366,7 @@ class ListingsController < ApplicationController
       Delayed::Job.enqueue(ListingUpdatedJob.new(@listing.id, @current_community.id))
       redirect_to @listing
     else
-      Rails.logger.error "Errors in editing listing: #{@listing.errors.full_messages.inspect}"
+      logger.error("Errors in editing listing: #{@listing.errors.full_messages.inspect}")
       flash[:error] = t("layouts.notifications.listing_could_not_be_saved", :contact_admin_link => view_context.link_to(t("layouts.notifications.contact_admin_link_text"), new_user_feedback_path, :class => "flash-error-link")).html_safe
       redirect_to edit_listing_path(@listing)
     end
@@ -402,7 +397,7 @@ class ListingsController < ApplicationController
       redirect_to homepage_index_path
     else
       flash[:warning] = "An error occured while trying to move the listing to the top of the homepage"
-      Rails.logger.error "An error occured while trying to move the listing (id=#{Maybe(@listing).id.or_else('No id available')}) to the top of the homepage"
+      logger.error("An error occured while trying to move the listing (id=#{Maybe(@listing).id.or_else('No id available')}) to the top of the homepage")
       redirect_to @listing
     end
   end
@@ -414,7 +409,7 @@ class ListingsController < ApplicationController
     if @listing.update_attribute(:updates_email_at, Time.now)
       render :nothing => true, :status => 200
     else
-      Rails.logger.error "An error occured while trying to move the listing (id=#{Maybe(@listing).id.or_else('No id available')}) to the top of the homepage"
+      logger.error("An error occured while trying to move the listing (id=#{Maybe(@listing).id.or_else('No id available')}) to the top of the homepage")
       render :nothing => true, :status => 500
     end
   end

--- a/app/utils/sharetribe_logger.rb
+++ b/app/utils/sharetribe_logger.rb
@@ -1,0 +1,52 @@
+class SharetribeLogger
+  attr_writer(
+    :community_id,
+    :community_ident,
+    :user_id,
+    :username
+  )
+
+  def initialize(tag = nil, system_logger = Rails.logger)
+    @tag = tag
+    @system_logger = system_logger
+  end
+
+  def debug(msg, type = :other)
+    @system_logger.debug(
+      add_details(to_json(msg, type)))
+  end
+
+  def info(msg, type = :other)
+    @system_logger.info(
+      add_details(to_json(msg, type)))
+  end
+
+  def warn(msg, type = :other)
+    @system_logger.warn(
+      add_details(to_json(msg, type)))
+  end
+
+  def error(msg, type = :other)
+    @system_logger.error(
+      add_details(to_json(msg, type)))
+  end
+
+  private
+
+  def to_json(msg, type)
+    {
+      tag: @tag,
+      free: msg,
+      type: type
+    }
+  end
+
+  def add_details(log_data)
+    {
+      user_id: @user_id,
+      username: @username,
+      community_id: @community_id,
+      community_ident: @community_ident
+    }.merge(log_data)
+  end
+end

--- a/app/utils/sharetribe_logger.rb
+++ b/app/utils/sharetribe_logger.rb
@@ -3,41 +3,43 @@ class SharetribeLogger
     :community_id,
     :community_ident,
     :user_id,
-    :username
+    :username,
+    :request_uuid
   )
 
-  def initialize(tag = nil, system_logger = Rails.logger)
+  def initialize(tag = nil, log_target = Rails.logger)
     @tag = tag
-    @system_logger = system_logger
+    @log_target = log_target
   end
 
-  def debug(msg, type = :other)
-    @system_logger.debug(
-      add_details(to_json(msg, type)))
+  def debug(msg, type = :other, structured = nil)
+    @log_target.debug(
+      add_details(to_hash(msg, type, structured)).to_json)
   end
 
-  def info(msg, type = :other)
-    @system_logger.info(
-      add_details(to_json(msg, type)))
+  def info(msg, type = :other, structured = nil)
+    @log_target.info(
+      add_details(to_hash(msg, type, structured)).to_json)
   end
 
-  def warn(msg, type = :other)
-    @system_logger.warn(
-      add_details(to_json(msg, type)))
+  def warn(msg, type = :other, structured = nil)
+    @log_target.warn(
+      add_details(to_hash(msg, type, structured)).to_json)
   end
 
-  def error(msg, type = :other)
-    @system_logger.error(
-      add_details(to_json(msg, type)))
+  def error(msg, type = :other, structured = nil)
+    @log_target.error(
+      add_details(to_hash(msg, type, structured)).to_json)
   end
 
   private
 
-  def to_json(msg, type)
+  def to_hash(msg, type, structured)
     {
       tag: @tag,
       free: msg,
-      type: type
+      type: type,
+      structured: structured,
     }
   end
 
@@ -46,7 +48,8 @@ class SharetribeLogger
       user_id: @user_id,
       username: @username,
       community_id: @community_id,
-      community_ident: @community_ident
+      community_ident: @community_ident,
+      request_uuid: @request_uuid
     }.merge(log_data)
   end
 end

--- a/spec/support/test_log_target.rb
+++ b/spec/support/test_log_target.rb
@@ -1,0 +1,32 @@
+class TestLogTarget
+  attr_reader(
+    :debug_log,
+    :info_log,
+    :warn_log,
+    :error_log,
+    :all_log)
+
+  def initialize
+    @debug_log, @info_log, @warn_log, @error_log, @all_log = [], [], [], [], []
+  end
+
+  def debug(msg)
+    @debug_log.push(msg)
+    @all_log.push(msg)
+  end
+
+  def info(msg)
+    @info_log.push(msg)
+    @all_log.push(msg)
+  end
+
+  def warn(msg)
+    @warn_log.push(msg)
+    @all_log.push(msg)
+  end
+
+  def error(msg)
+    @error_log.push(msg)
+    @all_log.push(msg)
+  end
+end

--- a/spec/utils/sharetribe_logger_spec.rb
+++ b/spec/utils/sharetribe_logger_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require_relative '../support/test_log_target'
+
+describe SharetribeLogger do
+
+  let(:log_target) { TestLogTarget.new }
+  let(:logger) { SharetribeLogger.new(:test, log_target) }
+
+  def test_log_level(level)
+    logger.send(level, "Debug message", :debug, {debug: true})
+    log = log_target.send("#{level}_log".to_sym)
+    expect(log.count)
+      .to eq(1)
+    expect(log.first)
+      .to eq({
+               user_id: nil,
+               username: nil,
+               community_id: nil,
+               community_ident: nil,
+               request_uuid: nil,
+               tag: :test,
+               free: "Debug message",
+               type: :debug,
+               structured: {debug: true}
+             }.to_json)
+
+  end
+
+  it "logs debug level messages" do
+    test_log_level(:debug)
+  end
+
+  it "logs warn level messages" do
+    test_log_level(:warn)
+  end
+
+  it "logs info level messages" do
+    test_log_level(:info)
+  end
+
+  it "logs error level messages" do
+    test_log_level(:error)
+  end
+end

--- a/spec/utils/sharetribe_logger_spec.rb
+++ b/spec/utils/sharetribe_logger_spec.rb
@@ -4,41 +4,70 @@ require_relative '../support/test_log_target'
 describe SharetribeLogger do
 
   let(:log_target) { TestLogTarget.new }
-  let(:logger) { SharetribeLogger.new(:test, log_target) }
 
-  def test_log_level(level)
-    logger.send(level, "Debug message", :debug, {debug: true})
-    log = log_target.send("#{level}_log".to_sym)
-    expect(log.count)
-      .to eq(1)
-    expect(log.first)
-      .to eq({
-               user_id: nil,
-               username: nil,
-               community_id: nil,
-               community_ident: nil,
-               request_uuid: nil,
-               tag: :test,
-               free: "Debug message",
-               type: :debug,
-               structured: {debug: true}
-             }.to_json)
+  describe "log levels" do
+    let(:logger) { SharetribeLogger.new(:test, [], log_target) }
 
+    def test_log_level(level)
+      logger.send(level, "Debug message", :debug, {debug: true})
+      log = log_target.send("#{level}_log".to_sym)
+      expect(log.count)
+        .to eq(1)
+      expect(log.first)
+        .to eq({
+                 tag: :test,
+                 free: "Debug message",
+                 type: :debug,
+                 structured: {debug: true}
+               }.to_json)
+
+    end
+
+    it "logs debug level messages" do
+      test_log_level(:debug)
+    end
+
+    it "logs warn level messages" do
+      test_log_level(:warn)
+    end
+
+    it "logs info level messages" do
+      test_log_level(:info)
+    end
+
+    it "logs error level messages" do
+      test_log_level(:error)
+    end
   end
 
-  it "logs debug level messages" do
-    test_log_level(:debug)
-  end
+  describe "#add_metadata" do
+    let(:logger) { SharetribeLogger.new(:test, [:community_id, :community_ident, :user_id, :username], log_target) }
 
-  it "logs warn level messages" do
-    test_log_level(:warn)
-  end
+    it "includes metadata" do
+      logger.add_metadata(community_id: 123, community_ident: "ident")
+      logger.add_metadata(user_id: "abc")
+      logger.info("Message")
 
-  it "logs info level messages" do
-    test_log_level(:info)
-  end
+      expect(log_target.info_log.first)
+        .to eq({
+                 community_id: 123,
+                 community_ident: "ident",
+                 user_id: "abc",
+                 tag: :test,
+                 free: "Message"
+               }.to_json)
+    end
 
-  it "logs error level messages" do
-    test_log_level(:error)
+    it "throws for unknown metadata keys" do
+
+      expect { logger.add_metadata(community_id: 123) }
+        .not_to raise_error
+
+      expect { logger.add_metadata(community_id: 123, unknown: "jes") }
+        .to raise_error(ArgumentError, "Unknown metadata keys: [:unknown]")
+
+      expect { logger.add_metadata(community_id: 123, community_ident: "ident", user_id: 123, username: "user", unknown: "jes") }
+        .to raise_error(ArgumentError, "Unknown metadata keys: [:unknown]")
+    end
   end
 end


### PR DESCRIPTION
### Description

Implement a thin logger around the default `Rails.logger`. It takes care of JSON formatting and adds additional details, such as `community_id` and `user_id`

### The Problem

**JSON logging:** We should log everything in JSON format to allow Loggly to parse the log messages. However, we don't have tools that actually encourage JSON logging.

**Passing additional information:** We have a lot of valuable information that should be passed with each log message (community_id, user_id, request_id). Adding those pieces of information would make debugging a lot easier.

**Copy-paste code** PayPal Service and SES Service already implement a logger wrapper, and they are basically copy-paste code

**Testing logging:** In some places, logging is critical operation (receiving webhooks etc.) and thus it should be tested. Testing side-effects (STDOUT, in this case) is pretty damn difficult, so the wrapper allows us to inject the logging target, which in case of tests can be something that makes testing easier.

### The Solution

This pull request implements a class `SharetribeLogger`. The constructor takes `tag` and `logging_target` parameters.

```ruby
logger = SharetribeLogger.new(:paypal, Rails.logger)
```

**JSON logging:**

The logger implements all 4 logging level methods `debug`, `info`, `warn` and `error`. Each method takes two arguments: `msg` and `type`. From these information and additional information, such as `community_id`, the logger outputs the following JSON string:

```ruby
# in controller
logger.info("Free message, for convenience", :testing, {testing_logging: true})

INFO {"user_id":"bTarZQWnKr5iaakm_Phqdd","username":"rap1ds","community_id":36,"community_ident":"kuha","request_uuid":"2341824a3bc65bf730ccf19657a4728b","tag":null,"free":"Free message, for convenience","type":"testing","structured":{"testing_logging":true}}
```

**Passing additional information:** Controllers implement a method `logger`, which returns the default `Rails.logger`. This PR overrides that method in ApplicationController. The new `logger` method returns an instance of SharetribeLogger. This PR also adds code that sets the current `community_id` and `user_id` to the logger, so that those are printed when ever something is logged from the controller context.

**Copy-paste code:** The SharetribeLogger can be instantiated with a specific that, and that way it in practise replaces the PaypalService::Logger:

```ruby
logger_for_paypal = SharetribeLogger.new(:paypal, Rails.logger)
```

PaypalService::Logger contains also helpers such as `log_response`. That's something the is not in the SharetribeLogger, so options are either extract these methods to another helper/util class, or make a new Logger class that inherits everything from SharetribeLogger

**Testing logging:**

For testing purposes, we could inject a logger that has a logging target which is something else than Rails.logger. This is not yet implemented, so I don't know exact details, but it could be something like this:

```ruby
# some spec file
before(:each) do
  @test_logger = TestLogger.new
  logger = SharetribeLogger.new(:paypal, @test_logger)
  api = PayPalService::API::Payments.new(logger)
end

it "tests logging"
  expect(@test_logger.logged_errors.count).to eq(0)
  @api.do_some_error_operation(:error)
  expect(@test_logger.logged_errors.count).to eq(1) # logger.error has been called once
  expect(@test_logger.logged_errors.first[:free]).to eq("The operation failed")
end
```