### PR TITLE
Link to external plan service, instead of knowledge base article

### DIFF
--- a/app/views/admin/communities/edit_welcome_email.haml
+++ b/app/views/admin/communities/edit_welcome_email.haml
@@ -115,7 +115,7 @@
               %span.alert-box-icon<>
                 = icon_tag("alert", ["icon-fix"])
               %span<
-                = t("admin.communities.outgoing_email.only_white_label_offer", upgrade_pro_plan_link: link_to(t("admin.communities.outgoing_email.upgrade_pro_plan_link"), "#{knowledge_base_url}/articles/463242")).html_safe
+                = t("admin.communities.outgoing_email.only_white_label_offer", upgrade_pro_plan_link: link_to(t("admin.communities.outgoing_email.upgrade_pro_plan_link"), admin_plan_path)).html_safe
 
     - disabled_attr = can_set_sender_address ? nil : :disabled
     - disabled_class = can_set_sender_address ? "" : "sender-address-disabled"


### PR DESCRIPTION
![screen shot 2015-12-04 at 12 34 53](https://cloud.githubusercontent.com/assets/429876/11587643/88f2a0ac-9a83-11e5-9b0b-75992327d543.png)
