### PR TITLE
Tweak labels and add instruction text for price filter admin page

### DIFF
--- a/app/views/admin/custom_fields/edit_price.haml
+++ b/app/views/admin/custom_fields/edit_price.haml
@@ -30,4 +30,8 @@
         = form.label "community[price_filter_max]", t(".price_max")
         = text_field_tag "community[price_filter_max]", max, :class => "required number-no-decimals"
 
+    .row
+      .col-12
+        = render :partial => "layouts/info_text", :locals => { :text => t("admin.custom_fields.edit_price.description") }
+
     = render :partial => "admin/custom_fields/form/buttons", :locals => { :form => form }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,10 +332,11 @@ en:
       edit:
         edit_listing_field: "Edit listing field '%{field_name}'"
       edit_price:
+        description: "The minimum and maximum price only affect the filter. They do not set a limit for listing prices."
         edit_price_field: "Edit price field"
         show_price_filter_homepage: "Show price filter on homepage"
-        price_min: "Minimum price"
-        price_max: "Maximum price"
+        price_min: "Filter minimum price"
+        price_max: "Filter maximum price"
       edit_location:
         edit_location_field: "Edit location field"
         this_field_is_required: "This field is required"


### PR DESCRIPTION
Users have been confused about what the price filter does. People have thought that the price limit affects the minimum and maximum prices for listings, not the filter. Rename the labels and add an instruction text to clarify this:

![screenshot 2015-11-02 15 13 40](https://cloud.githubusercontent.com/assets/888333/10882545/51e5cb20-8174-11e5-9260-a0d6cf60713b.png)

Mobile view:

![screenshot 2015-11-02 15 13 59](https://cloud.githubusercontent.com/assets/888333/10882550/5d072bca-8174-11e5-82d5-5087bf829076.png)
