### PR TITLE
Add possible youtube embeds at the end of the listing's description

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,6 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
   TargetRubyVersion: 2.1
+
+Style/RegexpLiteral:
+  Enabled: false

--- a/app/assets/stylesheets/views/_listings.css.scss
+++ b/app/assets/stylesheets/views/_listings.css.scss
@@ -7,6 +7,22 @@
   word-wrap: break-word;
 }
 
+.listing-description-youtube-wrapper {
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 */
+  position: relative;
+  margin-bottom:lines(1);
+}
+.listing-description-youtube-iframe {
+  width:100%;
+  height:100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 // Social buttons
 .listing-social {
   @include clearfix();

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -186,6 +186,8 @@ class ListingsController < ApplicationController
     received_positive_testimonials = TestimonialViewUtils.received_positive_testimonials_in_community(@listing.author, @current_community)
     feedback_positive_percentage = @listing.author.feedback_positive_percentage_in_community(@current_community)
 
+    youtube_link_ids = feature_enabled?(:youtube_embeds) ? youtube_video_ids(@listing.description) : []
+
     render locals: {
              form_path: form_path,
              payment_gateway: payment_gateway,
@@ -196,7 +198,8 @@ class ListingsController < ApplicationController
              country_code: community_country_code,
              received_testimonials: received_testimonials,
              received_positive_testimonials: received_positive_testimonials,
-             feedback_positive_percentage: feedback_positive_percentage
+             feedback_positive_percentage: feedback_positive_percentage,
+             youtube_link_ids: youtube_link_ids
            }
   end
 

--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -135,4 +135,13 @@ module ListingsHelper
   def action_button_label(listing)
     t(listing.action_button_tr_key)
   end
+
+  def youtube_video_ids(text)
+    text.scan(/https?:\/\/\S+/).map { |l| youtube_video_id(l) }.compact
+  end
+
+  def youtube_video_id(link)
+    pattern = /^.*(?:(?:youtu\.be\/|youtu.*v\/|youtu.*embed\/)|youtu.*(?:\?v=|\&v=))([^#\&\?]*).*/
+    Maybe(pattern.match(link))[1].or_else(nil)
+  end
 end

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -13,6 +13,7 @@ module FeatureFlagService::Store
       :new_search,
       :only_gtm,
       :customer_universal_analytics,
+      :youtube_embeds,
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/views/listings/form/_description.haml
+++ b/app/views/listings/form/_description.haml
@@ -1,2 +1,4 @@
-= form.label :description, t('.detailed_description'), :class => "input"
+= form.label :description, t('listings.form.description.detailed_description'), :class => "input"
+- if(feature_enabled?(:youtube_embeds))
+  = render partial: "layouts/info_text", locals: { text: t("listings.form.description.youtube_info") }
 = form.text_area(:description, :maxlength => "5000", :class => "listing_description_textarea")

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -71,6 +71,12 @@
         - if @listing.description && !@listing.description.blank?
           - text_with_line_breaks do
             = @listing.description
+          - if(feature_enabled?(:youtube_embeds))
+            - ids = youtube_video_ids(@listing.description)
+            - if(ids.present?)
+              - ids.each do |youtube_id|
+                .listing-description-youtube-wrapper
+                  %iframe.listing-description-youtube-iframe{ title: t("listings.show.youtube_video_player"), width: 640, height:390, src: "//www.youtube.com/embed/#{ youtube_id }", frameborder: 0, allowfullscreen: true}
 
     - @listing.custom_field_values.each do |custom_field_value|
       .row

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -72,9 +72,8 @@
           - text_with_line_breaks do
             = @listing.description
           - if(feature_enabled?(:youtube_embeds))
-            - ids = youtube_video_ids(@listing.description)
-            - if(ids.present?)
-              - ids.each do |youtube_id|
+            - if(youtube_link_ids.present?)
+              - youtube_link_ids.each do |youtube_id|
                 .listing-description-youtube-wrapper
                   %iframe.listing-description-youtube-iframe{ title: t("listings.show.youtube_video_player"), width: 640, height:390, src: "//www.youtube.com/embed/#{ youtube_id }", frameborder: 0, allowfullscreen: true}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1673,6 +1673,7 @@ en:
       shipping_price_additional: "Shipping (+%{price}, additional items: +%{shipping_price_additional})"
       pickup: Pickup
       pickup_no_price: Pickup
+      youtube_video_player: "YouTube video player"
     unit_types:
       piece: piece
       hour: hour

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1472,6 +1472,7 @@ en:
         repeated: "Repeated (add times and days in the field 'detailed description')"
       description:
         detailed_description: "Detailed description"
+        youtube_info: "If your description contains YouTube links, the videos will be shown below the description."
       destination:
         destination: Destination
       form_content:

--- a/spec/helpers/listings_helper_spec.rb
+++ b/spec/helpers/listings_helper_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+RSpec.describe ListingsHelper, type: :helper do
+
+  VALID_URLS = [
+      'http://www.youtube.com/watch?v=UffchBUUIoI',
+      'http://www.youtube.com/watch?v=UffchBUUIoI&feature=channel',
+      'http://www.youtube.com/watch?v=hpokm-pMaHg&playnext_from=TL&videos=osPknwzXEas&feature=sub',
+      'http://www.youtube.com/watch?v=BM7FWtADD0s&feature=youtube_gdata_player',
+      'https://www.youtube.com/watch?v=Kk8Mclb_LSw&feature=youtu.be',
+      'http://www.youtube.com/embed/UffchBUUIoI?rel=0',
+      'http://youtube.com/?v=BM7FWtADD0s&feature=youtube_gdata_player',
+      'http://youtube.com/watch?v=BM7FWtADD0s&feature=youtube_gdata_player',
+      'http://youtube.com/v/BM7FWtADD0s?feature=youtube_gdata_player',
+      'http://youtu.be/BM7FWtADD0s?feature=youtube_gdata_player',
+      'https://youtu.be/Kk8Mclb_LSw',
+      'http://youtu.be/hpokm-pMaHg'
+  ]
+
+  describe "#youtube_video_id" do
+    it "returns nil for strings that doesn't contain youtube_video_id" do
+      expect(helper.youtube_video_id("youtube.com")).to eq(nil)
+      expect(helper.youtube_video_id("example.com/?v=UffchBUUIoI")).to eq(nil)
+      expect(helper.youtube_video_id("example.com/embed/UffchBUUIoI")).to eq(nil)
+      expect(helper.youtube_video_id("example.com/v/BM7FWtADD0s")).to eq(nil)
+    end
+
+    it "returns an id if youtube link is given" do
+      VALID_RETURN_IDS = [
+        'UffchBUUIoI',
+        'hpokm-pMaHg',
+        'Kk8Mclb_LSw',
+        'BM7FWtADD0s'
+      ]
+
+      VALID_URLS.each {|url|
+        expect(VALID_RETURN_IDS).to include helper.youtube_video_id(url)
+      }
+    end
+  end
+
+  describe "#youtube_video_ids" do
+    it "does not return youtube ids if there ain't any" do
+      lorem = "Lorem ipsum consectetur adepisci velit"
+      expect(helper.youtube_video_ids(lorem)).to be_empty
+
+      httpasdf = "Lorem ipsum httpasdf consectetur adepisci velit"
+      expect(helper.youtube_video_ids(httpasdf)).to be_empty
+
+      vimeo = "Lorem ipsum http://vimeo.com?v=BM7FWtADD0s consectetur adepisci velit"
+      expect(helper.youtube_video_ids(vimeo)).to be_empty
+    end
+
+    it "returns youtube ids when there are valid urls among texts" do
+      expected_ids = [
+        "UffchBUUIoI",
+        "UffchBUUIoI",
+        "hpokm-pMaHg",
+        "BM7FWtADD0s",
+        "Kk8Mclb_LSw",
+        "UffchBUUIoI",
+        "BM7FWtADD0s",
+        "BM7FWtADD0s",
+        "BM7FWtADD0s",
+        "BM7FWtADD0s",
+        "Kk8Mclb_LSw",
+        "hpokm-pMaHg"]
+
+      expect(helper.youtube_video_ids(VALID_URLS.join(' '))).to eq(expected_ids)
+    end
+  end
+end


### PR DESCRIPTION
Embeds at the end of description, the second column

I chose this one to be initial suggestion over embed-videos-inside-description-texts option because:
- It doesn't break the form of description, written and designed by user
- It doesn't loose the last part of the description - push it below the fold (embeds take quite much space)
- It is more future proof: we can get rid of these embeds without breaking users descriptions (sellers have not written descriptions with a mindset that there are going to be embeds inside the text part)
- It looks better than embedding lots of Youtube videos into the beginning of the description area.


![embeds_first_last_inside](https://cloud.githubusercontent.com/assets/717315/13613115/5b26aac0-e573-11e5-8198-e6c6121bee41.jpg)
