### PR TITLE
Remove :new_search and :location_search feat flags

### DIFF
--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -14,11 +14,11 @@ module FeatureFlagHelper
 
   def search_engine
     use_external_search = Maybe(APP_CONFIG).external_search_in_use.map { |v| v == true || v.to_s.casecmp("true") == 0 }.or_else(false)
-    feature_enabled?(:new_search) || use_external_search ? :zappy : :sphinx
+    use_external_search ? :zappy : :sphinx
   end
 
   def location_search_available
-    feature_enabled?(:location_search) && search_engine == :zappy
+    search_engine == :zappy
   end
 
 end

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -8,9 +8,7 @@ module FeatureFlagService::Store
       [:features, :mandatory, :set])
 
     FLAGS = [
-      :location_search,
       :export_transactions_as_csv,
-      :new_search,
       :only_gtm,
       :customer_universal_analytics,
       :youtube_embeds,


### PR DESCRIPTION
This enables the new search as well as the location search for all
marketplaces if the config option external_search_in_use is set to true.