### PR TITLE
Remove legacy analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Marketplace ID is removed from the Admin Settings URL [#1839](https://github.com/sharetribe/sharetribe/pull/1839)
 
+### Deprecated
+
+- Google Analytics and Kissmetrics tracking snippets are deprecated in favor of Google Tag Manager [#1857](https://github.com/sharetribe/sharetribe/pull/1857)
+
 ### Removed
 
 - Delete duplicated memberships from the database [#1838](https://github.com/sharetribe/sharetribe/pull/1838)

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -201,8 +201,8 @@ function report_analytics_event(category, action, opt_label) {
   if (typeof _gaq !== 'undefined' && Array.isArray(_gaq)) {
     _gaq.push(['_trackEvent'].concat(params_array));
   }
-  if (typeof customer_report_event === 'function') {
-    customer_report_event(category, action, opt_label);
+  if (typeof ST.customer_report_event === 'function') {
+    ST.customer_report_event(category, action, opt_label);
   }
 }
 

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -8,8 +8,7 @@ module FeatureFlagService::Store
       [:features, :mandatory, :set])
 
     FLAGS = [
-      :export_transactions_as_csv,
-      :customer_universal_analytics,
+      :export_transactions_as_csv
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/views/analytics/_customer_analytics.haml
+++ b/app/views/analytics/_customer_analytics.haml
@@ -1,17 +1,23 @@
 :plain
+  window.ST = window.ST || {};
+
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga_customer');
+  })(window,document,'script','//www.google-analytics.com/analytics.js','gaCustomer');
 
-  var community_ga_key = "#{@current_community.google_analytics_key}"
-  var community_cookie_domain = "#{PublicSuffix.parse(request.host).domain}"
-  ga_customer('create', community_ga_key, 'auto', {'legacyCookieDomain': community_cookie_domain,   'allowLinker': true});
-  ga_customer('send', 'pageview');
-  var secondary_analytics_in_use = true;
+  (function(){
+    var communityGaKey = "#{@current_community.google_analytics_key}";
+    var communityCookieDomain = "#{PublicSuffix.parse(request.host).domain}";
 
-  var customer_report_event = function(category, action, opt_label) {
-    if (typeof ga_customer === 'function'){
-      ga_customer('send', 'event', category, action, opt_label);
+    gaCustomer('create', communityGaKey, 'auto', {'legacyCookieDomain': communityCookieDomain, 'allowLinker': true});
+    gaCustomer('send', 'pageview');
+  })();
+
+  ST.secondaryAnalyticsInUse = true;
+
+  ST.customerReportEvent = function(category, action, opt_label) {
+    if (typeof gaCustomer === 'function'){
+      gaCustomer('send', 'event', category, action, opt_label);
     }
   };

--- a/app/views/analytics/_customer_analytics.haml
+++ b/app/views/analytics/_customer_analytics.haml
@@ -1,38 +1,17 @@
-- if feature_enabled?(:customer_universal_analytics)
-  :plain
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga_customer');
+:plain
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga_customer');
 
-    var community_ga_key = "#{@current_community.google_analytics_key}"
-    var community_cookie_domain = "#{PublicSuffix.parse(request.host).domain}"
-    ga_customer('create', community_ga_key, 'auto', {'legacyCookieDomain': community_cookie_domain,   'allowLinker': true});
-    ga_customer('send', 'pageview');
-    var secondary_analytics_in_use = true;
+  var community_ga_key = "#{@current_community.google_analytics_key}"
+  var community_cookie_domain = "#{PublicSuffix.parse(request.host).domain}"
+  ga_customer('create', community_ga_key, 'auto', {'legacyCookieDomain': community_cookie_domain,   'allowLinker': true});
+  ga_customer('send', 'pageview');
+  var secondary_analytics_in_use = true;
 
-    var customer_report_event = function(category, action, opt_label) {
-      if (typeof ga_customer === 'function'){
-        ga_customer('send', 'event', category, action, opt_label);
-      }
-    };
-- else
-  :plain
-    var _gaq = _gaq || [];
-    _gaq.push(['b._setAccount', '#{@current_community.google_analytics_key}']);
-    _gaq.push(['b._setDomainName', '.#{PublicSuffix.parse(request.host).domain}']);
-    _gaq.push(['b._addIgnoredOrganic', '#{Maybe(@current_community.name(I18n.locale)).gsub("'","").or_else("")}']);
-    _gaq.push(['b._addIgnoredOrganic', '#{@current_community.domain || @current_community.ident}']);
-    _gaq.push(
-      ['b._setAllowLinker', true],
-      ['b._trackPageview'],
-      ['b._trackPageLoadTime']
-    );
-    var secondary_analytics_in_use = true;
-
-    var customer_report_event = function(category, action, opt_label) {
-      var params_array = [category, action, opt_label]
-      if (typeof _gaq != 'undefined') {
-        _gaq.push(['b._trackEvent'].concat(params_array));
-      }
-    };
+  var customer_report_event = function(category, action, opt_label) {
+    if (typeof ga_customer === 'function'){
+      ga_customer('send', 'event', category, action, opt_label);
+    }
+  };

--- a/app/views/analytics/_legacy_google_analytics.haml
+++ b/app/views/analytics/_legacy_google_analytics.haml
@@ -14,3 +14,9 @@
   ['_trackPageview'],
   ['_trackPageLoadTime']
   );
+
+  (function() {
+  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();

--- a/app/views/analytics/_legacy_google_analytics.haml
+++ b/app/views/analytics/_legacy_google_analytics.haml
@@ -1,3 +1,4 @@
+-# Deprecated, use Google Tag Manager instead
 :plain
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '#{APP_CONFIG.google_analytics_key}']);

--- a/app/views/layouts/_google_analytics_script.haml
+++ b/app/views/layouts/_google_analytics_script.haml
@@ -7,13 +7,4 @@
 
 - if @current_community && @current_community.google_analytics_key
   = render partial: "analytics/customer_analytics"
-
-- if APP_CONFIG.use_google_analytics.to_s == "true" || (@current_community && @current_community.google_analytics_key)
-  :plain
-    (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
-
 </script>

--- a/app/views/layouts/_head.haml
+++ b/app/views/layouts/_head.haml
@@ -7,7 +7,7 @@
 %head
   %meta{charset: "utf-8"}
 
-  / Unsupported - Kissmetrics is no longer used directly by Sharetribe.
+  -# Kissmetrics is deprecated, use Google Tag Manager instead
   = render :partial => "layouts/kissmetrics"
   = render :partial => "layouts/google_analytics_script"
   :css

--- a/app/views/layouts/_kissmetrics.haml
+++ b/app/views/layouts/_kissmetrics.haml
@@ -1,3 +1,4 @@
+-# Deprecated, use Google Tag Manager instead
 - if APP_CONFIG.use_kissmetrics
   <script type="text/javascript">
   var _kmq = _kmq || [];

--- a/config/application.rb
+++ b/config/application.rb
@@ -167,5 +167,9 @@ module Kassi
     # TODO Remove this when upgrading to RAILS 5 END
 
     config.active_job.queue_adapter = :delayed_job
+
+    # TODO remove deprecation warnings when removing legacy analytics
+    ActiveSupport::Deprecation.warn("Support for Kissmetrics is deprecated, please use Google Tag Manager instead") if APP_CONFIG.use_kissmetrics
+    ActiveSupport::Deprecation.warn("Support for Google Analytics is deprecated, please use Google Tag Manager instead") if APP_CONFIG.use_google_analytics
   end
 end

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -143,16 +143,20 @@ default: &default_settings
   grid_listings_limit: 24
   map_listings_limit: 150
 
+  # DEPRECATED, use Google Tag Manager instead
   # Google Analytics can be used to track traffic on the site
   # If set to true you need to obtain your own API key for analytics
   # and enter it below
   use_google_analytics: false
   google_analytics_key: "enter_your_key_here"
 
-  # You can also use Google Tag Manager
+  # Google Tag Manager can be used to track traffic on the site
+  # If set to true you need to obtain your own container key
+  # and enter it below
   use_google_tag_manager: false
   google_tag_manager_key: "enter_your_key_here"
 
+  # DEPRECATED, use Google Tag Manager instead
   # KISS metrics can be used to track many events on the site
   use_kissmetrics: false
   kissmetrics_url: '//doug1izaerwt3.cloudfront.net/INSERT_YOUR_API_KEY_HERE.1.js'


### PR DESCRIPTION
As we now use Google Tag Manager ourselves, we should remove the legacy Google Analytics snippet soon. Moving tracking to GTM takes some work, so I think a deprecation notice is a good idea.

None of our customers user legacy GA accounts that don't support Universal Analytics, so it's safe to move all customers to use it. 

 - [x] Add deprecation notices for Kissmetrics and GA
 - [x] Use universal analytics for all customer tracking