### PR TITLE
Fix analytics deprecation check

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -169,7 +169,7 @@ module Kassi
     config.active_job.queue_adapter = :delayed_job
 
     # TODO remove deprecation warnings when removing legacy analytics
-    ActiveSupport::Deprecation.warn("Support for Kissmetrics is deprecated, please use Google Tag Manager instead") if APP_CONFIG.use_kissmetrics
-    ActiveSupport::Deprecation.warn("Support for Google Analytics is deprecated, please use Google Tag Manager instead") if APP_CONFIG.use_google_analytics
+    ActiveSupport::Deprecation.warn("Support for Kissmetrics is deprecated, please use Google Tag Manager instead") if APP_CONFIG.use_kissmetrics.to_s == "true"
+    ActiveSupport::Deprecation.warn("Support for Google Analytics is deprecated, please use Google Tag Manager instead") if APP_CONFIG.use_google_analytics.to_s == "true"
   end
 end


### PR DESCRIPTION
When reading values from environment variables, they are always strings and `"false"` is a truthy value according to Ruby. So, let's just use the same check in deprecation warning as we use in the place it's actually used.