### PR TITLE
Fix Fastclick to work with autocomplete

### DIFF
--- a/app/assets/javascripts/fastclick.js
+++ b/app/assets/javascripts/fastclick.js
@@ -102,6 +102,14 @@
 		 */
 		this.tapTimeout = options.tapTimeout || 700;
 
+		/**
+		 * A node to exclude based on className. Alternative to manually applying needsclick.
+		 * This is a patch. https://github.com/ftlabs/fastclick/pull/347
+		 *
+		 * @type string
+		 */
+		this.excludeNode = options.excludeNode || null;
+
 		if (FastClick.notNeeded(layer)) {
 			return;
 		}
@@ -250,7 +258,9 @@
 			return true;
 		}
 
-		return (/\bneedsclick\b/).test(target.className);
+		// This is a patched version from https://github.com/ftlabs/fastclick/pull/347/files
+		// original: return (/\bneedsclick\b/).test(target.className);
+		return ((/\bneedsclick\b/).test(target.className) || (new RegExp(this.excludeNode).test(target.className)));
 	};
 
 

--- a/app/assets/stylesheets/views/_home.css.scss
+++ b/app/assets/stylesheets/views/_home.css.scss
@@ -518,3 +518,12 @@ $home-list-avatar-padding: lines(0.25);
   left: 0px;
   bottom: 0;
 }
+
+//////////////////////////////////////////////////
+// Fix for fastclick & google autocomplete bug  //
+// https://github.com/ftlabs/fastclick/pull/347 //
+//////////////////////////////////////////////////
+
+.pac-item span {
+  pointer-events: none;
+}

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -69,7 +69,7 @@
 
   :javascript
     $(function() {
-      FastClick.attach(document.body);
+      FastClick.attach(document.body, { excludeNode: '^pac-'} );
       $('input, textarea').placeholder();
     });
 


### PR DESCRIPTION
Mobile phone tapping on Google Places Autocomplete doesn't work with Fastclick.
There is old PR that would fix this issue, but Fastclick hasn't merged it yet.
https://github.com/ftlabs/fastclick/pull/347
