### PR TITLE
HOTFIX google analytics script was missing ga.js

### DIFF
--- a/app/views/layouts/_google_analytics_script.haml
+++ b/app/views/layouts/_google_analytics_script.haml
@@ -51,13 +51,14 @@
       ['b._trackPageLoadTime']
       );
 
-      (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-
     var secondary_analytics_in_use = true;
+
+  - unless(feature_enabled?(:universal_analytics) && feature_enabled?(:customer_universal_analytics))
+    (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
 
   function report_analytics_event(category, action, opt_label) {
   - if feature_enabled?(:universal_analytics)


### PR DESCRIPTION
I quickly made this change so that production deploy from master doesn't break Google analytics scripts.
However, I will not push this to production tonight since this was quickly reviewed by olli and to me it might be better that someone tomorrow morning checks this with fresh eyes. (There's probably some ways to improve this.)