### PR TITLE
Clean up paypal admin path

### DIFF
--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -55,11 +55,11 @@ class Admin::PaypalPreferencesController < ApplicationController
 
     render("index", locals: {
         paypal_account_email: paypal_account[:email].or_else(nil),
-        order_permission_action: account_create_admin_community_paypal_preferences_path(@current_community.id),
+        order_permission_action: admin_paypal_preferences_account_create_path(),
         paypal_account_form: PaypalAccountForm.new,
         paypal_prefs_valid: paypal_prefs_form.valid?,
         paypal_prefs_form: paypal_prefs_form,
-        paypal_prefs_form_action: preferences_update_admin_community_paypal_preferences_path(@current_community.id),
+        paypal_prefs_form_action: admin_paypal_preferences_preferences_update_path(),
         min_commission: minimum_commission,
         min_commission_percentage: MIN_COMMISSION_PERCENTAGE,
         max_commission_percentage: MAX_COMMISSION_PERCENTAGE,
@@ -100,7 +100,7 @@ class Admin::PaypalPreferencesController < ApplicationController
       body: PaypalService::API::DataTypes.create_create_account_request(
       {
         community_id: @current_community.id,
-        callback_url: permissions_verified_admin_community_paypal_preferences_url,
+        callback_url: admin_paypal_preferences_permissions_verified_url,
         country: community_country_code
       }))
     permissions_url = response.data[:redirect_url]

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -744,7 +744,7 @@ class ListingsController < ApplicationController
           t("listings.new.community_not_configured_for_payments_admin",
             payment_settings_link: view_context.link_to(
               t("listings.new.payment_settings_link"),
-              admin_community_paypal_preferences_path(community_id: community.id)))
+              admin_paypal_preferences_path()))
             .html_safe
         else
           t("listings.new.community_not_configured_for_payments",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -677,7 +677,7 @@ module ApplicationHelper
         :topic => :configure,
         :text => t("admin.communities.paypal_account.paypal_admin_account"),
         :icon_class => icon_class("payments"),
-        :path => admin_community_paypal_preferences_path(@current_community),
+        :path => admin_paypal_preferences_path(),
         :name => "paypal_account"
       }
     end

--- a/app/views/admin/communities/getting_started.haml
+++ b/app/views/admin/communities/getting_started.haml
@@ -12,7 +12,7 @@
 - custom_fields_link = link_to t("admin.communities.getting_started.custom_fields_link_text"), admin_custom_fields_path
 - filters_link = link_to t("admin.communities.getting_started.filters_link_text"), admin_custom_fields_path
 - order_types_link = link_to t("admin.communities.getting_started.order_types_link_text"), admin_listing_shapes_path
-- payments_link = link_to t("admin.communities.getting_started.payments_link_text"), admin_community_paypal_preferences_path(@current_community)
+- payments_link = link_to t("admin.communities.getting_started.payments_link_text"), admin_paypal_preferences_path()
 - about_page_link = link_to t("admin.communities.getting_started.about_page_link_text"), about_infos_path
 - terms_of_use_link = link_to t("admin.communities.getting_started.terms_of_use_link_text"), terms_infos_path
 - privacy_policy_link = link_to t("admin.communities.getting_started.privacy_policy_link_text"), privacy_infos_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,11 @@ Kassi::Application.routes.draw do
 
     namespace :admin do
 
+      get  "/paypal_preferences"                      => "paypal_preferences#index"
+      post "/paypal_preferences/preferences_update"   => "paypal_preferences#preferences_update"
+      get  "/paypal_preferences/account_create"       => "paypal_preferences#account_create"
+      get  "/paypal_preferences/permissions_verified" => "paypal_preferences#permissions_verified"
+
       resources :communities do
         member do
           get :getting_started, to: 'communities#getting_started'
@@ -153,11 +158,16 @@ Kassi::Application.routes.draw do
           end
         end
         resource :paypal_preferences, only: :index do
+
+          # DEPRECATED (2015-11-16)
+          # Do not add new routes here.
+          # See the above :paypal_preferences resource, outside of communities resource
+
           member do
-            get :index
-            post :preferences_update
-            get :account_create
-            get :permissions_verified
+            get :index,                to: redirect("/admin/paypal_preferences")
+            post :preferences_update   # POST request, no redirect
+            get :account_create,       to: redirect("/admin/paypal_preferences/account_create")
+            get :permissions_verified, to: redirect("/admin/paypal_preferences/permissions_verified")
           end
         end
       end


### PR DESCRIPTION
- [X] Old path: /admin/communities/<community_id>/paypal_preferences
- [X] New path: /admin/paypal_preferences
- [X] Redirect from old path to new path
- [X] Use the simpler and cleaner path definitions and ditch the restful route definition