### PR TITLE
Drop the community_plans table

### DIFF
--- a/db/migrate/20151204083028_drop_community_plans.rb
+++ b/db/migrate/20151204083028_drop_community_plans.rb
@@ -1,0 +1,15 @@
+class DropCommunityPlans < ActiveRecord::Migration
+  def up
+    drop_table :community_plans
+  end
+
+  def down
+    create_table "community_plans" do |t|
+      t.integer  "community_id",                :null => false
+      t.integer  "plan_level",   :default => 0, :null => false
+      t.datetime "expires_at"
+      t.datetime "created_at",                  :null => false
+      t.datetime "updated_at",                  :null => false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151202062609) do
+ActiveRecord::Schema.define(:version => 20151204083028) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -260,16 +260,6 @@ ActiveRecord::Schema.define(:version => 20151202062609) do
 
   add_index "community_memberships", ["community_id"], :name => "index_community_memberships_on_community_id"
   add_index "community_memberships", ["person_id", "community_id"], :name => "memberships"
-
-  create_table "community_plans", :force => true do |t|
-    t.integer  "community_id",                :null => false
-    t.integer  "plan_level",   :default => 0, :null => false
-    t.datetime "expires_at"
-    t.datetime "created_at",                  :null => false
-    t.datetime "updated_at",                  :null => false
-  end
-
-  add_index "community_plans", ["community_id"], :name => "index_community_plans_on_community_id"
 
   create_table "community_translations", :force => true do |t|
     t.integer  "community_id",                  :null => false


### PR DESCRIPTION
Currently, we are using two new tables, `marketplace_trials` and
`marketplace_plans`. All the data from `community_plans` table has been
migrated to `marketplace_trials` and `marketplace_plans`