### PR TITLE
Reserve marketplace-academy ident

### DIFF
--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -43,6 +43,7 @@ module MarketplaceService::API
       "internal",
       "webinar",
       "local",
+      "marketplace-academy",
       "academy-proxy",
       "proxy",
       "preproduction",


### PR DESCRIPTION
This is used as a domain for Academy Wordpress installation running in
marketplace-academy.sharetribe.com