### PR TITLE
Wrap lines also in browsers without hyphenation.

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -50,6 +50,8 @@ body {
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     hyphens: auto;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
   }
 
   br {


### PR DESCRIPTION
Only Firefox was able to wrap lines, since other browsers don't
seem to have hyphenation support. Not tested on IE, but according to MDN it should behave ok with this.

Before:
![screenshot 2015-11-30 11 52 54](https://cloud.githubusercontent.com/assets/432030/11468534/f8b9e4d2-9758-11e5-84a9-2b7e41d30dfe.png)

After:
![screenshot 2015-11-30 11 53 06](https://cloud.githubusercontent.com/assets/432030/11468535/fea83ee8-9758-11e5-9d8a-156e4019b168.png)
