### PR TITLE
Fix bug: PayPal fee info lightbox empties text inputs

### DIFF
--- a/app/assets/stylesheets/views/_listings.css.scss
+++ b/app/assets/stylesheets/views/_listings.css.scss
@@ -42,6 +42,10 @@
   color: $aside;
 }
 
+.listing-paypal-fee-info-link {
+  cursor: pointer;
+}
+
 // Listing quantity input
 .quantity-wrapper {
   width: 100%;

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -21,7 +21,10 @@
             = unit_option[:display]
 
     %small
-      - paypal_fee_info_link = "<a href=# id='paypal_fee_info_link'>#{t(".paypal_fee_info_link_text")}</a>"
+      - paypal_fee_info_link = capture do
+        %a.listing-paypal-fee-info-link#paypal_fee_info_link
+          = t(".paypal_fee_info_link_text")
+
       = t(".price_excludes_vat", :vat => @current_community.vat) if @current_community.vat
       - if !seller_commission_in_use && payment_gateway == :paypal
         = t(".no_service_fee_you_will_get_paypal_text", :paypal_fee_info_link => paypal_fee_info_link).html_safe


### PR DESCRIPTION
Steps to reproduce:

Precondition: Marketplace with PayPal enabled

1. Create a new listing, use Order Type that has online payments enabled
2. Add title and description to the listing
3. Click link that opens the lightbox info about PayPal fees
4. Close the lightbox

Expected result: Title and description are present

Actuual: Title and description disappered