### PR TITLE
Validate Mercury image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This file follows the best practices from [keepchangelog.com](http://keepachange
 
 - Removed environment variable `devise_allow_insecure_token_lookup`. [#1675](https://github.com/sharetribe/sharetribe/pull/1675)
 
+### Fixed
+
+- Fixed Mercury Editor image uploader [#1694](https://github.com/sharetribe/sharetribe/pull/1694)
+
 ### Security
 
 - Updated Devise gem to version 3.5 [#1675](https://github.com/sharetribe/sharetribe/pull/1675)

--- a/app/models/mercury/image.rb
+++ b/app/models/mercury/image.rb
@@ -21,6 +21,13 @@ class Mercury::Image < ActiveRecord::Base
         :path => "images/mercury/:attachment/:id/:style/:filename",
         :url => "/system/:class/:attachment/:id/:style/:filename"
 
+  validates_attachment_content_type :image,
+                                    :content_type => ["image/jpeg",
+                                                      "image/png",
+                                                      "image/gif",
+                                                      "image/pjpeg",
+                                                      "image/x-png"]
+
   delegate :url, :to => :image
 
   def serializable_hash(options = nil)


### PR DESCRIPTION
Image uploading through Mercury Editor is currently broken. Paperclip > 4.0.0 requires the the content-type is validated, otherwise 500 will be returned. This PR adds the content-type validation.