### PR TITLE
Add index for custom_field_values.type

### DIFF
--- a/app/models/custom_field_value.rb
+++ b/app/models/custom_field_value.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 class CustomFieldValue < ActiveRecord::Base

--- a/app/models/custom_field_values/checkbox_field_value.rb
+++ b/app/models/custom_field_values/checkbox_field_value.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 class CheckboxFieldValue < OptionFieldValue

--- a/app/models/custom_field_values/date_field_value.rb
+++ b/app/models/custom_field_values/date_field_value.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 class DateFieldValue < CustomFieldValue

--- a/app/models/custom_field_values/dropdown_field_value.rb
+++ b/app/models/custom_field_values/dropdown_field_value.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 class DropdownFieldValue < OptionFieldValue

--- a/app/models/custom_field_values/numeric_field_value.rb
+++ b/app/models/custom_field_values/numeric_field_value.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 class NumericFieldValue < CustomFieldValue

--- a/app/models/custom_field_values/option_field_value.rb
+++ b/app/models/custom_field_values/option_field_value.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 class OptionFieldValue < CustomFieldValue

--- a/app/models/custom_field_values/text_field_value.rb
+++ b/app/models/custom_field_values/text_field_value.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 class TextFieldValue < CustomFieldValue

--- a/db/migrate/20151231083524_add_custom_field_values_type_index.rb
+++ b/db/migrate/20151231083524_add_custom_field_values_type_index.rb
@@ -1,0 +1,5 @@
+class AddCustomFieldValuesTypeIndex < ActiveRecord::Migration
+  def change
+    add_index :custom_field_values, :type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151230095128) do
+ActiveRecord::Schema.define(version: 20151231083524) do
 
   create_table "auth_tokens", force: true do |t|
     t.string   "token"
@@ -349,6 +349,7 @@ ActiveRecord::Schema.define(version: 20151230095128) do
   end
 
   add_index "custom_field_values", ["listing_id"], name: "index_custom_field_values_on_listing_id", using: :btree
+  add_index "custom_field_values", ["type"], name: "index_custom_field_values_on_type", using: :btree
 
   create_table "custom_fields", force: true do |t|
     t.string   "type"
@@ -365,10 +366,10 @@ ActiveRecord::Schema.define(version: 20151230095128) do
   add_index "custom_fields", ["community_id"], name: "index_custom_fields_on_community_id", using: :btree
 
   create_table "delayed_jobs", force: true do |t|
-    t.integer  "priority",                    default: 0
-    t.integer  "attempts",                    default: 0
+    t.integer  "priority",   default: 0
+    t.integer  "attempts",   default: 0
     t.text     "handler"
-    t.text     "last_error", limit: 16777215
+    t.text     "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"

--- a/spec/models/date_field_value_spec.rb
+++ b/spec/models/date_field_value_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 require 'spec_helper'

--- a/spec/models/dropdown_field_value_spec.rb
+++ b/spec/models/dropdown_field_value_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 require 'spec_helper'

--- a/spec/models/numeric_field_value_spec.rb
+++ b/spec/models/numeric_field_value_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 require 'spec_helper'

--- a/spec/models/text_field_value_spec.rb
+++ b/spec/models/text_field_value_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_custom_field_values_on_listing_id  (listing_id)
+#  index_custom_field_values_on_type        (type)
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Without index the field causes full table scan queries.