### PR TITLE
Set config.eager_load

### DIFF
--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -251,8 +251,13 @@ default: &default_settings
   external_plan_service_secret:
   external_plan_service_login_url:
 
+  # Rails config.eager_load. Eager loads classes. Should be true only for production
+  eager_load: false
+
 production: &production_settings
   <<: *default_settings
+
+  eager_load: true
 
 staging:
   <<: *production_settings

--- a/config/environments/common.rb
+++ b/config/environments/common.rb
@@ -1,7 +1,21 @@
 Kassi::Application.configure do
 
+  str_to_bool = ->(v) {
+    if v == true || v == false
+      v
+    elsif v == "false"
+      false
+    else
+      true
+    end
+  }
+
   Maybe(APP_CONFIG.asset_host).each { |asset_host|
     config.action_controller.asset_host = asset_host
+  }
+
+  Maybe(APP_CONFIG.eager_load).each { |eager_load|
+    config.eager_load = str_to_bool.call(eager_load)
   }
 
 end


### PR DESCRIPTION
This PR removes the following message from Rails:

```
config.eager_load is set to nil. Please update your
config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true
```

The message is shown for example when you create a new migration `rails g
migration MyNewMigration`

The config value is added to the `config.defaults.yml` file. This allows
overriding the value locally by having different value in `config.yml` or by
setting `eager_load` ENV variable.