### PR TITLE
Logging improvements for listing image uploader

### DIFF
--- a/app/controllers/listing_images_controller.rb
+++ b/app/controllers/listing_images_controller.rb
@@ -23,7 +23,7 @@ class ListingImagesController < ApplicationController
     url = escape_s3_url(params[:path], params[:filename])
 
     if !url.present?
-      logger.warn("No image URL provided", :no_image_url_provided, params)
+      logger.info("No image URL provided", :no_image_url_provided, params)
       render json: {:errors => "No image URL provided"}, status: 400, content_type: 'text/plain'
     end
 
@@ -76,12 +76,12 @@ class ListingImagesController < ApplicationController
         logger.info("Asynchronously downloading image", :start_async_image_download, listing_image_id: listing_image.id, url: url, params: params)
         Delayed::Job.enqueue(DownloadListingImageJob.new(listing_image.id, url), priority: 1)
       else
-        logger.info("Listing image downloaded already", :image_downloaded_already, listing_image_id: listing_image.id, params: params)
+        logger.info("Listing image is already downloaded", :image_already_downloaded, listing_image_id: listing_image.id, params: params)
       end
 
       render json: ListingImageJSAdapter.new(listing_image).to_json, status: 202, content_type: 'text/plain' # Browsers without XHR fileupload support do not support other dataTypes than text
     else
-      logger.error("Saving listing image failed", :saving_listing_image_failed, params: params)
+      logger.error("Saving listing image failed", :saving_listing_image_failed, params: params, errors: listing_image.errors.full_messages)
       render json: {:errors => listing_image.errors.full_messages}, status: 400, content_type: 'text/plain'
     end
   end

--- a/app/controllers/listing_images_controller.rb
+++ b/app/controllers/listing_images_controller.rb
@@ -81,7 +81,7 @@ class ListingImagesController < ApplicationController
 
       render json: ListingImageJSAdapter.new(listing_image).to_json, status: 202, content_type: 'text/plain' # Browsers without XHR fileupload support do not support other dataTypes than text
     else
-      logger.error("Saving listing image failed", :saving_listing_image_failed, params: params, errors: listing_image.errors.full_messages)
+      logger.error("Saving listing image failed", :saving_listing_image_failed, params: params, errors: listing_image.errors.messages)
       render json: {:errors => listing_image.errors.full_messages}, status: 400, content_type: 'text/plain'
     end
   end

--- a/app/controllers/listing_images_controller.rb
+++ b/app/controllers/listing_images_controller.rb
@@ -23,6 +23,7 @@ class ListingImagesController < ApplicationController
     url = escape_s3_url(params[:path], params[:filename])
 
     if !url.present?
+      logger.warn("No image URL provided", :no_image_url_provided, params)
       render json: {:errors => "No image URL provided"}, status: 400, content_type: 'text/plain'
     end
 
@@ -56,10 +57,6 @@ class ListingImagesController < ApplicationController
   end
 
   def add_image(listing_id, params, url)
-    # if listing_id
-    #   ListingImage.destroy_all(listing_id: listing_id)
-    # end
-
     listing_image_params = params.merge(
       author: @current_user,
       listing_id: listing_id
@@ -75,11 +72,16 @@ class ListingImagesController < ApplicationController
     listing_image.image_downloaded = if url.present? then false else true end
 
     if listing_image.save
-      unless listing_image.image_downloaded
-        listing_image.delay.download_from_url(url)
+      if !listing_image.image_downloaded
+        logger.info("Asynchronously downloading image", :start_async_image_download, listing_image_id: listing_image.id, url: url, params: params)
+        Delayed::Job.enqueue(DownloadListingImageJob.new(listing_image.id, url), priority: 1)
+      else
+        logger.info("Listing image downloaded already", :image_downloaded_already, listing_image_id: listing_image.id, params: params)
       end
+
       render json: ListingImageJSAdapter.new(listing_image).to_json, status: 202, content_type: 'text/plain' # Browsers without XHR fileupload support do not support other dataTypes than text
     else
+      logger.error("Saving listing image failed", :saving_listing_image_failed, params: params)
       render json: {:errors => listing_image.errors.full_messages}, status: 400, content_type: 'text/plain'
     end
   end

--- a/app/jobs/download_listing_image_job.rb
+++ b/app/jobs/download_listing_image_job.rb
@@ -1,0 +1,56 @@
+class DownloadListingImageJob < Struct.new(:listing_image_id, :url)
+
+  include DelayedAirbrakeNotification
+
+  def perform
+    # Whou, paperclip and delayed paperclip gems are giving us a handful of black magic here.
+    #
+    # Setting `self.image` will download the image to local filesystem, if URL is given.
+    # It may throw.
+    #
+    # Calling `update_attribute` will save the original size image to S3 and create a new background
+    # job to resize the image. It will also save the new image value to database.
+    # It's doing network operations, so I guess it can also throw.
+    #
+
+    find_listing_image(listing_image_id).and_then { |listing_image|
+
+      # Download the original image
+      begin
+        listing_image.image = URI.parse(url)
+        Result::Success.new(listing_image)
+      rescue StandardError => e
+        Result::Error.new(e)
+      end
+
+    }.and_then { |listing_image|
+
+      # Save the image, create delayed jobs for processing, update the download status
+      begin
+        listing_image.update_attribute(:image_downloaded, true)
+        Result::Success.new(listing_image)
+      rescue StandardError => e
+        Result::Error.new(e)
+      end
+
+    }.on_error { |error_msg, data|
+      logger.error(error_msg, :listing_image_download_failed, data)
+    }
+  end
+
+  private
+
+  def logger
+    @logger ||= SharetribeLogger.new(:download_listing_image_job)
+  end
+
+  def find_listing_image(listing_image_id)
+    Maybe(ListingImage.where(id: listing_image_id).first).map { |listing_image|
+      Result::Success.new(listing_image)
+    }.or_else {
+      Result::Error.new("Could not find listing image with id #{listing_image_id}",
+                        :listing_image_not_found,
+                        listing_image_id: listing_image_id)
+    }
+  end
+end

--- a/app/models/listing_image.rb
+++ b/app/models/listing_image.rb
@@ -130,11 +130,6 @@ class ListingImage < ActiveRecord::Base
     width.to_f / height.to_f > aspect_ratio.to_f
   end
 
-  def download_from_url(url)
-    self.image = URI.parse(url)
-    self.update_attribute(:image_downloaded, true)
-  end
-
   def image_ready?
     image_downloaded && !image_processing
   end


### PR DESCRIPTION
- [X] Don't use `.delay`, instead create a separate job `DownloadListingImageJob`. This allows us to set the correct priority.
- [X] Catch and log possible errors
- [X] Add logging here and there