### PR TITLE
Pass person_id explicitely, not person model

### DIFF
--- a/app/models/payment_gateways/checkout.rb
+++ b/app/models/payment_gateways/checkout.rb
@@ -140,7 +140,7 @@ class Checkout < PaymentGateway
     end
 
     checkout_account = CheckoutAccount.new({
-        person_id: person,
+        person_id: person.id,
         merchant_id: response[/<id>([^<]+)<\/id>/, 1],
         merchant_key: response[/<secret>([^<]+)<\/secret>/, 1],
         company_id_or_personal_id: checkout_account_params.company_id_or_personal_id

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -228,7 +228,7 @@ end
 
 Given /^"(.*?)" has Checkout account$/ do |org_username|
   org = Person.find_by_username(org_username)
-  checkout = CheckoutAccount.new({ merchant_key: "SAIPPUAKAUPPIAS", merchant_id: "375917", person_id: org })
+  checkout = CheckoutAccount.new({ merchant_key: "SAIPPUAKAUPPIAS", merchant_id: "375917", person_id: org.id })
   checkout.save!
 end
 


### PR DESCRIPTION
Previously, it has been possible to pass Person model, and Rails magically picks the ID. However, this isn't working anymore in Rails 4.2