### PR TITLE
Don't create unsubscribe token in view layer

### DIFF
--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -36,6 +36,7 @@ class CommunityMailer < ActionMailer::Base
     @current_community = community
     @recipient = recipient
     @listings = listings
+    unsubscribe_token = AuthToken.create_unsubscribe_token(person_id: @recipient.id).token
 
     unless @recipient.member_of?(@community)
       logger.info "Trying to send community updates to a person who is not member of the given community. Skipping."
@@ -65,7 +66,7 @@ class CommunityMailer < ActionMailer::Base
                      :from => community_specific_sender(community),
                      :subject => subject,
                      :delivery_method => delivery_method) do |format|
-        format.html { render :layout => 'email_blank_layout' }
+        format.html { render layout: 'email_blank_layout', locals: { unsubscribe_token: unsubscribe_token } }
       end
     end
   end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -38,4 +38,12 @@ class AuthToken < ActiveRecord::Base
     where("expires_at < ?", 1.week.ago ).delete_all
   end
 
+  def self.create_unsubscribe_token(person_id:, expires_at: 1.week.from_now)
+    create(
+      person_id: person_id,
+      expires_at: expires_at,
+      token_type: "unsubscribe"
+    )
+  end
+
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -565,11 +565,6 @@ class Person < ActiveRecord::Base
     image_file_name.present?
   end
 
-  def new_email_auth_token
-    t = AuthToken.create(:person => self, :expires_at => 1.week.from_now, :token_type => "unsubscribe")
-    return t.token
-  end
-
   # Tell Devise that email is not required
   def email_required?
     false

--- a/app/utils/mail_utils.rb
+++ b/app/utils/mail_utils.rb
@@ -1,8 +1,10 @@
 module MailUtils
-  # Refactoring needed. This is an ugly method that sets
+  # Refactoring needed. This is an ugly method that sets a lot of global state
   #
-  # DEPRECATED! Do not use this anymore! See TransactionMailer.transaction_created how you can live without calling
-  # this method
+  # Avoid adding more state to instance variables. Instead, pass the data to
+  # the `render` method in `locals` hash.
+  #
+  # If the data is used in the layout, you can make an exception and set it to instance variable
   def set_up_urls(recipient, community, ref="email")
     @community = community
     @current_community = community
@@ -11,6 +13,7 @@ module MailUtils
     @url_params[:ref] = ref
     if recipient
       @recipient = recipient
+      @unsubscribe_token = AuthToken.create_unsubscribe_token(person_id: @recipient.id).token
       @url_params[:locale] = @recipient.locale
     end
   end

--- a/app/views/community_mailer/community_updates.html.haml
+++ b/app/views/community_mailer/community_updates.html.haml
@@ -36,4 +36,4 @@
             %tr
               %td{:style => "text-align: left;width:100%;max-width:602px;padding: 5px 30px;"}
                 %p{:style => "margin-top:10px;margin-bottom:5px;font-family:helvetica,arial,sans-serif;font-size:12px;color:#464646;"}
-                  = t("emails.community_updates.reduce_email_footer_text", :settings_link => link_to(t("emails.community_updates.settings_link_text"), notifications_person_settings_url(@recipient, @url_params)), :unsubscribe_link => link_to(t("emails.community_updates.unsubscribe_link_text"), unsubscribe_person_settings_url(@recipient, @url_params.merge({:email_type => "community_updates", auth: @recipient.new_email_auth_token})))).html_safe
+                  = t("emails.community_updates.reduce_email_footer_text", :settings_link => link_to(t("emails.community_updates.settings_link_text"), notifications_person_settings_url(@recipient, @url_params)), :unsubscribe_link => link_to(t("emails.community_updates.unsubscribe_link_text"), unsubscribe_person_settings_url(@recipient, @url_params.merge({:email_type => "community_updates", auth: unsubscribe_token})))).html_safe

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -35,4 +35,4 @@
                         = t("emails.welcome_email.welcome_email_footer_text", :settings_link => link_to(t("emails.welcome_email.settings_link_text"), notifications_person_settings_url(@recipient, @url_params))).html_safe
                         - if @email_type
                           = t("emails.common.or")
-                          = link_to(t("emails.common.unsubscribe_from_these_emails"), unsubscribe_person_settings_url(@recipient, @url_params.merge({email_type: @email_type, auth: @recipient.new_email_auth_token}))) + "."
+                          = link_to(t("emails.common.unsubscribe_from_these_emails"), unsubscribe_person_settings_url(@recipient, @url_params.merge({email_type: @email_type, auth: @unsubscribe_token}))) + "."

--- a/app/views/person_mailer/_email_signature.html.haml
+++ b/app/views/person_mailer/_email_signature.html.haml
@@ -1,5 +1,0 @@
-= t("emails.common.thanks")
-%br/
-= t("emails.common.kassi_team") + "."
-
-= render :partial => "settings_and_unsubscribe_links"

--- a/app/views/person_mailer/_email_signature.text.haml
+++ b/app/views/person_mailer/_email_signature.text.haml
@@ -1,5 +1,0 @@
-= t("emails.common.thanks")
-= t("emails.common.kassi_team")
-
-= "-- "
-= t("emails.common.want_to_control_emails") + " " + t("emails.common.check_your_settings") + " " +  @settings_url + "?ref=email"

--- a/app/views/person_mailer/_settings_and_unsubscribe_links.html.haml
+++ b/app/views/person_mailer/_settings_and_unsubscribe_links.html.haml
@@ -1,8 +1,0 @@
-%div{style: "margin-top: 6px; border-bottom: 3px solid #d1c9b4; line-height:3px"}
-  &nbsp;
-%div{style: "margin-top: 3px; font-size: 0.9em;"}
-  = t("emails.common.want_to_control_emails")
-  = link_to(t("emails.common.check_your_settings"), @settings_url)
-  - if @recipient && @url_params && @url_params[:host].present? && @email_type
-    = t("emails.common.or")
-    = link_to(t("emails.common.unsubscribe_from_these_emails"), unsubscribe_person_settings_url(@recipient, @url_params.merge({email_type: @email_type, auth: @recipient.new_email_auth_token}))) + "."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -888,11 +888,9 @@ en:
       or_paste_link: "Alternatively you can copy the following link to the address bar of your browser:"
       turning_on_confirmations_in_this_community: "We are starting to use email confirmations in this %{service_name} marketplace."
     common:
-      check_your_settings: "Check your settings"
       hey: "Hello %{name},"
       kassi_team: "The %{service_name} Team"
       thanks: "Thanks,"
-      want_to_control_emails: "Want to control which emails you receive from %{service_name}?"
       dont_want_to_receive_these_emails: "Don't want to receive these emails?"
       edit_your_email_settings_here: "Edit your email settings here"
       message_not_displaying_correctly: "Is this email not displaying correctly?"

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -26,8 +26,7 @@ describe SettingsController, type: :controller do
     end
 
     it "should unsubscribe with auth token" do
-      t = @person.new_email_auth_token
-      AuthToken.find_by_token(t)
+      t = AuthToken.create_unsubscribe_token(person_id: @person.id).token
       @person.set_default_preferences
       expect(@person.min_days_between_community_updates).to eq(1)
 

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -28,10 +28,13 @@ describe "CommunityMailer", type: :mailer do
           :community_id => @c1.id,
           :description => "<b>shiny</b> new hammer, see details at http://en.wikipedia.org/wiki/MC_Hammer")
 
+      @p1_unsubscribe_token = AuthToken.create_unsubscribe_token(person_id: @p1.id).token
+
       @email = CommunityMailer.community_updates(
-        @p1,
-        @p1.communities.first,
-        [@l2]
+        recipient: @p1,
+        community: @p1.communities.first,
+        listings: [@l2],
+        unsubscribe_token: @p1_unsubscribe_token
       )
     end
 
@@ -45,8 +48,7 @@ describe "CommunityMailer", type: :mailer do
     end
 
     it "should include valid auth_token in links" do
-      token = @p1.auth_tokens.last.token
-      expect(@email).to have_body_text("?auth=#{token}")
+      expect(@email).to have_body_text("?auth=#{@p1_unsubscribe_token}")
     end
 
     it "should contain correct service name in the link" do


### PR DESCRIPTION
- [x] Add `AuthToken.create_unsubscribe_token`
- [x] Create the token in Mailer, not in view layer

Accessing database in view layer is always bad, but in this case this would've caused trouble in Rails 4.2, apparently, beucase the mail is rendered lazily.