### PR TITLE
Include missing listing_shape_ids in the db query

### DIFF
--- a/app/services/listing_index_service/search/database_search_helper.rb
+++ b/app/services/listing_index_service/search/database_search_helper.rb
@@ -12,7 +12,8 @@ module ListingIndexService::Search::DatabaseSearchHelper
       {
         community_id: community_id,
         author_id: search[:author_id],
-        deleted: 0
+        deleted: 0,
+        listing_shape_id: Maybe(search[:listing_shape_ids]).or_else(nil)
       })
 
     query = Listing


### PR DESCRIPTION
The marketplace atom feed can be filtered to requests and offers with the `share_type` GET parameter. However, this parameter is mapped to a listing_shape_id which wasn't used to filter the DB query results. The fix adds the shape ids to the query filter.