### PR TITLE
Mechanism to add country specific PayPal instruction texts and links

### DIFF
--- a/app/controllers/accept_preauthorized_conversations_controller.rb
+++ b/app/controllers/accept_preauthorized_conversations_controller.rb
@@ -162,7 +162,7 @@ class AcceptPreauthorizedConversationsController < ApplicationController
         id: @listing_conversation.id
       ),
       preselected_action: preselected_action,
-      paypal_fees_url: PaypalHelper.fee_link(community_country_code)
+      paypal_fees_url: PaypalCountryHelper.fee_link(community_country_code)
     }
   end
 

--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -64,8 +64,6 @@ class Admin::PaypalPreferencesController < ApplicationController
         min_commission_percentage: MIN_COMMISSION_PERCENTAGE,
         max_commission_percentage: MAX_COMMISSION_PERCENTAGE,
         currency: currency,
-        create_url: "https://www.paypal.com/#{community_country_code}/signup/account",
-        upgrade_url: "https://www.paypal.com/#{community_country_code}/upgrade",
         display_knowledge_base_articles: APP_CONFIG.display_knowledge_base_articles,
         knowledge_base_url: APP_CONFIG.knowledge_base_url
       })

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -467,7 +467,7 @@ class ListingsController < ApplicationController
         pickup_enabled: @listing.pickup_enabled?,
         shipping_price_additional: shipping_price_additional,
         always_show_additional_shipping_price: shape[:units].length == 1 && shape[:units].first[:kind] == :quantity,
-        paypal_fees_url: PaypalHelper.fee_link(community_country_code)
+        paypal_fees_url: PaypalCountryHelper.fee_link(community_country_code)
       })
     else
       nil

--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -38,8 +38,9 @@ class PaypalAccountsController < ApplicationController
       minimum_commission: Money.new(payment_settings[:minimum_transaction_fee_cents], community_currency),
       commission_type: payment_settings[:commission_type],
       currency: community_currency,
-      paypal_fees_url: PaypalHelper.fee_link(community_country_code),
-      create_url: "https://www.paypal.com/#{community_country_code}/webapps/mpp/home",
+      paypal_fees_url: PaypalCountryHelper.fee_link(community_country_code),
+      create_url: PaypalCountryHelper.create_paypal_account_url(community_country_code),
+      receive_funds_info_label_tr_key: PaypalCountryHelper.receive_funds_info_label_tr_key(community_country_code),
       upgrade_url: "https://www.paypal.com/#{community_country_code}/upgrade"
     })
   end

--- a/app/view_utils/paypal_country_helper.rb
+++ b/app/view_utils/paypal_country_helper.rb
@@ -1,0 +1,74 @@
+
+
+# Specify all country specific PayPal instruction texts / link in this module
+#
+
+module PaypalCountryHelper
+
+  FEE_URL = {
+    # List all the contries that have the new fee page available
+    "us"      => "https://www.paypal.com/us/webapps/mpp/paypal-fees",
+    "de"      => "https://www.paypal.com/de/webapps/mpp/paypal-fees",
+    "br"      => "https://www.paypal.com/br/webapps/mpp/paypal-fees",
+    "fr"      => "https://www.paypal.com/fr/webapps/mpp/paypal-fees",
+    "au"      => "https://www.paypal.com/au/webapps/mpp/paypal-seller-fees",
+
+    "default" => "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside",
+  }
+
+  POPUP_URL = {
+    # List all the contries that have the popup URL available
+    "us"      => "https://www.paypal.com/us/webapps/mpp/paypal-popup",
+    "de"      => "https://www.paypal.com/de/webapps/mpp/paypal-popup",
+    "fr"      => "https://www.paypal.com/fr/webapps/mpp/paypal-popup",
+    "au"      => "https://www.paypal.com/au/webapps/mpp/paypal-popup",
+
+    # List all the countries that should use the home URL, because popup is not available
+    # (and default English popup is not good)
+    "br"      => "https://www.paypal.com/br/webapps/mpp/home",
+
+    "default" => "https://www.paypal.com/webapps/mpp/paypal-popup",
+  }
+
+  CREATE_ACCOUNT_URL = {
+    "au"      => "https://www.paypal.com/au/webapps/mpp/account-selection",
+
+    "default" => "https://www.paypal.com/%{country_code}/webapps/mpp/home",
+  }
+
+  RECEIVE_FUNDS_INFO_LABEL_TR_KEY = {
+    "au"      => "paypal_accounts.paypal_receive_funds_info_label_australia_only",
+
+    "default" => "paypal_accounts.paypal_receive_funds_info_label",
+  }
+
+  module_function
+
+
+  def fee_link(country_code)
+    find_or_default(FEE_URL, country_code)
+  end
+
+  def popup_link(country_code)
+    find_or_default(POPUP_URL, country_code)
+  end
+
+  def create_paypal_account_url(country_code)
+    find_or_default(CREATE_ACCOUNT_URL, country_code) % {country_code: country_code}
+  end
+
+  def receive_funds_info_label_tr_key(country_code)
+    find_or_default(RECEIVE_FUNDS_INFO_LABEL_TR_KEY, country_code)
+  end
+
+  # private
+
+  def find_or_default(hash, key)
+    Maybe(key).map { |k|
+      hash[k.to_s.downcase]
+    }.or_else {
+      hash["default"]
+    }
+  end
+
+end

--- a/app/view_utils/paypal_country_helper.rb
+++ b/app/view_utils/paypal_country_helper.rb
@@ -14,7 +14,7 @@ module PaypalCountryHelper
     "au"      => "https://www.paypal.com/au/webapps/mpp/paypal-seller-fees",
   }
 
-  FEE_URL.default = "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside",
+  FEE_URL.default = "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside"
 
 
   POPUP_URL = {
@@ -29,22 +29,23 @@ module PaypalCountryHelper
     "br"      => "https://www.paypal.com/br/webapps/mpp/home",
   }
 
-  POPUP_URL.default => "https://www.paypal.com/webapps/mpp/paypal-popup",
+  POPUP_URL.default = "https://www.paypal.com/webapps/mpp/paypal-popup"
+
 
   CREATE_ACCOUNT_URL = {
     "au"      => "https://www.paypal.com/au/webapps/mpp/account-selection",
-
-    "default" => "https://www.paypal.com/%{country_code}/webapps/mpp/home",
   }
+
+  CREATE_ACCOUNT_URL.default = "https://www.paypal.com/%{country_code}/webapps/mpp/home"
+
 
   RECEIVE_FUNDS_INFO_LABEL_TR_KEY = {
     "au"      => "paypal_accounts.paypal_receive_funds_info_label_australia_only",
-
-    "default" => "paypal_accounts.paypal_receive_funds_info_label",
   }
 
-  module_function
+  RECEIVE_FUNDS_INFO_LABEL_TR_KEY.default = "paypal_accounts.paypal_receive_funds_info_label"
 
+  module_function
 
   def fee_link(country_code)
     find_or_default(FEE_URL, country_code)

--- a/app/view_utils/paypal_country_helper.rb
+++ b/app/view_utils/paypal_country_helper.rb
@@ -7,11 +7,11 @@ module PaypalCountryHelper
 
   FEE_URL = {
     # List all the contries that have the new fee page available
-    "us"      => "https://www.paypal.com/us/webapps/mpp/paypal-fees",
-    "de"      => "https://www.paypal.com/de/webapps/mpp/paypal-fees",
-    "br"      => "https://www.paypal.com/br/webapps/mpp/paypal-fees",
-    "fr"      => "https://www.paypal.com/fr/webapps/mpp/paypal-fees",
-    "au"      => "https://www.paypal.com/au/webapps/mpp/paypal-seller-fees",
+    "us" => "https://www.paypal.com/us/webapps/mpp/paypal-fees",
+    "de" => "https://www.paypal.com/de/webapps/mpp/paypal-fees",
+    "br" => "https://www.paypal.com/br/webapps/mpp/paypal-fees",
+    "fr" => "https://www.paypal.com/fr/webapps/mpp/paypal-fees",
+    "au" => "https://www.paypal.com/au/webapps/mpp/paypal-seller-fees",
   }
 
   FEE_URL.default = "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside"
@@ -19,28 +19,28 @@ module PaypalCountryHelper
 
   POPUP_URL = {
     # List all the contries that have the popup URL available
-    "us"      => "https://www.paypal.com/us/webapps/mpp/paypal-popup",
-    "de"      => "https://www.paypal.com/de/webapps/mpp/paypal-popup",
-    "fr"      => "https://www.paypal.com/fr/webapps/mpp/paypal-popup",
-    "au"      => "https://www.paypal.com/au/webapps/mpp/paypal-popup",
+    "us" => "https://www.paypal.com/us/webapps/mpp/paypal-popup",
+    "de" => "https://www.paypal.com/de/webapps/mpp/paypal-popup",
+    "fr" => "https://www.paypal.com/fr/webapps/mpp/paypal-popup",
+    "au" => "https://www.paypal.com/au/webapps/mpp/paypal-popup",
 
     # List all the countries that should use the home URL, because popup is not available
     # (and default English popup is not good)
-    "br"      => "https://www.paypal.com/br/webapps/mpp/home",
+    "br" => "https://www.paypal.com/br/webapps/mpp/home",
   }
 
   POPUP_URL.default = "https://www.paypal.com/webapps/mpp/paypal-popup"
 
 
   CREATE_ACCOUNT_URL = {
-    "au"      => "https://www.paypal.com/au/webapps/mpp/account-selection",
+    "au" => "https://www.paypal.com/au/webapps/mpp/account-selection",
   }
 
   CREATE_ACCOUNT_URL.default = "https://www.paypal.com/%{country_code}/webapps/mpp/home"
 
 
   RECEIVE_FUNDS_INFO_LABEL_TR_KEY = {
-    "au"      => "paypal_accounts.paypal_receive_funds_info_label_australia_only",
+    "au" => "paypal_accounts.paypal_receive_funds_info_label_australia_only",
   }
 
   RECEIVE_FUNDS_INFO_LABEL_TR_KEY.default = "paypal_accounts.paypal_receive_funds_info_label"
@@ -48,29 +48,18 @@ module PaypalCountryHelper
   module_function
 
   def fee_link(country_code)
-    find_or_default(FEE_URL, country_code)
+    FEE_URL[country_code.to_s.downcase]
   end
 
   def popup_link(country_code)
-    find_or_default(POPUP_URL, country_code)
+    POPUP_URL[country_code.to_s.downcase]
   end
 
   def create_paypal_account_url(country_code)
-    find_or_default(CREATE_ACCOUNT_URL, country_code) % {country_code: country_code}
+    CREATE_ACCOUNT_URL[country_code.to_s.downcase] % {country_code: country_code}
   end
 
   def receive_funds_info_label_tr_key(country_code)
-    find_or_default(RECEIVE_FUNDS_INFO_LABEL_TR_KEY, country_code)
+    RECEIVE_FUNDS_INFO_LABEL_TR_KEY[country_code.to_s.downcase]
   end
-
-  # private
-
-  def find_or_default(hash, key)
-    Maybe(key).map { |k|
-      hash[k.to_s.downcase]
-    }.or_else {
-      hash.default
-    }
-  end
-
 end

--- a/app/view_utils/paypal_country_helper.rb
+++ b/app/view_utils/paypal_country_helper.rb
@@ -12,9 +12,10 @@ module PaypalCountryHelper
     "br"      => "https://www.paypal.com/br/webapps/mpp/paypal-fees",
     "fr"      => "https://www.paypal.com/fr/webapps/mpp/paypal-fees",
     "au"      => "https://www.paypal.com/au/webapps/mpp/paypal-seller-fees",
-
-    "default" => "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside",
   }
+
+  FEE_URL.default = "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside",
+
 
   POPUP_URL = {
     # List all the contries that have the popup URL available
@@ -26,9 +27,9 @@ module PaypalCountryHelper
     # List all the countries that should use the home URL, because popup is not available
     # (and default English popup is not good)
     "br"      => "https://www.paypal.com/br/webapps/mpp/home",
-
-    "default" => "https://www.paypal.com/webapps/mpp/paypal-popup",
   }
+
+  POPUP_URL.default => "https://www.paypal.com/webapps/mpp/paypal-popup",
 
   CREATE_ACCOUNT_URL = {
     "au"      => "https://www.paypal.com/au/webapps/mpp/account-selection",
@@ -67,7 +68,7 @@ module PaypalCountryHelper
     Maybe(key).map { |k|
       hash[k.to_s.downcase]
     }.or_else {
-      hash["default"]
+      hash.default
     }
   end
 

--- a/app/view_utils/paypal_helper.rb
+++ b/app/view_utils/paypal_helper.rb
@@ -1,15 +1,5 @@
 module PaypalHelper
 
-  # List all the contries that have the new fee page available
-  SHOW_NEW_FEE_PAGE = ["us", "de", "br", "fr"].to_set
-
-  # List all the contries that have the popup URL available
-  SHOW_POPUP_COUNTRIES = ["us", "de", "fr"].to_set
-
-  # List all the countries that should use the home URL, because popup is not available
-  # (and default English popup is not good)
-  SHOW_HOMEPAGE_COUNTRIES = ["br"].to_set
-
   TxApi = TransactionService::API::Api
 
   module_function
@@ -49,25 +39,6 @@ module PaypalHelper
 
   def account_prepared_for_community?(community_id)
     account_prepared?(community_id: community_id)
-  end
-
-  def fee_link(country_code)
-    if SHOW_NEW_FEE_PAGE.include?(country_code)
-      "https://www.paypal.com/#{country_code}/webapps/mpp/paypal-fees"
-    else
-      "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside"
-    end
-  end
-
-  def popup_link(country_code)
-    if SHOW_POPUP_COUNTRIES.include?(country_code)
-      "https://www.paypal.com/#{country_code}/webapps/mpp/paypal-popup"
-    elsif SHOW_HOMEPAGE_COUNTRIES.include?(country_code)
-      "https://www.paypal.com/#{country_code}/webapps/mpp/home"
-    else
-      # Default popup
-      "https://www.paypal.com/webapps/mpp/paypal-popup"
-    end
   end
 
   # Private

--- a/app/views/listing_conversations/_paypal_payment_methods.haml
+++ b/app/views/listing_conversations/_paypal_payment_methods.haml
@@ -1,4 +1,4 @@
-- how_paypal_works_link = PaypalHelper.popup_link(country_code)
+- how_paypal_works_link = PaypalCountryHelper.popup_link(country_code)
 
 = image_tag "https://www.paypalobjects.com/webstatic/en_US/i/buttons/cc-badges-ppmcvdam.png", style: "max-width: 100%"
 

--- a/app/views/paypal_accounts/_paypal_info.haml
+++ b/app/views/paypal_accounts/_paypal_info.haml
@@ -9,5 +9,5 @@
       .alert-text-icon
         = icon_tag("alert")
       .alert-text-content
-        %strong= t("paypal_accounts.paypal_receive_funds_info_label")
+        %strong= t(receive_funds_info_label_tr_key)
         %p= t("paypal_accounts.paypal_receive_funds_info", upgrade_paypal_account_link: upgrade_paypal_account_link).html_safe

--- a/app/views/paypal_accounts/_paypal_info.haml
+++ b/app/views/paypal_accounts/_paypal_info.haml
@@ -8,6 +8,6 @@
     .alert-text-container
       .alert-text-icon
         = icon_tag("alert")
-      .alert-text-content
+      %p.alert-text-content
         %strong= t(receive_funds_info_label_tr_key)
-        %p= t("paypal_accounts.paypal_receive_funds_info", upgrade_paypal_account_link: upgrade_paypal_account_link).html_safe
+        =t("paypal_accounts.paypal_receive_funds_info", upgrade_paypal_account_link: upgrade_paypal_account_link).html_safe

--- a/app/views/paypal_accounts/index.haml
+++ b/app/views/paypal_accounts/index.haml
@@ -12,6 +12,7 @@
     = render partial: "paypal_info", locals: { create_paypal_account_link: create_paypal_link,
         upgrade_paypal_account_link: upgrade_paypal_link,
         paypal_account_linked: next_action != :ask_order_permission,
+        receive_funds_info_label_tr_key: receive_funds_info_label_tr_key,
         commission_required: commission_type != :none }
 
     - if next_action == :ask_order_permission

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1734,6 +1734,7 @@ en:
     commission_permission_needed: "You will also need to grant %{service_name} permission to charge a transaction fee."
     create_paypal_account_link_text: "PayPal account"
     connected_account: "PayPal account '%{email}' connected successfully."
+    paypal_receive_funds_info_label_australia_only: "Your PayPal account needs to be able to accept payments. This might require a Premier or Business account."
     paypal_receive_funds_info_label: "Your PayPal account needs to be able to accept payments. This might require a Business account."
     paypal_receive_funds_info: "If you see an error when trying to connect your account to %{service_name}, upgrade your PayPal account by %{upgrade_paypal_account_link}. It's free and easy. If you're an individual, PayPal recommends using your name as the Business name."
     upgrade_paypal_account_link_text: "logging in and clicking the upgrade link"


### PR DESCRIPTION
- Clean up the old code regarding country specific links
- Add Australian instruction texts and links