### PR TITLE
Treat closed marketplace (hold plans and expired non-trial plans) as deleted

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,7 @@ class ApplicationController < ActionController::Base
 
   before_filter :check_auth_token,
     :fetch_community,
+    :fetch_community_plan_expiration_status,
     :perform_redirect,
     :fetch_logged_in_user,
     :save_current_host_with_port,
@@ -29,7 +30,6 @@ class ApplicationController < ActionController::Base
     :set_default_url_for_mailer,
     :fetch_chargebee_plan_data,
     :fetch_community_admin_status,
-    :fetch_community_plan_expiration_status,
     :warn_about_missing_payment_info,
     :set_homepage_path,
     :report_queue_size
@@ -239,7 +239,8 @@ class ApplicationController < ActionController::Base
         domain: c.domain,
         deleted: c.deleted?,
         use_domain: c.use_domain?,
-        domain_verification_file: c.dv_test_file_name
+        domain_verification_file: c.dv_test_file_name,
+        closed: Maybe(@current_plan)[:closed].or_else(false)
       }
     }.or_else(nil)
 

--- a/app/services/plan_service/api/no_plans.rb
+++ b/app/services/plan_service/api/no_plans.rb
@@ -26,10 +26,8 @@ module PlanService::API
         community_id: community_id,
         plan_level: PlanService::Levels::OS,
         expires_at: nil,
-        closed: false,
-        deleted: false,
         created_at: Time.now,
-        updated_at: Time.now).merge(expired: false)
+        updated_at: Time.now).merge(expired: false, closed: false)
       )
     end
 

--- a/app/services/plan_service/api/no_plans.rb
+++ b/app/services/plan_service/api/no_plans.rb
@@ -26,6 +26,8 @@ module PlanService::API
         community_id: community_id,
         plan_level: PlanService::Levels::OS,
         expires_at: nil,
+        closed: false,
+        deleted: false,
         created_at: Time.now,
         updated_at: Time.now).merge(expired: false)
       )

--- a/app/services/plan_service/api/plans.rb
+++ b/app/services/plan_service/api/plans.rb
@@ -25,7 +25,7 @@ module PlanService::API
 
     def create(community_id:, plan:)
       Result::Success.new(
-        with_expiration_status(
+        with_statuses(
           PlanStore.create(community_id: community_id, plan: plan)))
     end
 
@@ -38,14 +38,14 @@ module PlanService::API
     #
     def create_initial_trial(community_id:, plan:)
       Result::Success.new(
-        with_expiration_status(
+        with_statuses(
           PlanStore.create_trial(community_id: community_id, plan: plan)))
 
     end
 
     def get_current(community_id:)
       Maybe(PlanStore.get_current(community_id: community_id)).map { |plan|
-        Result::Success.new(with_expiration_status(plan))
+        Result::Success.new(with_statuses(plan))
       }.or_else {
         Result::Error.new("Can not find plan for community id: #{community_id}")
       }
@@ -96,7 +96,7 @@ module PlanService::API
 
     private
 
-    def with_expiration_status(plan)
+    def with_statuses(plan)
       plan.merge(
         expired: plan_expired?(plan),
         closed: plan_closed?(plan)

--- a/app/utils/marketplace_router.rb
+++ b/app/utils/marketplace_router.rb
@@ -12,6 +12,7 @@ module MarketplaceRouter
     Community = EntityUtils.define_builder(
       [:use_domain, :bool, :mandatory],
       [:deleted, :bool, :mandatory],
+      [:closed, :bool, :mandatory],
       [:domain, :string, :optional],
       [:domain_verification_file, :optional],
       [:ident, :string, :mandatory]
@@ -109,7 +110,7 @@ module MarketplaceRouter
         # -> Redirect to not found
         paths[:community_not_found].merge(status: :found, protocol: protocol)
 
-      elsif community && community[:deleted]
+      elsif community && (community[:deleted] || community[:closed])
         # Community deleted
         # -> Redirect to not found
         paths[:community_not_found].merge(status: :moved_permanently, protocol: protocol)

--- a/spec/utils/marketplace_router_spec.rb
+++ b/spec/utils/marketplace_router_spec.rb
@@ -13,6 +13,7 @@ describe MarketplaceRouter do
     default_community = {
       use_domain: true,
       deleted: false,
+      closed: false,
       domain: "www.marketplace.com",
       domain_verification_file: nil,
       ident: "marketplace",
@@ -92,10 +93,10 @@ describe MarketplaceRouter do
                       }).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end
 
-    it "redirects deleted marketplaces" do
+    it "redirects closed marketplaces" do
       expect_redirect(community: {
                         domain: "www.marketplace.com",
-                        deleted: true,
+                        closed: true,
                         use_domain: true,
                       }).to eq(route_name: :not_found, status: :moved_permanently, protocol: "https")
     end


### PR DESCRIPTION
- [X] Add `closed` status to plan entity
- [X] Redirect `closed` plans to not found
- [x] Make sure that the data is correct