### PR TITLE
Add new job queue "css_compile"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ## [Unreleased]
 
+### Added
+
+- Add new job queue (css_compile) for css compilations [#1815](https://github.com/sharetribe/sharetribe/pull/1815)
+
 ## [5.6.0] - 2016-03-11
 
 ### Added

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec passenger start -p $PORT --max-pool-size $PASSENGER_MAX_POOL_SIZE
-worker:  bundle exec rake jobs:work
-
+web:         bundle exec passenger start -p $PORT --max-pool-size $PASSENGER_MAX_POOL_SIZE
+worker:      bundle exec rake jobs:work --queue=default
+css_compile: bundle exec rake jobs:work --queue=css_compile

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web:         bundle exec passenger start -p $PORT --max-pool-size $PASSENGER_MAX_POOL_SIZE
-worker:      bundle exec rake jobs:work --queue=default
-css_compile: bundle exec rake jobs:work --queue=css_compile
+worker:      QUEUE=default bundle exec rake jobs:work
+css_compile: QUEUE=css_compile bundle exec rake jobs:work

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,6 +17,12 @@ rake assets:precompile
 
 ## Unreleased
 
+This release adds a new Delayed Job queue "css_compile". All CSS compilations during the deployment are added to this queue. However, CSS compilations triggered from the admin UI do NOT go into this queue, instead they are added to the "default" queue.
+
+A new worker is added to the Procfile to work for the new queue. If you're hosting in Heroku, you will see a new worker there.
+
+This change doesn't require any changes if you are compiling the stylesheets synchronously using the `rake sharetribe:generate_customization_stylesheets_immediately` command during the deployment. However, if you are compiling the stylesheets asynchronously using the `rake sharetribe:generate_customization_stylesheets` command, then you need to make sure that you have at least one worker working for the "css_compile" queue.
+
 ## Upgrade from 5.5.0 to 5.6.0
 
 Ruby version is updated from 2.1.8 to 2.2.4. The update should reduce memory usage and improve performance.

--- a/db/migrate/20160311070106_add_default_queue_name_to_delayed_jobs.rb
+++ b/db/migrate/20160311070106_add_default_queue_name_to_delayed_jobs.rb
@@ -1,0 +1,9 @@
+class AddDefaultQueueNameToDelayedJobs < ActiveRecord::Migration
+  def up
+    execute("UPDATE delayed_jobs SET queue = 'default'")
+  end
+
+  def down
+    execute("UPDATE delayed_jobs SET queue = NULL")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229114242) do
+ActiveRecord::Schema.define(version: 20160311070106) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255

--- a/lib/tasks/sharetribe.rake
+++ b/lib/tasks/sharetribe.rake
@@ -10,8 +10,7 @@ namespace :sharetribe do
   desc "Generates customized CSS stylesheets in the background"
   task :generate_customization_stylesheets => :environment do
     # If preboot in use, give 2 minutes time to load new code
-    delayed_opts = {priority: 10, :run_at => 2.minutes.from_now }
-    CommunityStylesheetCompiler.compile_all(delayed_opts)
+    CommunityStylesheetCompiler.compile_all(run_at: 2.minutes.from_now)
   end
 
   desc "Generates customized CSS stylesheets immediately"


### PR DESCRIPTION
This Pull Request adds a new job queue "css_compile". That queue is used for long running CSS compilations during the deploy.

Separating CSS compilations to own queue has some benefits:

* The CSS compilations are now completely isolated. They don't interfere the "default" job worker any way.
* CSS compilation workers can be scaled separately
* We can use different priorities for CSS queue

TODO:

- [x] Changelog and upgrade
- [X] Migration that adds "default" queue name for all existing jobs
- [X] Add the "css_compile" queue
- [X] Changes to Procfile

Merge this PR only after #1814 