### PR TITLE
Removed service name from meta_description

### DIFF
--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -18,9 +18,9 @@
 - full_url = "#{@current_community.full_url}#{request.fullpath}"
 
 - if content_for?(:meta_description)
-  - meta_description = "#{@current_community.name(I18n.locale)} - #{content_for(:meta_description)}"
+  - meta_description = "#{content_for(:meta_description)}"
 - else
-  - meta_description = "#{@current_community.name(I18n.locale)} - #{community_slogan} - #{community_description(false)}"
+  - meta_description = "#{community_description(false)} - #{community_slogan}"
 
 - if content_for?(:meta_image)
   - meta_image = content_for(:meta_image)


### PR DESCRIPTION
Service name was part of the meta description tag.
This isn't useful and even makes it less clear.

This changes removes the service name from the meta description tag (also in Twitter and Facebook description tags).