### PR TITLE
Add a MailCarrier

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -172,7 +172,7 @@ class Admin::CommunitiesController < ApplicationController
   end
 
   def test_welcome_email
-    PersonMailer.welcome_email(@current_user, @current_community, true, true).deliver
+    MailCarrier.deliver_later(PersonMailer.welcome_email(@current_user, @current_community, true, true))
     flash[:notice] = t("layouts.notifications.test_welcome_email_delivered_to", :email => @current_user.confirmed_notification_email_to)
     redirect_to edit_welcome_email_admin_community_path(@current_community)
   end

--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -23,7 +23,7 @@ class BraintreeWebhooksController < ApplicationController
 
         person = Person.find_by_id(person_id)
 
-        PersonMailer.braintree_account_approved(person, community).deliver
+        MailCarrier.deliver_later(PersonMailer.braintree_account_approved(person, community))
       end
 
       def sub_merchant_account_declined(notification, community)

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -35,7 +35,7 @@ class FeedbacksController < ApplicationController
                                     email: email
                                   }))
 
-    PersonMailer.new_feedback(feedback, @current_community).deliver
+    MailCarrier.deliver_later(PersonMailer.new_feedback(feedback, @current_community))
 
     flash[:notice] = t("layouts.notifications.feedback_saved")
     redirect_to root

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -99,7 +99,7 @@ class SessionsController < ApplicationController
   def request_new_password
     if person = Person.find_by_email(params[:email])
       token = person.reset_password_token_if_needed
-      PersonMailer.reset_password_instructions(person, params[:email], token, @current_community).deliver
+      MailCarrier.deliver_later(PersonMailer.reset_password_instructions(person, params[:email], token, @current_community))
       flash[:notice] = t("layouts.notifications.password_recovery_sent")
     else
       flash[:error] = t("layouts.notifications.email_not_found")

--- a/app/jobs/accept_reminder_job.rb
+++ b/app/jobs/accept_reminder_job.rb
@@ -14,7 +14,7 @@ class AcceptReminderJob < Struct.new(:conversation_id, :recipient_id, :community
     transaction = Transaction.find(conversation_id)
     community = Community.find(community_id)
     if transaction.status.eql?("pending")
-      PersonMailer.send("accept_reminder", transaction, transaction.listing.author, community).deliver
+      MailCarrier.deliver_now(PersonMailer.send("accept_reminder", transaction, transaction.listing.author, community))
     end
   end
 

--- a/app/jobs/automatic_booking_confirmation_job.rb
+++ b/app/jobs/automatic_booking_confirmation_job.rb
@@ -17,7 +17,7 @@ class AutomaticBookingConfirmationJob < Struct.new(:conversation_id, :current_us
 
     if MarketplaceService::Transaction::Query.can_transition_to?(transaction.id, :confirmed)
       MarketplaceService::Transaction::Command.transition_to(transaction.id, :confirmed)
-      PersonMailer.booking_transaction_automatically_confirmed(transaction, community).deliver
+      MailCarrier.deliver_now(PersonMailer.booking_transaction_automatically_confirmed(transaction, community))
     end
   end
 

--- a/app/jobs/community_joined_job.rb
+++ b/app/jobs/community_joined_job.rb
@@ -14,7 +14,7 @@ class CommunityJoinedJob < Struct.new(:person_id, :community_id)
     current_user = Person.find(person_id)
     current_community = Community.find(community_id)
 
-    PersonMailer.new_member_notification(current_user, current_community, current_user.emails.last.address).deliver if current_community.email_admins_about_new_members?
+    MailCarrier.deliver_now(PersonMailer.new_member_notification(current_user, current_community, current_user.emails.last.address)) if current_community.email_admins_about_new_members?
   end
 
 end

--- a/app/jobs/confirm_reminder_job.rb
+++ b/app/jobs/confirm_reminder_job.rb
@@ -14,7 +14,7 @@ class ConfirmReminderJob < Struct.new(:conversation_id, :recipient_id, :communit
     transaction = Transaction.find(conversation_id)
     community = Community.find(community_id)
     if transaction.status.eql?("accepted") || transaction.status.eql?("paid")
-      PersonMailer.send("confirm_reminder", transaction, transaction.buyer, community, days_to_cancel).deliver
+      MailCarrier.deliver_now(PersonMailer.send("confirm_reminder", transaction, transaction.buyer, community, days_to_cancel))
     end
   end
 

--- a/app/jobs/escrow_canceled_job.rb
+++ b/app/jobs/escrow_canceled_job.rb
@@ -13,7 +13,7 @@ class EscrowCanceledJob < Struct.new(:conversation_id, :community_id)
   def perform
     transaction = Transaction.find(conversation_id)
     community = Community.find(community_id)
-    PersonMailer.escrow_canceled(transaction, community).deliver
-    PersonMailer.admin_escrow_canceled(transaction, community).deliver
+    MailCarrier.deliver_now(PersonMailer.escrow_canceled(transaction, community))
+    MailCarrier.deliver_now(PersonMailer.admin_escrow_canceled(transaction, community))
   end
 end

--- a/app/jobs/invitation_created_job.rb
+++ b/app/jobs/invitation_created_job.rb
@@ -13,7 +13,7 @@ class InvitationCreatedJob < Struct.new(:invitation_id, :community_id)
 
   def perform
     invitation = Invitation.find(invitation_id)
-    PersonMailer.invitation_to_kassi(invitation).deliver
+    MailCarrier.deliver_now(PersonMailer.invitation_to_kassi(invitation))
   end
 
 end

--- a/app/jobs/listing_created_job.rb
+++ b/app/jobs/listing_created_job.rb
@@ -15,7 +15,7 @@ class ListingCreatedJob < Struct.new(:listing_id, :community_id)
     community = Community.find(community_id)
     # Send reminder about missing payment information
     if MarketplaceService::Listing::Entity.send_payment_settings_reminder?(listing_id, community_id)
-      PersonMailer.payment_settings_reminder(listing, listing.author, community).deliver
+      MailCarrier.deliver_now(PersonMailer.payment_settings_reminder(listing, listing.author, community))
     end
   end
 

--- a/app/jobs/notify_followers_job.rb
+++ b/app/jobs/notify_followers_job.rb
@@ -1,7 +1,7 @@
 class NotifyFollowersJob < Struct.new(:listing_id, :community_id)
-  
+
   DELAY = 30.minutes
-  
+
   include DelayedAirbrakeNotification
 
   # This before hook should be included in all Jobs to make sure that the service_name is
@@ -11,30 +11,30 @@ class NotifyFollowersJob < Struct.new(:listing_id, :community_id)
     # Set the correct service name to thread for I18n to pick it
     ApplicationHelper.store_community_service_name_to_thread_from_community_id(community_id)
   end
-  
+
   def perform
     return if !listing || listing.closed? || !author
     followers_to_notify.map do |follower|
-      PersonMailer.new_listing_by_followed_person(listing, follower, community).deliver
+      MailCarrier.deliver_now(PersonMailer.new_listing_by_followed_person(listing, follower, community))
     end
   end
-  
+
   private
-  
+
   def followers_to_notify
     author.followers.members_of(community).select do |follower|
       follower.preferences["email_about_new_listings_by_followed_people"]
     end
   end
-  
+
   def listing
     @listing ||= Listing.find_by_id(listing_id)
   end
-  
+
   def author
     @author ||= listing.author
   end
-  
+
   def community
     @community ||= Community.find_by_id(community_id)
   end

--- a/app/jobs/payment_reminder_job.rb
+++ b/app/jobs/payment_reminder_job.rb
@@ -17,7 +17,7 @@ class PaymentReminderJob < Struct.new(:conversation_id, :recipient_id, :communit
     can_transition_to_paid = MarketplaceService::Transaction::Query.can_transition_to?(transaction.id, :paid)
 
     if can_transition_to_paid && transaction.payment.status.eql?("pending")
-      PersonMailer.send("payment_reminder", transaction, transaction.payment.payer, community).deliver
+      MailCarrier.deliver_now(PersonMailer.send("payment_reminder", transaction, transaction.payment.payer, community))
     end
   end
 

--- a/app/jobs/send_payment_receipts.rb
+++ b/app/jobs/send_payment_receipts.rb
@@ -39,7 +39,7 @@ class SendPaymentReceipts < Struct.new(:transaction_id)
         []
       end
 
-    receipts.each { |receipt_mail| receipt_mail.deliver }
+    receipts.each { |receipt_mail| MailCarrier.deliver_now(receipt_mail) }
   end
 
   private

--- a/app/jobs/send_welcome_email.rb
+++ b/app/jobs/send_welcome_email.rb
@@ -7,7 +7,7 @@ class SendWelcomeEmail < Struct.new(:person_id, :community_id)
     person = Person.find(person_id)
     community = Community.find(community_id)
 
-    PersonMailer.welcome_email(person, community).deliver
+    MailCarrier.deliver_now(PersonMailer.welcome_email(person, community))
   end
 
   private

--- a/app/jobs/testimonial_given_job.rb
+++ b/app/jobs/testimonial_given_job.rb
@@ -16,7 +16,7 @@ class TestimonialGivenJob < Struct.new(:testimonial_id, :community_id)
     receiver = testimonial.receiver
 
     if receiver.should_receive?("email_about_new_received_testimonials")
-      PersonMailer.new_testimonial(testimonial, community).deliver
+      MailCarrier.deliver_now(PersonMailer.new_testimonial(testimonial, community))
     end
   end
 

--- a/app/jobs/testimonial_reminder_job.rb
+++ b/app/jobs/testimonial_reminder_job.rb
@@ -16,11 +16,11 @@ class TestimonialReminderJob < Struct.new(:conversation_id, :recipient_id, :comm
     community = Community.find(community_id)
 
     if transaction.testimonial_from_author.nil? && !transaction.author_skipped_feedback
-      PersonMailer.send("testimonial_reminder", transaction, transaction.author, community).deliver
+      MailCarrier.deliver_now(PersonMailer.send("testimonial_reminder", transaction, transaction.author, community))
     end
 
     if transaction.testimonial_from_starter.nil? && !transaction.starter_skipped_feedback
-      PersonMailer.send("testimonial_reminder", transaction, transaction.starter, community).deliver
+      MailCarrier.deliver_now(PersonMailer.send("testimonial_reminder", transaction, transaction.starter, community))
     end
   end
 

--- a/app/jobs/transaction_automatically_confirmed_job.rb
+++ b/app/jobs/transaction_automatically_confirmed_job.rb
@@ -14,7 +14,7 @@ class TransactionAutomaticallyConfirmedJob < Struct.new(:conversation_id, :commu
     begin
       transaction = Transaction.find(conversation_id)
       community = Community.find(community_id)
-      PersonMailer.transaction_automatically_confirmed(transaction, community).deliver
+      MailCarrier.deliver_now(PersonMailer.transaction_automatically_confirmed(transaction, community))
     rescue => ex
       puts ex.message
       puts ex.backtrace.join("\n")

--- a/app/jobs/transaction_canceled_job.rb
+++ b/app/jobs/transaction_canceled_job.rb
@@ -14,7 +14,7 @@ class TransactionCanceledJob < Struct.new(:conversation_id, :community_id)
     begin
       transaction = Transaction.find(conversation_id)
       community = Community.find(community_id)
-      PersonMailer.transaction_confirmed(transaction, community).deliver
+      MailCarrier.deliver_now(PersonMailer.transaction_confirmed(transaction, community))
     rescue => ex
       puts ex.message
       puts ex.backtrace.join("\n")

--- a/app/jobs/transaction_confirmed_job.rb
+++ b/app/jobs/transaction_confirmed_job.rb
@@ -13,6 +13,6 @@ class TransactionConfirmedJob < Struct.new(:conversation_id, :community_id)
   def perform
     transaction = Transaction.find(conversation_id)
     community = Community.find(community_id)
-    PersonMailer.transaction_confirmed(transaction, community).deliver
+    MailCarrier.deliver_now(PersonMailer.transaction_confirmed(transaction, community))
   end
 end

--- a/app/jobs/transaction_created_job.rb
+++ b/app/jobs/transaction_created_job.rb
@@ -12,7 +12,7 @@ class TransactionCreatedJob < Struct.new(:transaction_id, :community_id)
 
   def perform
     transaction = Transaction.find(transaction_id)
-    TransactionMailer.transaction_created(transaction).deliver
+    MailCarrier.deliver_now(TransactionMailer.transaction_created(transaction))
   end
 
 end

--- a/app/jobs/transaction_preauthorized_job.rb
+++ b/app/jobs/transaction_preauthorized_job.rb
@@ -13,6 +13,6 @@ class TransactionPreauthorizedJob < Struct.new(:transaction_id)
 
   def perform
     transaction = Transaction.find(transaction_id)
-    TransactionMailer.transaction_preauthorized(transaction).deliver
+    MailCarrier.deliver_now(TransactionMailer.transaction_preauthorized(transaction))
   end
 end

--- a/app/jobs/transaction_preauthorized_reminder_job.rb
+++ b/app/jobs/transaction_preauthorized_reminder_job.rb
@@ -15,7 +15,7 @@ class TransactionPreauthorizedReminderJob < Struct.new(:transaction_id)
     transaction = Transaction.find(transaction_id)
 
     if transaction.status == "preauthorized"
-      TransactionMailer.transaction_preauthorized_reminder(transaction).deliver
+      MailCarrier.deliver_now(TransactionMailer.transaction_preauthorized_reminder(transaction))
     end
   end
 end

--- a/app/jobs/transaction_status_changed_job.rb
+++ b/app/jobs/transaction_status_changed_job.rb
@@ -15,7 +15,7 @@ class TransactionStatusChangedJob < Struct.new(:conversation_id, :current_user_i
     transaction = Transaction.find(conversation_id)
     current_user = Person.find(current_user_id)
     if transaction.other_party(current_user).should_receive?("email_when_conversation_#{transaction.status}")
-      PersonMailer.conversation_status_changed(transaction, community).deliver
+      MailCarrier.deliver_now(PersonMailer.conversation_status_changed(transaction, community))
     end
   end
 

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -18,12 +18,13 @@ class CommunityMailer < ActionMailer::Base
           unless listings_to_send.empty?
             begin
               token = AuthToken.create_unsubscribe_token(person_id: person.id).token
-              CommunityMailer.community_updates(
-                recipient: person,
-                community: community,
-                listings: listings_to_send,
-                unsubscribe_token: token
-              ).deliver
+              MailCarrier.deliver_now(
+                CommunityMailer.community_updates(
+                  recipient: person,
+                  community: community,
+                  listings: listings_to_send,
+                  unsubscribe_token: token
+                ))
             rescue => e
               # Catch the exception and continue sending emails
             puts "Error sending mail to #{person.confirmed_notification_emails} community updates: #{e.message}"

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -418,7 +418,7 @@ class PersonMailer < ActionMailer::Base
   def self.community_member_email_from_admin(sender, recipient, community, email_subject, email_content, email_locale)
     if recipient.should_receive?("email_from_admins") && (email_locale.eql?("any") || recipient.locale.eql?(email_locale))
       begin
-        community_member_email(sender, recipient, email_subject, email_content, community).deliver
+        MailCarrier.deliver_now(community_member_email(sender, recipient, email_subject, email_content, community))
       rescue => e
         # Catch the exception and continue sending the emails
         ApplicationHelper.send_error_notification("Error sending email to all the members of community #{community.full_name(email_locale)}: #{e.message}", e.class)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -33,7 +33,7 @@ class Comment < ActiveRecord::Base
   def send_notifications(community)
     if !listing.author.id.eql?(author.id)
       if listing.author.should_receive?("email_about_new_comments_to_own_listing")
-        PersonMailer.new_comment_to_own_listing_notification(self, community).deliver
+        MailCarrier.deliver_now(PersonMailer.new_comment_to_own_listing_notification(self, community))
       end
     end
     listing.notify_followers(community, author, false)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -95,7 +95,7 @@ class Conversation < ActiveRecord::Base
   def send_email_to_participants(community)
     recipients(messages.last.sender).each do |recipient|
       if recipient.should_receive?("email_about_new_messages")
-        PersonMailer.new_message_notification(messages.last, community).deliver
+        MailCarrier.deliver_now(PersonMailer.new_message_notification(messages.last, community))
       end
     end
   end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -61,6 +61,6 @@ class Email < ActiveRecord::Base
   end
 
   def self.send_confirmation(email, community)
-    PersonMailer.email_confirmation(email, community).deliver
+    MailCarrier.deliver_later(PersonMailer.email_confirmation(email, community))
   end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -173,9 +173,9 @@ class Listing < ActiveRecord::Base
     followers.each do |follower|
       unless follower.id == current_user.id
         if update
-          PersonMailer.new_update_to_followed_listing_notification(self, follower, community).deliver
+          MailCarrier.deliver_now(PersonMailer.new_update_to_followed_listing_notification(self, follower, community))
         else
-          PersonMailer.new_comment_to_followed_listing_notification(comments.last, follower, community).deliver
+          MailCarrier.deliver_now(PersonMailer.new_comment_to_followed_listing_notification(comments.last, follower, community))
         end
       end
     end

--- a/app/utils/mail_carrier.rb
+++ b/app/utils/mail_carrier.rb
@@ -1,0 +1,15 @@
+module MailCarrier
+
+  module_function
+
+  # This is just a placeholder. Delivering later
+  # hasn't been implemented you.
+  def deliver_later(message)
+    deliver_now(message)
+  end
+
+  def deliver_now(message)
+    message.deliver_now
+  end
+
+end


### PR DESCRIPTION
`MailCarrier` is a utility layer that is a single point where all mails get delivered. It currently doesn't do much (or anything) but the fact that all mail deliveries are going through the same code path allows us to build features, such as:

- Better logging
- Resend logic (either manually on clients request or automatically if sending fails)

In addition, `Mail::Message#deliver` method is deprecated in Rails 4.2, so the `MailCarrier` layer uses `#deliver_now` instead of `#deliver`