### PR TITLE
Always log deprecation warnings to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file follows the best practices from [keepchangelog.com](http://keepachange
 ### Changed
 
 - Updated Rails to 4.1.14.1 [#1678](https://github.com/sharetribe/sharetribe/pull/1678)
+- Always log deprecation warnings to stderr [#1693](https://github.com/sharetribe/sharetribe/pull/1693)
 
 ### Removed
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -139,6 +139,9 @@ module Kassi
       Devise::Mailer.helper :email_template
     end
 
+    # Log deprecation warnings to stderr
+    config.active_support.deprecation = :stderr
+
     # Map custom errors to error pages
     config.action_dispatch.rescue_responses["PeopleController::PersonDeleted"] = :gone
     config.action_dispatch.rescue_responses["ListingsController::ListingDeleted"] = :gone

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,6 @@ Kassi::Application.configure do
     }
   end
 
-  config.active_support.deprecation = :stderr
 
   # Expands the lines which load the assets
   config.assets.debug = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,9 +15,6 @@ Kassi::Application.configure do
   # Specifies the header that your server uses for sending files
   config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
-  # Set how to handle deprecation warnings
-  config.active_support.deprecation = :notify
-
   # For nginx:
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,8 +28,6 @@ Kassi::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  config.active_support.deprecation = :stderr
-
   # As instructed by Devise, to make local mails work
   config.action_mailer.default_url_options = { :host => 'test.lvh.me:9887' }
 


### PR DESCRIPTION
Log deprecation warnings to stderr, always, in all environment.

In production, do not use [ActiveSupport Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) but instead log to stderr.