### PR TITLE
Make deliver_community_updates a class method.

### DIFF
--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -10,7 +10,7 @@ class CommunityMailer < ActionMailer::Base
 
   # This task is expected to be run with daily or hourly scheduling
   # It looks through all users and send email to those who want it now
-  def deliver_community_updates
+  def self.deliver_community_updates
     Person.find_each do |person|
       if person.should_receive_community_updates_now?
         person.communities.select { |c| c.automatic_newsletters }.each do |community|


### PR DESCRIPTION
In Rails 4.2, invocation of the instance methods are deferred.
`deliver_community_updates` is a non-mailer method that needs to be executed
synchronously. That's why it needs to be a class method.

Here's more information from Rails 4.2 upgrade guide:

START

Previously, calling a mailer method on a mailer class will result in the 
corresponding instance method being executed directly. With the introduction
of Active Job and `#deliver_later`, this is no longer true. In Rails 4.2, the 
invocation of the instance methods are deferred until either `deliver_now` or
`deliver_later` is called. For example:

```ruby
class Notifier < ActionMailer::Base
 def notify(user, ...)
   puts "Called"
   mail(to: user.email, ...)
 end end

mail = Notifier.notify(user, ...) # Notifier#notify is not yet called at this
point mail = mail.deliver_now           # Prints "Called"
```

This should not result in any noticeable differences for most applications. 
However, if you need some non-mailer methods to be executed synchronously, and 
you were previously relying on the synchronous proxying behavior, you should 
define them as class methods on the mailer class directly:

```ruby
class Notifier < ActionMailer::Base
 def self.broadcast_notifications(users, ...)
   users.each { |user| Notifier.notify(user, ...) }
 end end
```

END