### PR TITLE
Fix broken fonts

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,3 @@
-// The fonts file has to be the first one, since there are @imports in the fonts file
-//= require ./fonts
-
 // Vendor
 //= require jquery.nouislider
 //= require jquery.fileupload

--- a/app/assets/stylesheets/font-awesome.min.css.erb
+++ b/app/assets/stylesheets/font-awesome.min.css.erb
@@ -23,10 +23,10 @@
 
 @font-face{
   font-family:'FontAwesome';
-  src:asset-url('fontawesome-webfont.eot?v=3.0.1');
-  src:asset-url('fontawesome-webfont.eot?#iefix&v=3.0.1') format('embedded-opentype'),
-  asset-url('fontawesome-webfont.woff?v=3.0.1') format('woff'),
-  asset-url('fontawesome-webfont.ttf?v=3.0.1') format('truetype');
+  src:url(<%= asset_path('fontawesome-webfont.eot?v=3.0.1') %>);
+  src:url(<%= asset_path('fontawesome-webfont.eot?#iefix&v=3.0.1') %>) format('embedded-opentype'),
+  url(<%= asset_path('fontawesome-webfont.woff?v=3.0.1') %>) format('woff'),
+  url(<%= asset_path('fontawesome-webfont.ttf?v=3.0.1') %>) format('truetype');
   font-weight:normal;
   font-style:normal }
 

--- a/app/assets/stylesheets/fonts.scss.erb
+++ b/app/assets/stylesheets/fonts.scss.erb
@@ -1,9 +1,0 @@
-@charset "UTF-8";
-
-/*
-  This line has now ss-pika as default in order to get it loaded in Heroku.
-  If you want to run in Heroku with font-awesome, you'll need to change this
-  (e.g. by replacing the whole line with font-awesome.min import)
-*/
-
-<%= (APP_CONFIG.icon_pack == "font-awesome" ? "@import 'font-awesome.min';" : "@import '#{APP_CONFIG.ss_social_location}';\n@import '#{APP_CONFIG.ss_pika_location}';").html_safe %>

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -61,6 +61,12 @@
   %meta{ :property => "fb:app_id", :content => "#{@current_community.facebook_connect_id}" }
 
 / CSS
+- if APP_CONFIG.icon_pack == "font-awesome"
+  = stylesheet_link_tag "font-awesome.min"
+- else
+  = stylesheet_link_tag APP_CONFIG.ss_social_location
+  = stylesheet_link_tag APP_CONFIG.ss_pika_location
+
 - with_stylesheet_url(@current_community) do |stylesheet_url|
   = stylesheet_link_tag stylesheet_url
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,15 @@ module Kassi
     config.assets.paths << VENDOR_CSS_PATH
 
     # Define here additional Assset Pipeline Manifests to include to precompilation
-    config.assets.precompile += ['markerclusterer.js', 'communities/custom-style-*', 'ss-*', 'modernizr.min.js', 'mercury.js','jquery-1.7.js']
+    config.assets.precompile += [
+      'markerclusterer.js',
+      'communities/custom-style-*',
+      'ss-*',
+      'modernizr.min.js',
+      'mercury.js',
+      'jquery-1.7.js',
+      'font-awesome.min.css'
+    ]
 
     # Read the config from the config.yml
     APP_CONFIG = ConfigLoader.load_app_config


### PR DESCRIPTION
Problem: The font-awesome fonts are currently broken after customizing the marketplace appearance. The CSS compilation creates a relative path that expects that the font is found in S3 (where the compiled CSS is saved). However, we shouldn't rely that the fonts are there.

Solution: There's no reason why the fonts should be included in the main stylesheet. We can include the font stylesheet in separate link-tag.

Fixes #1849 #1824 