### PR TITLE
Updage Fog gem - Fixes #1569

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
+    CFPropertyList (2.3.2)
     action_mailer_cache_delivery (0.3.4)
       actionmailer (~> 3.0)
     actionmailer (3.2.21)
@@ -171,7 +172,7 @@ GEM
       mail (~> 2.2)
     erubis (2.7.0)
     eventmachine (1.0.3)
-    excon (0.25.3)
+    excon (0.45.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     factory_girl (4.4.0)
@@ -184,22 +185,120 @@ GEM
     fb-channel-file (0.0.2)
       rails (>= 3.0)
     ffi (1.9.8)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
     flying-sphinx (1.2.0)
       faraday (>= 0.9)
       multi_json (>= 1.3.0)
       pusher-client (~> 0.3)
       riddle (>= 1.5.6)
       thinking-sphinx
-    fog (1.9.0)
+    fog (1.36.0)
+      fog-aliyun (>= 0.1.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xenserver
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.7.6)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.9.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.35.0)
       builder
-      excon (~> 0.14)
-      formatador (~> 0.2.0)
-      mime-types
+      excon (~> 0.45)
+      formatador (~> 0.2)
+    fog-dynect (0.0.2)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.1)
+      fog-core (~> 1.0)
       multi_json (~> 1.0)
-      net-scp (~> 1.0.4)
-      net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5.0)
-      ruby-hmac
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.4.0)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.0.2)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xenserver (0.2.2)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
     fssm (0.2.10)
     gherkin (2.12.2)
@@ -233,7 +332,9 @@ GEM
       slop (>= 3.5.0)
       term-ansicolor
       terminal-table
+    inflecto (0.0.2)
     innertube (1.1.0)
+    ipaddress (0.8.0)
     jmespath (1.0.2)
       multi_json (~> 1.0)
     joiner (0.2.0)
@@ -282,6 +383,7 @@ GEM
     method_source (0.8.2)
     middleware (0.1.0)
     mime-types (1.25.1)
+    mini_portile2 (2.0.0)
     monetize (1.1.0)
       money (~> 6.5.0)
     money (6.5.1)
@@ -296,11 +398,9 @@ GEM
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     mysql2 (0.3.14)
-    net-scp (1.0.4)
-      net-ssh (>= 1.99.1)
-    net-ssh (2.6.2)
     newrelic_rpm (3.9.1.236)
-    nokogiri (1.5.11)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -434,7 +534,6 @@ GEM
       powerpack (~> 0.0.6)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
-    ruby-hmac (0.4.0)
     ruby-ole (1.2.11.6)
     ruby-prof (0.14.2)
     ruby-progressbar (1.4.2)


### PR DESCRIPTION
Steps to reproduce: 

1. Run `rails console`

Expected: Console opens without warnings

Actual: `Digest::Digest is deprecated; use Digest`

Fix: run `bundle update fog`

Fixes #1569 