### PR TITLE
Add 12 factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ gem 'public_suffix' # Needed currently to set GA hostname right, probably not
 
 group :staging, :production do
   gem 'newrelic_rpm', '~> 3.9.1.236'
+  gem 'rails_12factor', '~> 0.0.3'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,6 +491,11 @@ GEM
       railties (= 3.2.21)
     rails-i18n (0.7.2)
       i18n (~> 0.5)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (3.2.21)
       actionpack (= 3.2.21)
       activesupport (= 3.2.21)
@@ -684,6 +689,7 @@ DEPENDENCIES
   rack-test
   rails (= 3.2.21)
   rails-i18n
+  rails_12factor (~> 0.0.3)
   rake
   rb-fsevent
   recaptcha


### PR DESCRIPTION
Get rid of the warnings during the Heroku deploy by adding the [12 factor gem](https://github.com/heroku/rails_12factor)

The 12 factor gem includes two gems to our application, rails_log_stdout and rails3_serve_static_assets. If the 12factor gem is not included in the gem file, Heroku will inject those two plugins anyway and show the warning. So adding this gem will not change any behavior.

Before:

```
...
remote:        AssetSync: Syncing.
remote:        Using: Directory Search of /tmp/build_5b2107d59233788efdc2c1f76dd09231/public/assets
remote:        Ignoring: assets/application-11b99f7fb4abbf3d393179705b2b90c3.css.gz
remote:        AssetSync: Done.
remote:        Asset precompilation completed (61.92s)
remote:
remote: ###### WARNING:
remote:        Injecting plugin 'rails_log_stdout'
remote:
remote: ###### WARNING:
remote:        Injecting plugin 'rails3_serve_static_assets'
remote:
remote: ###### WARNING:
remote:        Add 'rails_12factor' gem to your Gemfile to skip plugin injection
remote:
remote: ###### WARNING:
remote:        You are deploying to a non-production environment: "staging".
remote:        See https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment for more information.
remote:
remote: ###### WARNING:
remote:        You are using the `asset_sync` gem.
remote:        See https://devcenter.heroku.com/articles/please-do-not-use-asset-sync for more information.
remote:
remote:
remote: -----> Discovering process types
remote:        Procfile declares types     -> web, worker
remote:        Default types for buildpack -> console, rake
remote:
remote: -----> Compressing... done, 65.9MB
remote: -----> Launching... done, v1436
remote:        https://sharetribe-staging.herokuapp.com/ deployed to Heroku
remote:
remote: Verifying deploy... done.
To git@heroku.com:sharetribe-staging.git
   a07dfdc..9c16a0d  add_12factor_gem -> master
```

After:

```
...
remote:        AssetSync: Syncing.
remote:        Using: Directory Search of /tmp/build_ed4baf22caaa2bfeeb94525ea6d4df4d/public/assets
remote:        Ignoring: assets/application-11b99f7fb4abbf3d393179705b2b90c3.css.gz
remote:        AssetSync: Done.
remote:        Asset precompilation completed (61.58s)
remote:
remote: ###### WARNING:
remote:        You are deploying to a non-production environment: "staging".
remote:        See https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment for more information.
remote:
remote: ###### WARNING:
remote:        You are using the `asset_sync` gem.
remote:        See https://devcenter.heroku.com/articles/please-do-not-use-asset-sync for more information.
remote:
remote:
remote: -----> Discovering process types
remote:        Procfile declares types     -> web, worker
remote:        Default types for buildpack -> console, rake
remote:
remote: -----> Compressing... done, 67.2MB
remote: -----> Launching... done, v1437
remote:        https://sharetribe-staging.herokuapp.com/ deployed to Heroku
remote:
remote: Verifying deploy.... done.
To git@heroku.com:sharetribe-staging.git
   9c16a0d..0a5c927  add_12factor_gem -> master
```