### PR TITLE
Paypal improvement fixes

### DIFF
--- a/app/assets/stylesheets/mixins/default-colors.scss
+++ b/app/assets/stylesheets/mixins/default-colors.scss
@@ -47,6 +47,8 @@ $emphasis:    hsl($primary-hue, 0%, 9%);
 $link:        #a64c5d;
 $link2:       #00a26c;
 
+$success-green: #19b400;
+
 // notification colors
 $green:       hsl($notification-hue, 73.4%, 28.2%);
 $light-green: hsl(110, 38%, 76%);

--- a/app/assets/stylesheets/partials/_paypal_account_connected.css.scss
+++ b/app/assets/stylesheets/partials/_paypal_account_connected.css.scss
@@ -1,0 +1,15 @@
+@import "mixins/all";
+
+.paypal-link-wrapper {
+  & .send-button-loading-img {
+    width: lines(0.75);
+    height: lines(0.75);
+    margin: 0 lines(0.5);
+    top: 3px;
+    position: relative;
+  }
+}
+
+.paypal-account-connected {
+  color: $success-green;
+}

--- a/app/assets/stylesheets/views/_account-settings.css.scss
+++ b/app/assets/stylesheets/views/_account-settings.css.scss
@@ -1,7 +1,5 @@
 @import "mixins/all";
 
-$success-green: #19b400;
-
 /*
   ----------------
   Person settings
@@ -192,12 +190,6 @@ $success-green: #19b400;
   }
 }
 
-.paypal-account-connected,
-.paypal-preferences-valid,
-.paypal-billing-agreement-made {
-  color: $success-green;
-}
-
 .alert-text-container {
   position: relative;
   margin-top: lines(0.25);
@@ -240,20 +232,6 @@ $success-green: #19b400;
 
 .paypal-change-link {
   cursor: pointer;
-}
-
-.paypal-success-mark {
-  color: $success-green;
-}
-
-.paypal-link-wrapper {
-  & .send-button-loading-img {
-    width: lines(0.75);
-    height: lines(0.75);
-    margin: 0 lines(0.5);
-    top: 3px;
-    position: relative;
-  }
 }
 
 .paypal-first-steps-list {

--- a/app/assets/stylesheets/views/admin/_paypal_preferences.css.scss
+++ b/app/assets/stylesheets/views/admin/_paypal_preferences.css.scss
@@ -17,6 +17,7 @@
 }
 
 .paypal-preferences {
+  margin-top: lines(0.5);
   margin-bottom: lines(1.5);
 }
 

--- a/app/views/admin/paypal_preferences/index.haml
+++ b/app/views/admin/paypal_preferences/index.haml
@@ -46,22 +46,9 @@
     .row.paypal-wizard
       .col-12
         .paypal-wizard-content
-          .row
-            .col-12
-              %h3.paypal-account-connected
-                =icon_tag("check", ["icon-fix"])
-                =t("paypal_accounts.paypal_account_connected_title")
-          .row.paypal-link-wrapper
-            .col-12
-              .paypal-connected-email.paypal-account-connected
-                = t("paypal_accounts.paypal_account_connected", :email => paypal_account_email)
-                %a.paypal-change-link#ask_paypal_permissions
-                  = t("paypal_accounts.change_account")
-          .row.js-paypal-redirect-order-permission.hidden
-            .col-12
-              .paypal-redirect-message
-                - paypal_redirect_link = "<a href='#' id='ask_paypal_permissions_redirect'>#{t("paypal_accounts.redirect_link_text")}</a>"
-                = t("paypal_accounts.redirect_message", redirect_link: paypal_redirect_link).html_safe
+          - paypal_redirect_link = "<a href='#' id='ask_paypal_permissions_redirect'>#{t("paypal_accounts.redirect_link_text")}</a>"
+          = render partial: "layouts/paypal_account_connected", locals: {paypal_account_email: paypal_account_email,
+              paypal_redirect_link: paypal_redirect_link}
         .paypal-wizard-divider
         .paypal-wizard-content
           = form_for paypal_prefs_form, url: paypal_prefs_form_action, html: { id: "paypal_preferences_form" } do |form|

--- a/app/views/layouts/_paypal_account_connected.haml
+++ b/app/views/layouts/_paypal_account_connected.haml
@@ -1,0 +1,18 @@
+.row
+  .col-12
+    %h3.paypal-account-connected
+      =icon_tag("check", ["icon-fix"])
+      =t("paypal_accounts.paypal_account_connected_title")
+.row
+  .col-12
+    .paypal-connected-email.paypal-account-connected
+      =t("paypal_accounts.paypal_account_connected", :email => paypal_account_email)
+.row.paypal-link-wrapper
+  .col-12
+    %a.paypal-change-link#ask_paypal_permissions
+      =t("paypal_accounts.change_account")
+.row.js-paypal-redirect-order-permission.hidden
+  .col-12
+    .paypal-redirect-message
+      - paypal_redirect_link = "<a href='#' id='ask_paypal_permissions_redirect'>#{t("paypal_accounts.redirect_link_text")}</a>"
+      =t("paypal_accounts.redirect_message", redirect_link: paypal_redirect_link).html_safe

--- a/app/views/paypal_accounts/index.haml
+++ b/app/views/paypal_accounts/index.haml
@@ -8,6 +8,7 @@
                                    create_url, target: "_blank")
     - upgrade_paypal_link = link_to(t("paypal_accounts.upgrade_paypal_account_link_text"),
                                     upgrade_url, target: "_blank")
+    - paypal_redirect_link = "<a href='#' id='ask_paypal_permissions_redirect'>#{t("paypal_accounts.redirect_link_text")}</a>"
     = render partial: "paypal_info", locals: { create_paypal_account_link: create_paypal_link,
         upgrade_paypal_account_link: upgrade_paypal_link,
         paypal_account_linked: next_action != :ask_order_permission,
@@ -38,12 +39,12 @@
             .row.js-paypal-redirect-order-permission.hidden
               .col-12
                 .paypal-redirect-message
-                  - paypal_redirect_link = "<a href='#' id='ask_paypal_permissions_redirect'>#{t("paypal_accounts.redirect_link_text")}</a>"
+
                   = t("paypal_accounts.redirect_message", redirect_link: paypal_redirect_link).html_safe
     - elsif next_action == :ask_billing_agreement
       - content_for :javascript do
         ST.initializeNewPaypalAccountHandler("ask_billing_agreement", "#{billing_agreement_action}", ".js-paypal-redirect-billing-agreement");
-
+        ST.initializeNewPaypalAccountHandler("ask_paypal_permissions", "#{order_permission_action}", ".js-paypal-redirect-change-account");
       - if commission_type != :none # only warn if the marketplace charges a commission
         .row.paypal-follow-steps
           .col-12
@@ -52,15 +53,8 @@
       .row.paypal-wizard
         .col-12
           .paypal-wizard-content
-            .row
-              .col-12
-                %h3.paypal-account-connected
-                  =icon_tag("check", ["icon-fix"])
-                  =t("paypal_accounts.paypal_account_connected_title")
-                .paypal-connected-email.paypal-account-connected
-                  = t("paypal_accounts.paypal_account_connected", :email => paypal_account_email)
-                  %a.paypal-change-link#ask_paypal_permissions
-                    = t("paypal_accounts.change_account")
+            = render partial: "layouts/paypal_account_connected", locals: {paypal_account_email: paypal_account_email,
+                paypal_redirect_link: paypal_redirect_link}
           .paypal-wizard-divider
           .paypal-wizard-content
             .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,7 +485,7 @@ en:
       contact_support_link_text: "contact Sharetribe support"
       integration_info_text: "Sharetribe payments are powered by PayPal. To allow your users to pay using your marketplace, you must connect your PayPal account. Once you have connected your PayPal account, you can choose a minimum transaction size and a possible commission fee."
       paypal_account_email: "1. Connect your PayPal account"
-      link_paypal_personal_account_label: "Are you selling products yourself?"
+      link_paypal_personal_account_label: "Are you providing products or services yourself?"
       paypal_account_email_completed: Completed!
       link_paypal_personal_account: "If so, you will also need to connect your PayPal account to %{personal_payment_preferences_link}."
       personal_payment_preferences_link_text: "your personal marketplace account"


### PR DESCRIPTION
1. Fix broken "Change PayPal account" for users on the second step.
2. Add padding above commission settings
3. Tweak copy for admins about having to connect their PayPal account twice.
4. Move PayPal account connected section to its own partial