### PR TITLE
Try to fix the failing test

### DIFF
--- a/features/listings/user_edits_his_own_listing.feature
+++ b/features/listings/user_edits_his_own_listing.feature
@@ -18,7 +18,7 @@ Feature: User edits his own listing
     And I log in as "kassi_testperson1"
     When I follow "Hammer"
     And I follow "Edit listing"
-    Then I should see "Listing title*"
+    Then I should see the listing form
     When the "listing_title" field should contain "Hammer"
     And the "description" field should contain "test"
     And I fill in "listing_title" with "Sledgehammer"
@@ -46,7 +46,7 @@ Feature: User edits his own listing
     And I log in as "kassi_testperson1"
     When I follow "Hammer"
     And I follow "Edit listing"
-    Then I should see "Listing title*"
+    Then I should see the listing form
     When the "listing_title" field should contain "Hammer"
     And the "description" field should contain "test"
     And I fill in "listing_title" with "Sledgehammer"
@@ -64,7 +64,7 @@ Feature: User edits his own listing
     And I am logged in as "kassi_testperson1"
     When I follow "Hammer"
     And I follow "Edit listing" within "#listing-message-links"
-    Then I should see "Listing title*"
+    Then I should see the listing form
     When I fill in "listing_title" with ""
     And I set the expiration date to 7 months from now
     And I press "Save listing"
@@ -93,7 +93,7 @@ Feature: User edits his own listing
     And "kassi_testperson2" is superadmin
     When I follow "Hammer"
     And I follow "Edit listing"
-    Then I should see "Listing title*"
+    Then I should see the listing form
     When I fill in "listing_title" with "Sledgehammer"
     And I press "Save listing"
     Then I should see "Sledgehammer" within "#listing-title"
@@ -110,7 +110,7 @@ Feature: User edits his own listing
     And "kassi_testperson2" has admin rights in community "Test"
     When I follow "Hammer"
     And I follow "Edit listing"
-    Then I should see "Listing title*"
+    Then I should see the listing form
     When I fill in "listing_title" with "Sledgehammer"
     And I press "Save listing"
     Then I should see "Sledgehammer" within "#listing-title"

--- a/features/step_definitions/listing_steps.rb
+++ b/features/step_definitions/listing_steps.rb
@@ -306,3 +306,9 @@ def select_days_from_now(day_count)
   select_start_date(Date.today)
   select_end_date(@booking_end_date)
 end
+
+Then(/^I should see the listing form$/) do
+  # If the Listing title label is visible, we expect that the whole
+  # form is visible.
+  page.find("label", text: "Listing title*", visible: true)
+end

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -5,22 +5,24 @@ echo "SUITE: ${SUITE}"
 
 if [ "$SUITE" = "rspec" ]
 then
-	bundle exec rspec spec 2>&1
-	exit
+  bundle exec rspec spec 2>&1
+  exit
 elif [ "$SUITE" = "rubocop" ]
 then
-	bundle exec rubocop -R 2>&1
-	exit
+  bundle exec rubocop -R 2>&1
+  exit
 elif [ "$SUITE" = "cucumber" ]
 then
-	phantomjs --webdriver=8910 &
-	PHANTOMJS=true bundle exec cucumber -ptravis 2>&1
-	exit
+  echo "PhantomJS version:"
+  phantomjs --version
+  phantomjs --webdriver=8910 &
+  PHANTOMJS=true bundle exec cucumber -ptravis 2>&1
+  exit
 elif [ "$SUITE" = "jshint" ]
 then
-	grunt jshint 2>&1
-	exit
+  grunt jshint 2>&1
+  exit
 else
-	echo -e "Error: SUITE is illegal or not set\n"
-	exit 1
+  echo -e "Error: SUITE is illegal or not set\n"
+  exit 1
 fi


### PR DESCRIPTION
This Pull Request (hopefully!) fixes the randomly failing Cucumber test.

**Background:** When editing the listing, the form is rendered by the server, but it's contains a `hidden` class. When the JavaScript is execute, the script will remove the `hidden` class and show the form to the user.

The Cucumber tests need to wait until the form is loaded and visible, because Cucumber (to my understanding) can't interact with elements that are visible.

The waiting was implemented by adding an additional step `I should see "Listing Title*` before interacting with the form. However, as opposed to what I remembered, Cucumber CAN find elements that are not visible. Due to this, the guard assertion that was waiting the form to be visible didn't work and the test execution continued even though the form wasn't visible.

**Solution:** Implement new step that specifically says to Cucumber to only find the element when it's visible.

**How did I make sure that this really fixes the issue:**

I checked out the `master` branch and ran test file `features/listings/user_edits_his_own_listing.feature ; pz cucumber features/listings/user_edits_his_own_listing.feature` three times. Then I checked out the `fix-broken-test` branch and rerun it three times. Results:

* `master`, 15 specs in total (3 x 5): 2 specs failed
* `fix-broken-test` 15 specs in total (3 x 5): 0 failed