### PR TITLE
Remove return statements from inline callbacks

### DIFF
--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -6,7 +6,7 @@ class BraintreeWebhooksController < ApplicationController
   before_filter do
     unless @current_community.braintree_in_use?
       BTLog.error("Received webhook notification even though '#{@current_community.ident}' does not have Braintree in use")
-      render :nothing => true, :status => 400 and return
+      render :nothing => true, :status => 400
     end
   end
 

--- a/app/controllers/paypal_service/checkout_orders_controller.rb
+++ b/app/controllers/paypal_service/checkout_orders_controller.rb
@@ -4,7 +4,7 @@ class PaypalService::CheckoutOrdersController < ApplicationController
 
   before_filter do
     unless PaypalHelper.community_ready_for_payments?(@current_community.id)
-      render :nothing => true, :status => 400 and return
+      render :nothing => true, :status => 400
     end
   end
 


### PR DESCRIPTION
Rails 4.1 throws LocalJumpError if there are returns in inline callbacks

Here's more detailed explanation from Rails Guides:

### Usage of `return` within inline callback blocks

Previously, Rails allowed inline callback blocks to use `return` this way:

```ruby
class ReadOnlyModel < ActiveRecord::Base
  before_save { return false } # BAD
end
```

This behavior was never intentionally supported. Due to a change in the internals
of `ActiveSupport::Callbacks`, this is no longer allowed in Rails 4.1. Using a
`return` statement in an inline callback block causes a `LocalJumpError` to
be raised when the callback is executed.

Inline callback blocks using `return` can be refactored to evaluate to the
returned value:

```ruby
class ReadOnlyModel < ActiveRecord::Base
  before_save { false } # GOOD
end
```

Alternatively, if `return` is preferred it is recommended to explicitly define
a method:

```ruby
class ReadOnlyModel < ActiveRecord::Base
  before_save :before_save_callback # GOOD

  private
    def before_save_callback
      return false
    end
end
```

This change applies to most places in Rails where callbacks are used, including
Active Record and Active Model callbacks, as well as filters in Action
Controller (e.g. `before_action`).
