### PR TITLE
Fix empty title error

### DIFF
--- a/app/assets/javascripts/listing_form.js
+++ b/app/assets/javascripts/listing_form.js
@@ -465,7 +465,7 @@ window.ST = window.ST || {};
       },
       debug: false,
       rules: _.extend(numericRules, {
-        "listing[title]": {required: true, maxlength: 60},
+        "listing[title]": {required: true, minlength: 2, maxlength: 60},
         "listing[origin]": {address_validator: true},
         "listing[price]": {required: pr, money: true, minimum_price_required: [minimum_price, subunit_to_unit]},
         "listing[shipping_price]": {money: true},

--- a/app/services/listing_index_service/data_types.rb
+++ b/app/services/listing_index_service/data_types.rb
@@ -49,7 +49,10 @@ module ListingIndexService::DataTypes
   Listing = EntityUtils.define_builder(
     [:id, :fixnum, :mandatory],
     [:url, :string, :mandatory],
-    [:title, :string, :mandatory],
+    # This is an ugly fix. Title should be mandatory, but if the title contains only unsupported characters
+    # it may happen that the title is empty and exception will be thrown.
+    # This can be removed when we properly support wider range of characters, e.g. after Rails 4 update.
+    [:title, :string, :optional],
     [:description, :string],
     [:category_id, :fixnum, :mandatory],
     [:author, entity: Author],


### PR DESCRIPTION
If the listing title is empty, the homepage will break.

This PR fixes two errors:

* The backend has a validation that requires the title length to be 2-60. However, the front-end validation requires title to be 1-60 characters. This PR changes the front-end validation to 2-60.
* ListingIndexService allows empty titles. That will ensure that the homepage doesn't break.