### PR TITLE
Add digest to missing profile image

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -353,16 +353,36 @@ module ApplicationHelper
 
   def avatar_thumb(size, person, avatar_html_options={})
     return "" if person.nil?
-    link_to_unless(person.deleted?, image_tag(person.image.url(size), avatar_html_options), person)
+
+    image_url = person.image.present? ? person.image.url(size) : missing_avatar(size)
+
+    link_to_unless(person.deleted?, image_tag(image_url, avatar_html_options), person)
   end
 
   def large_avatar_thumb(person, options={})
-    image_tag person.image.url(:medium), { :alt => person.name(@current_community) }.merge(options)
+    image_url = person.image.present? ? person.image.url(:medium) : missing_avatar(:medium)
+
+    image_tag image_url, { :alt => person.name(@current_community) }.merge(options)
   end
 
   def huge_avatar_thumb(person, options={})
     # FIXME! Need a new picture size: :large
-    image_tag person.image.url(:medium), { :alt => person.name(@current_community) }.merge(options)
+
+    image_url = person.image.present? ? person.image.url(:medium) : missing_avatar(:medium)
+
+    image_tag image_url, { :alt => person.name(@current_community) }.merge(options)
+  end
+
+  def missing_avatar(size = :medium)
+    case size.to_sym
+    when :small
+      image_path("profile_image/small/missing.png")
+    when :thumb
+      image_path("profile_image/thumb/missing.png")
+    else
+      # default to medium size
+      image_path("profile_image/medium/missing.png")
+    end
   end
 
   def pageless(total_pages, target_id, url=nil, loader_message='Loading more results')

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -169,8 +169,8 @@ class Person < ActiveRecord::Base
                       :medium => "288x288#",
                       :small => "108x108#",
                       :thumb => "48x48#",
-                      :original => "600x800>"},
-                    :default_url => ActionController::Base.helpers.asset_path("/assets/profile_image/:style/missing.png", :digest => true)
+                      :original => "600x800>"}
+
   process_in_background :image
 
   #validates_attachment_presence :image

--- a/app/services/marketplace_service/person.rb
+++ b/app/services/marketplace_service/person.rb
@@ -20,7 +20,7 @@ module MarketplaceService
           username: person_model.username,
           first_name: person_model.given_name,
           last_name: person_model.family_name,
-          avatar: person_model.image.url(:thumb),
+          avatar: person_model.image.present? ? person_model.image.url(:thumb) : ActionController::Base.helpers.image_path("profile_image/thumb/missing.png"),
           is_deleted: person_model.deleted?
         ]
       end

--- a/app/views/layouts/_header_anchors.haml
+++ b/app/views/layouts/_header_anchors.haml
@@ -2,7 +2,8 @@
   .header-user-toggle.header-hover.toggle{data: {toggle: '#header-user-toggle-menu', 'toggle-anchor-position' => 'right', 'toggle-position' => 'absolute'}}
     #header-user-mobile-anchor
       .left
-        = image_tag user.image.url(:thumb), alt: '', class: 'header-user-avatar'
+        - avatar_url = user.image.present? ? user.image.url(:thumb) : image_path("profile_image/thumb/missing.png")
+        = image_tag avatar_url, alt: '', class: 'header-user-avatar'
       .left
         %span.header-text-link
           %span#header-user-display-name.visible-tablet-inline


### PR DESCRIPTION
Currently, the picture for a person without an avatar is rendered without the digest. This will break in Rails 4, which will only deploy assets with digest.

- [X] Remove the default_url from the Person model
- [X] Where ever we use the image, check that it exists and use default image if that's not the case