### PR TITLE
Listing image error handling

### DIFF
--- a/app/assets/javascripts/image_uploader.js
+++ b/app/assets/javascripts/image_uploader.js
@@ -288,10 +288,6 @@ window.ST.imageUploader = function(listings, opts) {
     return value.ready && !value.errored;
   });
 
-  var errorDuringUpload = imageUploaded.filter(function(value) {
-    return value.errored;
-  });
-
   var newPreviewRendered = successfullyUploaded.map(function(listing) {
     return renderPreview(listing);
   });

--- a/app/assets/javascripts/image_uploader.js
+++ b/app/assets/javascripts/image_uploader.js
@@ -284,7 +284,15 @@ window.ST.imageUploader = function(listings, opts) {
   var status = Bacon.combineTemplate(
     {loading: numberOfLoadingImages, processing: numberOfProcessingImages });
 
-  var newPreviewRendered = imageUploaded.map(function(listing) {
+  var successfullyUploaded = imageUploaded.filter(function(value) {
+    return value.ready && !value.errored;
+  });
+
+  var errorDuringUpload = imageUploaded.filter(function(value) {
+    return value.errored;
+  });
+
+  var newPreviewRendered = successfullyUploaded.map(function(listing) {
     return renderPreview(listing);
   });
 
@@ -477,15 +485,27 @@ window.ST.imageUploader = function(listings, opts) {
     $element.showMessage(ST.t("listings.form.images.processing"), ST.t("listings.form.images.this_may_take_a_while"));
     $element.setListingId(listing.id);
 
-    var filePostprocessed = ST.utils.baconStreamFromAjaxPolling({url: listing.urls.status}, function(pollingResult) {
-      return pollingResult.ready;
+    var filePostprocessingDone = ST.utils.baconStreamFromAjaxPolling({url: listing.urls.status}, function(pollingResult) {
+      return pollingResult.ready || pollingResult.errored;
     });
 
-    filePostprocessed.onValue(function() {
+    var filePostprocessingSuccessful = filePostprocessingDone.filter(function(value) {
+      return value.ready && !value.errored;
+    });
+
+    var filePostprocessingError = filePostprocessingDone.filter(function(value) {
+      return value.errored;
+    });
+
+    filePostprocessingSuccessful.onValue(function() {
       elementManager.removeUploading($element.container);
     });
 
-    return {element: $element, stream: filePostprocessed};
+    filePostprocessingError.onValue(function() {
+      $element.showMessage(ST.t("listings.form.images.image_processing_failed"));
+    });
+
+    return {element: $element, stream: filePostprocessingDone};
   }
 
   function renderPreview(listing) {

--- a/app/jobs/download_listing_image_job.rb
+++ b/app/jobs/download_listing_image_job.rb
@@ -44,13 +44,9 @@ class DownloadListingImageJob < Struct.new(:listing_image_id, :url)
   private
 
   def logger
-    if @logger
-      @logger
-    else
-      @logger = SharetribeLogger.new(:download_listing_image_job, logger_metadata.keys).tap { |logger|
-        logger.add_metadata(logger_metadata)
-      }
-    end
+    @logger ||= SharetribeLogger.new(:download_listing_image_job, logger_metadata.keys).tap { |logger|
+      logger.add_metadata(logger_metadata)
+    }
   end
 
   def logger_metadata

--- a/app/jobs/download_listing_image_job.rb
+++ b/app/jobs/download_listing_image_job.rb
@@ -34,6 +34,7 @@ class DownloadListingImageJob < Struct.new(:listing_image_id, :url)
 
   def failure
     listing_image.on_success { |listing_image|
+      listing_image.update_column(:errored, true) # Have to use `update_column` here because `update_attribute` runs the before save hooks
       logger.error("Listing image process and download failed permanently", :listing_image_download_failed_permanently)
     }.on_error { |error_msg, data|
       logger.error(error_msg, :listing_image_download_failed_permanently, data)

--- a/app/jobs/download_listing_image_job.rb
+++ b/app/jobs/download_listing_image_job.rb
@@ -13,44 +13,59 @@ class DownloadListingImageJob < Struct.new(:listing_image_id, :url)
     # It's doing network operations, so I guess it can also throw.
     #
 
-    find_listing_image(listing_image_id).and_then { |listing_image|
+    listing_image.and_then { |listing_image|
 
-      # Download the original image
       begin
+        # Download the original image
         listing_image.image = URI.parse(url)
-        Result::Success.new(listing_image)
-      rescue StandardError => e
-        Result::Error.new(e)
-      end
-
-    }.and_then { |listing_image|
-
-      # Save the image, create delayed jobs for processing, update the download status
-      begin
+        # Save the image, create delayed jobs for processing, update the download status
         listing_image.update_attribute(:image_downloaded, true)
         Result::Success.new(listing_image)
       rescue StandardError => e
         Result::Error.new(e)
       end
 
+    }.on_error { |error_msg, ex|
+      logger.error(error_msg, :listing_image_download_failed)
+
+      raise ex # Reraise the exception to mark the delayed job failed
+    }
+  end
+
+  def failure
+    listing_image.on_success { |listing_image|
+      logger.error("Listing image process and download failed permanently", :listing_image_download_failed_permanently)
     }.on_error { |error_msg, data|
-      logger.error(error_msg, :listing_image_download_failed, data)
+      logger.error(error_msg, :listing_image_download_failed_permanently, data)
     }
   end
 
   private
 
   def logger
-    @logger ||= SharetribeLogger.new(:download_listing_image_job)
+    if @logger
+      @logger
+    else
+      @logger = SharetribeLogger.new(:download_listing_image_job, logger_metadata.keys).tap { |logger|
+        logger.add_metadata(logger_metadata)
+      }
+    end
   end
 
-  def find_listing_image(listing_image_id)
-    Maybe(ListingImage.where(id: listing_image_id).first).map { |listing_image|
+  def logger_metadata
+    @logger_metadata ||=
+      if listing_image.success
+        listing_image.data.attributes
+      else
+        {}
+      end
+  end
+
+  def listing_image
+    @listing_image ||= Maybe(ListingImage.where(id: listing_image_id).first).map { |listing_image|
       Result::Success.new(listing_image)
     }.or_else {
-      Result::Error.new("Could not find listing image with id #{listing_image_id}",
-                        :listing_image_not_found,
-                        listing_image_id: listing_image_id)
+      Result::Error.new(ArgumentError.new("Could not find listing image with id #{listing_image_id}"))
     }
   end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -68,7 +68,7 @@ class Listing < ActiveRecord::Base
 
   belongs_to :author, :class_name => "Person", :foreign_key => "author_id"
 
-  has_many :listing_images, :dependent => :destroy, conditions: ["errored = 0"]
+  has_many :listing_images, :dependent => :destroy, conditions: ["error IS NULL"]
 
   has_many :conversations
   has_many :comments, :dependent => :destroy

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -68,7 +68,7 @@ class Listing < ActiveRecord::Base
 
   belongs_to :author, :class_name => "Person", :foreign_key => "author_id"
 
-  has_many :listing_images, :dependent => :destroy
+  has_many :listing_images, :dependent => :destroy, conditions: ["errored = 0"]
 
   has_many :conversations
   has_many :comments, :dependent => :destroy

--- a/app/models/listing_image.rb
+++ b/app/models/listing_image.rb
@@ -12,7 +12,7 @@
 #  image_updated_at   :datetime
 #  image_processing   :boolean
 #  image_downloaded   :boolean          default(FALSE)
-#  errored            :boolean          default(FALSE), not null
+#  error              :string(255)
 #  width              :integer
 #  height             :integer
 #  author_id          :string(255)

--- a/app/models/listing_image.rb
+++ b/app/models/listing_image.rb
@@ -12,6 +12,7 @@
 #  image_updated_at   :datetime
 #  image_processing   :boolean
 #  image_downloaded   :boolean          default(FALSE)
+#  errored            :boolean          default(FALSE), not null
 #  width              :integer
 #  height             :integer
 #  author_id          :string(255)

--- a/app/models/listing_image_js_adapter.rb
+++ b/app/models/listing_image_js_adapter.rb
@@ -5,7 +5,7 @@ class ListingImageJSAdapter < JSAdapter
     @id = listing_image.id
     @listing_id = listing_image.listing_id
     @ready = !listing_image.image_processing && listing_image.image_downloaded;
-    @errored = listing_image.errored
+    @errored = listing_image.error.present?
     @images = {
       thumb: listing_image.image.url(:thumb),
       big: listing_image.image.url(:big)

--- a/app/models/listing_image_js_adapter.rb
+++ b/app/models/listing_image_js_adapter.rb
@@ -5,6 +5,7 @@ class ListingImageJSAdapter < JSAdapter
     @id = listing_image.id
     @listing_id = listing_image.listing_id
     @ready = !listing_image.image_processing && listing_image.image_downloaded;
+    @errored = listing_image.errored
     @images = {
       thumb: listing_image.image.url(:thumb),
       big: listing_image.image.url(:big)

--- a/app/views/listings/form/_javascripts.haml
+++ b/app/views/listings/form/_javascripts.haml
@@ -1,6 +1,6 @@
 - valid_until_msg = t('error_messages.listings.valid_until')
 
-= js_t ["listings.form.images.processing", "listings.form.images.this_may_take_a_while", "listings.form.images.percentage_loaded", "listings.form.images.uploading_failed", "listings.form.images.file_too_large", "listings.form.images.accepted_formats", "listings.form.images.loading_image", "listings.form.images.select_file", "listings.form.images.removing", "listings.form.images.add_more"], run_js_immediately
+= js_t ["listings.form.images.processing", "listings.form.images.this_may_take_a_while", "listings.form.images.percentage_loaded", "listings.form.images.uploading_failed", "listings.form.images.file_too_large", "listings.form.images.image_processing_failed", "listings.form.images.accepted_formats", "listings.form.images.loading_image", "listings.form.images.select_file", "listings.form.images.removing", "listings.form.images.add_more"], run_js_immediately
 
 - content_for :listing_js do
   :javascript

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1490,6 +1490,7 @@ en:
         this_may_take_a_while: "this only takes a second"
         percentage_loaded: "%{percentage}%"
         uploading_failed: "Image uploading failed"
+        image_processing_failed: "Image processing failed"
         file_too_large: "The file is too large"
         accepted_formats: "The image format must be either GIF, JPG or PNG."
         images_not_uploaded_confirm: "All images have not finished uploading. Do you really want to continue?"

--- a/db/migrate/20151208111610_add_error_status_to_listing_image.rb
+++ b/db/migrate/20151208111610_add_error_status_to_listing_image.rb
@@ -1,0 +1,5 @@
+class AddErrorStatusToListingImage < ActiveRecord::Migration
+  def change
+    add_column :listing_images, :errored, :boolean, after: :image_downloaded, default: false, null: false
+  end
+end

--- a/db/migrate/20151208111610_add_error_status_to_listing_image.rb
+++ b/db/migrate/20151208111610_add_error_status_to_listing_image.rb
@@ -1,5 +1,0 @@
-class AddErrorStatusToListingImage < ActiveRecord::Migration
-  def change
-    add_column :listing_images, :errored, :boolean, after: :image_downloaded, default: false, null: false
-  end
-end

--- a/db/migrate/20151209102951_add_error_to_listing_images.rb
+++ b/db/migrate/20151209102951_add_error_to_listing_images.rb
@@ -1,0 +1,9 @@
+class AddErrorToListingImages < ActiveRecord::Migration
+  def up
+    add_column :listing_images, :error, :string, null: true, after: :image_downloaded
+  end
+
+  def down
+    drop_column :listing_images, :error
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151208111610) do
+ActiveRecord::Schema.define(:version => 20151209102951) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -461,7 +461,7 @@ ActiveRecord::Schema.define(:version => 20151208111610) do
     t.datetime "image_updated_at"
     t.boolean  "image_processing"
     t.boolean  "image_downloaded",   :default => false
-    t.boolean  "errored",            :default => false, :null => false
+    t.string   "error"
     t.integer  "width"
     t.integer  "height"
     t.string   "author_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151204083028) do
+ActiveRecord::Schema.define(:version => 20151208111610) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -461,6 +461,7 @@ ActiveRecord::Schema.define(:version => 20151204083028) do
     t.datetime "image_updated_at"
     t.boolean  "image_processing"
     t.boolean  "image_downloaded",   :default => false
+    t.boolean  "errored",            :default => false, :null => false
     t.integer  "width"
     t.integer  "height"
     t.string   "author_id"

--- a/spec/models/listing_image_spec.rb
+++ b/spec/models/listing_image_spec.rb
@@ -12,7 +12,7 @@
 #  image_updated_at   :datetime
 #  image_processing   :boolean
 #  image_downloaded   :boolean          default(FALSE)
-#  errored            :boolean          default(FALSE), not null
+#  error              :string(255)
 #  width              :integer
 #  height             :integer
 #  author_id          :string(255)

--- a/spec/models/listing_image_spec.rb
+++ b/spec/models/listing_image_spec.rb
@@ -12,6 +12,7 @@
 #  image_updated_at   :datetime
 #  image_processing   :boolean
 #  image_downloaded   :boolean          default(FALSE)
+#  errored            :boolean          default(FALSE), not null
 #  width              :integer
 #  height             :integer
 #  author_id          :string(255)


### PR DESCRIPTION
### Why?

Every now and then we get support requests that complain that the **listing image processing has got stuck**. The reason is often that people are uploading broken image files or files that are now JPG, GIF or PNG, but they have just renamed the files and changed the extension. Solving these issues add support load.

### What?

Makes image processing more error resilient. Fixes two bug, here are steps to reproduce:

**Not showing error message**:

1. Go to new listings page
1. Upload a broken image file (e.g. take a .html file and rename it to .jpg)
1. Wait for awhile

Expected: You see an error saying that the image processing failed

Actual: Nothing. The "Processing, this takes only a second" text is there for ever.

**Listing images get stuck**:

1. Go to new listings page
1. Upload a broken image file (e.g. take a .html file and rename it to .jpg)
1. Wait until the image is uploaded and you see text "Processing, this takes only a second"
1. Save the listing

Expected: You arrive to listing page. You see a text that says that the image is being processed. Wait awhile and refresh and you see the listing image

Actual: Expected: You arrive to listing page. You see a text that says that the image is being processed. No matter how long you wait, you see the text saying that the listing image is being processed.

### How?

- [x] Raraise the exception in `on_error` handler in `DownloadListingImageJob`. This will make the Delayed Job to retry to job 3 times
- [x] Add a new boolean column `errored` to `listing_images`. If this column is true, it's a signal that the listing image processing failed and the listing image should be ignored.
- [x] Change the listing image status poller (during the image upload/process on new listing page) so that it shows error message if the processing fails.

### Screenshots

![screen shot 2015-12-09 at 10 05 56](https://cloud.githubusercontent.com/assets/429876/11679787/782b9120-9e5c-11e5-8eaf-1828add6aff7.png)
