### PR TITLE
Admin and comment author can delete a comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
     controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_send_a_comment")
   end
 
-  before_filter :ensure_authorized_to_comment
+  before_filter :ensure_authorized_to_comment, only: [:create]
 
   def create
     if @comment.save
@@ -16,6 +16,20 @@ class CommentsController < ApplicationController
     respond_to do |format|
       format.html { redirect_to listing_path(params[:comment][:listing_id]) }
       format.js { render :layout => false }
+    end
+  end
+
+  def destroy
+    @comment = Comment.find(params[:id])
+    if current_user?(@comment.author) || @current_user.has_admin_rights_in?(@current_community)
+      @comment.destroy
+      respond_to do |format|
+        format.html { redirect_to listing_path(params[:listing_id]) }
+        format.js { render :layout => false }
+      end
+    else
+      flash[:error] = t("layouts.notifications.you_are_not_authorized_to_do_this")
+      redirect_to listing_path(params[:listing_id])
     end
   end
 

--- a/app/views/comments/destroy.js.erb
+++ b/app/views/comments/destroy.js.erb
@@ -1,0 +1,5 @@
+/* Remove the comment */
+$("#comment<%= @comment.id.to_s %>").fadeOut(300, function() { $(this).remove(); });
+
+/* Update comment count */
+$("#comment_count").html("(<%= @comment.listing.comments_count - 1 %>)");

--- a/app/views/listings/_comment.haml
+++ b/app/views/listings/_comment.haml
@@ -4,6 +4,8 @@
   %h3
     = link_to_unless comment.author.deleted?, PersonViewUtils.person_display_name(comment.author, @current_community), comment.author
   %small= time_ago(comment.created_at)
+  - if @current_user && (current_user?(comment.author) || @current_user.has_admin_rights_in?(@current_community))
+    %small= link_to t('listings.comment.delete'), listing_comment_path(:listing_id => comment.listing.id, :id => comment.id), {method: :delete, confirm: t('listings.comment.are_you_sure'), :remote => :true}
   .comment-content
     - text_with_line_breaks do
       = comment.content

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1408,6 +1408,8 @@ en:
     comment:
       wrote: wrote
       send_private_message: "Send private message to %{person}"
+      delete: delete
+      are_you_sure: "Are you sure?"
     comment_form:
       ask_a_question: "Comment on the listing or ask for more details. All the other users will be able to see your comment."
       log_in: "sign in"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1409,7 +1409,7 @@ en:
       wrote: wrote
       send_private_message: "Send private message to %{person}"
       delete: delete
-      are_you_sure: "Are you sure?"
+      are_you_sure: "Are you sure you want to delete the comment?"
     comment_form:
       ask_a_question: "Comment on the listing or ask for more details. All the other users will be able to see your comment."
       log_in: "sign in"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1397,8 +1397,6 @@ zh:
     comment:
       wrote: 写到
       send_private_message: "发送私人消息给%{person}"
-      delete: 删除
-      are_you_sure: 你确定要删除吗？
     comment_form:
       ask_a_question: 评论该条信息或者询问更多细节。所有其他用户都能看到你的评论。
       log_in: 登录

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1397,6 +1397,8 @@ zh:
     comment:
       wrote: 写到
       send_private_message: "发送私人消息给%{person}"
+      delete: 删除
+      are_you_sure: 你确定要删除吗？
     comment_form:
       ask_a_question: 评论该条信息或者询问更多细节。所有其他用户都能看到你的评论。
       log_in: 登录

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,7 +219,7 @@ Kassi::Application.routes.draw do
         get :locations_json
         get :verification_required
       end
-      resources :comments
+      resources :comments, :only => [:create, :destroy]
       resources :listing_images do
         collection do
           post :add_from_file

--- a/features/listings/user_comments_a_listing.feature
+++ b/features/listings/user_comments_a_listing.feature
@@ -42,6 +42,28 @@ Feature: User comments a listing
     Then I should see "Don't get emails about new comments"
 
   @javascript
+  Scenario: Deleting a comment successfully
+  Given there are following users:
+      | person |
+      | kassi_testperson1 |
+      | kassi_testperson2 |
+  And there is a listing with title "Massage" from "kassi_testperson1" with category "Services" and with listing shape "Requesting"
+  And listing comments are in use in community "test"
+  And I am logged in as "kassi_testperson2"
+  When I follow "Massage"
+  And I fill in "comment_content" with "Test comment"
+  And I press "Send comment"
+  And I should see "Test comment" within "#comments"
+  And I should see "1" within "#comment_count"
+  And I should see "delete" within "#comments"
+  And the system processes jobs
+  And I will confirm all following confirmation dialogs in this page if I am running PhantomJS
+  And I follow "delete"
+  When I confirm alert popup
+  And I should not see "Test comment" within "#comments"
+  And I should see "0" within "#comment_count"
+
+  @javascript
   Scenario: Trying to add a new comment without content
     Given there are following users:
       | person |


### PR DESCRIPTION
Rebase of a branch originally authored by @bingxie 

Comments on listings can be deleted either by the marketplace admin or then by the comment author. Listing authors cannot delete comments about their listings. If they do think a comment is inappropriate they can get in touch with marketplace owner who then decides if the comment should be deleted.