### PR TITLE
Remove Rack::Timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ gem 'jquery-rails', '2.1.4'
 
 # gem 'heroku' install the Heroku toolbelt (https://toolbelt.heroku.com/) instead (as gem had some problems)
 gem "passenger", "~> 5.0.18"
-gem "rack-timeout"
 
 gem "mysql2"
 gem 'haml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,6 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rack-timeout (0.1.1)
     rails (3.2.21)
       actionmailer (= 3.2.21)
       actionpack (= 3.2.21)
@@ -584,7 +583,6 @@ DEPENDENCIES
   rabl
   rack-livereload
   rack-test
-  rack-timeout
   rails (= 3.2.21)
   rails-i18n
   rake

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,6 +1,0 @@
-# config/initializers/timeout.rb
-if Rails.env.production?
-  Rack::Timeout.timeout = 23 # seconds, see also unicorn.rb for timeout config
-else
-  Rails.configuration.middleware.delete Rack::Timeout
-end


### PR DESCRIPTION
Rely on just Heroku timeouts instead of using Rack::Timeout.