### PR TITLE
Link to all listings from user menu

### DIFF
--- a/app/views/layouts/_header_user_menu.haml
+++ b/app/views/layouts/_header_user_menu.haml
@@ -12,6 +12,10 @@
     = icon_tag("user", ["icon-with-text"])
     = t("header.profile")
 
+  = link_to person_path(user, :show_closed => true) do
+    = icon_tag("list", ["icon-with-text"])
+    = t("header.manage_listings")
+
   = link_to person_settings_path(user) do
     = icon_tag("settings", ["icon-with-text"])
     = t("layouts.logged_in.settings")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1109,6 +1109,7 @@ en:
     create_new_marketplace: "Create a new marketplace"
     contact_us: "Contact us"
     profile: Profile
+    manage_listings: "Manage listings"
     invite: "Invite new members"
     login: "Log in"
     signup: "Sign up"


### PR DESCRIPTION
According to feedback, users may have hard time finding their own listings. Antti, Vesa, Thomas and Janne suggested adding this link in this thread: https://www.flowdock.com/app/kassi/browse-view-visual-design/threads/D5_9hSP_ZxRpfGtERaQJFn98m4w