### PR TITLE
Hide "contact support" message from email config page

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -34,6 +34,7 @@ class Admin::CommunitiesController < ApplicationController
 
     sender_address = EmailService::API::Api.addresses.get_sender(community_id: @current_community.id).data
     user_defined_address = EmailService::API::Api.addresses.get_user_defined(community_id: @current_community.id).data
+    ses_in_use = EmailService::API::Api.ses_client.present?
 
     enqueue_status_sync!(user_defined_address)
 
@@ -46,6 +47,7 @@ class Admin::CommunitiesController < ApplicationController
              post_sender_address_url: create_sender_address_admin_community_path,
              can_set_sender_address: can_set_sender_address(@current_plan),
              knowledge_base_url: APP_CONFIG.knowledge_base_url,
+             ses_in_use: ses_in_use,
            }
   end
 

--- a/app/views/admin/communities/edit_welcome_email.haml
+++ b/app/views/admin/communities/edit_welcome_email.haml
@@ -34,7 +34,8 @@
   - content_for(:resend_link) do
     = link_to(t("admin.communities.outgoing_email.resend_link"), nil, class: "js-sender-address-resend-verification")
 
-  - if user_defined_address.nil?
+  - if user_defined_address.nil? || !ses_in_use
+    -# SES not in use, or the marketplace uses default sender address
     .row
       .col-12
         .sender-address-preview
@@ -42,6 +43,7 @@
             = content_for(:sender_address_preview)
 
   - elsif [:none, :requested, :expired].include?(user_defined_address[:verification_status])
+    -# Custom sender address is set, but not yet verified
     .row.js-status-loading
       .col-12
         = image_tag("ajax-loader-grey.gif", class: "sender-address-status-loading-spinner")


### PR DESCRIPTION
If the marketplace doesn't use SES, they don't need to contact us for changing the sender email. In practice, this applies to open source installations