### PR TITLE
Take orientation into account when determining image dimensions

### DIFF
--- a/app/models/listing_image.rb
+++ b/app/models/listing_image.rb
@@ -104,6 +104,8 @@ class ListingImage < ActiveRecord::Base
     end
 
     geometry = Paperclip::Geometry.from_file(path_or_url)
+    geometry.auto_orient
+    geometry
   end
 
   def authorized?(user)


### PR DESCRIPTION
The dimensions we save to DB didn't seem to take into account orientation data in EXIF headers, resulting in misinformed cropping decisions. This should fix it.

Before:
<img width="747" alt="screenshot 2016-03-09 17 02 01" src="https://cloud.githubusercontent.com/assets/432030/13639273/c2209bbe-e618-11e5-84aa-719410dff02a.png">

After:
<img width="751" alt="screenshot 2016-03-09 17 01 55" src="https://cloud.githubusercontent.com/assets/432030/13639282/c97d0686-e618-11e5-8220-8ef8cde135cc.png">
