### PR TITLE
[HIBERNATING] Cache homepage listings block

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -232,6 +232,8 @@ class PeopleController < Devise::RegistrationsController
           Email.send_confirmation(@person.emails.last, @current_community)
         end
 
+        invalidate_caches(@person)
+
         flash[:notice] = t("layouts.notifications.person_updated_successfully")
 
         # Send new confirmation email, if was changing for that
@@ -257,6 +259,7 @@ class PeopleController < Devise::RegistrationsController
 
     # Do all delete operations in transaction. Rollback if any of them fails
     ActiveRecord::Base.transaction do
+      invalidate_caches(@current_user)
       UserService::API::Users.delete_user(@current_user.id)
       MarketplaceService::Listing::Command.delete_listings(@current_user.id)
 
@@ -408,6 +411,14 @@ class PeopleController < Devise::RegistrationsController
         render :layout => false
       }
     end
+  end
+
+  def invalidate_caches(person_model)
+    author_id = person_model.id
+    communities = person_model.communities.map(&:id)
+
+    listings_updated = Listing.where(author_id: author_id).update_all(updated_at: Time.now)
+    Community.where(id: communities).update_all(updated_at: Time.now) if listings_updated
   end
 
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -67,6 +67,7 @@ class Listing < ActiveRecord::Base
   include Rails.application.routes.url_helpers
 
   belongs_to :author, :class_name => "Person", :foreign_key => "author_id"
+  belongs_to :community, :foreign_key => "community_id", :touch => true
 
   has_many :listing_images, :dependent => :destroy
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -113,11 +113,6 @@ class Person < ActiveRecord::Base
 
   has_and_belongs_to_many :followed_listings, :class_name => "Listing", :join_table => "listing_followers"
 
-  after_save do
-    # This is required to invalidate the fragment caches for listings on front page, since the author is shown there.
-    self.listings.all.map(&:touch)
-  end
-
   def to_param
     username
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -113,6 +113,11 @@ class Person < ActiveRecord::Base
 
   has_and_belongs_to_many :followed_listings, :class_name => "Listing", :join_table => "listing_followers"
 
+  after_save do
+    # This is required to invalidate the fragment caches for listings on front page, since the author is shown there.
+    self.listings.all.map(&:touch)
+  end
+
   def to_param
     username
   end

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -115,26 +115,27 @@
           - # Filters will be relocated here when in desktop
 
     - main_container_class = if @category_menu_enabled then "col-9" else "col-12" end
-    %div{:class => main_container_class}
-      - if @listings.total_entries > 0
-        - if @view_type.eql?("map")
-          .home-map
-            = render :partial => "map"
+    - cache(["index_haml", @current_community.cache_key, param_digest]) do
+      %div{:class => main_container_class}
+        - if @listings.total_entries > 0
+          - if @view_type.eql?("map")
+            .home-map
+              = render :partial => "map"
+          - else
+            - if @view_type.eql?("grid")
+              %div{class: @category_menu_enabled ? "home-fluid-thumbnail-grid-narrow" : "home-fluid-thumbnail-grid-wide"}
+                .home-fluid-thumbnail-grid
+                  = render :partial => "grid_item", :collection => @listings, :as => :listing
+            - else
+              .home-listings
+                = render :partial => "list_item", :collection => @listings, :as => :listing, locals:{shape_name_map: shape_name_map, testimonials_in_use: testimonials_in_use}
+            .home-loading-more
+              = will_paginate(@listings)
+              - item_container = if @view_type.eql?("grid") then '.home-fluid-thumbnail-grid' else '.home-listings' end
+              = pageless(@listings.total_pages, item_container, request.fullpath, t('.loading_more_content'))
         - else
-          - if @view_type.eql?("grid")
-            %div{class: @category_menu_enabled ? "home-fluid-thumbnail-grid-narrow" : "home-fluid-thumbnail-grid-wide"}
-              .home-fluid-thumbnail-grid
-                = render :partial => "grid_item", :collection => @listings, :as => :listing
-          - else
-            .home-listings
-              = render :partial => "list_item", :collection => @listings, :as => :listing, locals:{shape_name_map: shape_name_map, testimonials_in_use: testimonials_in_use}
-          .home-loading-more
-            = will_paginate(@listings)
-            - item_container = if @view_type.eql?("grid") then '.home-fluid-thumbnail-grid' else '.home-listings' end
-            = pageless(@listings.total_pages, item_container, request.fullpath, t('.loading_more_content'))
-      - else
-        .home-no-listings
-          - if params[:q] || params[:category] || params[:share_type] # Some filter in use
-            = t(".no_listings_with_your_search_criteria")
-          - else
-            = t(".no_listings_notification", :add_listing_link => link_to(t(".add_listing_link_text"), new_listing_path)).html_safe
+          .home-no-listings
+            - if params[:q] || params[:category] || params[:share_type] # Some filter in use
+              = t(".no_listings_with_your_search_criteria")
+            - else
+              = t(".no_listings_notification", :add_listing_link => link_to(t(".add_listing_link_text"), new_listing_path)).html_safe


### PR DESCRIPTION
This PR adds caching to front page listings block. Previously, only the individual listing cards (red outline below) were cached, but now the complete blue block is cached.

![screenshot 2015-12-07 14 00 49](https://cloud.githubusercontent.com/assets/432030/11626418/45d09030-9ceb-11e5-9b76-3e112bb07c47.png)

The cache for the listings block (actually [cache key](https://signalvnoise.com/posts/3113-how-key-based-cache-expiration-works)) is expired when any of these happen:
 1. `community` is updated
 2. `listing` is updated
 3. `author` of a listing on frontpage is updated

In practise only `community.id` and `community.updated_at` are checked. Updating a listing touches `community.updated_at`, and updating a listing author touches `listing.updated_at` of all their listings, which causes also community to be touched. If author had a `belongs_to` relationship with community, this could be simplified.

Performance results on Testing were inconclusive, but DB queries were reduced. Let's see how this works in production, this PR can be reverted with no harm caused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sharetribe/sharetribe/1588)
<!-- Reviewable:end -->
