### PR TITLE
Updated text to explain that a paragraph is only visible to admins

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1187,7 +1187,7 @@ en:
       message: "A personal message"
       send_invitation: "Send invitation"
       add_email_addresses_description: "Add the email addresses of the people you are inviting to the field below. To add multiple email addresses, separate them with comma."
-      add_lots_of_email_addresses: "If you plan to send lots of invitations, you should use an emailing tool. Check out %{this_article_link} to find out resources about suitable email services."
+      add_lots_of_email_addresses: "As you are an administrator, here is a tip: if you plan to send lots of invitations, you should use an emailing tool. Check out %{this_article_link} to find out resources about suitable email services."
       this_article_link: "this article"
       invitation_emails_field_placeholder: "friend1@example.com, friend2@example.com, ..."
       invitation_message_field_placeholder: "I joined this amazing marketplace. You should too!"


### PR DESCRIPTION
At present, instructions about invitations contain a paragraph only visible to administrator.

![screenshot-marketplace thomasmalbaux fr 2016-01-08 11-36-05](https://cloud.githubusercontent.com/assets/2463785/12391196/982eea42-bdee-11e5-93fb-4641ac62a7c3.png)

However this isn't clear as nothing states that this isn't displayed to all users.
It was asked/discussed/mentioned 11 times in 5 weeks at Support.

This changes the text to add a few more words to explain this a bit better to administrators.