### PR TITLE
Fix JS bug on create new listing page

### DIFF
--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -34,7 +34,7 @@
                 "#fee_display",
                 "#listing_currency",
                 #{commission_from_seller},
-                #{minimum_commission.format(decimal_mark: ".", symbol: false)},
+                #{minimum_commission.format(decimal_mark: ".", delimiter: "", symbol: false)},
                 #{payment_gateway == :paypal});
             });
         - if run_js_immediately


### PR DESCRIPTION
Format money with no thousands separator, since it's used as JS variable.

Yeah, needs deeper refactoring but this fixes the live bug.