### PR TITLE
Refactor and fix radiobuttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Update Ruby to 2.2.4 [#1774](https://github.com/sharetribe/sharetribe/pull/1774)
 
+### Fixed
+
+- Wrong action was executed when radio buttons were clicked back and forth [#1802](https://github.com/sharetribe/sharetribe/pull/1802)
+
 ### Security
 
 - Redirect to HTTPS (if configured) before requesting HTTP basic authentication: [#1793](https://github.com/sharetribe/sharetribe/pull/1793)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -72,4 +72,5 @@
 //= require paypal_account_settings
 //= require transaction
 //= require listing_form
+//= require radio_buttons
 //= require_self

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -368,7 +368,6 @@ function initialize_accept_transaction_form(
   minimum_price_message) {
 
   auto_resize_text_areas("text_area");
-  style_action_selectors();
 
   if (commission_percentage != null) {
     if (form_type === "simple") {
@@ -470,41 +469,6 @@ function update_complex_form_price_fields(commissionPercentage, serviceFeeVat) {
   $("#service-fee-total").text(totalFee.toFixed(2) + euro);
 
   $("#total").text(youWillGet.toFixed(2) + euro);
-}
-
-function style_action_selectors() {
-  $(".conversation-action").each(function() {
-    $(this).find('label').hide();
-    $(this).find('.conversation-action').each(
-      function() {
-        $(this).removeClass('hidden');
-        $(this).click(
-          function() {
-            var action = $(this).attr('id');
-            $(this).siblings().removeClass('accept').removeClass('reject').removeClass('confirm').removeClass('cancel');
-
-            // Show or hide description text
-            $(".confirm-description").addClass('hidden');
-            $(".cancel-description").addClass('hidden');
-            $("." + action + "-description").removeClass('hidden');
-
-            // Show or hide price field
-            $(".conversation-price").addClass('hidden');
-            $("." + action +  "-price").removeClass('hidden');
-
-            // Show or hide payout details missing information
-            $(".hidden-accept-form").addClass('hidden');
-            $(".visible-when-" + action).removeClass('hidden');
-
-            $(this).addClass(action);
-            $(".conversation-action").find('input:radio[id=' + $(this).attr('name') + ']').attr('checked', true);
-            $("#conversation_message_attributes_action").val(action);
-            $("#conversation_status").val(action + 'ed');
-          }
-        );
-      }
-    );
-  });
 }
 
 function initialize_give_feedback_form(locale, grade_error_message, text_error_message) {

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -472,10 +472,6 @@ function update_complex_form_price_fields(commissionPercentage, serviceFeeVat) {
   $("#total").text(youWillGet.toFixed(2) + euro);
 }
 
-function initialize_confirm_transaction_form() {
-  style_action_selectors();
-}
-
 function style_action_selectors() {
   $(".conversation-action").each(function() {
     $(this).find('label').hide();

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -459,7 +459,6 @@ function update_complex_form_price_fields(commissionPercentage, serviceFeeVat) {
 function initialize_give_feedback_form(locale, grade_error_message, text_error_message) {
   auto_resize_text_areas("text_area");
   $('textarea').focus();
-  style_grade_selectors();
   var form_id = "#new_testimonial";
   $(form_id).validate({
     errorPlacement: function(error, element) {
@@ -479,24 +478,6 @@ function initialize_give_feedback_form(locale, grade_error_message, text_error_m
     submitHandler: function(form) {
       disable_and_submit(form_id, form, "false", locale);
     }
-  });
-}
-
-function style_grade_selectors() {
-  $(".feedback-grade").each(function() {
-    $(this).find('label').hide();
-    $(this).find('.grade').each(
-      function() {
-        $(this).removeClass('hidden');
-        $(this).click(
-          function() {
-            $(this).siblings().removeClass('negative').removeClass('positive');
-            $(this).addClass($(this).attr('id'));
-            $(".feedback-grade").find('input:radio[id=' + $(this).attr('name') + ']').attr('checked', true);
-          }
-        );
-      }
-    );
   });
 }
 

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -74,21 +74,6 @@ function add_validator_methods() {
     );
 
   $.validator.
-    addMethod("required_when_not_neutral_feedback",
-      function(value, element, param) {
-        if (value == "") {
-          var radioButtonArray = new Array("1", "2", "4", "5");
-          for (var i = 0; i < radioButtonArray.length; i++) {
-            if ($('#grade-' + radioButtonArray[i]).is(':checked')) {
-              return false;
-            }
-          }
-        }
-        return true;
-       }
-    );
-
-  $.validator.
     addMethod( "positive_integer",
       function(value, element, param) {
         var n = ~~Number(value);

--- a/app/assets/javascripts/radio_buttons.js
+++ b/app/assets/javascripts/radio_buttons.js
@@ -27,7 +27,6 @@ window.ST = window.ST || {};
    *
    * - buttonSelectors: array of button selectors
    * - inputSelector: selector for the input element
-   * - selectedSelector: (optional) selector for the initally selected button
    *
    */
 

--- a/app/assets/javascripts/radio_buttons.js
+++ b/app/assets/javascripts/radio_buttons.js
@@ -1,0 +1,84 @@
+window.ST = window.ST || {};
+
+(function(exports) {
+
+  /**
+   * Adds radiobutton functionality
+   *
+   * Usage:
+   *
+   * - create an `input` tag
+   * - create two or more buttons
+   * - invoke initializeRadioButtons
+   *
+   * Input tag:
+   *
+   * The selected value will be added to the `input` element. There's no special
+   * requirements for the input element. It has to have a unique selector
+   * (prefer classes over ids)
+   *
+   * Buttons:
+   *
+   * Button needs to contain data attribute `radio-button-value`. The attribute
+   * value will be copied to the `input` element when selected. Also, a class
+   * `radio-button-selected` will be added to the button when it's selected.
+   *
+   * Parameters:
+   *
+   * - buttonSelectors: array of button selectors
+   * - inputSelector: selector for the input element
+   * - selectedSelector: (optional) selector for the initally selected button
+   *
+   */
+
+  var SELECTED_CLASS = "radio-button-selected";
+  var DATA_ATTR_NAME = "radio-button-value";
+
+  var select = function(selectedButton, input, buttons) {
+    var selectedButtonEl = selectedButton.element;
+    input.val(selectedButtonEl.data(DATA_ATTR_NAME));
+
+    buttons.forEach(function(button) {
+      var buttonEl = button.element;
+
+      if (buttonEl.is(selectedButtonEl)) {
+        buttonEl.addClass(SELECTED_CLASS);
+      } else {
+        buttonEl.removeClass(SELECTED_CLASS);
+      }
+    });
+  };
+
+  var initializeButton = function(buttonSelector) {
+    return {
+      selector: buttonSelector,
+      element: $(buttonSelector)
+    };
+  };
+
+  var initialize = function(opts) {
+    opts = opts || {};
+
+    var buttonSelectors  = opts.buttons;
+    var inputSelector    = opts.input;
+    var selectedSelector = opts.selected;
+    var callback         = opts.callback || function() {};
+
+    var input = $(inputSelector);
+    var buttons = buttonSelectors.map(initializeButton);
+    var initiallySelected = initializeButton(selectedSelector);
+
+    buttons.forEach(function(button) {
+      button.element.click(function() {
+        select(button, input, buttons);
+        callback(button.selector, button.element);
+      });
+    });
+
+    // Initial selection
+    select(initiallySelected, input, buttons);
+  };
+
+  exports.initializeRadioButtons = initialize;
+
+})(window.ST);

--- a/app/assets/javascripts/radio_buttons.js
+++ b/app/assets/javascripts/radio_buttons.js
@@ -61,12 +61,10 @@ window.ST = window.ST || {};
 
     var buttonSelectors  = opts.buttons;
     var inputSelector    = opts.input;
-    var selectedSelector = opts.selected;
     var callback         = opts.callback || function() {};
 
     var input = $(inputSelector);
     var buttons = buttonSelectors.map(initializeButton);
-    var initiallySelected = initializeButton(selectedSelector);
 
     buttons.forEach(function(button) {
       button.element.click(function() {
@@ -74,9 +72,6 @@ window.ST = window.ST || {};
         callback(button.selector, button.element);
       });
     });
-
-    // Initial selection
-    select(initiallySelected, input, buttons);
   };
 
   exports.initializeRadioButtons = initialize;

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -1675,42 +1675,8 @@ input[type=text].delivery-price-field {
 
 .testimonial-form, .conversation-status-form, .payment-form {
 
-  a.grade, a.conversation-action {
-    color: $body;
-    cursor: pointer;
-    position: relative;
-    display: block;
-    width: 100%;
-    @include border-radius(em(5));
-    border: 2px solid $border;
-    &:hover { background: $highlight; }
-    margin-bottom: lines(0.25);
-    .link-icon {
-      position: absolute;
-      top: em(8);
-      left: em(12);
-    }
-    .link-text {
-      margin-left: em(40);
-      margin-right: lines(1.5);
-      padding: em(6) 0 em(10) 0;
-    }
-  }
-
   a.hidden, div.hidden {
     display: none;
-  }
-
-  a.positive, a.accept, a.confirm {
-    color: $green;
-    background: lighten($green, 40%);
-    &:hover { background: lighten($green, 40%); }
-  }
-
-  a.negative, a.reject, a.cancel {
-    color: $red;
-    background: lighten($red, 40%);
-    &:hover { background: lighten($red, 40%); }
   }
 
   span.currency-symbol {

--- a/app/assets/stylesheets/partials/radio_buttons.css.scss
+++ b/app/assets/stylesheets/partials/radio_buttons.css.scss
@@ -1,0 +1,37 @@
+@import "mixins/all";
+
+.radio-button {
+  color: $body;
+  cursor: pointer;
+  position: relative;
+  display: block;
+  width: 100%;
+  @include border-radius(em(5));
+  border: 2px solid $border;
+  &:hover { background: $highlight; }
+  margin-bottom: lines(0.25);
+}
+
+.radio-button-icon {
+  position: absolute;
+  top: em(8);
+  left: em(12);
+}
+
+.radio-button-label {
+  margin-left: em(40);
+  margin-right: lines(1.5);
+  padding: em(6) 0 em(10) 0;
+}
+
+.radio-button-positive.radio-button-selected {
+  color: $green;
+  background: lighten($green, 40%);
+  &:hover { background: lighten($green, 40%); }
+}
+
+.radio-button-negative.radio-button-selected {
+  color: $red;
+  background: lighten($red, 40%);
+  &:hover { background: lighten($red, 40%); }
+}

--- a/app/assets/stylesheets/partials/radio_buttons.css.scss
+++ b/app/assets/stylesheets/partials/radio_buttons.css.scss
@@ -24,14 +24,22 @@
   padding: em(6) 0 em(10) 0;
 }
 
-.radio-button-positive.radio-button-selected {
-  color: $green;
-  background: lighten($green, 40%);
-  &:hover { background: lighten($green, 40%); }
+.radio-button-positive {
+  @extend .radio-button;
+
+  &.radio-button-selected {
+    color: $green;
+    background: lighten($green, 40%);
+    &:hover { background: lighten($green, 40%); }
+  }
 }
 
-.radio-button-negative.radio-button-selected {
-  color: $red;
-  background: lighten($red, 40%);
-  &:hover { background: lighten($red, 40%); }
+.radio-button-negative {
+  @extend .radio-button;
+
+  &.radio-button-selected {
+    color: $red;
+    background: lighten($red, 40%);
+    &:hover { background: lighten($red, 40%); }
+  }
 }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -430,14 +430,6 @@ class Person < ActiveRecord::Base
     conversation.participations.where(["person_id LIKE ?", self.id]).first.update_attribute(:is_read, true)
   end
 
-  def grade_amounts
-    grade_amounts = []
-    Testimonial::GRADES.each_with_index do |grade, index|
-      grade_amounts[Testimonial::GRADES.size - 1 - index] = [grade[0], received_testimonials.where(:grade => grade[1][:db_value]).count, grade[1][:form_value]]
-    end
-    return grade_amounts
-  end
-
   def consent(community)
     community_memberships.find_by_community_id(community.id).consent
   end

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -21,11 +21,6 @@
 
 class Testimonial < ActiveRecord::Base
 
-  GRADES = [
-    [ "positive", { :form_value => "5", :db_value => 1, :default => false, :icon => "like" } ],
-    [ "negative", { :form_value => "1", :db_value => 0, :default => false, :icon => "dislike" } ]
-  ]
-
   belongs_to :author, :class_name => "Person"
   belongs_to :receiver, :class_name => "Person"
   belongs_to :tx, class_name: "Transaction", foreign_key: "transaction_id"

--- a/app/views/accept_conversations/accept.haml
+++ b/app/views/accept_conversations/accept.haml
@@ -32,10 +32,10 @@
 
     %input.js-accept-status{type: :hidden, name: "listing_conversation[status]", value: @action == "accept" ? "accepted" : "rejected" }
 
-    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accepted" }, class: @action == "accept" ? "radio-button-selected" : "" }
+    %a.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accepted" }, class: @action == "accept" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("accepted")}
       .radio-button-label= t("conversations.accept.accept_request")
-    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" }, class: @action == "reject" ? "radio-button-selected" : "" }
+    %a.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" }, class: @action == "reject" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("rejected")}
       .radio-button-label= t("conversations.accept.reject_request")
 

--- a/app/views/accept_conversations/accept.haml
+++ b/app/views/accept_conversations/accept.haml
@@ -2,6 +2,28 @@
 - content_for :javascript do
   initialize_accept_transaction_form(#{@current_community.commission_from_seller || "null"}, #{APP_CONFIG.service_fee_tax_percentage || "0"}, '#{@current_community.invoice_form_type_for(@listing_conversation.listing)}', '#edit_transaction_#{@listing_conversation.id.to_s}', #{@current_community.absolute_minimum_price(@listing_conversation.listing.currency).cents}, "#{Money::Currency.new(@listing_conversation.listing.currency).subunit_to_unit}", "#{t('conversations.accept.minimum_price_error_message', :amount => humanized_money_with_symbol(@current_community.absolute_minimum_price(@listing_conversation.listing.currency)))}");
 
+- content_for :extra_javascript do
+  :javascript
+    ST.initializeRadioButtons({
+      buttons: [".js-accept-radio-button", ".js-reject-radio-button"],
+      input: ".js-accept-status",
+      selected: ".js-#{@action}-radio-button",
+      callback: function(selector) {
+        $(".hidden-accept-form").addClass('hidden');
+        $(".conversation-price").addClass('hidden');
+        switch(selector) {
+          case ".js-accept-radio-button":
+            $(".accept-price").removeClass('hidden');
+            $(".visible-when-accept").removeClass('hidden');
+          break;
+          case ".js-reject-radio-button":
+            $(".reject-price").removeClass('hidden');
+            $(".visible-when-reject").removeClass('hidden');
+          break;
+        }
+      }
+    });
+
 - content_for :title_header do
   %h1= t("layouts.no_tribe.inbox")
 
@@ -9,13 +31,14 @@
   %h2= t("conversations.accept.respond_to_request")
   = form_for @listing_conversation, :url => acceptance_person_message_path(:person_id => @current_user.id, :id => @listing_conversation.id), :html => { :method => "put" } do |form|
 
-    .conversation-action
-      - ["accept", "reject"].each do |action|
-        %label{:for => "action-#{action}", :class => "radio hidden"}
-          = radio_button_tag "listing_conversation[status]", "#{action}ed", @action.eql?(action), :id => "action-#{action}"
-        %a.conversation-action.hidden{:id => "#{action}", :name => "#{action}-link", :class => (@action.eql?(action) ? action : "")}
-          .link-icon{:class => icon_for("#{action}ed")}
-          .link-text{:id => "#{action}-action-link"}= t("conversations.accept.#{action}_request")
+    %input.js-accept-status{type: :hidden, name: "listing_conversation[status]"}
+
+    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accepted" } }
+      .radio-button-icon{class: icon_for("accepted")}
+      .radio-button-label= t("conversations.accept.accept_request")
+    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" } }
+      .radio-button-icon{class: icon_for("rejected")}
+      .radio-button-label= t("conversations.accept.reject_request")
 
     - if @payout_registration_missing
       .hidden-accept-form.visible-when-accept{:class => (@action.eql?("accept") ? "" : "hidden")}

--- a/app/views/accept_conversations/accept.haml
+++ b/app/views/accept_conversations/accept.haml
@@ -7,7 +7,6 @@
     ST.initializeRadioButtons({
       buttons: [".js-accept-radio-button", ".js-reject-radio-button"],
       input: ".js-accept-status",
-      selected: ".js-#{@action}-radio-button",
       callback: function(selector) {
         $(".hidden-accept-form").addClass('hidden');
         $(".conversation-price").addClass('hidden');
@@ -31,12 +30,12 @@
   %h2= t("conversations.accept.respond_to_request")
   = form_for @listing_conversation, :url => acceptance_person_message_path(:person_id => @current_user.id, :id => @listing_conversation.id), :html => { :method => "put" } do |form|
 
-    %input.js-accept-status{type: :hidden, name: "listing_conversation[status]"}
+    %input.js-accept-status{type: :hidden, name: "listing_conversation[status]", value: @action == "accept" ? "accepted" : "rejected" }
 
-    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accepted" } }
+    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accepted" }, class: @action == "accept" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("accepted")}
       .radio-button-label= t("conversations.accept.accept_request")
-    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" } }
+    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" }, class: @action == "reject" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("rejected")}
       .radio-button-label= t("conversations.accept.reject_request")
 

--- a/app/views/accept_preauthorized_conversations/accept.haml
+++ b/app/views/accept_preauthorized_conversations/accept.haml
@@ -113,10 +113,10 @@
 
     %input.js-accept-status{type: :hidden, name: "listing_conversation[status]", value: preselected_action == "accept" ? "paid" : "rejected"}
 
-    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "paid" }, class: preselected_action == "accept" ? "radio-button-selected" : "" }
+    %a.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "paid" }, class: preselected_action == "accept" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("accepted")}
       .radio-button-label= t("conversations.accept.accept_request")
-    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" }, class: preselected_action == "reject" ? "radio-button-selected" : "" }
+    %a.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" }, class: preselected_action == "reject" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("rejected")}
       .radio-button-label= t("conversations.accept.reject_request")
 

--- a/app/views/accept_preauthorized_conversations/accept.haml
+++ b/app/views/accept_preauthorized_conversations/accept.haml
@@ -6,19 +6,21 @@
     (function() {
       var btn = $('#send_testimonial_button');
 
-      $('#accept').click(function() {
-        btn.text('#{t("conversations.accept.accept")}');
-      });
-
-      $('#reject').click(function() {
-        btn.text('#{t("conversations.accept.decline")}');
-      });
-
       btn.click(function() {
         disable_and_submit("#accept-reject-form", $("#accept-reject-form"), "false", '#{I18n.locale}');
       })
 
-      style_action_selectors();
+      ST.initializeRadioButtons({
+        buttons: [".js-accept-radio-button", ".js-reject-radio-button"],
+        input: ".js-accept-status",
+        selected: ".js-#{preselected_action}-radio-button",
+        callback: function(selector) {
+          switch(selector) {
+            case ".js-accept-radio-button": btn.text('#{t("conversations.accept.accept")}'); break;
+            case ".js-reject-radio-button": btn.text('#{t("conversations.accept.decline")}'); break;
+          }
+        }
+      })
     })();
 .conversation-status-form.centered-section
   %h2= t("conversations.accept.details")
@@ -110,18 +112,14 @@
 
   = form_for form, :url => form_action, :html => { id: "accept-reject-form", :method => "put" } do |form|
 
-    .conversation-action
-      %label{:for => "action-accept", :class => "radio hidden"}
-        = radio_button_tag "listing_conversation[status]", "paid", preselected_action.eql?("accept"), :id => "accept-link"
-      %a.conversation-action{:id => "accept", :name => "accept-link", :class => (preselected_action.eql?("accept") ? "accept" : "")}
-        .link-icon{:class => icon_for("accepted")}
-        .link-text{:id => "accept-action-link"}= t("conversations.accept.accept_request")
+    %input.js-accept-status{type: :hidden, name: "listing_conversation[status]"}
 
-      %label{:for => "action-reject", :class => "radio hidden"}
-        = radio_button_tag "listing_conversation[status]", "rejected", preselected_action.eql?("reject"), :id => "reject-link"
-      %a.conversation-action{:id => "reject", :name => "reject-link", :class => (preselected_action.eql?("reject") ? "reject" : "")}
-        .link-icon{:class => icon_for("rejected")}
-        .link-text{:id => "reject-action-link"}= t("conversations.accept.reject_request")
+    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "paid" } }
+      .radio-button-icon{class: icon_for("accepted")}
+      .radio-button-label= t("conversations.accept.accept_request")
+    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" } }
+      .radio-button-icon{class: icon_for("rejected")}
+      .radio-button-label= t("conversations.accept.reject_request")
 
     %div
       = fields_for "listing_conversation[message_attributes]", Message.new do |message_form|

--- a/app/views/accept_preauthorized_conversations/accept.haml
+++ b/app/views/accept_preauthorized_conversations/accept.haml
@@ -13,7 +13,6 @@
       ST.initializeRadioButtons({
         buttons: [".js-accept-radio-button", ".js-reject-radio-button"],
         input: ".js-accept-status",
-        selected: ".js-#{preselected_action}-radio-button",
         callback: function(selector) {
           switch(selector) {
             case ".js-accept-radio-button": btn.text('#{t("conversations.accept.accept")}'); break;
@@ -112,12 +111,12 @@
 
   = form_for form, :url => form_action, :html => { id: "accept-reject-form", :method => "put" } do |form|
 
-    %input.js-accept-status{type: :hidden, name: "listing_conversation[status]"}
+    %input.js-accept-status{type: :hidden, name: "listing_conversation[status]", value: preselected_action == "accept" ? "paid" : "rejected"}
 
-    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "paid" } }
+    %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "paid" }, class: preselected_action == "accept" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("accepted")}
       .radio-button-label= t("conversations.accept.accept_request")
-    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" } }
+    %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "rejected" }, class: preselected_action == "reject" ? "radio-button-selected" : "" }
       .radio-button-icon{class: icon_for("rejected")}
       .radio-button-label= t("conversations.accept.reject_request")
 

--- a/app/views/confirm_conversations/confirm.haml
+++ b/app/views/confirm_conversations/confirm.haml
@@ -1,5 +1,24 @@
-- content_for :javascript do
-  initialize_confirm_transaction_form();
+- content_for :extra_javascript do
+  :javascript
+    (function() {
+      ST.initializeRadioButtons({
+        buttons: [".js-confirm-radio-button", ".js-cancel-radio-button"],
+        input: ".js-confirmation-status",
+        selected: ".js-#{action_type}-radio-button",
+        callback: function(selector) {
+          switch(selector) {
+            case ".js-confirm-radio-button":
+            $(".confirm-description").removeClass("hidden");
+            $(".cancel-description").addClass("hidden");
+            break;
+            case ".js-cancel-radio-button":
+            $(".cancel-description").removeClass("hidden");
+            $(".confirm-description").addClass("hidden");
+            break;
+          }
+        }
+      })
+    })();
 
 - content_for :title_header do
   %h1= t("layouts.no_tribe.inbox")
@@ -8,20 +27,20 @@
   = form_for form, :url => confirmation_person_message_path(:person_id => @current_user.id, :id => listing_transaction[:id]), :html => { :method => "put" } do |form|
     - if can_be_confirmed
 
-      .conversation-action
-        - ["confirm", "cancel"].each do |action|
-          %label{:for => "action-#{action}", :class => "radio hidden"}
-            = radio_button_tag "status", action, action_type.eql?(action), :id => "action-#{action}"
-          %a.conversation-action.hidden{:id => "#{action}", :name => "#{action}-link", :class => (action_type.eql?(action) ? action : "")}
-            .link-icon{:class => icon_for("#{action}ed")}
-            .link-text{:id => "#{action}-action-link"}= t("conversations.confirm.#{action}")
+      %input.js-confirmation-status{type: :hidden, name: "transaction[status]"}
+
+      %a.radio-button.radio-button-positive.js-confirm-radio-button{ data: { :"radio-button-value" => "confirmed" } }
+        .radio-button-icon{class: icon_for("confirmed")}
+        .radio-button-label= t("conversations.confirm.confirm")
+      %a.radio-button.radio-button-negative.js-cancel-radio-button{ data: { :"radio-button-value" => "canceled" } }
+        .radio-button-icon{class: icon_for("canceled")}
+        .radio-button-label= t("conversations.confirm.cancel")
 
       .conversation-action-description
-        - ["confirm", "cancel"].each do |action|
-          %div{:class => "#{action}-description #{action_type.eql?(action) ? '' : 'hidden'}"}
-            = t("conversations.confirm.#{action}_description")
-
-      = form.hidden_field :status, :value => "#{action_type}ed"
+        %div{:class => "confirm-description #{action_type.eql?('confirm') ? '' : 'hidden'}"}
+          = t("conversations.confirm.confirm_description")
+        %div{:class => "cancel-description #{action_type.eql?('cancel') ? '' : 'hidden'}"}
+          = t("conversations.confirm.cancel_description")
 
     - else
 

--- a/app/views/confirm_conversations/confirm.haml
+++ b/app/views/confirm_conversations/confirm.haml
@@ -28,10 +28,10 @@
 
       %input.js-confirmation-status{type: :hidden, name: "transaction[status]", value: action_type == "confirm" ? "confirmed" : "canceled"}
 
-      %a#confirm-action-link.radio-button.radio-button-positive.js-confirm-radio-button{ data: { :"radio-button-value" => "confirmed" }, class: action_type == "confirm" ? "radio-button-selected" : "" }
+      %a#confirm-action-link.radio-button-positive.js-confirm-radio-button{ data: { :"radio-button-value" => "confirmed" }, class: action_type == "confirm" ? "radio-button-selected" : "" }
         .radio-button-icon{class: icon_for("confirmed")}
         .radio-button-label= t("conversations.confirm.confirm")
-      %a#cancel-action-link.radio-button.radio-button-negative.js-cancel-radio-button{ data: { :"radio-button-value" => "canceled" }, class: action_type == "cancel" ? "radio-button-selected" : "" }
+      %a#cancel-action-link.radio-button-negative.js-cancel-radio-button{ data: { :"radio-button-value" => "canceled" }, class: action_type == "cancel" ? "radio-button-selected" : "" }
         .radio-button-icon{class: icon_for("canceled")}
         .radio-button-label= t("conversations.confirm.cancel")
 

--- a/app/views/confirm_conversations/confirm.haml
+++ b/app/views/confirm_conversations/confirm.haml
@@ -28,10 +28,10 @@
 
       %input.js-confirmation-status{type: :hidden, name: "transaction[status]", value: action_type == "confirm" ? "confirmed" : "canceled"}
 
-      %a.radio-button.radio-button-positive.js-confirm-radio-button{ data: { :"radio-button-value" => "confirmed" }, class: action_type == "confirm" ? "radio-button-selected" : "" }
+      %a#confirm-action-link.radio-button.radio-button-positive.js-confirm-radio-button{ data: { :"radio-button-value" => "confirmed" }, class: action_type == "confirm" ? "radio-button-selected" : "" }
         .radio-button-icon{class: icon_for("confirmed")}
         .radio-button-label= t("conversations.confirm.confirm")
-      %a.radio-button.radio-button-negative.js-cancel-radio-button{ data: { :"radio-button-value" => "canceled" }, class: action_type == "cancel" ? "radio-button-selected" : "" }
+      %a#cancel-action-link.radio-button.radio-button-negative.js-cancel-radio-button{ data: { :"radio-button-value" => "canceled" }, class: action_type == "cancel" ? "radio-button-selected" : "" }
         .radio-button-icon{class: icon_for("canceled")}
         .radio-button-label= t("conversations.confirm.cancel")
 

--- a/app/views/confirm_conversations/confirm.haml
+++ b/app/views/confirm_conversations/confirm.haml
@@ -4,7 +4,6 @@
       ST.initializeRadioButtons({
         buttons: [".js-confirm-radio-button", ".js-cancel-radio-button"],
         input: ".js-confirmation-status",
-        selected: ".js-#{action_type}-radio-button",
         callback: function(selector) {
           switch(selector) {
             case ".js-confirm-radio-button":
@@ -27,12 +26,12 @@
   = form_for form, :url => confirmation_person_message_path(:person_id => @current_user.id, :id => listing_transaction[:id]), :html => { :method => "put" } do |form|
     - if can_be_confirmed
 
-      %input.js-confirmation-status{type: :hidden, name: "transaction[status]"}
+      %input.js-confirmation-status{type: :hidden, name: "transaction[status]", value: action_type == "confirm" ? "confirmed" : "canceled"}
 
-      %a.radio-button.radio-button-positive.js-confirm-radio-button{ data: { :"radio-button-value" => "confirmed" } }
+      %a.radio-button.radio-button-positive.js-confirm-radio-button{ data: { :"radio-button-value" => "confirmed" }, class: action_type == "confirm" ? "radio-button-selected" : "" }
         .radio-button-icon{class: icon_for("confirmed")}
         .radio-button-label= t("conversations.confirm.confirm")
-      %a.radio-button.radio-button-negative.js-cancel-radio-button{ data: { :"radio-button-value" => "canceled" } }
+      %a.radio-button.radio-button-negative.js-cancel-radio-button{ data: { :"radio-button-value" => "canceled" }, class: action_type == "cancel" ? "radio-button-selected" : "" }
         .radio-button-icon{class: icon_for("canceled")}
         .radio-button-label= t("conversations.confirm.cancel")
 

--- a/app/views/design/design.haml
+++ b/app/views/design/design.haml
@@ -618,7 +618,30 @@
 
         stripe.show(0);
 
+  .design-section
+    %h3.design-h3
+      = "Radio buttons"
+    .design-component
+      .design-example
+        .radio-button-value
+          %label
+            This input contains the radiobutton value
+          %input.js-radio-button-value
+          %br/
+          %br/
 
-      .design-code
-        %pre
-          :plain
+        .radio-buttons
+          %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accept"} }
+            .radio-button-icon{class: icon_for("accepted")}
+            .radio-button-label= t("conversations.accept.accept_request")
+          %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "reject"} }
+            .radio-button-icon{class: icon_for("rejected")}
+            .radio-button-label= t("conversations.accept.reject_request")
+
+        - content_for :extra_javascript do
+          :javascript
+            ST.initializeRadioButtons({
+              buttons: [".js-accept-radio-button", ".js-reject-radio-button"],
+              input: ".js-radio-button-value",
+              selected: ".js-accept-radio-button",
+              callback: function(sel, el) { console.log(sel, el) } });

--- a/app/views/design/design.haml
+++ b/app/views/design/design.haml
@@ -623,18 +623,21 @@
       = "Radio buttons"
     .design-component
       .design-example
+        / It's a good idea to use server rendering to render the initially selected value
+        - selected = "reject"
+
         .radio-button-value
           %label
             This input contains the radiobutton value
-          %input.js-radio-button-value
+          %input.js-radio-button-value{value: selected == "accept" ? "accept" : "reject" }
           %br/
           %br/
 
         .radio-buttons
-          %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accept"} }
+          %a.radio-button.radio-button-positive.js-accept-radio-button{ data: { :"radio-button-value" => "accept"}, class: selected == "accept" ? "radio-button-selected" : "" }
             .radio-button-icon{class: icon_for("accepted")}
             .radio-button-label= t("conversations.accept.accept_request")
-          %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "reject"} }
+          %a.radio-button.radio-button-negative.js-reject-radio-button{ data: { :"radio-button-value" => "reject"}, class: selected == "reject" ? "radio-button-selected" : "" }
             .radio-button-icon{class: icon_for("rejected")}
             .radio-button-label= t("conversations.accept.reject_request")
 
@@ -643,5 +646,4 @@
             ST.initializeRadioButtons({
               buttons: [".js-accept-radio-button", ".js-reject-radio-button"],
               input: ".js-radio-button-value",
-              selected: ".js-accept-radio-button",
               callback: function(sel, el) { console.log(sel, el) } });

--- a/app/views/testimonials/new.haml
+++ b/app/views/testimonials/new.haml
@@ -9,10 +9,16 @@
     = form.text_area :text, :placeholder => t(".default_textual_feedback")
     = form.label :grade, t(".grade")
     .feedback-grade
-      - Testimonial::GRADES.each do |grade|
-        %label{:for => "grade-#{grade[1][:form_value]}", :class => "radio hidden"}
-          = radio_button_tag "testimonial[grade]", grade[1][:db_value], grade[1][:default], :id => "grade-#{grade[1][:form_value]}"
-        %a.grade.hidden{:id => grade[0], :name => "grade-#{grade[1][:form_value]}"}
-          = icon_tag(grade[1][:icon], ["link-icon"])
-          .link-text{:id => "#{grade[0]}-grade-link"}= t(".#{grade[0]}")
+      %label{:for => "grade-5", :class => "radio hidden"}
+        = radio_button_tag "testimonial[grade]", 1, false, :id => "grade-5"
+      %a.grade.hidden{:id => "positive", :name => "grade-5"}
+        = icon_tag("like", ["link-icon"])
+        .link-text{:id => "positive-grade-link"}= t(".positive")
+
+      %label{:for => "grade-1", :class => "radio hidden"}
+        = radio_button_tag "testimonial[grade]", 0, false, :id => "grade-1"
+      %a.grade.hidden{:id => "negative", :name => "grade-1"}
+        = icon_tag("dislike", ["link-icon"])
+        .link-text{:id => "negative-grade-link"}= t(".negative")
+
     = form.button t(".send_feedback"), :class => "send_button", :id => "send_testimonial_button"

--- a/app/views/testimonials/new.haml
+++ b/app/views/testimonials/new.haml
@@ -18,11 +18,11 @@
 
     %input.js-testimonial-grade{type: :hidden, name: "testimonial[grade]"}
 
-    %a.radio-button.radio-button-positive.js-positive-radio-button{ data: { :"radio-button-value" => 1 } }
+    %a#positive-grade-link.radio-button.radio-button-positive.js-positive-radio-button{ data: { :"radio-button-value" => 1 } }
       .radio-button-icon
         = icon_tag("like", ["link-icon"])
       .radio-button-label= t(".positive")
-    %a.radio-button.radio-button-negative.js-negative-radio-button{ data: { :"radio-button-value" => 0 } }
+    %a#negative-grade-link.radio-button.radio-button-negative.js-negative-radio-button{ data: { :"radio-button-value" => 0 } }
       .radio-button-icon
         = icon_tag("dislike", ["link-icon"])
       .radio-button-label= t(".negative")

--- a/app/views/testimonials/new.haml
+++ b/app/views/testimonials/new.haml
@@ -1,5 +1,12 @@
 - content_for :javascript do
   initialize_give_feedback_form("#{I18n.locale}","#{t('error_messages.testimonials.you_must_select_a_grade')}","#{t('error_messages.testimonials.you_must_explain_not_neutral_feedback')}");
+
+- content_for :extra_javascript do
+  :javascript
+    ST.initializeRadioButtons({
+      buttons: [".js-positive-radio-button", ".js-negative-radio-button"],
+      input: ".js-testimonial-grade"
+    });
 .centered-section.testimonial-form
   %h2= t(".give_feedback_to", :person => transaction.other_party(@current_user).name(@current_community))
   %p= t(".this_will_be_shown_in_profile", :person => transaction.other_party(@current_user).given_name_or_username)
@@ -8,17 +15,16 @@
     = form.label :text, t('.textual_feedback')
     = form.text_area :text, :placeholder => t(".default_textual_feedback")
     = form.label :grade, t(".grade")
-    .feedback-grade
-      %label{:for => "grade-5", :class => "radio hidden"}
-        = radio_button_tag "testimonial[grade]", 1, false, :id => "grade-5"
-      %a.grade.hidden{:id => "positive", :name => "grade-5"}
-        = icon_tag("like", ["link-icon"])
-        .link-text{:id => "positive-grade-link"}= t(".positive")
 
-      %label{:for => "grade-1", :class => "radio hidden"}
-        = radio_button_tag "testimonial[grade]", 0, false, :id => "grade-1"
-      %a.grade.hidden{:id => "negative", :name => "grade-1"}
+    %input.js-testimonial-grade{type: :hidden, name: "testimonial[grade]"}
+
+    %a.radio-button.radio-button-positive.js-positive-radio-button{ data: { :"radio-button-value" => 1 } }
+      .radio-button-icon
+        = icon_tag("like", ["link-icon"])
+      .radio-button-label= t(".positive")
+    %a.radio-button.radio-button-negative.js-negative-radio-button{ data: { :"radio-button-value" => 0 } }
+      .radio-button-icon
         = icon_tag("dislike", ["link-icon"])
-        .link-text{:id => "negative-grade-link"}= t(".negative")
+      .radio-button-label= t(".negative")
 
     = form.button t(".send_feedback"), :class => "send_button", :id => "send_testimonial_button"


### PR DESCRIPTION

![screen shot 2016-03-08 at 16 30 24](https://cloud.githubusercontent.com/assets/429876/13604400/1e6e5876-e54b-11e5-948d-d465f76f4e6a.png)


The radio buttons had some issues: A customer reported that if he tries to accept a transaction and clicks the buttons back and forth, the wrong action is executed when he sends the form.

Here are steps to reproduce:

1. create a transaction and pay to send request to seller
1. log in as seller
1. open inbox
1. open transaction conversation thread by clicking message "Payment authorized..." then (from customer) after clicking on "Accept request" and "Send reply“ the Order Details window opens. In this window "Accept the request" is automatically chosen but when you switch to „Not this time“ without accepting but immediately switch back to „Accept the request" and then push the „Accept“ button to confirm it, the request gets rejected, but it should get confirmed.

In addition to that, the code needed refactoring. It had several short comings:

1. Relied on global DOM class names, that might be different per each view
2. Wrong abstractions (the icon to use in testimonials view was defined in the Testimonials Model)
3. Over using DRY: ["confirm", "cancel"].each { ... complicated code with a lot of string concatenations } instead of just simply duplicating.