### PR TITLE
Warnings for REMOVED_LOCALES already defined : fixed #1757

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,9 +47,7 @@ Kassi::Application.routes.draw do
     get "/check_email_availability" => "marketplaces#check_email_availability"
   end
 
-  REMOVED_LOCALES ||= Rails.application.config.REMOVED_LOCALES.to_a
-
-  locale_matcher = Regexp.new(Sharetribe::AVAILABLE_LOCALES.map { |l| l[:ident] }.concat(REMOVED_LOCALES).join("|"))
+  locale_matcher = Regexp.new(Sharetribe::AVAILABLE_LOCALES.map { |l| l[:ident] }.concat(Sharetribe::REMOVED_LOCALES.to_a).join("|"))
 
   # Inside this constraits are the routes that are used when request has subdomain other than www
   get '/:locale/' => 'homepage#index', :constraints => { :locale => locale_matcher }, as: :homepage_with_locale

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Kassi::Application.routes.draw do
     get "/check_email_availability" => "marketplaces#check_email_availability"
   end
 
-  REMOVED_LOCALES = Rails.application.config.REMOVED_LOCALES.to_a
+  REMOVED_LOCALES ||= Rails.application.config.REMOVED_LOCALES.to_a
 
   locale_matcher = Regexp.new(Sharetribe::AVAILABLE_LOCALES.map { |l| l[:ident] }.concat(REMOVED_LOCALES).join("|"))
 


### PR DESCRIPTION
When executed using Mac OS X
`bundle exec rake jobs:work`
show messages:
```
Users/vtorves/Projects/sharetribe/config/routes.rb:50: warning: already initialized constant REMOVED_LOCALES
/Users/vtorves/Projects/sharetribe/config/routes.rb:50: warning: previous definition of REMOVED_LOCALES was here
```
fixed #1757 