### PR TITLE
Remove Mocha tests from Travis suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   - SUITE="rspec"
   - SUITE="rubocop"
   - SUITE="cucumber"
-  - SUITE="mocha"
   - SUITE="jshint"
   global:
     - BUNDLE_ARCHIVE="travis-bundle-cache"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,11 +42,3 @@ We are using [Mocha](http://visionmedia.github.io/mocha/) test framework for Jav
 2. Go to `http://localhost:3000/test/`
 
 When running on development mode, make sure you DO NOT have a file `public/assets/application.js`. If you do, delete it. This way Rails will use asset pipeline instead of precompiled file.
-
-### Run Mocha tests from command-line
-
-1. Install node
-2. `npm install`
-3. `npm install -g grunt-cli`
-4. `rake assets:precompile`
-5. `grunt connect mocha`

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -32,17 +32,6 @@ then
 	gem specific_install https://github.com/sharetribe/bundle_cache
 	bundle_cache_install
 	exit
-elif [ "$SUITE" = "mocha" ]
-then
-	gem install nokogiri -- --use-system-libraries
-	gem install bundler specific_install
-	# Install a modified version of bundle_cache gem
-	# If the modifications get merged to bundle_cache use the upstream repo, not this one
-	gem specific_install https://github.com/sharetribe/bundle_cache
-	bundle_cache_install
-	npm install
-	npm install -g grunt-cli
-	exit
 elif [ "$SUITE" = "jshint" ]
 then
 	npm install

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -18,12 +18,6 @@ then
 	mysql -e 'create database sharetribe_test;'
 	bundle exec rake db:test:load
 	exit
-elif [ "$SUITE" = "mocha" ]
-then
-	cp config/database.example.yml config/database.yml
-	mysql -e 'create database sharetribe_test;'
-	bundle exec rake assets:precompile
-	exit
 elif [ "$SUITE" = "jshint" ]
 then
 	exit

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -15,10 +15,6 @@ elif [ "$SUITE" = "cucumber" ]
 then
 	bundle install --without development --path=~/.bundle
 	exit
-elif [ "$SUITE" = "mocha" ]
-then
-	bundle install --without development --path=~/.bundle
-	exit
 elif [ "$SUITE" = "jshint" ]
 then
 	exit

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -16,10 +16,6 @@ then
 	phantomjs --webdriver=8910 &
 	PHANTOMJS=true bundle exec cucumber -ptravis 2>&1
 	exit
-elif [ "$SUITE" = "mocha" ]
-then
-	grunt connect mocha 2>&1
-	exit
 elif [ "$SUITE" = "jshint" ]
 then
 	grunt jshint 2>&1


### PR DESCRIPTION
Due to the latest changes to Sprockets in Rails 4, [it's impossible to compile
assets (like JavaScript files) without the digest in the file name](https://github.com/rails/sprockets-rails#changes-from-rails-3x). That
breaks the current setup, since for Travis tests we need to reference the
compiled file name outside of Rails application, and because there's the digest, it's hard to reference the file.

Mocha tests (JavaScript tests) are rarely used. The tests haven't probably
ever failed. I don't think these tests are super useful.

If needed, the Mocha tests can be still accessed if the Rails server is
running.

P.S. What do you think? Should I acctually remove all the tests and the Mocha framework? Do we need that, ever?