### PR TITLE
Handle UnknownFormat and RoutingError as 404 instead of 500

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -11,7 +11,17 @@ class ErrorsController < ActionController::Base
   end
 
   def not_found
-    render "status_404", status: 404, locals: { status: 404, title: title(404) }
+    respond_to do |format|
+      format.html {render "status_404", status: 404, locals: { status: 404, title: title(404) }}
+      format.all { render nothing: true, status: 404 }
+    end
+  end
+
+  def not_acceptable
+    respond_to do |format|
+      format.html {render "status_404", status: 406, locals: { status: 406, title: title(406) }}
+      format.all { render nothing: true, status: 406 }
+    end
   end
 
   def gone

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,6 +42,22 @@ Kassi::Application.configure do
       request_uuid: event.payload[:request_uuid] }
   }
 
+  # NB: ignores for other services are defined in airbrake.rb and
+  # newrelic.yml, consider keeping them in sync!
+  config.lograge.ignore_custom = lambda do |event|
+    exceptions = event.payload[:exception]
+    return false unless exceptions
+    ignore = ["AbstractController::ActionNotFound",
+              "ActiveRecord::RecordNotFound",
+              "ActionController::RoutingError",
+              "ActionController::UnknownAction",
+              "PeopleController::PersonDeleted",
+              "ListingsController::ListingDeleted"
+              ]
+    relevant_errors = exceptions - ignore
+    relevant_errors.empty?
+  end
+
   config.lograge.formatter = Lograge::Formatters::Json.new
 
   config.after_initialize do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,21 +42,7 @@ Kassi::Application.configure do
       request_uuid: event.payload[:request_uuid] }
   }
 
-  # NB: ignores for other services are defined in airbrake.rb and
-  # newrelic.yml, consider keeping them in sync!
-  config.lograge.ignore_custom = lambda do |event|
-    exceptions = event.payload[:exception]
-    return false unless exceptions
-    ignore = ["AbstractController::ActionNotFound",
-              "ActiveRecord::RecordNotFound",
-              "ActionController::RoutingError",
-              "ActionController::UnknownAction",
-              "PeopleController::PersonDeleted",
-              "ListingsController::ListingDeleted"
-              ]
-    relevant_errors = exceptions - ignore
-    relevant_errors.empty?
-  end
+  # to ignore certain messages, see commit e1ac643f677b0a9f73b10454fa04f67595c8c0c5
 
   config.lograge.formatter = Lograge::Formatters::Json.new
 

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -13,6 +13,9 @@ if APP_CONFIG.use_airbrake
     # The erros above are the defaults (from https://github.com/airbrake/airbrake)
     # commented few out to see how often they happen
 
+    # NB: ignores for other services are defined in newrelic.yml and
+    # production.rb, consider keeping them in sync!
+
     # config.http_open_timeout = 60
     # config.http_read_timeout = 60
   end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -13,8 +13,8 @@ if APP_CONFIG.use_airbrake
     # The erros above are the defaults (from https://github.com/airbrake/airbrake)
     # commented few out to see how often they happen
 
-    # NB: ignores for other services are defined in newrelic.yml and
-    # production.rb, consider keeping them in sync!
+    # NB: ignores for other services are defined in newrelic.yml,
+    # consider keeping them in sync!
 
     # config.http_open_timeout = 60
     # config.http_read_timeout = 60

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -157,8 +157,8 @@ common: &default_settings
     # to comma separated values.  Default is to ignore routing errors
     # which are how 404's get triggered.
     #
-    # NB: ignores for other services are defined in airbrake.rb and
-    # production.rb, consider keeping them in sync!
+    # NB: ignores for other services are defined in airbrake.rb,
+    # consider keeping them in sync!
     ignore_errors: >-
       ActionController::RoutingError,
       AbstractController::ActionNotFound,

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -157,7 +157,15 @@ common: &default_settings
     # to comma separated values.  Default is to ignore routing errors
     # which are how 404's get triggered.
     #
-    ignore_errors: ActionController::RoutingError
+    # NB: ignores for other services are defined in airbrake.rb and
+    # production.rb, consider keeping them in sync!
+    ignore_errors: >-
+      ActionController::RoutingError,
+      AbstractController::ActionNotFound,
+      ActiveRecord::RecordNotFound,
+      ActionController::UnknownAction,
+      PeopleController::PersonDeleted,
+      ListingsController::ListingDeleted
 
   # (Advanced) Uncomment this to ensure the cpu and memory samplers
   # won't run.  Useful when you are using the agent to monitor an

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Kassi::Application.routes.draw do
   # error handling: 3$: http://blog.plataformatec.com.br/2012/01/my-five-favorite-hidden-features-in-rails-3-2/
   get '/500' => 'errors#server_error'
   get '/404' => 'errors#not_found', :as => :error_not_found
+  get '/406' => 'errors#not_acceptable', :as => :error_not_acceptable
   get '/410' => 'errors#gone', as: :error_gone
   get '/community_not_found' => 'errors#community_not_found', as: :community_not_found
 


### PR DESCRIPTION
Users accessing weird paths can result in errors in some cases, which creates log clutter. In this PR I tell the reporting clients to ignore the most common errors resulting from accessing invalid paths, as they are not actual errors.