### PR TITLE
Add rudimental A/B test solution for onboarding process redesigns

### DIFF
--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -73,7 +73,7 @@ class IntApi::MarketplacesController < ApplicationController
   end
 
   def assign_onboarding_feature_flag(community_id:)
-    if(rand(2) == 1)
+    if(rand < 0.5)
       FeatureFlagService::API::Api.features.enable(community_id: community_id, features: [:onboarding_redesign_v1])
     end
   end

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -49,6 +49,8 @@ class IntApi::MarketplacesController < ApplicationController
     auth_token = UserService::API::AuthTokens.create_login_token(user[:id])
     url = URLUtils.append_query_param(marketplace[:url], "auth", auth_token[:token])
 
+    assign_onboarding_feature_flag(community_id: marketplace[:id])
+
     # TODO handle error cases with proper response
 
     render status: 201, json: {"marketplace_url" => url, "marketplace_id" => marketplace[:id]}
@@ -68,6 +70,12 @@ class IntApi::MarketplacesController < ApplicationController
   def set_access_control_headers
     # TODO change this to more strict setting when done testing
     headers['Access-Control-Allow-Origin'] = '*'
+  end
+
+  def assign_onboarding_feature_flag(community_id:)
+    if(rand(2) == 1)
+      FeatureFlagService::API::Api.features.enable(community_id: community_id, features: [:onboarding_redesign_v1])
+    end
   end
 
 end


### PR DESCRIPTION
Using feature flags as alternatives and sending that data to GTM
TODO:
- [x] Is this approach enough as initial solution? 
- [x] Add GTM support to ab_test_script partial
- [x] Decide how we should deal with enabling this on-boarding A/B test (Should we add global feature flag context in addition to community specific feature flags?)
- [x] test with gtm

-> We went even more specific direction this case. 
-> We splitted to another branch a related feature: expose feature flags to GTM
-> This won't be merged before we need it