### PR TITLE
Fix a custom field order bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The Change Log starts from the release 5.0.0. For older releases, see [RELEASE_N
 - Gemfile clean up. Removed bunch of unused gems. [#1625](https://github.com/sharetribe/sharetribe/pull/1625)
 - Removed ability to downgrade to Rails 3. [#1669](https://github.com/sharetribe/sharetribe/pull/1669)
 
+### Fixed
+
+- Updating a listing field changes the sorting order [#1673](https://github.com/sharetribe/sharetribe/pull/1673)
+
 ## [5.1.0] - 2016-01-21
 
 ### Added

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -38,6 +38,7 @@ class Admin::CustomFieldsController < ApplicationController
   CUSTOM_FIELD_SPEC = [
     [:name_attributes, :hash, :mandatory],
     [:category_attributes, collection: CategoryAttributeSpec],
+    [:sort_priority, :fixnum, :optional],
     [:required, :bool, :optional, default: false, transform_with: CHECKBOX_TO_BOOLEAN],
     [:search_filter, :bool, :optional, default: false, transform_with: CHECKBOX_TO_BOOLEAN]
   ]
@@ -159,9 +160,11 @@ class Admin::CustomFieldsController < ApplicationController
     params[:custom_field][:min] = ParamsService.parse_float(params[:custom_field][:min]) if params[:custom_field][:min].present?
     params[:custom_field][:max] = ParamsService.parse_float(params[:custom_field][:max]) if params[:custom_field][:max].present?
 
-    custom_field_entity = build_custom_field_entity(@custom_field.type, params[:custom_field]).merge(
+    custom_field_params = params[:custom_field].merge(
       sort_priority: @custom_field.sort_priority
     )
+
+    custom_field_entity = build_custom_field_entity(@custom_field.type, custom_field_params)
 
     @custom_field.update_attributes(custom_field_entity)
 

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -38,7 +38,6 @@ class Admin::CustomFieldsController < ApplicationController
   CUSTOM_FIELD_SPEC = [
     [:name_attributes, :hash, :mandatory],
     [:category_attributes, collection: CategoryAttributeSpec],
-    [:sort_priority, :fixnum, :optional],
     [:required, :bool, :optional, default: false, transform_with: CHECKBOX_TO_BOOLEAN],
     [:search_filter, :bool, :optional, default: false, transform_with: CHECKBOX_TO_BOOLEAN]
   ]
@@ -160,7 +159,9 @@ class Admin::CustomFieldsController < ApplicationController
     params[:custom_field][:min] = ParamsService.parse_float(params[:custom_field][:min]) if params[:custom_field][:min].present?
     params[:custom_field][:max] = ParamsService.parse_float(params[:custom_field][:max]) if params[:custom_field][:max].present?
 
-    custom_field_entity = build_custom_field_entity(@custom_field.type, params[:custom_field])
+    custom_field_entity = build_custom_field_entity(@custom_field.type, params[:custom_field]).merge(
+      sort_priority: @custom_field.sort_priority
+    )
 
     @custom_field.update_attributes(custom_field_entity)
 


### PR DESCRIPTION
Steps to reproduce:

1. Create a new custom field "1"
2. Create another custom field "2"
3. Create third custom field "3"
4. Change the order so that you move "3" one step up. The order is now 1, 3, 2
5. Edit the custom field 2. Change its name to "2a"

Expected result:

The order is 1, 3, 2a

Actual:

The order is 1, 2a, 3