### PR TITLE
Cleaner admin/settings path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Add a new job queue (css_compile) for css compilations [#1815](https://github.com/sharetribe/sharetribe/pull/1815)
 - Add a warning message which will be shown 15 minutes before the next scheduled maintenance [#1835](https://github.com/sharetribe/sharetribe/pull/1835)
 
+### Changed
+
+- Marketplace ID is removed from the Admin Settings URL [#1839](https://github.com/sharetribe/sharetribe/pull/1839)
+
 ### Fixed
 
 - Errors from Braintree API were ignored [#1832](https://github.com/sharetribe/sharetribe/pull/1832) by [@priviterag](https://github.com/priviterag)

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -302,7 +302,7 @@ class Admin::CommunitiesController < ApplicationController
 
     update(@current_community,
             settings_params,
-            settings_admin_community_path(@current_community),
+            admin_settings_path,
             :settings)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -744,7 +744,7 @@ module ApplicationHelper
       :topic => :configure,
       :text => t("admin.communities.settings.settings"),
       :icon_class => icon_class("settings"),
-      :path => settings_admin_community_path(@current_community),
+      :path => admin_settings_path,
       :name => "admin_settings"
     }
 

--- a/app/views/admin/communities/getting_started.haml
+++ b/app/views/admin/communities/getting_started.haml
@@ -21,7 +21,7 @@
 - facebook_link = link_to t("admin.communities.getting_started.facebook_link_text"), social_media_admin_community_path(@current_community)
 - twitter_link = link_to t("admin.communities.getting_started.twitter_link_text"), social_media_admin_community_path(@current_community)
 - analytics_link = link_to t("admin.communities.getting_started.analytics_link_text"), analytics_admin_community_path(@current_community)
-- settings_link = link_to t("admin.communities.getting_started.settings_link_text"), settings_admin_community_path(@current_community)
+- settings_link = link_to t("admin.communities.getting_started.settings_link_text"), admin_settings_path()
 - invite_link = link_to t("admin.communities.getting_started.invite_link_text"), new_invitation_path
 - view_users_link = link_to t("admin.communities.getting_started.view_users_link_text"), admin_community_community_memberships_path(@current_community, sort: "join_date", direction: "desc")
 - view_transactions_link = link_to t("admin.communities.getting_started.view_transactions_link_text"), admin_community_transactions_path(@current_community, sort: "last_activity", direction: "desc")

--- a/app/views/admin/communities/settings.haml
+++ b/app/views/admin/communities/settings.haml
@@ -7,7 +7,7 @@
 = render :partial => "admin/left_hand_navigation", :locals => { :links => admin_links_for(@current_community) }
 
 .left-navi-section
-  = form_for @current_community, :url => update_settings_admin_community_path(@current_community), :method => :put do |form|
+  = form_for @current_community, url: admin_update_settings_path, method: :patch do |form|
     %h2= t(".settings")
 
     - Maybe(@current_community).payment_gateway.each do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,10 +114,15 @@ Kassi::Application.routes.draw do
 
     namespace :admin do
 
+      # Payments
       get  "/paypal_preferences"                      => "paypal_preferences#index"
       post "/paypal_preferences/preferences_update"   => "paypal_preferences#preferences_update"
       get  "/paypal_preferences/account_create"       => "paypal_preferences#account_create"
       get  "/paypal_preferences/permissions_verified" => "paypal_preferences#permissions_verified"
+
+      # Settings
+      get   "/settings" => "communities#settings",        as: :settings
+      patch "/settings" => "communities#update_settings", as: :update_settings
 
       resources :communities do
         member do
@@ -132,7 +137,6 @@ Kassi::Application.routes.draw do
           post :resend_verification_email
           get :edit_text_instructions
           get :test_welcome_email
-          get :settings
           get :payment_gateways
           put :payment_gateways, to: 'communities#update_payment_gateway'
           post :payment_gateways, to: 'communities#create_payment_gateway'
@@ -142,8 +146,14 @@ Kassi::Application.routes.draw do
           put :analytics, to: 'communities#update_analytics'
           get :menu_links
           put :menu_links, to: 'communities#update_menu_links'
-          put :update_settings
           delete :delete_marketplace
+
+          # DEPRECATED (2016-03-22)
+          # These routes are not in use anymore, don't use them
+          # See the above :admin_settings routes, outside of :communities resource
+          get :settings,       to: redirect("/admin/settings")
+          put :update_settings # PUT request, no redirect
+
         end
         resources :transactions, controller: :community_transactions, only: :index
         resources :emails
@@ -160,7 +170,7 @@ Kassi::Application.routes.draw do
 
           # DEPRECATED (2015-11-16)
           # Do not add new routes here.
-          # See the above :paypal_preferences resource, outside of communities resource
+          # See the above :paypal_preferences routes, outside of communities resource
 
           member do
             get :index,                to: redirect("/admin/paypal_preferences")


### PR DESCRIPTION
Use `/admin/settings` path instead of `admin/communities/1234/settings`

- [X] Add the new paths, using the non-resourceful routes (they are easier to read and understand)
- [X] Add redirection from old URL to new URL
- [X] Change the path name from `settings_admin_community_path` to `admin_settings_path`. Also, generating the path doesn't require `@current_community` parameter anymore, because the community ID is not part of the URL.