### PR TITLE
Improve Delayed Job logging

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,5 +1,42 @@
 require 'delayed_job'
+
+class DelayedJobLoggerPlugin < Delayed::Plugin
+
+  callbacks do |lifecycle|
+
+    lifecycle.around(:invoke_job) do |job, &block|
+      logger.info "Running job", job_to_hash(job)
+      begin
+        block.call(job)
+        logger.info "Job success", job_to_hash(job)
+      rescue Exception => e
+        # log and reraise
+        logger.info "Job error: #{e.inspect}", job_to_hash(job)
+        raise e
+      end
+    end
+  end
+
+  def self.job_to_hash(job)
+    payload = job.payload_object # Usually the Struct, but can be a PerformableObject also
+
+    case payload
+    when Struct
+      {job_name: payload.class.name, args: payload.to_h }
+    when Delayed::PerformableMethod
+      {job_name: "#{payload.object.to_s}.#{payload.method_name.to_s}", args: payload.args.to_s}
+    else
+      {payload: payload.inspect}
+    end
+  end
+
+  def self.logger
+    @logger ||= SharetribeLogger.new(:delayed_job)
+  end
+end
+
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_attempts = 3
 Delayed::Worker.max_run_time = 3.minutes # In order to recover from hanging DelayedDelta. Currently no jobs should be longer than 3min.
 Delayed::Worker.default_priority = 5
+Delayed::Worker.plugins << DelayedJobLoggerPlugin


### PR DESCRIPTION
Delayed job worker is configured so that only failed jobs are kept in the
database. If job is completed successfully, it's deleted from the database and
we have no way to e.g. debug when it was run.

This PR adds logging, which makes possible to debug jobs

- Implement a Delayed Job Plugin, that hooks to the :invoke_job lifecycle
event
- Log the name of the job, params
- Log succes/error results