### PR TITLE
Use bold font only for unread messages

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -435,10 +435,6 @@ label.error {
 
 }
 
-.unread {
-  background: $highlight;
-}
-
 // Notification that doesn't disappear
 .permanent-notification {
   margin-bottom: lines(0.5);

--- a/app/assets/stylesheets/views/_conversation.css.scss
+++ b/app/assets/stylesheets/views/_conversation.css.scss
@@ -1,5 +1,9 @@
 @import "mixins/all";
 
+.conversation-unread {
+  background: $highlight;
+}
+
 .conversation-details-container {
   position: relative;
 }
@@ -24,9 +28,13 @@
 }
 
 .conversation-title-link {
-  font-weight: bold;
   display: block;
   @include ellipsis;
+}
+
+.conversation-title-link-unread {
+  font-weight: bold;
+  @extend .conversation-title-link;
 }
 
 .conversation-title-link-text {

--- a/app/views/inboxes/_inbox_row.haml
+++ b/app/views/inboxes/_inbox_row.haml
@@ -1,4 +1,4 @@
-.row-with-divider.without-margin.conversation-row{:class => conversation[:should_notify] ? "unread" : ""}
+.row-with-divider.without-margin.conversation-row{:class => conversation[:should_notify] ? "conversation-unread" : ""}
 
   .col-3
     .conversation-details-container
@@ -11,7 +11,7 @@
           = conversation[:last_activity_ago]
 
   %div{class: payments_in_use ? "col-6" : "col-9"}
-    = link_to conversation[:path], class: "conversation-title-link" do
+    = link_to conversation[:path], class:(conversation[:should_notify] ? 'conversation-title-link-unread' : 'conversation-title-link') do
       = conversation[:title]
     .conversation-context
       - if conversation[:listing_url].present?

--- a/features/conversations/user_checks_inbox.feature
+++ b/features/conversations/user_checks_inbox.feature
@@ -67,7 +67,7 @@ Feature: User checks inbox
     And I should see "Fine"
     And I follow "Fine"
     And I follow inbox link
-    And I should not see "Fine" within ".unread"
+    And I should not see "Fine" within ".conversation-title-link-unread"
     And I should see that there is 1 new message
 
   Scenario: Viewing sent messages when there are multiple messages from different senders

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -131,7 +131,7 @@ Given /^I want to pay "(.*?)"$/ do |item_title|
   steps %Q{
     Given I am on the messages page
     Then I should see "Waiting for you to pay"
-    When I click ".conversation-title-link"
+    When I click ".conversation-title-link-unread"
     And I follow "Pay"
     Then I should see payment details form for Braintree
   }
@@ -142,7 +142,7 @@ When /^I cancel the transaction$/ do
   steps %Q{
     Given I am on the messages page
     Then I should see "Waiting for you to mark the request completed"
-    When I click ".conversation-title-link"
+    When I click ".conversation-title-link-unread"
     And I follow "Dispute"
   }
 end


### PR DESCRIPTION
Small usability improvement: In inbox, use bold font only for unread messages. This makes is easier to differentiate unread and read messages.

Before:

![screen shot 2015-10-22 at 08 53 39](https://cloud.githubusercontent.com/assets/429876/10657936/9cc24ee4-789a-11e5-81fc-b34af47bc3a1.png)

After:

![screen shot 2015-10-22 at 08 53 11](https://cloud.githubusercontent.com/assets/429876/10657938/a2dfce46-789a-11e5-9b55-355c5f2f4202.png)

