### PR TITLE
Improve transaction conversations sentences

### DIFF
--- a/app/helpers/transaction_helper.rb
+++ b/app/helpers/transaction_helper.rb
@@ -348,7 +348,7 @@ module TransactionHelper
         t("conversations.status.waiting_for_current_user_to_deliver_listing",
           :listing_title => link_to(conversation.listing.title, conversation.listing)
         ).html_safe,
-        icon_classes: "ss-deliveryvan"
+        icon_classes: "ss-clockwise"
       )
     else
       status_info(
@@ -356,7 +356,7 @@ module TransactionHelper
           :listing_title => link_to(conversation.listing.title, conversation.listing),
           :listing_author_name => link_to(PersonViewUtils.person_display_name(conversation.author, conversation.community))
         ).html_safe,
-        icon_classes: "ss-deliveryvan"
+        icon_classes: "ss-clockwise"
       )
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -724,8 +724,8 @@ en:
           multicurrency: "We couldn't process the PayPal payment because your PayPal account has not been set up to receive money in %{currency}. Go to %{paypal_url} and log in to your account to manually accept or reject the payment."
           verify: "You cannot accept this transaction because you haven't verified your PayPal account. Go to %{paypal_url} to verify your account."
           intl: "We couldn't process the PayPal payment because your PayPal account does not have a withdrawal mechanism. Go to %{paypal_url} and log in to your account to manually accept or reject the payment."
-      waiting_for_current_user_to_deliver_listing: "Waiting for you to deliver %{listing_title}"
-      waiting_for_listing_author_to_deliver_listing: "Waiting for %{listing_author_name} to deliver %{listing_title}"
+      waiting_for_current_user_to_deliver_listing: "Waiting for you to fulfill the order for %{listing_title}"
+      waiting_for_listing_author_to_deliver_listing: "Waiting for %{listing_author_name} to fulfill the order for %{listing_title}"
       request_accepted: Accepted
       request_rejected: Rejected
       request_confirmed: Completed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -641,7 +641,7 @@ en:
       accepted_request: "accepted the request"
       received_payment: "accepted the request, received payment for %{sum}"
       accepted_offer: "accepted the offer"
-      rejected_request: "rejected the request"
+      rejected_request: "rejected the request, canceled the payment"
       rejected_offer: "rejected the offer"
       confirmed_request: "marked the order as completed"
       confirmed_offer: "marked the offer as completed"

--- a/features/step_definitions/conversation_steps.rb
+++ b/features/step_definitions/conversation_steps.rb
@@ -222,7 +222,7 @@ Then(/^I should see that the order is waiting for buyer confirmation$/) do
 end
 
 Then /^I should see that I should now deliver the board$/ do
-  page.should have_content(/Waiting for you to deliver (.*)/)
+  page.should have_content(/Waiting for you to fulfill the order for (.*)/)
 end
 
 Then(/^I should see that the order is confirmed/) do


### PR DESCRIPTION
**Fullfil vs Deliver**
In transaction conversations, the "deliver" status has been really confusing to users. Lots of people understand "deliver" as "ship". This status is the one after the payment happened (so after the seller has accepted the transaction) and before the review process.

The earlier label was `Waiting for %{listing_author_name} to deliver %{listing_title}` and used a moving van icon.

With this change, text is now `Waiting for %{listing_author_name} to fulfill the order for %{listing_title}` with a clockwise icon.

**Payment canceled when request is rejected**
If a request is rejected by the seller, there is not mention that the payment didn't happen. Some users reported this and asked what happened to the payment.

The sentence has been updated to mention that the payment was canceled when the request was rejected.