### PR TITLE
Add a link to open the listing address in Google Maps

### DIFF
--- a/app/assets/stylesheets/views/_listings.css.scss
+++ b/app/assets/stylesheets/views/_listings.css.scss
@@ -159,6 +159,12 @@ $listing-author-avatar-height: 108;
   margin: lines(0.5) 0; // Some top & bottom margin to give links some space
 }
 
+.map-link {
+  float: right;
+  font-size: 14px;
+  margin-top: 0.2em;
+}
+
 // Delivery options
 .delivery-title {
   margin-bottom: 0;

--- a/app/assets/stylesheets/views/_listings.css.scss
+++ b/app/assets/stylesheets/views/_listings.css.scss
@@ -161,7 +161,7 @@ $listing-author-avatar-height: 108;
 
 .map-link {
   float: right;
-  font-size: 14px;
+  font-size: em(14);
   margin-top: 0.2em;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,6 +66,7 @@ module ApplicationHelper
       "send" => "ss-send",
       "form" => "ss-form",
       "link" => "ss-link",
+      "external_link" => "ss-action",
       "social_media" => "ss-share",
       "analytics" => "ss-analytics",
       "openbook" => "ss-openbook",
@@ -187,6 +188,8 @@ module ApplicationHelper
       "facebook" => "icon-facebook",
       "invite" => "icon-users",
       "download" => "icon-download",
+      "link" => "icon-link",
+      "external_link" => "icon-external-link",
 
       "information" => "icon-info-sign",
       "alert" => "icon-warning-sign",

--- a/app/views/listings/_googlemap.haml
+++ b/app/views/listings/_googlemap.haml
@@ -5,3 +5,7 @@
       $(document).ready(function() {
         googlemapMarkerInit('map_canvas', "origin_loc", undefined, undefined, #{tribe_latitude}, #{tribe_longitude}, "#{listing.location.address}");
       });
+  .map-link
+    %a.icon-with-text-container{href: "https://maps.google.com/?q=#{CGI.escape(listing.location.address)}", target: "_blank"}
+      = icon_tag("external_link", ["icon-part"])
+      .text-part= t("listings.map.open_in_google_maps")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1426,6 +1426,8 @@ en:
       show_in_updates_email_loading: Loading...
       show_in_updates_email_error: "Couldn't reach server. Try again after page refresh."
       show_in_updates_email_success: "This listing will be shown in the next automatic update email sent to the users"
+    map:
+      open_in_google_maps: "Open in Google Maps"
     error:
       something_went_wrong: "Something went wrong, error code: %{error_code}"
     follow_links:


### PR DESCRIPTION
When viewing a list, it would be useful to be able to get directions to the location. Add a link to open the address in Google Maps, which provides directions. When opening on mobile, users can also open the Google Maps app.

![screenshot 2015-10-15 12 24 26](https://cloud.githubusercontent.com/assets/888333/10509772/b594f236-7337-11e5-845b-0501ad43fe11.png)
