### PR TITLE
Login without initial trial doesn't crash

### DIFF
--- a/app/services/plan_service/api/api.rb
+++ b/app/services/plan_service/api/api.rb
@@ -25,7 +25,7 @@ module PlanService::API
     def self.build_configuration()
       Configuration.call(
         active: APP_CONFIG.external_plan_service_in_use,
-        external_plan_service_url: APP_CONFIG.external_plan_service_url,
+        external_plan_service_login_url: APP_CONFIG.external_plan_service_login_url,
         jwt_secret: APP_CONFIG.external_plan_service_secret
       )
     end

--- a/app/services/plan_service/api/plans.rb
+++ b/app/services/plan_service/api/plans.rb
@@ -81,7 +81,7 @@ module PlanService::API
               id: :marketplace_plan_id,
               community_id: :marketplace_id
             }, trial_data))
-        }
+        }.or_else(nil)
 
         payload = {
           marketplace: marketplace,

--- a/app/services/plan_service/api/plans.rb
+++ b/app/services/plan_service/api/plans.rb
@@ -71,8 +71,7 @@ module PlanService::API
     end
 
     def get_external_service_link(marketplace_data)
-      Maybe(@external_plan_service_login_url)
-        .map { |external_plan_service_login_url|
+      Maybe(@external_plan_service_login_url).map { |external_plan_service_login_url|
         marketplace = LoginLinkMarketplaceData.call(marketplace_data)
 
         trial_hash = Maybe(PlanStore.get_initial_trial(community_id: marketplace[:id])).map { |trial_data|

--- a/app/services/plan_service/data_types.rb
+++ b/app/services/plan_service/data_types.rb
@@ -2,7 +2,7 @@ module PlanService::DataTypes
   Configuration = EntityUtils.define_builder(
     [:active, :str_to_bool, :to_bool, :mandatory],
     [:jwt_secret, :string, :optional], # Not needed if not in use
-    [:external_plan_service_url, :string, :optional] # Not needed if not in use
+    [:external_plan_service_login_url, :string, :optional] # Not needed if not in use
   )
 
   Plan = EntityUtils.define_builder(
@@ -21,6 +21,13 @@ module PlanService::DataTypes
     [:expires_at, :time, :optional],
     [:created_at, :time, :mandatory],
     [:updated_at, :time, :mandatory],
+  )
+
+  LoginLinkMarketplaceData = EntityUtils.define_builder(
+    [:id, :fixnum, :mandatory],
+    [:ident, :string, :mandatory],
+    [:domain, :string],
+    [:marketplace_default_name, :string, :mandatory]
   )
 
 end

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -242,7 +242,7 @@ default: &default_settings
   # The connection details hosted Sharetribe uses to connect to external subscription management system.
   external_plan_service_in_use: false
   external_plan_service_secret:
-  external_plan_service_url:
+  external_plan_service_login_url:
 
 production: &production_settings
   <<: *default_settings

--- a/spec/services/plan_service/api/api.rb
+++ b/spec/services/plan_service/api/api.rb
@@ -40,7 +40,8 @@ module PlanService::API
     def self.default_test_environment()
       {
         active: true,
-        jwt_secret: "test_secret"
+        jwt_secret: "test_secret",
+        external_plan_service_login_url: "http://external.plan.service.com",
       }
     end
 

--- a/spec/services/plan_service/api/plans_spec.rb
+++ b/spec/services/plan_service/api/plans_spec.rb
@@ -105,6 +105,43 @@ describe PlanService::API::Plans do
       end
     end
 
+    describe "#get_external_service_link" do
+
+      it "creates a link to external service with initial trial" do
+        # First, create initial trial plan
+        plans_api.create_initial_trial(community_id: 123, plan: {})
+
+        link_res = plans_api.get_external_service_link(
+          id: 123,
+          ident: "marketplace",
+          domain: "www.marketplace.com",
+          marketplace_default_name: "Marketplace"
+        )
+
+        expect(link_res.success).to eq(true)
+        expect(link_res.data.present?).to eq(true)
+        expect(link_res.data).to be_a(String)
+
+        # Improvement idea: decode the token and verify the correct data
+      end
+
+      it "creates a link to external service without initial trial" do
+        link_res = plans_api.get_external_service_link(
+          id: 123,
+          ident: "marketplace",
+          domain: "www.marketplace.com",
+          marketplace_default_name: "Marketplace"
+        )
+
+        expect(link_res.success).to eq(true)
+        expect(link_res.data.present?).to eq(true)
+        expect(link_res.data).to be_a(String)
+
+        # Improvement idea: decode the token and verify the correct data
+      end
+
+    end
+
     describe "#expired?" do
       it "returns false if plan never expires" do
         plan = plans_api.create(


### PR DESCRIPTION
- [X] Fix bug: Login without initial trial doesn't crash
- [X] Add tests for external login service link
- [X] Remove hard-coded external login service path, (`/login`) and include it in the environment variable. Also, rename the environment variable.