### PR TITLE
Fix: Font awesome URL was hardcoded and not coming from asset pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ### Changed
 
- - Add listing id to option selections table: [#1761](https://github.com/sharetribe/sharetribe/pull/1761) and [#1762](https://github.com/sharetribe/sharetribe/pull/1762)
+- Add listing id to option selections table: [#1761](https://github.com/sharetribe/sharetribe/pull/1761) and [#1762](https://github.com/sharetribe/sharetribe/pull/1762)
+
+### Fixed
+
+- Fixed broken FontAwesome asset path [#1756](https://github.com/sharetribe/sharetribe/pull/1756)
 
 ## [5.4.0] - 2016-02-22
 

--- a/app/assets/stylesheets/font-awesome.min.css
+++ b/app/assets/stylesheets/font-awesome.min.css
@@ -23,10 +23,10 @@
 
 @font-face{
   font-family:'FontAwesome';
-  src:url('/assets/fontawesome-webfont.eot?v=3.0.1');
-  src:url('/assets/fontawesome-webfont.eot?#iefix&v=3.0.1') format('embedded-opentype'),
-  url('/assets/fontawesome-webfont.woff?v=3.0.1') format('woff'),
-  url('/assets/fontawesome-webfont.ttf?v=3.0.1') format('truetype');
+  src:asset-url('fontawesome-webfont.eot?v=3.0.1');
+  src:asset-url('fontawesome-webfont.eot?#iefix&v=3.0.1') format('embedded-opentype'),
+  asset-url('fontawesome-webfont.woff?v=3.0.1') format('woff'),
+  asset-url('fontawesome-webfont.ttf?v=3.0.1') format('truetype');
   font-weight:normal;
   font-style:normal }
 


### PR DESCRIPTION
Fixes #1706

Steps to reproduce:

1. Make sure that the app is configured to use FontAwesome icons
1. Run `rake assets:precompile`
1. Run `RAILS_ENV=production rails server`

Expected: Font Awesome icons are in use

Actual: Font Awesome icons are not loaded