### PR TITLE
Don't break the inbox if message content is empty

### DIFF
--- a/app/assets/stylesheets/views/_conversation.css.scss
+++ b/app/assets/stylesheets/views/_conversation.css.scss
@@ -43,6 +43,10 @@
   }
 }
 
+.conversation-last-message-content-not-available {
+  font-style: italic;
+}
+
 .conversation-context {
   @include small-type;
   line-height: lines(1, $small-type)

--- a/app/services/marketplace_service/inbox.rb
+++ b/app/services/marketplace_service/inbox.rb
@@ -75,7 +75,7 @@ module MarketplaceService
       conversation_spec = [
         [:type, const_value: :conversation],
         [:last_message_at, :time, :mandatory],
-        [:last_message_content, :string, :mandatory]
+        [:last_message_content, :string, :optional]
       ]
 
       transaction_spec = [

--- a/app/views/inboxes/_inbox_row.haml
+++ b/app/views/inboxes/_inbox_row.haml
@@ -12,7 +12,11 @@
 
   %div{class: payments_in_use ? "col-6" : "col-9"}
     = link_to conversation[:path], class:(conversation[:should_notify] ? 'conversation-title-link-unread' : 'conversation-title-link') do
-      = conversation[:title]
+      - if conversation[:title].present?
+        conversation[:title]
+      - else
+        %span.conversation-last-message-content-not-available
+          = t("conversations.conversation.message_content_not_available")
     .conversation-context
       - if conversation[:listing_url].present?
         = t("conversations.conversation.about_listing", listing_title: link_to_unless(conversation[:listing_deleted], conversation[:listing_title], conversation[:listing_url])).html_safe

--- a/app/views/inboxes/_inbox_row.haml
+++ b/app/views/inboxes/_inbox_row.haml
@@ -13,7 +13,7 @@
   %div{class: payments_in_use ? "col-6" : "col-9"}
     = link_to conversation[:path], class:(conversation[:should_notify] ? 'conversation-title-link-unread' : 'conversation-title-link') do
       - if conversation[:title].present?
-        conversation[:title]
+        = conversation[:title]
       - else
         %span.conversation-last-message-content-not-available
           = t("conversations.conversation.message_content_not_available")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -631,6 +631,7 @@ en:
       message_from: "Message from %{person}"
       about_listing: "About listing %{listing_title}"
       free_message: "Free message"
+      message_content_not_available: "Message content not available"
     message:
       accepted_request: "accepted the request"
       accepted_offer: "accepted the offer"


### PR DESCRIPTION
In some rare edge cases, the message content may be null and it will break the inbox.

This PR fixes the bug by allowing null content. In the inbox, we show a message "Message content not available", if the content is empty.