### PR TITLE
Implement optional HTTP basic authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 ### Changed
 
 - Add listing id to option selections table: [#1761](https://github.com/sharetribe/sharetribe/pull/1761) and [#1762](https://github.com/sharetribe/sharetribe/pull/1762)
+- Support optional site-wide HTTP basic authentication: [#1766](https://github.com/sharetribe/sharetribe/pull/1766)
 
 ### Fixed
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   layout 'application'
 
-  before_filter :check_auth_token,
+  before_filter :check_http_auth,
+    :check_auth_token,
     :fetch_community,
     :fetch_community_plan_expiration_status,
     :perform_redirect,
@@ -468,6 +469,15 @@ class ApplicationController < ActionController::Base
 
   def fetch_translations
     WebTranslateIt.fetch_translations
+  end
+
+  def check_http_auth
+    return true unless APP_CONFIG.use_http_auth.to_s.downcase == 'true'
+    if authenticate_with_http_basic { |u, p| u == APP_CONFIG.http_auth_username && p == APP_CONFIG.http_auth_password }
+      true
+    else
+      request_http_basic_authentication
+    end
   end
 
   def check_auth_token

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -1,6 +1,6 @@
 class IntApi::MarketplacesController < ApplicationController
 
-  skip_filter :fetch_community
+  skip_filter :fetch_community, :check_http_auth
 
   before_filter :set_access_control_headers
 

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -268,6 +268,11 @@ default: &default_settings
   # Delayed job maximum run time in seconds
   delayed_job_max_run_time: 180
 
+  # Optional HTTP basic auth for the entire installation
+  use_http_auth: false
+  http_auth_username: sharetribe
+  http_auth_password: changeme
+
 production: &production_settings
   <<: *default_settings
 

--- a/spec/requests/http_basic_auth_spec.rb
+++ b/spec/requests/http_basic_auth_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe "HTTP basic auth", type: :request do
+  before do
+    APP_CONFIG.use_http_auth = true
+    APP_CONFIG.http_auth_username = "testuser"
+    APP_CONFIG.http_auth_password = "secret"
+  end
+
+  after do
+    APP_CONFIG.use_http_auth = false
+  end
+
+  it "is required when enabled" do
+    get "/"
+    expect(response.status).to eq(401)
+
+    get "/admin"
+    expect(response.status).to eq(401)
+  end
+
+  it "is bypassed for internal API" do
+    get "/int_api/check_email_availability", email: "test123@example.com"
+    expect(response.status).to eq(200)
+  end
+
+  it "is not required when disabled" do
+    APP_CONFIG.use_http_auth = false
+    get "/"
+    expect(response.status).not_to eq(401)
+  end
+end


### PR DESCRIPTION
Allows site administrator to enable HTTP basic authentication for all incoming requests. Can be useful for test installations that are otherwise publicly accessible.