### PR TITLE
Add queues to the default worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web:         bundle exec passenger start -p $PORT --max-pool-size $PASSENGER_MAX_POOL_SIZE
-worker:      bundle exec rake jobs:work
+worker:      QUEUES=default,paperclip,mailers bundle exec rake jobs:work
 css_compile: QUEUE=css_compile bundle exec rake jobs:work


### PR DESCRIPTION
Since we added another worker for css compilations, we want the default
worker to concentrate to other tasks.

Add list of queue names that the default worker will process.