### PR TITLE
Log all Person.find calls with username

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -113,7 +113,7 @@ class Person < ActiveRecord::Base
   end
 
   def self.find(username_or_id)
-    by_username = self.find_by_username(username_or_id)
+    by_username = self.find_by(username: username_or_id)
 
     if by_username.nil?
       # Couldn't find by username, trying to find by id

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -112,8 +112,19 @@ class Person < ActiveRecord::Base
     username
   end
 
-  def self.find(username)
-    super(self.find_by_username(username).try(:id) || username)
+  def self.find(username_or_id)
+    by_username = self.find_by_username(username_or_id)
+
+    if by_username.nil?
+      # Couldn't find by username, trying to find by id
+      super(username_or_id)
+    else
+      # Found it by username
+      logger = SharetribeLogger.new(:person)
+      logger.warn("Used Person.find with username. This is deprecated and support for finding by username will be removed from this method.", :find_by_username, caller: caller)
+
+      by_username
+    end
   end
 
   DEFAULT_TIME_FOR_COMMUNITY_UPDATES = 7.days


### PR DESCRIPTION
The default Rails `Person.find` method takes person ID as a parameter and finds the person by that ID. However, that method has been overriden so that the `Person.find` accepts also `username` as a parameter. This is very confusing and we are about to remove that and not override the method. In addition, in the future we are not able to search user by only username, because the usernames will not be unique anymore, instead, we need to add `community_id` when ever we want to search by username. So that's another reason why this needs to be changed.

In controllers, there are a lot code like this:

```
@person = Person.find(params[:person_id] || params[:id])
```

...and in practice it's impossible to say whether the params contain ID or username. That's why we thought that a good way to find out is to add some logging and deploy that to production and see the result.