### PR TITLE
Maintenance mode warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ### Added
 
-- Add new job queue (css_compile) for css compilations [#1815](https://github.com/sharetribe/sharetribe/pull/1815)
+- Add a new job queue (css_compile) for css compilations [#1815](https://github.com/sharetribe/sharetribe/pull/1815)
+- Add a warning message which will be shown 15 minutes before the next scheduled maintenance [#1835](https://github.com/sharetribe/sharetribe/pull/1835)
 
 ## [5.6.0] - 2016-03-11
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,8 @@ class ApplicationController < ActionController::Base
     :fetch_community_admin_status,
     :warn_about_missing_payment_info,
     :set_homepage_path,
-    :report_queue_size
+    :report_queue_size,
+    :maintenance_warning
   before_filter :cannot_access_without_joining, :except => [ :confirmation_pending, :check_email_availability]
   before_filter :can_access_only_organizations_communities
   before_filter :check_email_confirmation, :except => [ :confirmation_pending, :check_email_availability_and_validity]
@@ -398,6 +399,12 @@ class ApplicationController < ActionController::Base
 
   def report_queue_size
     MonitoringService::Monitoring.report_queue_size
+  end
+
+  def maintenance_warning
+    now = Time.now
+    @show_maintenance_warning = NextMaintenance.show_warning?(15.minutes, now)
+    @minutes_to_maintenance = NextMaintenance.minutes_to(now)
   end
 
   private

--- a/app/utils/maintenance.rb
+++ b/app/utils/maintenance.rb
@@ -1,0 +1,54 @@
+class Maintenance
+
+  def initialize(env_value)
+    @next_maintenance_at = Maintenance.parse_time_from_env(env_value)
+  end
+
+  # Returns true if warning should be shown
+  #
+  # Usage:
+  # show_warning?(15.minutes, Time.now)
+  #
+  # Returns true if Time is within the "show before" timeframe or if the
+  # time is in the past
+  def show_warning?(show_before, now)
+    if @next_maintenance_at.nil?
+      false
+    else
+      now > (@next_maintenance_at - show_before)
+    end
+  end
+
+  # Returns time (in minutes) to the next maintenance
+  # Return 0 if the next maintenance is in the past or not scheduled
+  def minutes_to(now)
+    (time_to(now) / 60).floor
+  end
+
+  # Returns time (in seconds) to the next maintenance
+  # Return 0 if the next maintenance is in the past or not scheduled
+  def time_to(now)
+    if @next_maintenance_at.nil?
+      0
+    else
+      [@next_maintenance_at - now, 0].max
+    end
+  end
+
+  def self.parse_time_from_env(env_value)
+    if env_value.blank?
+      nil
+    elsif env_value.is_a?(Time)
+      env_value
+    elsif env_value.is_a?(String)
+      Time.parse(env_value)
+    else
+      SharetribeLogger.warn(
+        "Unknown environment variable value for next maintenance mode",
+        :maintenance,
+        value: env_value, class: env_value.class.name
+      )
+      nil
+    end
+  end
+end

--- a/app/views/layouts/_notifications.haml
+++ b/app/views/layouts/_notifications.haml
@@ -1,8 +1,8 @@
 
 - if @show_maintenance_warning
   .flash-notifications
-    .flash-notification{:class => "flash-error"}
-      .flash-icon{:class => "ss-alert"}
+    .flash-notification{:class => "flash-warning"}
+      .flash-icon{:class => "ss-info"}
       .flash-text
         = t("layouts.notifications.maintenance_mode", count: @minutes_to_maintenance)
 

--- a/app/views/layouts/_notifications.haml
+++ b/app/views/layouts/_notifications.haml
@@ -1,3 +1,11 @@
+
+- if @show_maintenance_warning
+  .flash-notifications
+    .flash-notification{:class => "flash-error"}
+      .flash-icon{:class => "ss-alert"}
+      .flash-text
+        = t("layouts.notifications.maintenance_mode", count: @minutes_to_maintenance)
+
 - { :notice => "ss-check", :warning => "ss-info", :error => "ss-alert" }.each do |announcement, icon_class|
   - if flash[announcement]
     .flash-notifications

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -273,6 +273,15 @@ default: &default_settings
   http_auth_username: sharetribe
   http_auth_password: changeme
 
+  # When is the next maintenance happening?
+  #
+  # Format: Time object or any string that can be parsed with Time.parse
+  #
+  # Example:
+  # "2016-03-21 13:30:24 +0200"
+  #
+  next_maintenance_at:
+
 production: &production_settings
   <<: *default_settings
 

--- a/config/initializers/next_maintenance.rb
+++ b/config/initializers/next_maintenance.rb
@@ -1,0 +1,1 @@
+NextMaintenance = Maintenance.new(APP_CONFIG.next_maintenance_at)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1421,9 +1421,9 @@ en:
       listing_author_payment_details_missing: "Please contact the author by pressing the 'Contact' button below. They need to update their payment details to receive payments."
       stylesheet_needs_recompiling: "Stylesheet is recompiling. Please, reload the page after a while."
       maintenance_mode:
-        zero: "The system is going to maintenance mode now!"
-        one: "The system is going to maintenance mode in %{count} minute"
-        other: "The system is going to maintenance mode in %{count} minutes"
+        zero: "The website will now go offline for maintenance"
+        one: "The website will be offline for maintenance in %{count} minute"
+        other: "The website will be offline for maintenance in %{count} minutes"
     settings:
       account: Account
       notifications: Notifications

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1420,6 +1420,10 @@ en:
       payment_details_add_error: "Could not add payment details"
       listing_author_payment_details_missing: "Please contact the author by pressing the 'Contact' button below. They need to update their payment details to receive payments."
       stylesheet_needs_recompiling: "Stylesheet is recompiling. Please, reload the page after a while."
+      maintenance_mode:
+        zero: "The system is going to maintenance mode now!"
+        one: "The system is going to maintenance mode in %{count} minute"
+        other: "The system is going to maintenance mode in %{count} minutes"
     settings:
       account: Account
       notifications: Notifications

--- a/spec/utils/maintenance_spec.rb
+++ b/spec/utils/maintenance_spec.rb
@@ -1,0 +1,89 @@
+describe Maintenance do
+  describe "self.parse_time_from_env" do
+    it "accepts nil, Time and String" do
+      expect(Maintenance.parse_time_from_env(Time.utc(2016, 3, 21, 12, 0, 0)))
+        .to eq(Time.utc(2016, 3, 21, 12, 0, 0))
+
+      expect(Maintenance.parse_time_from_env("2016-03-21 12:00:00 +0200"))
+        .to eq(Time.utc(2016, 3, 21, 10, 0, 0))
+
+      expect(Maintenance.parse_time_from_env(nil))
+        .to eq(nil)
+    end
+  end
+
+  describe "show_warning?" do
+
+    context "next maintenance scheduled" do
+
+      let(:next_at) { Time.utc(2016, 3, 21, 12, 0, 0) }
+      let(:next_maintenance) { Maintenance.new(next_at) }
+
+      it "returns false if too early to show the warning" do
+        expect(next_maintenance.show_warning?(
+                15.minutes, Time.utc(2016, 3, 21, 11, 0, 0)))
+          .to eq(false)
+      end
+
+      it "returns true if it's time to show the warning" do
+        expect(next_maintenance.show_warning?(
+                15.minutes, Time.utc(2016, 3, 21, 11, 55, 0)))
+          .to eq(true)
+      end
+
+      it "returns true if the time is in the past" do
+        expect(next_maintenance.show_warning?(
+                15.minutes, Time.utc(2016, 3, 21, 12, 05, 0)))
+          .to eq(true)
+      end
+    end
+
+    context "no maintenance scheduled" do
+
+      let(:next_at) { "" }
+      let(:next_maintenance) { Maintenance.new(next_at) }
+
+      it "returns always false" do
+        expect(next_maintenance.show_warning?(
+                15.minutes, Time.utc(2016, 3, 21, 11, 55, 0)))
+          .to eq(false)
+      end
+    end
+  end
+
+  describe "minutes to" do
+
+    context "next maintenance scheduled" do
+
+      let(:next_at) { Time.utc(2016, 3, 21, 12, 0, 0) }
+      let(:next_maintenance) { Maintenance.new(next_at) }
+
+      it "returns minutes to next maintenance" do
+        expect(next_maintenance.minutes_to(Time.utc(2016, 3, 21, 11, 55, 0)))
+          .to eq(5)
+
+        expect(next_maintenance.minutes_to(Time.utc(2016, 3, 21, 11, 59, 0)))
+          .to eq(1)
+
+        expect(next_maintenance.minutes_to(Time.utc(2016, 3, 21, 12, 0, 0)))
+          .to eq(0)
+      end
+
+      it "returns zero if next maintenance is in the past" do
+        expect(next_maintenance.minutes_to(Time.utc(2016, 3, 21, 12, 1, 0)))
+          .to eq(0)
+      end
+    end
+
+    context "no maintenance scheduled" do
+
+      let(:next_at) { "" }
+      let(:next_maintenance) { Maintenance.new(next_at) }
+
+      it "returns always 0" do
+        expect(next_maintenance.minutes_to(Time.utc(2016, 3, 21, 11, 55, 0)))
+          .to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds ability to show a maintenance mode warning. Here's a screenshot:

![screen shot 2016-03-21 at 14 35 45](https://cloud.githubusercontent.com/assets/429876/13918885/b5f1373c-ef72-11e5-9f7f-7b1f153e64a1.png)

There's a new environment variable `next_maintenance_at` which can be set to the time when the next maintenance happens. I guess environment variable is a good place for this information, since maintenance is very environment specific thing (e.g. some servers might go maintenance while others keep running)

There's a new `initializer` which reads the environment variable and parses it during the app initialization.