### PR TITLE
Refactor custom fields

### DIFF
--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -35,7 +35,7 @@ class Admin::CustomFieldsController < ApplicationController
     [:title_attributes, :hash, :to_hash, :mandatory]
   )
 
-  CustomFieldSpec = [
+  CUSTOM_FIELD_SPEC = [
     [:name_attributes, :hash, :mandatory],
     [:category_attributes, collection: CategoryAttributeSpec],
     [:sort_priority, :fixnum, :optional],
@@ -44,25 +44,25 @@ class Admin::CustomFieldsController < ApplicationController
 
   TextFieldSpec = [
     # nothing here
-  ] + CustomFieldSpec
+  ] + CUSTOM_FIELD_SPEC
 
   NumericFieldSpec = [
     [:min, :mandatory],
     [:max, :mandatory],
     [:allow_decimals, :bool, :mandatory, transform_with: CHECKBOX_TO_BOOLEAN]
-  ] + CustomFieldSpec
+  ] + CUSTOM_FIELD_SPEC
 
   DropdownFieldSpec = [
     [:option_attributes, :mandatory, transform_with: HASH_VALUES, collection: OptionAttribute]
-  ] + CustomFieldSpec
+  ] + CUSTOM_FIELD_SPEC
 
   CheckboxFieldSpec = [
     [:option_attributes, :mandatory, transform_with: HASH_VALUES, collection: OptionAttribute]
-  ] + CustomFieldSpec
+  ] + CUSTOM_FIELD_SPEC
 
   DateFieldSpec = [
     # nothing here
-  ] + CustomFieldSpec
+  ] + CUSTOM_FIELD_SPEC
 
   TextFieldEntity     = EntityUtils.define_builder(*TextFieldSpec)
   NumericFieldEntity  = EntityUtils.define_builder(*NumericFieldSpec)

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -32,21 +32,21 @@ class CustomField < ActiveRecord::Base
     :max
   )
 
-  has_many :names, :class_name => "CustomFieldName", :dependent => :destroy
+  has_many :names, class_name: "CustomFieldName", dependent: :destroy
 
-  has_many :category_custom_fields, :dependent => :destroy
-  has_many :categories, :through => :category_custom_fields
+  has_many :category_custom_fields, dependent: :destroy
+  has_many :categories, through: :category_custom_fields
 
-  has_many :answers, :class_name => "CustomFieldValue", :dependent => :destroy
+  has_many :answers, class_name: "CustomFieldValue", dependent: :destroy
 
-  has_many :options, :class_name => "CustomFieldOption"
+  has_many :options, class_name: "CustomFieldOption"
 
   belongs_to :community
 
   VALID_TYPES = ["TextField", "NumericField", "DropdownField", "CheckboxField","DateField"]
 
-  validates_length_of :names, :minimum => 1
-  validates_length_of :category_custom_fields, :minimum => 1
+  validates_length_of :names, minimum: 1
+  validates_length_of :category_custom_fields, minimum: 1
   validates_presence_of :community
 
   def name_attributes=(attributes)

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -21,17 +21,6 @@
 class CustomField < ActiveRecord::Base
   include SortableByPriority # use `sort_priority()` for sorting
 
-  attr_accessible(
-    :type,
-    :name_attributes,
-    :category_attributes,
-    :option_attributes,
-    :sort_priority,
-    :required,
-    :min,
-    :max
-  )
-
   has_many :names, class_name: "CustomFieldName", dependent: :destroy
 
   has_many :category_custom_fields, dependent: :destroy

--- a/app/models/custom_field_name.rb
+++ b/app/models/custom_field_name.rb
@@ -16,7 +16,6 @@
 #
 
 class CustomFieldName < ActiveRecord::Base
-  attr_accessible :locale, :value
   belongs_to :custom_field, touch: true
   validates :locale, :value, presence: true
 end

--- a/app/models/custom_field_option.rb
+++ b/app/models/custom_field_option.rb
@@ -17,8 +17,6 @@ class CustomFieldOption < ActiveRecord::Base
   include SortableByPriority # use `sort_priority()` for sorting
 
   belongs_to :custom_field
-  attr_accessible :sort_priority, :title_attributes
-
   has_many :titles, :foreign_key => "custom_field_option_id", :class_name => "CustomFieldOptionTitle", :dependent => :destroy
 
   has_many :custom_field_option_selections, :dependent => :destroy

--- a/app/models/custom_field_option_title.rb
+++ b/app/models/custom_field_option_title.rb
@@ -16,7 +16,6 @@
 #
 
 class CustomFieldOptionTitle < ActiveRecord::Base
-  attr_accessible :locale, :value
   validates :value, :locale, presence: true
 
   belongs_to :custom_field_option, touch: true

--- a/app/models/custom_fields/numeric_field.rb
+++ b/app/models/custom_fields/numeric_field.rb
@@ -19,8 +19,6 @@
 #
 
 class NumericField < CustomField
-  attr_accessible :allow_decimals
-
   validates_numericality_of :min
   validates_numericality_of :max, greater_than: :min
 

--- a/app/models/custom_fields/option_field.rb
+++ b/app/models/custom_fields/option_field.rb
@@ -45,11 +45,11 @@ class OptionField < CustomField
       }
     }
 
-    attributes_hash = attributes.map { |(option_id, opts)|
+    attributes_hash = attributes.map { |opts|
       {
-        id: Maybe(option_id).to_i.or_else(nil),
-        sort_priority: opts["sort_priority"].to_i,
-        title_attributes: opts["title_attributes"]
+        id: Maybe(opts[:id]).to_i.or_else(nil),
+        sort_priority: opts[:sort_priority].to_i,
+        title_attributes: opts[:title_attributes]
       }
     }
 

--- a/app/models/custom_fields/option_field.rb
+++ b/app/models/custom_fields/option_field.rb
@@ -47,7 +47,7 @@ class OptionField < CustomField
 
     attributes_hash = attributes.map { |opts|
       {
-        id: Maybe(opts[:id]).to_i.or_else(nil),
+        id: str_to_integer(opts[:id]),
         sort_priority: opts[:sort_priority].to_i,
         title_attributes: opts[:title_attributes]
       }
@@ -66,5 +66,16 @@ class OptionField < CustomField
     diff.select { |d| d[:action] == :changed }.map { |added| added[:value] }.each { |changed|
       options.where(id: changed[:id]).first.update_attributes(changed)
     }
+  end
+
+  def str_to_integer(s)
+    if s.nil?
+      nil
+    elsif !/\A\d+\z/.match(s)
+      # not positive integer
+      nil
+    else
+      s.to_i
+    end
   end
 end

--- a/app/utils/entity_utils.rb
+++ b/app/utils/entity_utils.rb
@@ -144,6 +144,7 @@ module EntityUtils
     to_symbol: -> (_, v) { v.to_sym unless v.nil? },
     to_string: -> (_, v) { v.to_s unless v.nil? },
     to_integer: -> (_, v) { v.to_i unless v.nil? },
+    to_hash: -> (_, v) { v.to_h unless v.nil? },
     str_to_time: -> (format, v) {
       if v.nil?
         nil

--- a/app/views/admin/custom_fields/_new_option.haml
+++ b/app/views/admin/custom_fields/_new_option.haml
@@ -4,6 +4,7 @@
       - show_locales = available_locales.size > 1
       .col-8{:class => show_locales ? "" : "custom-field-column-without-bottom-margin"}
         = fields_for "custom_field[option_attributes][#{option_id}][]", option do |option_form|
+          = hidden_field_tag "custom_field[option_attributes][#{option_id}][id]", option_id
           - input_col_size = show_locales ? "9" : "12"
           - available_locales.each do |locale_name, locale_value|
             .row.custom-field-option-locale-row


### PR DESCRIPTION
This PR removes `attr_accessible` from CustomField and related models. `attr_accessible` needs to be removed because it's deprecated in Rails 4.

The parameter validation is handled by the EntityUtils in `custom_field_controller`.

Also, CustomField model is changed to use new Hash syntax (key: :value, instead of key => :value)

Todo: 

- [X] Use new style hash syntax
- [X] Get rid of attr_accessible