### PR TITLE
Delete duplicate memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Marketplace ID is removed from the Admin Settings URL [#1839](https://github.com/sharetribe/sharetribe/pull/1839)
 
+### Removed
+
+- Delete duplicated memberships from the database [#1838](https://github.com/sharetribe/sharetribe/pull/1838)
+
 ### Fixed
 
 - Errors from Braintree API were ignored [#1832](https://github.com/sharetribe/sharetribe/pull/1832) by [@priviterag](https://github.com/priviterag)

--- a/app/models/community_membership.rb
+++ b/app/models/community_membership.rb
@@ -3,8 +3,8 @@
 # Table name: community_memberships
 #
 #  id                  :integer          not null, primary key
-#  person_id           :string(255)
-#  community_id        :integer
+#  person_id           :string(255)      not null
+#  community_id        :integer          not null
 #  admin               :boolean          default(FALSE)
 #  created_at          :datetime
 #  updated_at          :datetime
@@ -17,7 +17,7 @@
 # Indexes
 #
 #  index_community_memberships_on_community_id  (community_id)
-#  memberships                                  (person_id,community_id)
+#  memberships                                  (person_id,community_id) UNIQUE
 #
 
 class CommunityMembership < ActiveRecord::Base

--- a/db/migrate/20160322103154_delete_duplicate_community_memberships.rb
+++ b/db/migrate/20160322103154_delete_duplicate_community_memberships.rb
@@ -1,0 +1,26 @@
+class DeleteDuplicateCommunityMemberships < ActiveRecord::Migration
+  def up
+    execute("
+      DELETE community_memberships FROM community_memberships
+
+      # Select the first id (MIN) of duplicated community_memberships
+      LEFT JOIN
+        (SELECT MIN(id) as first_id, person_id, community_id
+        FROM community_memberships
+        GROUP BY person_id, community_id
+        HAVING count(*) > 1) AS dup
+        ON dup.person_id = community_memberships.person_id AND dup.community_id = community_memberships.community_id
+
+      # Delete all the other memberships, except the first one
+      WHERE
+        dup.person_id = community_memberships.person_id AND
+        dup.community_id = community_memberships.community_id AND
+        dup.first_id != community_memberships.id
+    ")
+  end
+
+  def down
+    # Nothing to do.
+    # The UP migration deletes data, so there's no way to get it back
+  end
+end

--- a/db/migrate/20160322103155_delete_null_values_from_community_memberships.rb
+++ b/db/migrate/20160322103155_delete_null_values_from_community_memberships.rb
@@ -1,0 +1,9 @@
+class DeleteNullValuesFromCommunityMemberships < ActiveRecord::Migration
+  def up
+    execute("DELETE FROM community_memberships WHERE person_id IS NULL OR community_id IS NULL")
+  end
+
+  def down
+    # Nothing. The UP migration deletes data, so we don't have anyway to get that data back
+  end
+end

--- a/db/migrate/20160322103156_community_membership_not_null_and_unique.rb
+++ b/db/migrate/20160322103156_community_membership_not_null_and_unique.rb
@@ -1,0 +1,17 @@
+class CommunityMembershipNotNullAndUnique < ActiveRecord::Migration
+  def up
+    change_column :community_memberships, :person_id, :string, null: false
+    change_column :community_memberships, :community_id, :integer, null: false
+
+    remove_index :community_memberships, name: "memberships"
+    add_index :community_memberships, [:person_id, :community_id], name: "memberships", unique: true
+  end
+
+  def down
+    change_column :community_memberships, :person_id, :string, null: true
+    change_column :community_memberships, :community_id, :integer, null: true
+
+    remove_index :community_memberships, name: "memberships"
+    add_index :community_memberships, [:person_id, :community_id], name: "memberships"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160311070106) do
+ActiveRecord::Schema.define(version: 20160322103156) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -247,8 +247,8 @@ ActiveRecord::Schema.define(version: 20160311070106) do
   add_index "community_customizations", ["community_id"], name: "index_community_customizations_on_community_id", using: :btree
 
   create_table "community_memberships", force: :cascade do |t|
-    t.string   "person_id",           limit: 255
-    t.integer  "community_id",        limit: 4
+    t.string   "person_id",           limit: 255,                      null: false
+    t.integer  "community_id",        limit: 4,                        null: false
     t.boolean  "admin",                           default: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -260,7 +260,7 @@ ActiveRecord::Schema.define(version: 20160311070106) do
   end
 
   add_index "community_memberships", ["community_id"], name: "index_community_memberships_on_community_id", using: :btree
-  add_index "community_memberships", ["person_id", "community_id"], name: "memberships", using: :btree
+  add_index "community_memberships", ["person_id", "community_id"], name: "memberships", unique: true, using: :btree
 
   create_table "community_translations", force: :cascade do |t|
     t.integer  "community_id",    limit: 4,     null: false

--- a/spec/models/community_membership_spec.rb
+++ b/spec/models/community_membership_spec.rb
@@ -3,8 +3,8 @@
 # Table name: community_memberships
 #
 #  id                  :integer          not null, primary key
-#  person_id           :string(255)
-#  community_id        :integer
+#  person_id           :string(255)      not null
+#  community_id        :integer          not null
 #  admin               :boolean          default(FALSE)
 #  created_at          :datetime
 #  updated_at          :datetime
@@ -17,7 +17,7 @@
 # Indexes
 #
 #  index_community_memberships_on_community_id  (community_id)
-#  memberships                                  (person_id,community_id)
+#  memberships                                  (person_id,community_id) UNIQUE
 #
 
 require 'spec_helper'


### PR DESCRIPTION
This Pull Request deletes duplicate memberships from the `community_memberships` table. After that, a new index is set so that there will be no duplicates in the future.

- [X] Delete all memberships where `person_id` is `null` or `community_id` is `null`
- [X] Delete all duplicate memberships
- [X] Change `person_id` and `community_id` to not accept `null` values
- [X] Change `memberships` index so that `person_id` and `community_id` pair is always unique