### PR TITLE
Autocomplete suggestions differ from Places API suggestions.

### DIFF
--- a/app/assets/javascripts/googlemaps.js
+++ b/app/assets/javascripts/googlemaps.js
@@ -485,7 +485,7 @@ function initialize_listing_map(listings, community_location_lat, community_loca
   helsinki = new google.maps.LatLng(60.17, 24.94);
   flagMarker = new google.maps.Marker();
   var myOptions = {
-    zoom: 13,
+    zoom: 16,
     maxZoom: 17,
     mapTypeId: google.maps.MapTypeId.ROADMAP
   };

--- a/app/assets/javascripts/location_search.js
+++ b/app/assets/javascripts/location_search.js
@@ -8,7 +8,7 @@ window.ST = window.ST || {};
     var coordinateInput = document.getElementById('lc');
     var boundingboxInput = document.getElementById('boundingbox');
     var homepageForm = document.getElementById('homepage-filters');
-    var autocomplete = new window.google.maps.places.Autocomplete(searchInput);
+    var autocomplete = new window.google.maps.places.Autocomplete(searchInput, { bounds: { north: -90, east: -180, south: 90, west: 180 } });
     autocomplete.setTypes(['geocode']);
 
     boundingboxInput.value = null;
@@ -41,6 +41,12 @@ window.ST = window.ST || {};
       }
     });
 
+    // With location search searchInput should not cause form submit
+    searchInput.addEventListener('keypress', function(e) {
+      if (e.keyCode === 13) {
+        e.preventDefault();
+      }
+    });
 
     var queryPredictions = function(inputString, callback) {
       var autocompleteService = new window.google.maps.places.AutocompleteService();


### PR DESCRIPTION
- Setting bounds (as whole world) to Autocomplete seems to fix Google's search result personalization
- Fixing form submit - rare too-early-submission. (Q-input should never send default submit since it's handled by Autocomplete related google events)