### PR TITLE
Rename serve_static_files and add log level

### DIFF
--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -37,6 +37,12 @@ default: &default_settings
   # Bucket for files users upload directly to S3. You can add an expiration policy to these files.
   s3_upload_bucket_name:
 
+  # Server assets directly from the Rails application, defaults to true
+  #
+  # Recommended setup: Set serve_static_files to true and setup CDN distribution
+  # Alternative setup: Set serve_static_files to false and setup Nginx/Apache in front of the Rails servers
+  serve_static_files: true
+
   # Your CDN distribution host name
   #
   # From Rails documations: Browsers typically open at most two simultaneous connections to a single host,

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -273,9 +273,13 @@ production: &production_settings
 
   eager_load: true
 
+  log_level: INFO
+
 staging:
   <<: *production_settings
   # By default staging has same settings as production, but those can be overridden here.
+
+  log_level: INFO
 
 development:
   <<: *default_settings
@@ -287,6 +291,8 @@ development:
   skip_email_confirmation: true
 
   secret_key_base: "fd1af50b59b5e27776941b3205f92aca0f704c2252225cf93e3d97ae53f4774d25736cbdb19c1580839a2f68e15009209227e966003f53932c1bcc5d65616948"
+
+  log_level: DEBUG
 
 test:
   <<: *default_settings
@@ -345,3 +351,5 @@ test:
   braintree_client_side_encryption_key: MIIBCgKCAQEArIfLwPsGtsJ5ELsvaFrdww/vEcBBiS3ViPoMg0mmV67nM3RqkFuWu7JQ1bln12PVQgyU7Bn6O7OLUjAdaO35kunmRfwLNb/SStyGfd5JIFOFP2Pu4CRnKr2tTR+OkitqXTwoa9den8RmMFJlQyadozcpWvAIGtAa21r0RWNaSoHS9gkbmhiEa/94gvxVuPlEQTrlKWHp3pnOuTwST/xEcDI73q7Ug4nVhFgtqqU0Kck6HOBnF5Gby+tIfI5blih64sxPGKVGuExopcWNos4lV7x7fKxYT07vOCeRUIFUSYhfxRs8hZ/tLfXxzNsInOnaddFJpM8Mda8jKWs+aFhPiwIDAQAB
 
   secret_key_base: "8fb582997a5e3ba2efb57c020dd01aa81647674dbb1aee6efcf30d75ec442e3a48832379e1ebaae2801782075efbf02ebed797a1df3f2b3ad87ec3faf37ccc64"
+
+  log_level: DEBUG

--- a/config/environments/common.rb
+++ b/config/environments/common.rb
@@ -2,7 +2,8 @@ Kassi::Application.configure do
 
   Config = EntityUtils.define_builder(
     [:asset_host, :string, :optional],
-    [:eager_load, :bool, :mandatory, :str_to_bool]
+    [:eager_load, :bool, :mandatory, :str_to_bool],
+    [:serve_static_files, :bool, :optional, :str_to_bool]
   )
 
   m_config = Maybe(Config.call(APP_CONFIG.to_h))
@@ -13,5 +14,9 @@ Kassi::Application.configure do
 
   m_config[:eager_load].each { |eager_load|
     config.eager_load = eager_load
+  }
+
+  m_config[:serve_static_files].each { |serve_static_files|
+    config.serve_static_files = serve_static_files
   }
 end

--- a/config/environments/common.rb
+++ b/config/environments/common.rb
@@ -1,9 +1,18 @@
 Kassi::Application.configure do
 
+  str_to_lowercase_sym = ->(v) {
+    if v.nil? || v.is_a?(Symbol)
+      v
+    else
+      v.downcase.to_sym
+    end
+  }
+
   Config = EntityUtils.define_builder(
     [:asset_host, :string, :optional],
     [:eager_load, :bool, :mandatory, :str_to_bool],
-    [:serve_static_files, :bool, :optional, :str_to_bool]
+    [:serve_static_files, :bool, :optional, :str_to_bool],
+    [:log_level, transform_with: str_to_lowercase_sym, one_of: [:debug, :info, :warn, :error]]
   )
 
   m_config = Maybe(Config.call(APP_CONFIG.to_h))
@@ -18,5 +27,9 @@ Kassi::Application.configure do
 
   m_config[:serve_static_files].each { |serve_static_files|
     config.serve_static_files = serve_static_files
+  }
+
+  m_config[:log_level].each { |log_level|
+    config.log_level = log_level
   }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,7 +49,6 @@ Kassi::Application.configure do
   ENV['RAILS_ASSET_ID'] = ""
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
   # Raise exception on mass assignment protection for Active Record models


### PR DESCRIPTION
- [X] Rename `serve_static_assets` to `serve_static_files`. `serve_static_assets` is deprecated in Rails 4.2
- [X] Add `log_level` configuration. 