### PR TITLE
Transaction conversation status with new translation key

### DIFF
--- a/app/view_utils/transaction_view_utils.rb
+++ b/app/view_utils/transaction_view_utils.rb
@@ -141,11 +141,11 @@ module TransactionViewUtils
     when "preauthorized"
       t("conversations.message.payment_preauthorized", sum: humanized_money_with_symbol(payment_sum))
     when "accepted"
-      t("conversations.message.received_payment", sum: humanized_money_with_symbol(payment_sum))
+      t("conversations.message.accepted_request")
     when "rejected"
       t("conversations.message.rejected_request")
     when preauthorize_accepted
-      t("conversations.message.accepted_request")
+      t("conversations.message.received_payment", sum: humanized_money_with_symbol(payment_sum))
     when post_pay_accepted
       t("conversations.message.paid", sum: humanized_money_with_symbol(payment_sum))
     when "canceled"

--- a/app/view_utils/transaction_view_utils.rb
+++ b/app/view_utils/transaction_view_utils.rb
@@ -141,7 +141,7 @@ module TransactionViewUtils
     when "preauthorized"
       t("conversations.message.payment_preauthorized", sum: humanized_money_with_symbol(payment_sum))
     when "accepted"
-      t("conversations.message.accepted_request", sum: humanized_money_with_symbol(payment_sum))
+      t("conversations.message.received_payment", sum: humanized_money_with_symbol(payment_sum))
     when "rejected"
       t("conversations.message.rejected_request")
     when preauthorize_accepted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -638,7 +638,8 @@ en:
       free_message: "Free message"
       message_content_not_available: "Message content not available"
     message:
-      accepted_request: "accepted the request, received payment for %{sum}"
+      accepted_request: "accepted the request"
+      received_payment: "accepted the request, received payment for %{sum}"
       accepted_offer: "accepted the offer"
       rejected_request: "rejected the request"
       rejected_offer: "rejected the offer"


### PR DESCRIPTION
Earlier try to change the sentence and add a variable (%sum) didn't work.
Trying again by creating a new translation key (admin.conversations.message.received_payment) instead of using the current one (admin.conversations.message.accepted_request).

Also reverted the text for old translation key (admin.conversations.message.accepted_request) back to the original value.