### PR TITLE
Auto logout, if user has an active session but belongs to other comm.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -187,9 +187,6 @@ class ApplicationController < ActionController::Base
   # community are all expired.
   def ensure_user_belongs_to_community
     if @current_user && @current_user.community_id != @current_community.id
-      sign_out
-      session[:person_id] = nil
-      flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
 
       logger.info(
         "Automatically logged out user that doesn't belong to community",
@@ -198,6 +195,10 @@ class ApplicationController < ActionController::Base
         current_community_id: @current_community.id,
         current_user_community_id: @current_user.community_id
       )
+
+      sign_out
+      session[:person_id] = nil
+      flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
 
       redirect_to root
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -190,6 +190,15 @@ class ApplicationController < ActionController::Base
       sign_out
       session[:person_id] = nil
       flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
+
+      logger.info(
+        "Automatically logged out user that doesn't belong to community",
+        :autologout,
+        current_user_id: @current_user.id,
+        current_community_id: @current_community.id,
+        current_user_community_id: @current_user.community_id
+      )
+
       redirect_to root
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
     :fetch_community_plan_expiration_status,
     :perform_redirect,
     :fetch_logged_in_user,
+    :ensure_user_belongs_to_community,
     :save_current_host_with_port,
     :fetch_community_membership,
     :redirect_removed_locale,
@@ -167,6 +168,29 @@ class ApplicationController < ActionController::Base
     if person_signed_in?
       @current_user = current_person
       setup_logger!(user_id: @current_user.id, username: @current_user.username)
+    end
+  end
+
+  # Ensure that user belongs to community,
+  # i.e. @current_user.community_id == @current_community.id
+  #
+  # This check is in most cases useless: When user logs in we already
+  # check that the user belongs to the community she is trying to log
+  # in. However, after the user account separation migration in March
+  # 2016, there was a possibility that user had an existing session
+  # which pointed to a person_id that belonged to another
+  # community. That's why we need to check the community membership
+  # even after logging in.
+  #
+  # This extra check can be removed when we are sure that all the
+  # sessions which potentially had a person_id pointing to another
+  # community are all expired.
+  def ensure_user_belongs_to_community
+    if @current_user && @current_user.community_id != @current_community.id
+      sign_out
+      session[:person_id] = nil
+      flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
+      redirect_to root
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1420,6 +1420,7 @@ en:
       payment_details_add_error: "Could not add payment details"
       listing_author_payment_details_missing: "Please contact the author by pressing the 'Contact' button below. They need to update their payment details to receive payments."
       stylesheet_needs_recompiling: "Stylesheet is recompiling. Please, reload the page after a while."
+      automatically_logged_out_please_sign_in: "You have been automatically logged out. Please sign in again."
     settings:
       account: Account
       notifications: Notifications


### PR DESCRIPTION
**Background:** When we run the migration that clones users, we might end up in a situation where user is logged in in a community with a person that actually doesn't belong to the community.

**Steps to reproduce:**

1. Checkout `master` branch
1. Create two communities, A and B
1. Create a user that joins to both communities
1. Leave the browser and the session open
1. Checkout the migration branch and run the migrations
1. Add a `binding.pry` breakpoint somewhere in the `application_controller` where you can inspect the `@current_user` value.
1. Go to marketplace A. When the breakpoint is hit, see the `@current_user.community_id` and remember it.
2. Go to marketplace B. When the breakpoint is hit, see the `@current_user.community_id` and remember it.

Expected result: In marketplace A, `@current_user.community_id` matches to A's id. In marketplace B, `@current_user.community_id` matches to B's id.

Actual result: One of the ids doesn't match.

**Solution:** After fetching the current user, we make sure that the community_id matches. If not, we will log out the user.