### PR TITLE
Send domain only if it's in use

### DIFF
--- a/app/controllers/admin/plans_controller.rb
+++ b/app/controllers/admin/plans_controller.rb
@@ -9,7 +9,7 @@ class Admin::PlansController < ApplicationController
     PlanService::API::Api.plans.get_external_service_link(
       id: @current_community.id,
       ident: @current_community.ident,
-      domain: @current_community.domain,
+      domain: @current_community.use_domain? ? @current_community.domain : nil,
       marketplace_default_name: marketplace_default_name
     ).on_success { |link|
       redirect_to link


### PR DESCRIPTION
Steps to reproduce:

Precondition: Community with `communities.domain = www.google.com` and `communities.use_domain = false`

1. Go to Admin
2. Click Your plan
3. Click Back to my marketplace

Expected: Goes back to marketplace

Actual: Goes to www.google.com