### PR TITLE
Fix atom feed and homepage to use same array format for listing shapes

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -134,7 +134,7 @@ class HomepageController < ApplicationController
     search = {
       # Add listing_id
       categories: filter_params[:categories],
-      listing_shape_id: Maybe(filter_params)[:listing_shape].or_else(nil),
+      listing_shape_id: filter_params[:listing_shape] ? [filter_params[:listing_shape]] : nil,
       price_cents: filter_params[:price_cents],
       keywords: filter_params[:search],
       fields: checkboxes.concat(dropdowns).concat(numbers),

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -134,7 +134,7 @@ class HomepageController < ApplicationController
     search = {
       # Add listing_id
       categories: filter_params[:categories],
-      listing_shape_id: filter_params[:listing_shape] ? [filter_params[:listing_shape]] : nil,
+      listing_shape_id: Array(filter_params[:listing_shape]),
       price_cents: filter_params[:price_cents],
       keywords: filter_params[:search],
       fields: checkboxes.concat(dropdowns).concat(numbers),

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -134,7 +134,7 @@ class HomepageController < ApplicationController
     search = {
       # Add listing_id
       categories: filter_params[:categories],
-      listing_shape_id: Array(filter_params[:listing_shape]),
+      listing_shape_ids: Array(filter_params[:listing_shape]),
       price_cents: filter_params[:price_cents],
       keywords: filter_params[:search],
       fields: checkboxes.concat(dropdowns).concat(numbers),

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -85,7 +85,7 @@ class ListingsController < ApplicationController
         search_res = @current_community.private ? Result::Success.new({count: 0, listings: []}) : ListingIndexService::API::Api.listings.search(
                      community_id: @current_community.id,
                      search: {
-                       listing_shape_id: params[:listing_shapes],
+                       listing_shape_ids: params[:listing_shapes],
                        page: page,
                        per_page: per_page
                      },

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -77,17 +77,15 @@ class ListingsController < ApplicationController
 
         if params[:share_type].present?
           direction = params[:share_type]
-
-          params[:listing_shapes] = {
-            id: all_shapes.select { |shape|
+          params[:listing_shapes] =
+            all_shapes.select { |shape|
               direction_map[shape[:id]] == direction
             }.map { |shape| shape[:id] }
-          }
         end
         search_res = @current_community.private ? Result::Success.new({count: 0, listings: []}) : ListingIndexService::API::Api.listings.search(
                      community_id: @current_community.id,
                      search: {
-                       listing_shapes: params[:listing_shapes],
+                       listing_shape_id: params[:listing_shapes],
                        page: page,
                        per_page: per_page
                      },

--- a/app/services/listing_index_service/data_types.rb
+++ b/app/services/listing_index_service/data_types.rb
@@ -17,7 +17,7 @@ module ListingIndexService::DataTypes
     [:per_page, :to_integer, :mandatory, gte: 1],
     [:keywords, :string, :optional],
     [:categories, :array, :optional],
-    [:listing_shape_id, :array, :optional],
+    [:listing_shape_ids, :array, :optional],
     [:price_cents, :range, :optional],
     [:fields, :array, default: []],
     [:author_id, :string],

--- a/app/services/listing_index_service/data_types.rb
+++ b/app/services/listing_index_service/data_types.rb
@@ -17,7 +17,7 @@ module ListingIndexService::DataTypes
     [:per_page, :to_integer, :mandatory, gte: 1],
     [:keywords, :string, :optional],
     [:categories, :array, :optional],
-    [:listing_shape_id, :fixnum, :optional],
+    [:listing_shape_id, :array, :optional],
     [:price_cents, :range, :optional],
     [:fields, :array, default: []],
     [:author_id, :string],

--- a/app/services/listing_index_service/search/sphinx_adapter.rb
+++ b/app/services/listing_index_service/search/sphinx_adapter.rb
@@ -15,14 +15,11 @@ module ListingIndexService::Search
     def search(community_id:, search:, includes:)
       included_models = includes.map { |m| INCLUDE_MAP[m] }
 
+      # rename listing_shape_ids to singular so that Sphinx understands it
+      search = HashUtils.rename_keys({:listing_shape_ids => :listing_shape_id}, search)
+
       if needs_db_query?(search) && needs_search?(search)
         Result::Error.new(ArgumentError.new("Both DB query and search engine would be needed to fulfill the search"))
-      end
-
-      # rename listing_shape_ids to singular so that Sphinx understands it
-      if search[:listing_shape_ids] && search[:listing_shape_id].nil?
-        search[:listing_shape_id] = search[:listing_shape_ids]
-        search.delete(:listing_shape_ids)
       end
 
       if needs_search?(search)

--- a/app/services/listing_index_service/search/sphinx_adapter.rb
+++ b/app/services/listing_index_service/search/sphinx_adapter.rb
@@ -19,6 +19,12 @@ module ListingIndexService::Search
         Result::Error.new(ArgumentError.new("Both DB query and search engine would be needed to fulfill the search"))
       end
 
+      # rename listing_shape_ids to singular so that Sphinx understands it
+      if search[:listing_shape_ids] && search[:listing_shape_id].nil?
+        search[:listing_shape_id] = search[:listing_shape_ids]
+        search.delete(:listing_shape_ids)
+      end
+
       if needs_search?(search)
         if search_out_of_bounds?(search[:per_page], search[:page])
           success_result(0, [], includes)


### PR DESCRIPTION
Earlier homepage used listing_shape_id as fixnum and atom feed could
with some filters use multiple listing_shape ids, now the parameters
is always calle listing_shape_id and is always an array.

This fixes the bug of offer/request filters not working with atom feed