### PR TITLE
Update compass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,13 @@ end
 
 gem 'sass-rails'
 gem 'compass-rails'
+
+# Requiring 'compass' gem directly is not normally needed,
+# 'compass-rails' already does that.
+#
+# However, we want to have compass version which is at least 0.13,
+# because it fixes a bug that caused compass helpers to override
+# important Rails asset helpers
 gem 'compass', '~> 0.13.alpha'
 
 gem 'jquery-rails', '2.1.4'

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 
 gem 'sass-rails'
 gem 'compass-rails'
+gem 'compass', '~> 0.13.alpha'
 
 gem 'jquery-rails', '2.1.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       timers (~> 1.1.0)
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
-    chunky_png (1.2.6)
+    chunky_png (1.3.5)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.1)
@@ -108,10 +108,10 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.4.0)
-    compass (0.12.2)
+    compass (0.13.alpha.0)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
-      sass (~> 3.1)
+      sass (~> 3.2.0.alpha.93)
     compass-rails (1.0.3)
       compass (>= 0.12.2, < 0.14)
     connection_pool (0.9.3)
@@ -201,7 +201,7 @@ GEM
       nokogiri (~> 1.5.0)
       ruby-hmac
     formatador (0.2.5)
-    fssm (0.2.9)
+    fssm (0.2.10)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     guard (2.6.1)
@@ -440,7 +440,7 @@ GEM
     ruby-prof (0.14.2)
     ruby-progressbar (1.4.2)
     rubyzip (1.1.7)
-    sass (3.2.10)
+    sass (3.2.19)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
@@ -527,6 +527,7 @@ DEPENDENCIES
   cache_digests
   capybara
   coffee-rails (~> 3.2.2)
+  compass (~> 0.13.alpha)
   compass-rails
   connection_pool
   country_select (> 1.2.0)

--- a/app/assets/stylesheets/mixins/default-colors.scss
+++ b/app/assets/stylesheets/mixins/default-colors.scss
@@ -54,12 +54,12 @@ $red:         hsl($error-hue, 73.4%, 38.2%);
 $error-red:   hsl($error-hue, 73.4%, 45.2%);
 $yellow:      #D1C905;
 
-$cover-photo-url: "/assets/cover_photos/header/default.jpg";
-$small-cover-photo-url: "/assets/cover_photos/header/default.jpg";
-$wide-logo-lowres-url: "/assets/logos/full/default.png";
-$wide-logo-highres-url: "/assets/logos/full/default-highres.png";
-$square-logo-lowres-url: "/assets/logos/mobile/default.png";
-$square-logo-highres-url: "/assets/logos/mobile/default-highres.png";
+$cover-photo-url: "cover_photos/header/default.jpg";
+$small-cover-photo-url: "cover_photos/header/default.jpg";
+$wide-logo-lowres-url: "logos/full/default.png";
+$wide-logo-highres-url: "logos/full/default-highres.png";
+$square-logo-lowres-url: "logos/mobile/default.png";
+$square-logo-highres-url: "logos/mobile/default-highres.png";
 $cover-photo-height: 453;
 $cover-photo-mobile-height: 365;
 $small-cover-photo-height: 96;


### PR DESCRIPTION
The `compass` version we were using has a bug, which causes Compass to override the Rails asset helpers, such as `image-path`. The result was that the path to the image wasn't coming from Assets Pipeline and that's why it was missing the fingerprint.

This PR updates compass and fixes the issue.