### PR TITLE
Save listing_id to option selections

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -656,7 +656,9 @@ class ListingsController < ApplicationController
       when :dropdown
         option_id = answer_value.to_i
         answer = DropdownFieldValue.new
-        answer.custom_field_option_selections = [CustomFieldOptionSelection.new(:custom_field_value => answer, :custom_field_option_id => answer_value)]
+        answer.custom_field_option_selections = [CustomFieldOptionSelection.new(:custom_field_value => answer,
+                                                                                :custom_field_option_id => answer_value,
+                                                                                :listing_id => listing_id)]
         answer
       when :text
         answer = TextFieldValue.new
@@ -668,7 +670,9 @@ class ListingsController < ApplicationController
         answer
       when :checkbox
         answer = CheckboxFieldValue.new
-        answer.custom_field_option_selections = answer_value.map { |value| CustomFieldOptionSelection.new(:custom_field_value => answer, :custom_field_option_id => value) }
+        answer.custom_field_option_selections = answer_value.map { |value|
+          CustomFieldOptionSelection.new(:custom_field_value => answer, :custom_field_option_id => value, :listing_id => listing_id)
+        }
         answer
       when :date_field
         answer = DateFieldValue.new

--- a/app/models/custom_field_option_selection.rb
+++ b/app/models/custom_field_option_selection.rb
@@ -5,6 +5,7 @@
 #  id                     :integer          not null, primary key
 #  custom_field_value_id  :integer
 #  custom_field_option_id :integer
+#  listing_id             :integer
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #

--- a/db/migrate/20160223083004_add_listing_id_to_custom_field_option_selections.rb
+++ b/db/migrate/20160223083004_add_listing_id_to_custom_field_option_selections.rb
@@ -1,0 +1,5 @@
+class AddListingIdToCustomFieldOptionSelections < ActiveRecord::Migration
+  def change
+    add_column :custom_field_option_selections, :listing_id, :integer, after: :custom_field_option_id, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160209183917) do
+ActiveRecord::Schema.define(version: 20160223084741) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -309,6 +309,7 @@ ActiveRecord::Schema.define(version: 20160209183917) do
   create_table "custom_field_option_selections", force: :cascade do |t|
     t.integer  "custom_field_value_id",  limit: 4
     t.integer  "custom_field_option_id", limit: 4
+    t.integer  "listing_id",             limit: 4
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
   end


### PR DESCRIPTION
To make indexing option selections easier add the id of the related listing directly to custom_field_option_selections table. This PR:

* Adds a DB column to store the listing_id in custom_field_option_selectsions
* Modifies listing controller so that listing_id is always saved when listing is edited. This is the only code path that creates option selections so we always have it in place from now on.

Another PR will follow that migrates the listing_id into previously created custom_field_option_selections rows after this has been successfully deployed to production.