### PR TITLE
Fix bug: Author can not give feedback if starter skipped it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 ### Fixed
 
 - Fixed broken FontAwesome asset path [#1756](https://github.com/sharetribe/sharetribe/pull/1756)
+- Listing author wasn't able to give feedback if the transaction starter skipped the feedback [#1767](https://github.com/sharetribe/sharetribe/pull/1767)
 
 ## [5.4.0] - 2016-02-22
 

--- a/app/services/marketplace_service/transaction.rb
+++ b/app/services/marketplace_service/transaction.rb
@@ -47,7 +47,7 @@ module MarketplaceService
       def waiting_testimonial_from?(transaction, person_id)
         if transaction[:starter_id] == person_id && transaction[:starter_skipped_feedback]
           false
-        elsif transaction[:author_skipped_feedback]
+        elsif transaction[:author_id] == person_id && transaction[:author_skipped_feedback]
           false
         else
           testimonial_from(transaction, person_id).nil?


### PR DESCRIPTION
Steps to reproduce:

1. Buyer: Start a new transaction
2. Seller: Accept it
3: Buyer: Click mark as completed
4. Buyer: Check the "Give feedback" radio button and move on
5. Buyer: Do not write the feedback, instead leave the page
6. Seller: Go and skip feedback
7. Buyer: Try to give feedback

Expected: Buyer can give feedback

Actual: Error is shown, feedback given already