### PR TITLE
Inline JSON translations

### DIFF
--- a/app/assets/javascripts/sharetribe_common.js
+++ b/app/assets/javascripts/sharetribe_common.js
@@ -44,11 +44,11 @@ function prepare_ajax_form(form_id, locale, rules) {
   });
 }
 
-function disable_submit_button(form_id, locale) {
+function disable_submit_button(form_id) {
   $(form_id).find("button").attr('disabled', 'disabled');
-  jQuery.getJSON('/assets/locales/' + locale + '.json', function(json) {
-    $(form_id).find("button").text(json.please_wait);
-  });
+
+  var json = ST.jsonTranslations;
+  $(form_id).find("button").text(json.please_wait);
 }
 
 function auto_resize_text_areas(class_name) {
@@ -63,34 +63,33 @@ function translate_validation_messages(locale) {
     }
   }
 
-  jQuery.getJSON('/assets/locales/' + locale + '.json', function(json) {
-    jQuery.extend(jQuery.validator.messages, {
-        required: json.validation_messages.required,
-        remote: json.validation_messages.remote,
-        email: json.validation_messages.email,
-        url: json.validation_messages.url,
-        date: json.validation_messages.date,
-        dateISO: json.validation_messages.dateISO,
-        number: json.validation_messages.number,
-        digits: json.validation_messages.digits,
-        creditcard: json.validation_messages.creditcard,
-        equalTo: json.validation_messages.equalTo,
-        accept: json.validation_messages.accept,
-        maxlength: jQuery.validator.format(json.validation_messages.maxlength),
-        minlength: jQuery.validator.format(json.validation_messages.minlength),
-        rangelength: jQuery.validator.format(json.validation_messages.rangelength),
-        range: jQuery.validator.format(json.validation_messages.range),
-        max: jQuery.validator.format(json.validation_messages.max),
-        min: jQuery.validator.format(json.validation_messages.min),
-        address_validator: jQuery.validator.format(json.validation_messages.address_validator),
-        money: jQuery.validator.format(json.validation_messages.money),
-        min_bound: formatMinMaxMessage(json.validation_messages.min_bound),
-        max_bound: formatMinMaxMessage(json.validation_messages.max_bound),
-        number_min: jQuery.validator.format(json.validation_messages.min),
-        number_max: jQuery.validator.format(json.validation_messages.max),
-        number_no_decimals: json.validation_messages.number_no_decimals,
-        number_decimals: json.validation_messages.number_decimals,
-        number_conditional_decimals: json.validation_messages.number
-    });
+  var json = ST.jsonTranslations;
+  jQuery.extend(jQuery.validator.messages, {
+      required: json.validation_messages.required,
+      remote: json.validation_messages.remote,
+      email: json.validation_messages.email,
+      url: json.validation_messages.url,
+      date: json.validation_messages.date,
+      dateISO: json.validation_messages.dateISO,
+      number: json.validation_messages.number,
+      digits: json.validation_messages.digits,
+      creditcard: json.validation_messages.creditcard,
+      equalTo: json.validation_messages.equalTo,
+      accept: json.validation_messages.accept,
+      maxlength: jQuery.validator.format(json.validation_messages.maxlength),
+      minlength: jQuery.validator.format(json.validation_messages.minlength),
+      rangelength: jQuery.validator.format(json.validation_messages.rangelength),
+      range: jQuery.validator.format(json.validation_messages.range),
+      max: jQuery.validator.format(json.validation_messages.max),
+      min: jQuery.validator.format(json.validation_messages.min),
+      address_validator: jQuery.validator.format(json.validation_messages.address_validator),
+      money: jQuery.validator.format(json.validation_messages.money),
+      min_bound: formatMinMaxMessage(json.validation_messages.min_bound),
+      max_bound: formatMinMaxMessage(json.validation_messages.max_bound),
+      number_min: jQuery.validator.format(json.validation_messages.min),
+      number_max: jQuery.validator.format(json.validation_messages.max),
+      number_no_decimals: json.validation_messages.number_no_decimals,
+      number_decimals: json.validation_messages.number_decimals,
+      number_conditional_decimals: json.validation_messages.number
   });
 }

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -62,6 +62,9 @@
 
   = javascript_include_tag 'application'
 
+  :javascript
+    window.ST.jsonTranslations = #{JSONTranslations.get(I18n.locale)}
+
   - if @analytics_event
     :javascript
       report_analytics_event(#{@analytics_event});

--- a/config/initializers/json_translations.rb
+++ b/config/initializers/json_translations.rb
@@ -1,0 +1,26 @@
+# Load old-style JSON translations
+#
+# These translations will be inlined to the document so that JavaScript
+# scripts can use these translations
+
+module JSONTranslations
+
+  module_function
+
+  def load_all()
+    @json_locales = {};
+    Sharetribe::AVAILABLE_LOCALES.each { |locale|
+      # Read the file and save the content as JSON string.
+      # No need to parse it
+      ident = locale[:ident]
+      @json_locales[ident] = File.read(Rails.root.join("app/assets/javascripts/locales/#{ident}.json"))
+    }
+  end
+
+  def get(ident)
+    @json_locales[ident.to_s]
+  end
+
+end
+
+JSONTranslations.load_all


### PR DESCRIPTION
Part of our translations are saved to separate JSON files. Previously, those files were fetched by jQuery from the server and thus creating additional HTTP request.

After Rails 4 update, we are not able to reference to a asset with a hard-coded path, because all the assets contain now the digest part.

Better solution than fetching the translations with jQuery is just to inline them to the document.

In the future we might want to get rid of the JSON files altogether and move all translations to the main translation files.