### PR TITLE
Add default queue name

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -39,4 +39,5 @@ Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_attempts = 3
 Delayed::Worker.max_run_time = APP_CONFIG.delayed_job_max_run_time.to_i.seconds
 Delayed::Worker.default_priority = 5
+Delayed::Worker.default_queue_name = "default"
 Delayed::Worker.plugins << DelayedJobLoggerPlugin


### PR DESCRIPTION
This Pull Requests adds a default queue name. The name for the queue is "default".

Adding a default queue name makes it possible to have two worker types, one that purges only the default queue and other that purges some other queue. This is useful for example if we want to add a separate queue for CSS compilations during the deployment.