### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,15 +188,22 @@ To automatically run unit tests when code is changed, start [Guard](https://gith
 
 Before starting these steps, perform [steps 1-5 from above](#setting-up-the-development-environment).
 
-1. Set environment variables
+1. Set `secret_key_base`
 
-  Set environment variable `secret_key_base`.
+  Generate secret key
 
-  To generate the new `secret_key_base` key, go rails console and type:
-
-  ```ruby
-  SecureRandom.hex(64)
+  ```bash
+  rake secret
   ```
+
+  Add the following lines to `config/config.yml`:
+
+  ```yml
+  production:
+    secret_key_base: # add here the generated key
+  ```
+
+  (You can also set the `secret_key_base` environment variable, if you don't want to store the secret key in a file)
 
 1. Create the database:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Before you get started, the following needs to be installed:
 
 1. Add your database configuration details to `config/database.yml`. You will probably only need to fill in the password for the database(s).
 
+1. Create a config.yml file by copying the example configutions file:
+
+  ```bash
+  cp config/config.example.yml config/config.yml
+  ```
+
+
 1. Create the database:
 
   ```bash
@@ -121,7 +128,7 @@ Use [Mailcatcher](http://mailcatcher.me) to receive sent emails locally:
   mailcatcher
   ```
 
-1. Create a `config/config.yml` file and add the following lines to it:
+1. Add the following lines to `config/config.yml`:
 
 ```yml
 development:
@@ -248,7 +255,7 @@ It is not recommended to serve static assets from a Rails server in production. 
 
 ### Advanced settings
 
-Default configuration settings are stored in `config/config.default.yml`. If you need to change these, we recommend creating a `config/config.yml` file to override these values. You can also set configuration values to environment variables.
+Default configuration settings are stored in `config/config.default.yml`. If you need to change these, use the `config/config.yml` file to override the defaults. You can also set configuration values to environment variables.
 
 ### Unofficial installation instructions
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Before you get started, the following needs to be installed:
 
 1. Add your database configuration details to `config/database.yml`. You will probably only need to fill in the password for the database(s).
 
-1. Create a config.yml file by copying the example configutions file:
+1. Create a config.yml file by copying the example configution file:
 
   ```bash
   cp config/config.example.yml config/config.yml

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ To automatically run unit tests when code is changed, start [Guard](https://gith
 
 Before starting these steps, perform [steps 1-5 from above](#setting-up-the-development-environment).
 
+1. Set environment variables
+
+  Set environment variable `secret_key_base`.
+
+  To generate the new `secret_key_base` key, go rails console and type:
+
+  ```ruby
+  SecureRandom.hex(64)
+  ```
+
 1. Create the database:
 
   ```bash
@@ -209,16 +219,6 @@ Before starting these steps, perform [steps 1-5 from above](#setting-up-the-deve
 
   ```bash
   bundle exec rake assets:precompile
-  ```
-
-1. Set environment variables
-
-  Set environment variable `secret_key_base`.
-
-  To generate the new `secret_key_base` key, go rails console and type:
-
-  ```ruby
-  SecureRandom.hex(64)
   ```
 
 1. Invoke the delayed job worker:

--- a/README.md
+++ b/README.md
@@ -92,29 +92,6 @@ Before you get started, the following needs to be installed:
   bundle exec rake ts:start
   ```
 
-1. Use [Mailcatcher](http://mailcatcher.me) to receive sent emails locally:
-    1. Install Mailcatcher:
-
-        ```bash
-        gem install mailcatcher
-        ```
-
-    1. Start it:
-
-        ```bash
-        mailcatcher
-        ```
-
-    1. Create a `config/config.yml` file and add the following lines to it:
-
-        ```yml
-        development:
-          mail_delivery_method: smtp
-          smtp_email_address: "localhost"
-          smtp_email_port: 1025
-        ```
-
-    1. Open `http://localhost:1080` in your browser
 1. Invoke the delayed job worker:
 
   ```bash
@@ -127,8 +104,34 @@ Before you get started, the following needs to be installed:
   bundle exec rails server
   ```
 
-
 Congratulations! Sharetribe should now be up and running for development purposes. Open a browser and go to the server URL (e.g. http://lvh.me:3000). Fill in the form to create a new marketplace and admin user. You should be now able to access your marketplace and modify it from the admin area.
+
+### Mailcatcher
+
+Use [Mailcatcher](http://mailcatcher.me) to receive sent emails locally:
+
+1. Install Mailcatcher:
+
+  ```bash
+  gem install mailcatcher
+  ```
+
+1. Start it:
+
+  ```bash
+  mailcatcher
+  ```
+
+1. Create a `config/config.yml` file and add the following lines to it:
+
+```yml
+development:
+  mail_delivery_method: smtp
+  smtp_email_address: "localhost"
+  smtp_email_port: 1025
+```
+
+1. Open `http://localhost:1080` in your browser
 
 ### Database migrations
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,10 @@ Before you get started, the following needs to be installed:
 
 1. Add your database configuration details to `config/database.yml`. You will probably only need to fill in the password for the database(s).
 
-1. Create the required databases
+1. Create the database:
 
   ```bash
-  rake db:create:all
-  rake db:schema:load
+  bundle exec rake db:create
   ```
 
 1. Initialize your database:
@@ -180,7 +179,13 @@ To automatically run unit tests when code is changed, start [Guard](https://gith
 
 ### Setting up Sharetribe for production
 
-Before starting these steps, perform [steps 1-6 from above](#setting-up-the-development-environment).
+Before starting these steps, perform [steps 1-5 from above](#setting-up-the-development-environment).
+
+1. Create the database:
+
+  ```bash
+  bundle exec rake RAILS_ENV=production db:create
+  ```
 
 1. Initialize your database:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Before you get started, the following needs to be installed:
   cd sharetribe
   ```
 
+1. Install the required gems by running the following command in the project root directory:
+
+  ```bash
+  bundle install
+  ```
+
 1. Create a database.yml file by copying the example database configuration:
 
   ```bash
@@ -66,12 +72,6 @@ Before you get started, the following needs to be installed:
   ```bash
   rake db:create:all
   rake db:schema:load
-  ```
-
-1. Install the required gems by running the following command in the project root directory:
-
-  ```bash
-  bundle install
   ```
 
 1. Initialize your database:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,15 @@ Before you get started, the following needs to be installed:
   cp config/database.example.yml config/database.yml
   ```
 
-1. Create the required databases with [these commands](https://gist.github.com/804314).
 1. Add your database configuration details to `config/database.yml`. You will probably only need to fill in the password for the database(s).
+
+1. Create the required databases
+
+  ```bash
+  rake db:create:all
+  rake db:schema:load
+  ```
+
 1. Install the required gems by running the following command in the project root directory:
 
   ```bash

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,0 +1,21 @@
+# Locally override default configurations
+#
+# This file overrides configurations set in `config/config.defaults.yml`.
+# Keep in mind that environment variables override setting in this file.
+#
+# Usage:
+#
+# Copy this file from `config/config.example.yml` to `config/config.yml`
+#
+
+development:
+  # Add local `development` environment configuration overrides here
+
+test:
+  # Add local `test` environment configuration overrides here
+
+staging:
+  # Add local `staging` environment configuration overrides here
+
+production:
+  # Add local `production` environment configuration overrides here

--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -1,41 +1,37 @@
-# SQLite version 3.x
-#   gem install sqlite3-ruby (not necessary on OS X Leopard)
 development:
     adapter: mysql2
     database: sharetribe_development
     encoding: utf8
-    username: sharetribe
-    password: secret
+    username: # ADD DATABASE USERNAME
+    password: # ADD DATABASE PASSWORD
     host: localhost
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
-# The example has user root for tests to work with Travis CI
 test: &test
     adapter: mysql2
     database: sharetribe_test
     encoding: utf8
-    username: root
-    password:
+    username: # ADD DATABASE USERNAME
+    password: # ADD DATABASE PASSWORD
     host: localhost
 
 staging:
     adapter: mysql2
     database: sharetribe_staging
     encoding: utf8
-    username: sharetribe
-    password: secret
+    username: # ADD DATABASE USERNAME
+    password: # ADD DATABASE PASSWORD
     host: localhost
 
 production:
     adapter: mysql2
     database: sharetribe_production
     encoding: utf8
-    username: sharetribe
-    password: secret
+    username: # ADD DATABASE USERNAME
+    password: # ADD DATABASE PASSWORD
     host: localhost
-#    socket: /var/run/mysqld/mysqld.sock
 
 cucumber:
   <<: *test


### PR DESCRIPTION
- [X] Remove default username/password from the database.example.yml. The current once are just guesses which are probably never right.
- [X] Use `rake` to create databases
- [X] Move optional Mailcatcher instructions under the critical instructions
- [X] Use `rake secret` to generate secret key
- [X] Add `config.example.yml`

*Review tip:* use [?w=0](https://github.com/sharetribe/sharetribe/pull/1755/files?w=0)