### PR TITLE
Adjust delayed job priorities

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -201,7 +201,7 @@ class Admin::CommunitiesController < ApplicationController
            params[:community].merge(stylesheet_needs_recompile: regenerate_css?(params, @current_community)),
            edit_look_and_feel_admin_community_path(@current_community),
            :edit_look_and_feel) {
-      Delayed::Job.enqueue(CompileCustomStylesheetJob.new(@current_community.id))
+      Delayed::Job.enqueue(CompileCustomStylesheetJob.new(@current_community.id), priority: 3)
     }
   end
 

--- a/app/controllers/post_pay_transactions_controller.rb
+++ b/app/controllers/post_pay_transactions_controller.rb
@@ -59,7 +59,7 @@ class PostPayTransactionsController < ApplicationController
           AcceptReminderJob.new(
             transaction_id,
             @listing.author.id, @current_community.id),
-          :priority => 10, :run_at => send_interval.days.from_now)
+          :priority => 9, :run_at => send_interval.days.from_now)
       end
 
       redirect_to session[:return_to_content] || root

--- a/app/services/confirm_conversation.rb
+++ b/app/services/confirm_conversation.rb
@@ -20,7 +20,7 @@ class ConfirmConversation
   def confirm!
     Delayed::Job.enqueue(TransactionConfirmedJob.new(@transaction.id, @community.id))
     [3, 10].each do |send_interval|
-      Delayed::Job.enqueue(TestimonialReminderJob.new(@transaction.id, nil, @community.id), :priority => 10, :run_at => send_interval.days.from_now)
+      Delayed::Job.enqueue(TestimonialReminderJob.new(@transaction.id, nil, @community.id), :priority => 9, :run_at => send_interval.days.from_now)
     end
     release_escrow if @hold_in_escrow
   end
@@ -68,7 +68,7 @@ class ConfirmConversation
     activate_reminder           = @community.testimonials_in_use && @transaction.automatic_confirmation_after_days > REMIND_DAYS_BEFORE_CLOSING
 
     if activate_reminder
-      Delayed::Job.enqueue(ConfirmReminderJob.new(@transaction.id, @requester.id, @community.id, REMIND_DAYS_BEFORE_CLOSING), :priority => 10, :run_at => reminder_email_at)
+      Delayed::Job.enqueue(ConfirmReminderJob.new(@transaction.id, @requester.id, @community.id, REMIND_DAYS_BEFORE_CLOSING), :priority => 9, :run_at => reminder_email_at)
     end
   end
 

--- a/app/services/marketplace_service/transaction.rb
+++ b/app/services/marketplace_service/transaction.rb
@@ -351,8 +351,8 @@ module MarketplaceService
         booking_ends_on = Maybe(transaction)[:booking][:end_on].or_else(nil)
         expire_at = Entity.preauth_expires_at(gateway_expires_at, booking_ends_on)
 
-        Delayed::Job.enqueue(TransactionPreauthorizedJob.new(transaction[:id]), :priority => 10)
-        Delayed::Job.enqueue(AutomaticallyRejectPreauthorizedTransactionJob.new(transaction[:id]), priority: 7, run_at: expire_at)
+        Delayed::Job.enqueue(TransactionPreauthorizedJob.new(transaction[:id]), priority: 5)
+        Delayed::Job.enqueue(AutomaticallyRejectPreauthorizedTransactionJob.new(transaction[:id]), priority: 8, run_at: expire_at)
 
         setup_preauthorize_reminder(transaction[:id], expire_at)
       end
@@ -366,7 +366,7 @@ module MarketplaceService
         send_reminder = reminder_at > DateTime.now
 
         if send_reminder
-          Delayed::Job.enqueue(TransactionPreauthorizedReminderJob.new(transaction_id), :priority => 10, :run_at => reminder_at)
+          Delayed::Job.enqueue(TransactionPreauthorizedReminderJob.new(transaction_id), priority: 9, :run_at => reminder_at)
         end
       end
     end

--- a/app/services/monitoring_service/monitoring.rb
+++ b/app/services/monitoring_service/monitoring.rb
@@ -7,13 +7,13 @@ module MonitoringService::Monitoring
 
   def report_queue_size
     if Librato.tracker.should_start? && should_report?
-      # Priorities are from 0..10, where 0..6 are high priority and 7..10 low
+      # Priorities are from 0..10, where 0..5 are high priority and 6..10 low
       priority_counts = Delayed::Job.where('attempts < ? AND run_at < ?', 3, Time.now).group(:priority).count
 
       Librato.group 'delayed_job_queue' do |g|
         # We are measuring an average in the sampling period, by default 60 seconds
-        g.measure 'high', priority_counts.select { |p, _| p < 7 }.values.sum
-        g.measure 'low', priority_counts.select { |p, _| p >= 7 }.values.sum
+        g.measure 'high', priority_counts.select { |p, _| p < 6 }.values.sum
+        g.measure 'low', priority_counts.select { |p, _| p >= 6 }.values.sum
       end
       @delayed_job_last_reported = Time.now
     end

--- a/app/state_machines/transaction_process_state_machine.rb
+++ b/app/state_machines/transaction_process_state_machine.rb
@@ -33,7 +33,7 @@ class TransactionProcessStateMachine
     Delayed::Job.enqueue(TransactionStatusChangedJob.new(transaction.id, accepter.id, current_community.id))
 
     [3, 10].each do |send_interval|
-      Delayed::Job.enqueue(PaymentReminderJob.new(transaction.id, transaction.payment.payer.id, current_community.id), :priority => 10, :run_at => send_interval.days.from_now)
+      Delayed::Job.enqueue(PaymentReminderJob.new(transaction.id, transaction.payment.payer.id, current_community.id), :priority => 9, :run_at => send_interval.days.from_now)
     end
   end
 

--- a/docs/delayed-job-priorities.md
+++ b/docs/delayed-job-priorities.md
@@ -7,14 +7,14 @@ We use priorities for delayed jobs. The priorities are from 0 (highest) to 10 (l
 * 0: API calls (fast jobs user is waiting to finnish)
 * 1: Image processing (slow jobs user is waiting to finnish)
 * 2: Confirmation emails
-* 3: -
+* 3: User triggered custom CSS compilation
 * 4: Search indexing
-* 5: Default
+* 5: Default, Notification emails (new message, new payment etc.)
 * 6: Escrow release / money related
-* 7: Custom CSS compilation
+* 7: -
 * 8: Automatic listing confirmation
-* 9: -
-* 10: Reminder emails
+* 9: Reminder emails
+* 10: Custom CSS reprocessing at deploy
 
 ## The rule of thumb
 

--- a/lib/tasks/sharetribe.rake
+++ b/lib/tasks/sharetribe.rake
@@ -271,7 +271,7 @@ namespace :sharetribe do
   desc "Generates customized CSS stylesheets in the background"
   task :generate_customization_stylesheets => :environment do
     # If preboot in use, give 2 minutes time to load new code
-    delayed_opts = {priority: 8, :run_at => 2.minutes.from_now }
+    delayed_opts = {priority: 10, :run_at => 2.minutes.from_now }
     CommunityStylesheetCompiler.compile_all(delayed_opts)
   end
 


### PR DESCRIPTION
This fixes a bug where sending notification about new transaction was delayed
significantly due to large number of CSS compilation happening during the
deploy.

In addition, this PR updated the Delayed job priorities guideline.