### PR TITLE
Fix big cover image to be cover image

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -1979,18 +1979,6 @@ figure.fluidratio {
   background-position: center center;
 }
 
-.lander-content {
-  position: absolute;
-  left: lines(0.5);
-  right: lines(0.5);
-  text-align: center;
-
-  @include media(tablet) {
-    left: 0;
-    right: 0;
-  }
-}
-
 .mobile {
   display: block;
   @include media(tablet) {
@@ -2009,7 +1997,6 @@ figure.fluidratio {
   Lander
 */
 
-.lander-content-container,
 .network-header-content-container {
   position: relative;
 }
@@ -2019,10 +2006,8 @@ figure.fluidratio {
 
   figure.marketplace-cover {
     background-image: url(image-path($cover-photo-url));
-    height: em($cover-photo-mobile-height);
-    @include media(tablet) {
-      @include fluid-ratio(em(1920) em($cover-photo-height), em(300) em($cover-photo-height));
-    }
+    height: auto;
+    background-size: cover;
   }
 
   figure.marketplace-cover-small {
@@ -2055,7 +2040,9 @@ figure.fluidratio {
   }
 
   .marketplace-lander-content {
-    top: lines($lander-content-top-mobile);
+    padding-top: 5em;
+    padding-bottom: 5em;
+    text-align: center;
   }
 
   .marketplace-lander-content-title {
@@ -2193,9 +2180,6 @@ figure.fluidratio {
 
   @include media(tablet) {
 
-    .marketplace-lander-content {
-      top: lines($lander-content-top);
-    }
 
     .marketplace-lander-content-title {
       margin-bottom: 0;

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -17,9 +17,7 @@
       - with_big_cover_photo do
         .coverimage
           %figure.marketplace-cover.fluidratio
-        .wrapper
-          .lander-content-container
-            .lander-content.marketplace-lander-content
+            .lander-content.marketplace-lander-content{style: "top:2em;"}
               = yield :title_header
       - with_small_cover_photo do
         .coverimage


### PR DESCRIPTION
This adds the content of big cover image inside the cover image. So that the cover image will stretch with the title & slogan.

After working with Thomas we figured out that there ain't that many active marketplaces, which have made changes to the affected dom structure with custom scripts.
