### PR TITLE
Redirect to HTTPS before requesting HTTP basic authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ## [Unreleased]
 
+### Security
+
+- Redirect to HTTPS (if configured) before requesting HTTP basic authentication: [#1793](https://github.com/sharetribe/sharetribe/pull/1793)
+
 ## [5.5.0] - 2016-03-02
 
 ### Changed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -471,10 +471,21 @@ class ApplicationController < ActionController::Base
     WebTranslateIt.fetch_translations
   end
 
+  def redirect_https?
+    always_use_ssl = APP_CONFIG.always_use_ssl.to_s.downcase == "true"
+    !request.ssl? && always_use_ssl
+  end
+
+  def redirect_https!
+    redirect_to protocol: "https://", status: :moved_permanently
+  end
+
   def check_http_auth
     return true unless APP_CONFIG.use_http_auth.to_s.downcase == 'true'
     if authenticate_with_http_basic { |u, p| u == APP_CONFIG.http_auth_username && p == APP_CONFIG.http_auth_password }
       true
+    elsif redirect_https?
+      redirect_https!
     else
       request_http_basic_authentication
     end

--- a/spec/requests/http_basic_auth_spec.rb
+++ b/spec/requests/http_basic_auth_spec.rb
@@ -7,6 +7,16 @@ describe "HTTP basic auth", type: :request do
     APP_CONFIG.http_auth_password = "secret"
   end
 
+  before(:each) do
+    @domain = "market.custom.org"
+    @http_url = "http://#{@domain}"
+    @https_url = "https://#{@domain}"
+    @community = FactoryGirl.create(:community, :domain => @domain, use_domain: true)
+
+    # Refresh from DB
+    @community.reload
+  end
+
   after do
     APP_CONFIG.use_http_auth = false
   end
@@ -28,5 +38,28 @@ describe "HTTP basic auth", type: :request do
     APP_CONFIG.use_http_auth = false
     get "/"
     expect(response.status).not_to eq(401)
+  end
+
+  context "when always_use_ssl is true" do
+    before do
+      APP_CONFIG.always_use_ssl = true
+    end
+
+    after do
+      APP_CONFIG.always_use_ssl = false
+    end
+
+    it "is required after redirect" do
+      get @http_url
+      expect(response.status).to eq(301)
+
+      get response.location
+      expect(response.status).to eq(401)
+    end
+
+    it "is required when using HTTPS" do
+      get @https_url
+      expect(response.status).to eq(401)
+    end
   end
 end


### PR DESCRIPTION
This is possibly an additional redirect that only happens if basic auth is enabled.