### PR TITLE
Fix turkish font rendering

### DIFF
--- a/app/services/paypal_service/api/lookup.rb
+++ b/app/services/paypal_service/api/lookup.rb
@@ -89,7 +89,7 @@ module PaypalService::API
         return log_and_return(Result::Error.new("Payment is not in :completed state. State was: #{payment[:payment_status]}."))
       end
 
-      unless ([:not_charged, :errored].include?(payment[:commission_status])
+      unless ([:not_charged, :errored].include?(payment[:commission_status]))
         return log_and_return(Result::Error.new("Commission already charged. Commission status was: #{payment[:commission_status]}"))
       end
 

--- a/app/views/layouts/_head.haml
+++ b/app/views/layouts/_head.haml
@@ -9,7 +9,7 @@
 
   = render :partial => "layouts/kissmetrics"
   :css
-    @import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700);
+    @import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700&subset=latin-ext);
   %meta{content: "width=device-width, initial-scale=1.0, user-scalable=no", name: "viewport"}
   %meta{ :property => "og:type", :content =>"website"}
   %meta{:"http-equiv" => "content-language", content: "#{I18n.locale}"}

--- a/app/views/layouts/blank_layout.erb
+++ b/app/views/layouts/blank_layout.erb
@@ -4,7 +4,7 @@
 
   <meta charset="utf-8">
     <title><%= locals(local_assigns, :title) %></title>
-    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600' rel='stylesheet' type='text/css'>
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600&subset=latin-ext' rel='stylesheet' type='text/css'>
 
     <style type="text/css">
 


### PR DESCRIPTION
This PR fixes an issue with font-rendering in Turkish.

Before:

![screen shot 2016-02-25 at 13 58 03](https://cloud.githubusercontent.com/assets/429876/13319291/749caba2-dbc9-11e5-8604-dc3aba6f36a0.png)
![screen shot 2016-02-25 at 13 57 57](https://cloud.githubusercontent.com/assets/429876/13319292/749d7d2a-dbc9-11e5-8e50-921755aa5042.png)

After:

![screen shot 2016-02-25 at 13 59 58](https://cloud.githubusercontent.com/assets/429876/13319305/81765d78-dbc9-11e5-817b-4af3e6c834fd.png)
![screen shot 2016-02-25 at 13 59 54](https://cloud.githubusercontent.com/assets/429876/13319306/817c760e-dbc9-11e5-90df-5cb8dea32a60.png)

Background: latin-ext subset was missing from the font we load from Google. This issue only occured with Safari, Firefox etc. Google Chrome was able to render characters even before this change, because it support unicode-range and can smartly use the correct font subset.

This will increase the font-size for Safari, Firefox e.g. The current font-size is ~14 kb and this will increase it to ~21 kb per font-weight (we're currently including 400, 600, 700 font weights)