### PR TITLE
Cleaner URL for plans

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -11,21 +11,6 @@ class Admin::CommunitiesController < ApplicationController
     render locals: {paypal_enabled: PaypalHelper.paypal_active?(@current_community.id)}
   end
 
-  def plan
-    marketplace_default_name = @current_community.name(@current_community.default_locale)
-
-    PlanService::API::Api.plans.get_external_service_link(
-      id: @current_community.id,
-      ident: @current_community.ident,
-      domain: @current_community.domain,
-      marketplace_default_name: marketplace_default_name
-    ).on_success { |link|
-      redirect_to link
-    }.on_error { |error_msg|
-      render_not_found!(error_msg)
-    }
-  end
-
   def edit_look_and_feel
     @selected_left_navi_link = "tribe_look_and_feel"
     @community = @current_community

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -14,14 +14,16 @@ class Admin::CommunitiesController < ApplicationController
   def plan
     marketplace_default_name = @current_community.name(@current_community.default_locale)
 
-    link = PlanService::API::Api.plans.get_external_service_link({
+    PlanService::API::Api.plans.get_external_service_link(
       id: @current_community.id,
       ident: @current_community.ident,
       domain: @current_community.domain,
       marketplace_default_name: marketplace_default_name
-    }).data
-
-    redirect_to link
+    ).on_success { |link|
+      redirect_to link
+    }.on_error { |error_msg|
+      render_not_found!(error_msg)
+    }
   end
 
   def edit_look_and_feel

--- a/app/controllers/admin/plans_controller.rb
+++ b/app/controllers/admin/plans_controller.rb
@@ -1,0 +1,21 @@
+class Admin::PlansController < ApplicationController
+
+  before_filter :ensure_is_admin
+
+  # Redirect to external plan service. Nothing else.
+  def show
+    marketplace_default_name = @current_community.name(@current_community.default_locale)
+
+    PlanService::API::Api.plans.get_external_service_link(
+      id: @current_community.id,
+      ident: @current_community.ident,
+      domain: @current_community.domain,
+      marketplace_default_name: marketplace_default_name
+    ).on_success { |link|
+      redirect_to link
+    }.on_error { |error_msg|
+      render_not_found!(error_msg)
+    }
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -589,7 +589,7 @@ module ApplicationHelper
         :topic => :general,
         :text => t("admin.left_hand_navigation.plan"),
         :icon_class => icon_class("credit_card"),
-        :path => plan_admin_community_path(@current_community),
+        :path => admin_plan_path,
         :name => "plan",
       }
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,7 +120,6 @@ Kassi::Application.routes.draw do
       resources :communities do
         member do
           get :getting_started, to: 'communities#getting_started'
-          get :plan, to: 'communities#plan'
           get :edit_details, to: 'community_customizations#edit_details'
           put :update_details, to: 'community_customizations#update_details'
           get :edit_look_and_feel
@@ -191,6 +190,7 @@ Kassi::Application.routes.draw do
           get :close_listings
         end
       end
+      resource :plan, only: [:show]
     end
 
     resources :invitations


### PR DESCRIPTION
- Add a new `Admin::PlansController`
- The URL is now `www.marketplace.com/admin/plan`
- Fix null pointer if ext plan service is not in use