### PR TITLE
Autologout non-members

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -192,6 +192,15 @@ class ApplicationController < ActionController::Base
       sign_out
       session[:person_id] = nil
       flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
+
+      logger.info(
+        "Automatically logged out user that doesn't belong to community",
+        :autologout,
+        current_user_id: @current_user.id,
+        current_community_id: @current_community.id,
+        current_user_community_id: @current_user.community_id
+      )
+
       redirect_to root
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -189,9 +189,6 @@ class ApplicationController < ActionController::Base
   # community are all expired.
   def ensure_user_belongs_to_community
     if @current_user && @current_user.community_id != @current_community.id
-      sign_out
-      session[:person_id] = nil
-      flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
 
       logger.info(
         "Automatically logged out user that doesn't belong to community",
@@ -200,6 +197,10 @@ class ApplicationController < ActionController::Base
         current_community_id: @current_community.id,
         current_user_community_id: @current_user.community_id
       )
+
+      sign_out
+      session[:person_id] = nil
+      flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
 
       redirect_to root
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,6 @@ class ApplicationController < ActionController::Base
     :fetch_community_plan_expiration_status,
     :perform_redirect,
     :fetch_logged_in_user,
-    :ensure_user_belongs_to_community,
     :save_current_host_with_port,
     :fetch_community_membership,
     :redirect_removed_locale,
@@ -36,6 +35,7 @@ class ApplicationController < ActionController::Base
     :report_queue_size,
     :maintenance_warning
   before_filter :cannot_access_if_banned, :except => [ :confirmation_pending, :check_email_availability]
+  before_filter :ensure_user_belongs_to_community, except: [ :confirmation_pending, :check_email_availability]
   before_filter :can_access_only_organizations_communities
   before_filter :check_email_confirmation, :except => [ :confirmation_pending, :check_email_availability_and_validity]
 
@@ -188,7 +188,7 @@ class ApplicationController < ActionController::Base
   # sessions which potentially had a person_id pointing to another
   # community are all expired.
   def ensure_user_belongs_to_community
-    if @current_user && @current_user.community_id != @current_community.id
+    if @current_user && @current_user.communities.include?(@current_community)
 
       logger.info(
         "Automatically logged out user that doesn't belong to community",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1424,6 +1424,7 @@ en:
         zero: "The website will now go offline for maintenance"
         one: "The website will be offline for maintenance in %{count} minute"
         other: "The website will be offline for maintenance in %{count} minutes"
+      automatically_logged_out_please_sign_in: "You have been automatically logged out. Please sign in again."
     settings:
       account: Account
       notifications: Notifications


### PR DESCRIPTION
This PR cherry-picks the three commits from `community-specific-user-migrations` and adds one, which changes `person.community_id` to `person.communities`, since the `community_id` doesn't exist at this point.

In the first place, I felt that this piece of code should not be in `community-specific-user-migrations`. However, I put it there because I though I need to use the `person.community_id` but `person.communities` works as well atm.