### PR TITLE
Reserve academy-proxy for internal usage

### DIFF
--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -43,6 +43,7 @@ module MarketplaceService::API
       "internal",
       "webinar",
       "local",
+      "academy-proxy",
       "proxy",
       "preproduction",
       "staging",


### PR DESCRIPTION
I intend to use this subdomain as reverse proxy for the academy.