### PR TITLE
Change "en" time format from dd/mm/yyyy to mm/dd/yyyy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2120,10 +2120,9 @@ en:
     format: mm/dd/yyyy
   time:
     formats:
-      short: "%e %b %Y at %H:%M"
-      shorter: "%e %b at %H:%M"
-      short_date: "%e %b %Y"
-      sms: "%e %b at %H:%M"
+      short: "%b %e, %Y at %H:%M"
+      shorter: "%b %e at %H:%M"
+      short_date: "%b %e, %Y"
   timestamps:
     day_ago: "%{count} day ago"
     days_ago: "%{count} days ago"

--- a/features/admin/manage_members/admin_lists_members.feature
+++ b/features/admin/manage_members/admin_lists_members.feature
@@ -14,34 +14,34 @@ Feature: Admin lists members
 
   Scenario: Admin views & sorts list of members
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed | Remove User |
-      | matti manager | manager@example.com | 1 Mar 2014 |                 |             |
-      | john doe      | test2@example.com   | 1 Mar 2013 |                 |             |
-      | jane doe      | test1@example.com   | 1 Mar 2012 |                 |             |
+      | Name          | Email               | Joined     | Posting allowed  | Remove User |
+      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
+      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
+      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
     When I follow "Name"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed | Remove User |
-      | jane doe      | test1@example.com   | 1 Mar 2012 |                 |             |
-      | john doe      | test2@example.com   | 1 Mar 2013 |                 |             |
-      | matti manager | manager@example.com | 1 Mar 2014 |                 |             |
+      | Name          | Email               | Joined     | Posting allowed  | Remove User |
+      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
+      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
+      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
     When I follow "Name"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed | Remove User |
-      | matti manager | manager@example.com | 1 Mar 2014 |                 |             |
-      | john doe      | test2@example.com   | 1 Mar 2013 |                 |             |
-      | jane doe      | test1@example.com   | 1 Mar 2012 |                 |             |
+      | Name          | Email               | Joined     | Posting allowed  | Remove User |
+      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
+      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
+      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
     When I follow "Email"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed | Remove User |
-      | matti manager | manager@example.com | 1 Mar 2014 |                 |             |
-      | jane doe      | test1@example.com   | 1 Mar 2012 |                 |             |
-      | john doe      | test2@example.com   | 1 Mar 2013 |                 |             |
+      | Name          | Email               | Joined     | Posting allowed  | Remove User |
+      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
+      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
+      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
     When I follow "Joined"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed | Remove User |
-      | jane doe      | test1@example.com   | 1 Mar 2012 |                 |             |
-      | john doe      | test2@example.com   | 1 Mar 2013 |                 |             |
-      | matti manager | manager@example.com | 1 Mar 2014 |                 |             |
+      | Name          | Email               | Joined     | Posting allowed  | Remove User |
+      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
+      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
+      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
 
   Scenario: Admin views member count
     Given there are 50 users with name prefix "User" "Number"

--- a/features/listings/user_creates_a_new_listing.feature
+++ b/features/listings/user_creates_a_new_listing.feature
@@ -197,7 +197,7 @@ Scenario: User creates a new listing with date field
   And I fill in "listing_title" with "My house"
   And I fill select custom date "building_date_test" with day="19", month="April" and year="2014"
   And I press "Save listing"
-  Then I should see "building_date_test: 19 Apr 2014"
+  Then I should see "building_date_test: Apr 19, 2014"
 
   @javascript @sphinx @no-transaction
   Scenario: User creates a new listing with checkbox field


### PR DESCRIPTION
The "en" locale is currently en-US, but the date format is dd/mm/yyyy and that's wrong. This PR changes the "en" date formats from dd/mm/yyyy to mm/dd/yyyy.

We have the en-GB which can be used for English with dd/mm/yyyy format.

Todo:

- [X] Change "en" timeformat
- [x] Go to WebTranslateIt and add the time formats for en-GB