### PR TITLE
Use asset-url instead of image-path for logos

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -2013,7 +2013,7 @@ figure.fluidratio {
   position: relative;
 
   figure.marketplace-cover {
-    background-image: url(image-path($cover-photo-url));
+    background-image: asset-url($cover-photo-url, image);
     height: em($cover-photo-mobile-height);
     @include media(tablet) {
       @include fluid-ratio(em(1920) em($cover-photo-height), em(300) em($cover-photo-height));
@@ -2021,7 +2021,7 @@ figure.fluidratio {
   }
 
   figure.marketplace-cover-small {
-    background-image: url(image-path($small-cover-photo-url));
+    background-image: asset-url($small-cover-photo-url, image);
     height: em($small-cover-photo-mobile-height);
     @include media(tablet) {
       @include fluid-ratio(em(1920) em($small-cover-photo-height), em(300) em($small-cover-photo-height));

--- a/app/assets/stylesheets/mixins/default-colors.scss
+++ b/app/assets/stylesheets/mixins/default-colors.scss
@@ -54,12 +54,12 @@ $red:         hsl($error-hue, 73.4%, 38.2%);
 $error-red:   hsl($error-hue, 73.4%, 45.2%);
 $yellow:      #D1C905;
 
-$cover-photo-url: "/assets/cover_photos/header/default.jpg";
-$small-cover-photo-url: "/assets/cover_photos/header/default.jpg";
-$wide-logo-lowres-url: "/assets/logos/full/default.png";
-$wide-logo-highres-url: "/assets/logos/full/default-highres.png";
-$square-logo-lowres-url: "/assets/logos/mobile/default.png";
-$square-logo-highres-url: "/assets/logos/mobile/default-highres.png";
+$cover-photo-url: "cover_photos/header/default.jpg";
+$small-cover-photo-url: "cover_photos/header/default.jpg";
+$wide-logo-lowres-url: "logos/full/default.png";
+$wide-logo-highres-url: "logos/full/default-highres.png";
+$square-logo-lowres-url: "logos/mobile/default.png";
+$square-logo-highres-url: "logos/mobile/default-highres.png";
 $cover-photo-height: 453;
 $cover-photo-mobile-height: 365;
 $small-cover-photo-height: 96;

--- a/app/assets/stylesheets/views/_header.css.scss
+++ b/app/assets/stylesheets/views/_header.css.scss
@@ -193,10 +193,10 @@ $elementSpacing: lines(0.5);
 }
 
 .header-wide-logo {
-  background-image: url(image-path($wide-logo-lowres-url));
+  background-image: asset-url($wide-logo-lowres-url, image);
 
   @include highres {
-    background-image: url(image-path($wide-logo-highres-url));
+    background-image: asset-url($wide-logo-highres-url, image);
   }
 
   width: em(168);
@@ -210,10 +210,10 @@ $elementSpacing: lines(0.5);
 }
 
 .header-square-logo {
-  background-image: url(image-path($square-logo-lowres-url));
+  background-image: asset-url($square-logo-lowres-url, image);
 
   @include highres {
-    background-image: url(image-path($square-logo-highres-url));
+    background-image: asset-url($square-logo-highres-url, image);
   }
 
   width: em(40);


### PR DESCRIPTION
For marketplaces that hadn't set their own logo, we were using the static path for e.g. `/assets/logos/mobile/default-highres.png`. This is the wrong path since it doesn't contain the hash of the file in the filename.

Replace `url(image-path(...))` with `asset-url(...)` to fix this.