### PR TITLE
Cache only attributes, serialize/deserialize the result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file follows the best practices from [keepchangelog.com](http://keepachange
 
 - Updated Rails to 4.1.14.1 [#1678](https://github.com/sharetribe/sharetribe/pull/1678)
 - Always log deprecation warnings to stderr [#1693](https://github.com/sharetribe/sharetribe/pull/1693)
+- Save model attributes to cache instead of model instances [#1714](https://github.com/sharetribe/sharetribe/pull/1714)
 
 ### Removed
 


### PR DESCRIPTION
`TranslationCache` saves ActiveRecord models to the cache. Saving complex data (e.g. instances of classes) to the cache is a bad idea. This causes problems in Rails 4.2

**Fix:** Save only model attributes (Hash) to the cache and instantiate it manually by hand.

(Btw. `TranslationCache` will be hopefully removed soon, since we have a lot better and more performant solution built, the `TranslationService`)