### PR TITLE
add title attribute to grid items name and distance fields

### DIFF
--- a/app/views/homepage/_grid_item.haml
+++ b/app/views/homepage/_grid_item.haml
@@ -11,13 +11,15 @@
             = image_tag(listing.author.avatar.thumb || missing_avatar(:thumb), :class => "home-fluid-thumbnail-grid-author-avatar-image")
 
         - distance = Maybe(listing.distance).or_else(nil)
+        - name = PersonViewUtils::person_entity_display_name(listing.author, @current_community.name_display_type)
         - if(!show_distance || distance.blank?)
-          = link_to(person_path(id: listing.author.username), :class => "home-fluid-thumbnail-grid-author-name") do
-            = PersonViewUtils::person_entity_display_name(listing.author, @current_community.name_display_type)
+          = link_to(person_path(id: listing.author.username), :class => "home-fluid-thumbnail-grid-author-name", title: name) do
+            = name
         - else
           .home-fluid-thumbnail-grid-details
-            = link_to(person_path(id: listing.author.username), class: "home-fluid-thumbnail-grid-details-author-name") do
-              = PersonViewUtils::person_entity_display_name(listing.author, @current_community.name_display_type)
-            .home-fluid-thumbnail-grid-details-distance
-              - dist = number_with_delimiter(distance.round(2), locale: locale)
-              = "#{dist} #{listing.distance_unit}"
+            = link_to(person_path(id: listing.author.username), class: "home-fluid-thumbnail-grid-details-author-name", title: name) do
+              = name
+            - dist = number_with_delimiter(distance.round(2), locale: locale)
+            - dist_string = "#{dist} #{listing.distance_unit}"
+            .home-fluid-thumbnail-grid-details-distance{title: dist_string}
+              = dist_string


### PR DESCRIPTION
Name: Long full names might be too long for the grid items and therefore they might be ellipsed
Distance: the biggest distance possible "xx,xxx.xx miles" is shortened as "xx,xxx.xx mi…"
(That rarely happens, and therefore I wouldn't add shorthand for miles. With that, we would only gain the removal of one nonessential character … ("xx,xxx.xx mi")