### PR TITLE
Handle UnknownFormat and RoutingError as 404 instead of 500

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,6 +44,16 @@ class ApplicationController < ActionController::Base
 
   rescue_from RestClient::Unauthorized, :with => :session_unauthorized
 
+  rescue_from ActionController::UnknownFormat, :with => :not_found
+  rescue_from ActionController::RoutingError, :with => :not_found
+
+  def not_found
+    respond_to do |format|
+      format.html {render "status_404", status: 404, locals: { status: 404, title: title(404) }}
+      format.all { render nothing: true, status: 404 }
+    end
+  end
+
   helper_method :root, :logged_in?, :current_user?
 
   def redirect_removed_locale

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -10,8 +10,13 @@ class ErrorsController < ActionController::Base
     render "status_500", status: 500, locals: { status: 500, title: title(500), error_id: error_id }
   end
 
+  # not_found is duplicated in ApplicationController, since we need to handle some special
+  # cases by rescuing exceptions
   def not_found
-    render "status_404", status: 404, locals: { status: 404, title: title(404) }
+    respond_to do |format|
+      format.html {render "status_404", status: 404, locals: { status: 404, title: title(404) }}
+      format.all { render nothing: true, status: 404 }
+    end
   end
 
   def gone


### PR DESCRIPTION
Users accessing weird paths can result to 500 errors in some cases. Semantically 404 would be more correct, and create less log clutter.

The `rescue_from` statements need to be in `ApplicationController` since other controllers inherit it, but our error handlers are in `ErrorsController`. I'm not sure what's the best way to solve this, right now I've duplicated the 404 handler to `ApplicationController`. Comments welcome!