### PR TITLE
Add `references` and fix `update_all` wrong num of arguments error in Rails 4.1

### DIFF
--- a/app/controllers/testimonials_controller.rb
+++ b/app/controllers/testimonials_controller.rb
@@ -79,7 +79,9 @@ class TestimonialsController < ApplicationController
       .where({
         community_id: @current_community.id,
         id: params[:message_id]
-      }).first
+      })
+      .references(:listing)
+      .first
 
     if @transaction.nil?
       flash[:error] = t("layouts.notifications.you_are_not_allowed_to_give_feedback_on_this_transaction")

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -6,12 +6,12 @@ module UserSteps
   # Thus this helper function
   def force_override_model_id(id, model_instance, model_class, associated_model_classes=[])
     old_id = model_instance.id
-    model_class.update_all({:id => id}, {:id => old_id})
+    model_class.where(id: old_id).update_all(id: id)
 
     # Associates
     foreign_key = "#{model_class.name.downcase}_id".to_sym
     associated_model_classes.each do |associated_model_class|
-      associated_model_class.update_all({foreign_key => id}, {foreign_key => old_id})
+      associated_model_class.where(foreign_key => old_id).update_all(foreign_key => id)
     end
 
     # Reload


### PR DESCRIPTION
### Fix `update_all` arity

`update_all` arity has changed from 1..3 to 1

### Add `references` to AR relation

This change fixes the warning:

DEPRECATION WARNING: It looks like you are eager loading table(s) (one of:
transactions, listings) that are referenced in a string SQL snippet. For
example:

    Post.includes(:comments).where("comments.title = 'foo'")

Currently, Active Record recognizes the table in the string, and knows to
JOIN the comments table to the query, rather than loading comments in a
separate query. However, doing this without writing a full-blown SQL parser
is inherently flawed. Since we don't want to write an SQL parser, we are
removing this functionality. From now on, you must explicitly tell Active
Record when you are referencing a table from a string:

    Post.includes(:comments).where("comments.title =
'foo'").references(:comments)

This will also brake in Rails 4.1, thus this needs to be fixes now.