### PR TITLE
Rename AR relation from `transaction` to `tx`

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -40,7 +40,7 @@ class PaymentsController < ApplicationController
       flash[:error] = t("layouts.notifications.error_in_payment")
     elsif check[:status] == "paid"
       @payment.paid!
-      MarketplaceService::Transaction::Command.transition_to(@payment.transaction.id, "paid")
+      MarketplaceService::Transaction::Command.transition_to(@payment.tx.id, "paid")
       @payment_gateway.handle_paid_payment(@payment)
       flash[:notice] = check[:notice]
     else # not yet paid

--- a/app/mailers/mail_view_test_data.rb
+++ b/app/mailers/mail_view_test_data.rb
@@ -56,7 +56,7 @@ module MailViewTestData
     )
 
     # Avoid infinite loop, set conversation here
-    @payment.transaction = transaction
+    @payment.tx = transaction
     @payment
   end
 

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -104,27 +104,27 @@ class TransactionMailer < ActionMailer::Base
       service_fee = payment.total_commission
       you_get = payment.seller_gets
 
-      transaction = payment.transaction
+      transaction = payment.tx
       unit_type = Maybe(transaction).select { |t| t.unit_type.present? }.map { |t| ListingViewUtils.translate_unit(t.unit_type, t.unit_tr_key) }.or_else(nil)
-      duration = payment.transaction.booking.present? ? payment.transaction.booking.duration : nil
+      duration = payment.tx.booking.present? ? payment.tx.booking.duration : nil
 
       premailer_mail(:to => payment.recipient.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
                      :subject => t("emails.new_payment.new_payment")) { |format|
         format.html {
           render "braintree_payment_receipt_to_seller", locals: {
-                   conversation_url: person_transaction_url(payment.recipient, @url_params.merge({:id => payment.transaction.id.to_s})),
-                   listing_title: payment.transaction.listing_title,
+                   conversation_url: person_transaction_url(payment.recipient, @url_params.merge({:id => payment.tx.id.to_s})),
+                   listing_title: payment.tx.listing_title,
                    price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
-                   listing_price: humanized_money_with_symbol(payment.transaction.unit_price),
-                   listing_quantity: payment.transaction.listing_quantity,
+                   listing_price: humanized_money_with_symbol(payment.tx.unit_price),
+                   listing_quantity: payment.tx.listing_quantity,
                    duration: duration,
                    payment_total: humanized_money_with_symbol(payment.total_sum),
                    payment_service_fee: humanized_money_with_symbol(-service_fee),
                    payment_seller_gets: humanized_money_with_symbol(you_get),
                    payer_full_name: payment.payer.name(community),
                    payer_given_name: payment.payer.given_name_or_username,
-                   automatic_confirmation_days: payment.transaction.automatic_confirmation_after_days,
+                   automatic_confirmation_days: payment.tx.automatic_confirmation_after_days,
                    show_money_will_be_transferred_note: true
                  }
         }
@@ -137,26 +137,26 @@ class TransactionMailer < ActionMailer::Base
     prepare_template(community, recipient, "email_about_new_payments")
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
 
-      unit_type = Maybe(payment.transaction).select { |t| t.unit_type.present? }.map { |t| ListingViewUtils.translate_unit(t.unit_type, t.unit_tr_key) }.or_else(nil)
-      duration = payment.transaction.booking.present? ? payment.transaction.booking.duration : nil
+      unit_type = Maybe(payment.tx).select { |t| t.unit_type.present? }.map { |t| ListingViewUtils.translate_unit(t.unit_type, t.unit_tr_key) }.or_else(nil)
+      duration = payment.tx.booking.present? ? payment.tx.booking.duration : nil
 
       premailer_mail(:to => payment.payer.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
                      :subject => t("emails.receipt_to_payer.receipt_of_payment")) { |format|
         format.html {
           render "payment_receipt_to_buyer", locals: {
-                   conversation_url: person_transaction_url(payment.payer, @url_params.merge({:id => payment.transaction.id.to_s})),
-                   listing_title: payment.transaction.listing_title,
+                   conversation_url: person_transaction_url(payment.payer, @url_params.merge({:id => payment.tx.id.to_s})),
+                   listing_title: payment.tx.listing_title,
                    price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
-                   listing_price: humanized_money_with_symbol(payment.transaction.unit_price),
-                   listing_quantity: payment.transaction.listing_quantity,
+                   listing_price: humanized_money_with_symbol(payment.tx.unit_price),
+                   listing_quantity: payment.tx.listing_quantity,
                    duration: duration,
                    payment_total: humanized_money_with_symbol(payment.total_sum),
                    subtotal: humanized_money_with_symbol(payment.total_sum),
                    shipping_total: nil,
                    recipient_full_name: payment.recipient.name(community),
                    recipient_given_name: payment.recipient.given_name_or_username,
-                   automatic_confirmation_days: payment.transaction.automatic_confirmation_after_days,
+                   automatic_confirmation_days: payment.tx.automatic_confirmation_after_days,
                    show_money_will_be_transferred_note: true
                  }
         }

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -16,7 +16,7 @@
 
 class Booking < ActiveRecord::Base
 
-  belongs_to :transaction
+  belongs_to :tx, class_name: "Transaction", foreign_key: "transaction_id"
 
   attr_accessible :transaction_id, :end_on, :start_on
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -27,7 +27,7 @@ class Conversation < ActiveRecord::Base
   has_many :participations
   has_many :participants, :through => :participations, :source => :person
   belongs_to :listing
-  has_one :transaction
+  has_one :tx, class_name: "Transaction", foreign_key: "transaction_id"
   belongs_to :community
 
   scope :for_person, -> (person){

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -31,7 +31,7 @@ class Payment < ActiveRecord::Base
 
   attr_accessible :transaction_id, :conversation_id, :payer_id, :recipient_id, :community_id, :payment_gateway_id, :status
 
-  belongs_to :transaction
+  belongs_to :tx, class_name: "Transaction", foreign_key: "transaction_id"
   belongs_to :payer, :class_name => "Person"
   belongs_to :recipient, :class_name => "Person"
 

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -33,5 +33,5 @@ class ShippingAddress < ActiveRecord::Base
     :street2
   )
 
-  belongs_to :transaction
+  belongs_to :tx, class_name: "Transaction", foreign_key: "transaction_id"
 end

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -31,7 +31,7 @@ class Testimonial < ActiveRecord::Base
 
   belongs_to :author, :class_name => "Person"
   belongs_to :receiver, :class_name => "Person"
-  belongs_to :transaction
+  belongs_to :tx, class_name: "Transaction", foreign_key: "transaction_id"
 
   validates_inclusion_of :grade, :in => 0..1, :allow_nil => false
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -115,7 +115,7 @@ class Transaction < ActiveRecord::Base
   def initialize_payment
     payment ||= community.payment_gateway.new_payment
     payment.payment_gateway ||= community.payment_gateway
-    payment.transaction = self
+    payment.tx = self
     payment.status = "pending"
     payment.payer = starter
     payment.recipient = author

--- a/app/models/transaction_transition.rb
+++ b/app/models/transaction_transition.rb
@@ -21,5 +21,5 @@ class TransactionTransition < ActiveRecord::Base
 
   attr_accessible :to_state, :metadata, :sort_key
 
-  belongs_to :transaction, inverse_of: :transaction_transitions, touch: true
+  belongs_to :tx, class_name: "Transaction", foreign_key: "transaction_id", inverse_of: :transaction_transitions, touch: true
 end

--- a/app/view_utils/testimonial_view_utils.rb
+++ b/app/view_utils/testimonial_view_utils.rb
@@ -7,12 +7,12 @@ module TestimonialViewUtils
   # one account in many communities is disabled. Then these can be deleted
   # and return to use just simpler received_testimonials named scopes
   def received_testimonials_in_community(person, community)
-    person.received_testimonials.includes(:transaction).select{|t|t.transaction.community_id == community.id }
+    person.received_testimonials.includes(:tx).select{|t|t.tx.community_id == community.id }
   end
   def received_positive_testimonials_in_community(person, community)
-    person.received_positive_testimonials.includes(:transaction).select{|t|t.transaction.community_id == community.id }
+    person.received_positive_testimonials.includes(:tx).select{|t|t.tx.community_id == community.id }
   end
   def received_negative_testimonials_in_community(person, community)
-    person.received_negative_testimonials.includes(:transaction).select{|t|t.transaction.community_id == community.id }
+    person.received_negative_testimonials.includes(:tx).select{|t|t.tx.community_id == community.id }
   end
 end

--- a/app/views/payments/complex_form/_show.haml
+++ b/app/views/payments/complex_form/_show.haml
@@ -21,7 +21,7 @@
   .payment-row-vat-text.payment-row-text
 
   #total.payment-row-total-text.payment-row-text
-    = @payment.total_sum.to_s + @payment.transaction.listing.price_symbol
+    = @payment.total_sum.to_s + @payment.tx.listing.price_symbol
 
 = form_tag(@payment_data[:payment_url], :method => "post", :id => "payment_form") do
   .payment-form-field-container

--- a/app/views/people/_testimonial.haml
+++ b/app/views/people/_testimonial.haml
@@ -1,5 +1,5 @@
 .testimonial{:class => "light_#{testimonial.displayed_grade > 2 ? 'green' : 'red' }", :id => "testimonial#{testimonial.id.to_s}"}
-  - listing = testimonial.transaction.listing
+  - listing = testimonial.tx.listing
   .testimonial-avatar
     = small_avatar_thumb(testimonial.author)
   .testimonial-details

--- a/app/views/person_mailer/new_payment.html.haml
+++ b/app/views/person_mailer/new_payment.html.haml
@@ -1,9 +1,9 @@
-- conversation_url = person_transaction_url(@recipient, @url_params.merge({:id => @payment.transaction.id.to_s}))
+- conversation_url = person_transaction_url(@recipient, @url_params.merge({:id => @payment.tx.id.to_s}))
 
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.new_payment.you_have_received_new_payment", :listing_title => @payment.transaction.listing.title, :payment_sum => humanized_money_with_symbol(@payment.total_sum), :payer_full_name => @payment.payer.name(@payment.community), :payer_given_name => @payment.payer.given_name_or_username).html_safe
+      = t("emails.new_payment.you_have_received_new_payment", :listing_title => @payment.tx.listing.title, :payment_sum => humanized_money_with_symbol(@payment.total_sum), :payer_full_name => @payment.payer.name(@payment.community), :payer_given_name => @payment.payer.given_name_or_username).html_safe
 
 %tr
   %td{:align => "left", :style => "padding: 10px 0;"}

--- a/app/views/person_mailer/new_testimonial.html.haml
+++ b/app/views/person_mailer/new_testimonial.html.haml
@@ -1,5 +1,5 @@
 - view_url = person_url(@recipient, @url_params) + "#testimonial#{@testimonial.id.to_s}"
-- give_url = new_person_message_feedback_url(@recipient, @url_params.merge({:message_id => @testimonial.transaction.id}))
+- give_url = new_person_message_feedback_url(@recipient, @url_params.merge({:message_id => @testimonial.tx.id}))
 
 %tr
   %td{:align => "left"}
@@ -9,7 +9,7 @@
 = render :partial => "action_button", :locals => { :text => t("emails.new_testimonial.view_feedback"), :url => view_url}
 
 -# TODO Move to Mailer, and pass as locals
-- if MarketplaceService::Transaction::Entity.waiting_testimonial_from?(MarketplaceService::Transaction::Entity.transaction(@testimonial.transaction), @testimonial.receiver.id)
+- if MarketplaceService::Transaction::Entity.waiting_testimonial_from?(MarketplaceService::Transaction::Entity.transaction(@testimonial.tx), @testimonial.receiver.id)
   %tr
     %td{:align => "left"}
       %font{body_font}

--- a/app/views/person_mailer/receipt_to_payer.html.haml
+++ b/app/views/person_mailer/receipt_to_payer.html.haml
@@ -1,9 +1,9 @@
-- conversation_url = person_transaction_url(@recipient, @url_params.merge({:id => @payment.transaction.id.to_s}))
+- conversation_url = person_transaction_url(@recipient, @url_params.merge({:id => @payment.tx.id.to_s}))
 
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.receipt_to_payer.you_have_made_new_payment", :listing_title => @payment.transaction.listing.title, :payment_sum => humanized_money_with_symbol(@payment.total_sum), :recipient_full_name => @payment.recipient.name(@community), :recipient_given_name => @payment.recipient.given_name_or_username).html_safe
+      = t("emails.receipt_to_payer.you_have_made_new_payment", :listing_title => @payment.tx.listing.title, :payment_sum => humanized_money_with_symbol(@payment.total_sum), :recipient_full_name => @payment.recipient.name(@community), :recipient_given_name => @payment.recipient.given_name_or_username).html_safe
 
 %tr
   %td{:align => "left", :style => "padding: 10px 0;"}

--- a/features/step_definitions/conversation_steps.rb
+++ b/features/step_definitions/conversation_steps.rb
@@ -77,7 +77,7 @@ Given /^the (offer|request) is (accepted|rejected|confirmed|canceled|paid)$/ do 
       recipient = @transaction.listing.author
 
       if @transaction.payment == nil
-        payment = FactoryGirl.build(type, :transaction => @transaction, :recipient => recipient, :status => "pending", :community => @current_community)
+        payment = FactoryGirl.build(type, tx: @transaction, recipient: recipient, status: "pending", community: @current_community)
         payment.default_sum(@transaction.listing, 24)
         payment.save!
 

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -34,7 +34,7 @@ end
 Given /^there is a payment for that request from "(.*?)" with price "(.*?)"$/ do |payer_username, price|
   listing = @transaction.listing
   payer = Person.find_by_username(payer_username)
-  @payment = FactoryGirl.create(:braintree_payment, payer: payer, recipient: listing.author, community: @current_community, sum_cents: price.to_i * 100, transaction: @transaction)
+  @payment = FactoryGirl.create(:braintree_payment, payer: payer, recipient: listing.author, community: @current_community, sum_cents: price.to_i * 100, tx: @transaction)
 end
 
 Given /^that payment is (pending|paid)$/ do |status|

--- a/features/step_definitions/testimonial_steps.rb
+++ b/features/step_definitions/testimonial_steps.rb
@@ -7,7 +7,7 @@ Given /^I have "([^"]*)" testimonials? with grade "([^"]*)"$/ do |amount, grade|
                         author: @people["kassi_testperson2"],
                         receiver: @people["kassi_testperson1"],
                         grade: grade,
-                        transaction: tr
+                        tx: tr
                       )
   end
 end

--- a/spec/controllers/braintree_webhooks_controller_spec.rb
+++ b/spec/controllers/braintree_webhooks_controller_spec.rb
@@ -69,7 +69,7 @@ describe BraintreeWebhooksController do
       before(:each) do
         # Prepare
         @transaction = FactoryGirl.create(:transaction)
-        @payment = FactoryGirl.create(:braintree_payment, :status => "paid", :braintree_transaction_id => "123abc", :type => "BraintreePayment", :transaction => @transaction, :sum_cents => 1000, :currency => "EUR")
+        @payment = FactoryGirl.create(:braintree_payment, status: "paid", braintree_transaction_id: "123abc", type: "BraintreePayment", tx: @transaction, sum_cents: 1000, currency: "EUR")
         Payment.find_by_braintree_transaction_id("123abc").status.should == "paid"
       end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -135,7 +135,7 @@ FactoryGirl.define do
   end
 
   factory :booking do
-    build_association(:transaction)
+    build_association(:transaction, as: :tx)
     start_on 1.day.from_now
     end_on 2.days.from_now
   end
@@ -156,7 +156,7 @@ FactoryGirl.define do
   factory :testimonial do
     build_association(:author)
     build_association(:receiver)
-    build_association(:transaction)
+    build_association(:transaction, as: :tx)
     grade 0.5
     text "Test text"
   end
@@ -322,12 +322,12 @@ FactoryGirl.define do
 
   factory :transaction_transition do
     to_state "not_started"
-    build_association(:transaction)
+    build_association(:transaction, as: :tx)
   end
 
   factory :payment do
     build_association(:community)
-    build_association(:transaction)
+    build_association(:transaction, as: :tx)
 
     factory :braintree_payment, class: 'BraintreePayment' do
       build_association(:payer)

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -116,7 +116,7 @@ describe PersonMailer do
                                 listing_shape_id: 123, # not needed, but mandatory
                                 author: @test_person)
     transaction = FactoryGirl.create(:transaction, starter: @test_person2, listing: listing, transaction_transitions: [transition])
-    testimonial = FactoryGirl.create(:testimonial, :grade => 0.75, :text => "Yeah", :author => @test_person, :receiver => @test_person2, :transaction => transaction)
+    testimonial = FactoryGirl.create(:testimonial, grade: 0.75, text: "Yeah", author: @test_person, receiver: @test_person2, tx: transaction)
 
     email = PersonMailer.new_testimonial(testimonial, @community).deliver
     assert !ActionMailer::Base.deliveries.empty?


### PR DESCRIPTION
`transaction` gives an error in Rails 4.1, because it clashes with
ActiveRecord's `transaction` method