### PR TITLE
Wait for .js-listing-form-ready class to be there

### DIFF
--- a/app/assets/javascripts/listing_form.js
+++ b/app/assets/javascripts/listing_form.js
@@ -530,6 +530,8 @@ window.ST = window.ST || {};
 
     set_textarea_maxlength();
     auto_resize_text_areas("listing_description_textarea");
+
+    $(form_id).addClass("js-listing-form-ready");
   };
 
 })(window.ST);

--- a/features/step_definitions/listing_steps.rb
+++ b/features/step_definitions/listing_steps.rb
@@ -308,7 +308,5 @@ def select_days_from_now(day_count)
 end
 
 Then(/^I should see the listing form$/) do
-  # If the Listing title label is visible, we expect that the whole
-  # form is visible.
-  page.find("label", text: "Listing title*", visible: true)
+  expect(page).to have_selector("form.js-listing-form-ready")
 end


### PR DESCRIPTION
New attempt to fix broken Cucumber tests.

Apparently, one reason for test failure was that the validator wasn't initialized before the test runner hit send button.

Now we add a class `.js-listing-form-ready` when the validator is initialized. Capybara will then wait until the class is there and move on with the test after that.