### PR TITLE
Fix checking search args

### DIFF
--- a/app/services/listing_index_service/search/sphinx_adapter.rb
+++ b/app/services/listing_index_service/search/sphinx_adapter.rb
@@ -19,7 +19,7 @@ module ListingIndexService::Search
       search = HashUtils.rename_keys({:listing_shape_ids => :listing_shape_id}, search)
 
       if DatabaseSearchHelper.needs_db_query?(search) && DatabaseSearchHelper.needs_search?(search)
-        Result::Error.new(ArgumentError.new("Both DB query and search engine would be needed to fulfill the search"))
+        return Result::Error.new(ArgumentError.new("Both DB query and search engine would be needed to fulfill the search"))
       end
 
       if DatabaseSearchHelper.needs_search?(search)


### PR DESCRIPTION
The if expression checks if a search needs DB as well as the Sphinx
search engine, and seemingly attempted to make an early return in that
case. However, the execution is continued and a search is always made to
the search engine and the `Result:Error` object is just ignored.