### PR TITLE
Add "Select/clear all" links for listing fields and categories admin pages

### DIFF
--- a/app/assets/javascripts/admin/categories.js
+++ b/app/assets/javascripts/admin/categories.js
@@ -8,7 +8,7 @@ window.ST.initializeCategoriesSelectionClickHandlers = function() {
   $(".deselect-all").click(function() {
     $(".category-listing-shape-checkbox").prop("checked", false);
   });
-}
+};
 
 /**
   Category order manager

--- a/app/assets/javascripts/admin/categories.js
+++ b/app/assets/javascripts/admin/categories.js
@@ -1,4 +1,16 @@
 /**
+  Add click handlers for the select/clear all links.
+*/
+window.ST.initializeCategoriesSelectionClickHandlers = function() {
+  $(".select-all").click(function() {
+    $(".category-listing-shape-checkbox").prop("checked", true);
+  });
+  $(".deselect-all").click(function() {
+    $(".category-listing-shape-checkbox").prop("checked", false);
+  });
+}
+
+/**
   Category order manager
 */
 window.ST.initializeCategoriesOrder = function() {

--- a/app/assets/javascripts/admin/custom_fields.js
+++ b/app/assets/javascripts/admin/custom_fields.js
@@ -1,6 +1,18 @@
 window.ST = window.ST || {};
 
 /**
+  Add click handlers for the select/clear all links.
+*/
+window.ST.initializeCustomFieldsSelectionClickHandlers = function() {
+  $(".select-all").click(function() {
+    $(".custom-field-category-checkbox").prop("checked", true);
+  });
+  $(".deselect-all").click(function() {
+    $(".custom-field-category-checkbox").prop("checked", false);
+  });
+}
+
+/**
   Custom field order manager.
 
   Makes a POST request when order changes.

--- a/app/assets/javascripts/admin/custom_fields.js
+++ b/app/assets/javascripts/admin/custom_fields.js
@@ -10,7 +10,7 @@ window.ST.initializeCustomFieldsSelectionClickHandlers = function() {
   $(".deselect-all").click(function() {
     $(".custom-field-category-checkbox").prop("checked", false);
   });
-}
+};
 
 /**
   Custom field order manager.

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -2251,3 +2251,11 @@ figure.fluidratio {
     }
   }
 }
+
+.selection-options {
+  @include media(tablet) {
+    margin-top: lines(0.5);
+    margin-bottom: em(3);
+    float: right;
+  }
+}

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -2251,11 +2251,3 @@ figure.fluidratio {
     }
   }
 }
-
-.selection-options {
-  @include media(tablet) {
-    margin-top: lines(0.5);
-    margin-bottom: em(3);
-    float: right;
-  }
-}

--- a/app/assets/stylesheets/partials/_forms.css.scss
+++ b/app/assets/stylesheets/partials/_forms.css.scss
@@ -50,5 +50,13 @@ input.auto_width {
     padding: lines(0.4);
     border-radius: 6px;
   }
+}
 
+// Select all / clear all links in a few admin pages
+.selection-options {
+  @include media(tablet) {
+    margin-top: lines(0.5);
+    margin-bottom: em(3);
+    float: right;
+  }
 }

--- a/app/views/admin/categories/edit.haml
+++ b/app/views/admin/categories/edit.haml
@@ -1,5 +1,6 @@
 - content_for :javascript do
   initialize_admin_category_form_view("#{I18n.locale}", "#edit_category_#{@category.id}");
+  ST.initializeCategoriesSelectionClickHandlers();
 
 - content_for :title_header do
   %h1

--- a/app/views/admin/categories/form/_category_listing_shapes.haml
+++ b/app/views/admin/categories/form/_category_listing_shapes.haml
@@ -1,5 +1,14 @@
 - if shapes.size > 1
-  %label= t("admin.categories.form.category_transaction_types.transaction_types")
+  .row
+    .col-8
+      %label= t("admin.categories.form.category_transaction_types.transaction_types")
+    .col-4
+      .selection-options
+        %a.select-all{href: "#"}
+          = t("admin.categories.form.category_transaction_types.select_all")
+        |
+        %a.deselect-all{href: "#"}
+          = t("admin.categories.form.category_transaction_types.clear_all")
   = render :partial => "layouts/info_text", :locals => { :text => t("admin.categories.form.category_transaction_types.transaction_types_description") }
   .row
     .col-12

--- a/app/views/admin/categories/new.haml
+++ b/app/views/admin/categories/new.haml
@@ -1,5 +1,6 @@
 - content_for :javascript do
   initialize_admin_category_form_view("#{I18n.locale}", "#new_category");
+  ST.initializeCategoriesSelectionClickHandlers();
 
 - content_for :title_header do
   %h1

--- a/app/views/admin/custom_fields/edit.haml
+++ b/app/views/admin/custom_fields/edit.haml
@@ -1,6 +1,7 @@
 - content_for :javascript do
   initialize_admin_listing_field_form_view("#{I18n.locale}", "#edit_custom_field", #{@custom_field.options.size}, #{@min_option_count});
   ST.customFieldOptionOrder = ST.createCustomFieldOptionOrder(".custom-field-option-container");
+  ST.initializeCustomFieldsSelectionClickHandlers();
 
 - content_for :title_header do
   %h1

--- a/app/views/admin/custom_fields/form/_field_categories.haml
+++ b/app/views/admin/custom_fields/form/_field_categories.haml
@@ -1,5 +1,14 @@
 - if @current_community.categories.size > 1
-  = form.label :category_attributes, t("admin.custom_fields.index.categories")
+  .row
+    .col-8
+      = form.label :category_attributes, t("admin.custom_fields.index.categories")
+    .col-4
+      .selection-options
+        %a.select-all{href: "#"}
+          = t("admin.custom_fields.index.select_all")
+        |
+        %a.deselect-all{href: "#"}
+          = t("admin.custom_fields.index.clear_all")
   .row
     .col-12
       .custom-field-categories-container.clearfix#custom-field-categories-container

--- a/app/views/admin/custom_fields/new.haml
+++ b/app/views/admin/custom_fields/new.haml
@@ -1,6 +1,7 @@
 - content_for :javascript do
   initialize_admin_listing_field_form_view("#{I18n.locale}", "#new_custom_field", #{@custom_field.options.size}, #{@min_option_count});
   ST.customFieldOptionOrder = ST.createCustomFieldOptionOrder(".custom-field-option-container");
+  ST.initializeCustomFieldsSelectionClickHandlers();
 
 - content_for :title_header do
   %h1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,8 @@ en:
         field_title: "Field title"
         field_type: "Field type"
         categories: "Listing categories where the field is used"
+        select_all: "Select all"
+        clear_all: "Clear all"
         options: Options
         add_option: "+ Add option"
         saving_order: "Saving field order"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
         category_transaction_types:
           transaction_types: "Order types"
           transaction_types_description: "Order types determine what kind of order process is allowed with listings in this category. For example, is it only selling, or are renting and giving away for free also allowed."
+          select_all: "Select all"
+          clear_all: "Clear all"
         buttons:
           save: Save
           cancel: Cancel


### PR DESCRIPTION
If a marketplace has many order types or categories, selecting them all can be a pain when making new categories or listing fields. Add Select all / Clear all links to these pages:

![screenshot 2015-11-02 11 19 47](https://cloud.githubusercontent.com/assets/888333/10878027/b0dc732a-8153-11e5-8318-bd7e9a0d8782.png)

On mobile size:

![screenshot 2015-11-02 11 19 56](https://cloud.githubusercontent.com/assets/888333/10878035/b57b7bb0-8153-11e5-9c3b-10ae6b508592.png)
