### PR TITLE
Update delayed_job gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,8 +54,8 @@ gem 'ts-delayed-delta', "~>2.0.2",
   :branch => 'master',
   :ref    => '839284f2f28b3f4caf3a3bf5ccde9a6d222c7f4d'
 gem 'possibly', '~> 0.2.0'
-gem 'delayed_job', "~>3.0.5"
-gem 'delayed_job_active_record'
+gem 'delayed_job', "~> 4.0.0", "<= 4.0.3" # Test break with > 4.0.3
+gem 'delayed_job_active_record', "~> 4.0.0"
 gem 'json', "~>1.8.0"
 gem 'multi_json', "~>1.7.3" # 1.8.0 caused "invalid byte sequence in UTF-8" at heroku
 gem 'web_translate_it'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,11 +144,11 @@ GEM
     dalli (2.6.4)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
-    delayed_job (3.0.5)
-      activesupport (~> 3.0)
-    delayed_job_active_record (0.3.3)
-      activerecord (>= 2.1.0, < 4)
-      delayed_job (~> 3.0)
+    delayed_job (4.0.3)
+      activesupport (>= 3.0, < 4.2)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
     delayed_paperclip (2.6.1)
       paperclip (>= 3.3.0)
     devise (2.2.7)
@@ -629,8 +629,8 @@ DEPENDENCIES
   cucumber-rails (~> 1.4.0)
   dalli
   database_cleaner (~> 1.1)
-  delayed_job (~> 3.0.5)
-  delayed_job_active_record
+  delayed_job (~> 4.0.0, <= 4.0.3)
+  delayed_job_active_record (~> 4.0.0)
   delayed_paperclip
   devise (~> 2.2.4)
   devise-encryptable


### PR DESCRIPTION
Update delayed_job gem. Version 4.0.4 broke test, so that why I updated to 4.0.3

Testing: This is pretty well covered by the tests. No manual testing done.