### PR TITLE
Remove Person.find_by_username invocations

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -116,6 +116,13 @@ class Person < ActiveRecord::Base
     super(self.find_by_username(username).try(:id) || username)
   end
 
+  def self.find_by_username_and_community_id(username, community_id)
+    Person
+      .joins(:community_memberships)
+      .where(username: username, community_memberships: { community_id: community_id })
+      .first
+  end
+
   DEFAULT_TIME_FOR_COMMUNITY_UPDATES = 7.days
 
   # These are the email notifications, excluding newsletters settings

--- a/features/admin/statistics_and_info/admin_views_transactions.feature
+++ b/features/admin/statistics_and_info/admin_views_transactions.feature
@@ -11,10 +11,10 @@ I want to see see all the transactions happening in my community
       | kassi_testperson1 | john       | doe         | test2@example.com   | 2013-03-01 00:12:35 +0200 |
       | kassi_testperson2 | jane       | doe         | test1@example.com   | 2012-03-01 00:00:00 +0200 |
     And there are following transactions
-      | listing     | status  | sum | currency | started_at  | latest_activity | starter           | other_party       |
-      | Moving help | pending | 127 | EUR      | 2 days ago  | 3 hours ago     | kassi_testperson1 | kassi_testperson2 |
-      | Red apples  | paid    | 60  | USD      | 1 week ago  | 2 hours ago     | kassi_testperson2 | kassi_testperson1 |
-      | Power drill | free    |     |          | 2 hours ago | 1 hour ago      | kassi_testperson1 | kassi_testperson2 |
+      | listing     | status  | sum | currency | started_at  | latest_activity | starter           | other_party       | community_ident |
+      | Moving help | pending | 127 | EUR      | 2 days ago  | 3 hours ago     | kassi_testperson1 | kassi_testperson2 | test            |
+      | Red apples  | paid    | 60  | USD      | 1 week ago  | 2 hours ago     | kassi_testperson2 | kassi_testperson1 | test            |
+      | Power drill | free    |     |          | 2 hours ago | 1 hour ago      | kassi_testperson1 | kassi_testperson2 | test            |
     And I am logged in as "manager"
     And "manager" has admin rights in community "test"
     And the community has payments in use via BraintreePaymentGateway

--- a/features/step_definitions/admin_manage_members_steps.rb
+++ b/features/step_definitions/admin_manage_members_steps.rb
@@ -83,12 +83,12 @@ When(/^I remove user "(.*?)"$/) do |full_name|
 end
 
 Then(/^"(.*?)" should be banned from this community$/) do |username|
-  person = Person.find_by_username(username)
+  person = Person.find_by_username_and_community_id(username, @current_community.id)
   expect(CommunityMembership.find_by_person_id_and_community_id(person.id, @current_community.id).status).to eq("banned")
 end
 
 Given(/^user "(.*?)" is banned in this community$/) do |username|
-  CommunityMembership.find_by_person_id_and_community_id(Person.find_by_username(username).id, @current_community.id).update_attribute(:status, "banned")
+  CommunityMembership.find_by(person_id: Person.find_by(username: username).id, community_id: @current_community.id).update_attribute(:status, "banned")
 end
 
 Then(/^I should see a message that I have been banned$/) do

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -63,7 +63,7 @@ end
 
 Given /^"(.*?)" is a member of community "(.*?)"$/ do |username, community_name|
   community = Community.where(ident: community_name).first
-  person = Person.find_by_username!(username)
+  person = Person.find_by!(username: username)
   membership = FactoryGirl.create(:community_membership, :person => person, :community => community)
   membership.save!
 end

--- a/features/step_definitions/conversation_steps.rb
+++ b/features/step_definitions/conversation_steps.rb
@@ -286,7 +286,7 @@ end
 
 Then /^I should send a message to "(.*?)"$/ do |seller_name|
   expect(find("#new_listing_conversation").visible?).to be_truthy
-  seller = Person.find_by_username(seller_name)
+  seller = Person.find_by(username: seller_name)
   expect(find("label[for=listing_conversation_content]")).to have_content("Message to #{seller.given_name}")
 end
 

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -26,13 +26,13 @@
 Given /^there are following emails:$/ do |emails_table|
   # Clean up old emails first
   emails_table.hashes.each do |hash|
-    person = Person.find_by_username(hash[:person])
+    person = Person.find_by(username: hash[:person])
     person.emails.each { |email| email.destroy }
   end
 
   # Create new emails
   emails_table.hashes.each do |hash|
-    person = Person.find_by_username(hash[:person])
+    person = Person.find_by(username: hash[:person])
     @hash_email = FactoryGirl.create(:email, :person => person)
 
     attributes_to_update = hash.except('person')

--- a/features/step_definitions/listing_steps.rb
+++ b/features/step_definitions/listing_steps.rb
@@ -2,7 +2,7 @@ Given /^there is a listing with title "([^"]*)"(?: from "([^"]*)")?(?: with cate
   opts = Hash.new
   opts[:title] = title
   opts[:category] = find_category_by_name(category_name) if category_name
-  opts[:author] = Person.find_by_username(author) if author
+  opts[:author] = Person.find_by(username: author) if author
 
   shape =
     if shape_name

--- a/features/step_definitions/organization_steps.rb
+++ b/features/step_definitions/organization_steps.rb
@@ -18,7 +18,7 @@ Given /^I signup as an organization "(.*?)" with name "(.*?)"$/ do |org_username
 end
 
 Then /^there should be an organization account "(.*?)"$/ do |org_username|
-  o = Person.find_by_username(org_username)
+  o = Person.find_by(username: org_username)
   expect(o.is_organization).to be_truthy
 end
 
@@ -31,7 +31,7 @@ Given /^there is an organization "(.*?)"$/ do |org_username|
 end
 
 Given /^"(.*?)" is not an organization$/ do |username|
-  user = Person.find_by_username(username)
+  user = Person.find_by(username: username)
   user.is_organization = false
   user.save!
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -32,13 +32,13 @@ end
 
 Given /^I am logged in(?: as "([^"]*)")?$/ do |person|
   username = person || "kassi_testperson1"
-  person = Person.find_by_username(username)
+  person = Person.find_by(username: username)
   login_user_without_browser(person.username)
 end
 
 Given /^I am logged in as organization(?: "([^"]*)")?$/ do |org_username|
   username = org_username || "company"
-  person = Person.find_by_username(username) || FactoryGirl.create(:person, :username => username, :is_organization => true)
+  person = Person.find_by(username: username) || FactoryGirl.create(:person, :username => username, :is_organization => true)
   login_as(person, :scope => :person)
   visit root_path(:locale => :en)
   @logged_in_user = person
@@ -73,7 +73,7 @@ Given /^my phone number in my profile is "([^"]*)"$/ do |phone_number|
 end
 
 Given /^user "(.*?)" has additional email "(.*?)"$/ do |username, email|
-  Email.create(:person => Person.find_by_username(username), :address => email, :confirmed_at => Time.now)
+  Email.create(:person => Person.find_by(username: username), :address => email, :confirmed_at => Time.now)
 end
 
 Given /^there will be and error in my Facebook login$/ do
@@ -112,7 +112,7 @@ Given /^there are following users:$/ do |person_table|
       username: hash['person'],
     }).merge(hash.except('person', 'membership_created_at'))
 
-    @hash_person, @hash_session = Person.find_by_username(username) || FactoryGirl.create(:person, person_opts)
+    @hash_person, @hash_session = Person.find_by(username: username) || FactoryGirl.create(:person, person_opts)
     @hash_person.save!
 
     @hash_person = force_override_model_id(id, @hash_person, Person, [Email]) if id
@@ -177,25 +177,25 @@ Then /^(?:|I )should see the (username|email) I gave(?: within "([^"]*)")?$/ do 
 end
 
 Given /^"([^"]*)" is superadmin$/ do |username|
-  user = Person.find_by_username(username)
+  user = Person.find_by(username: username)
   user.update_attribute(:is_admin, true)
 end
 
 Given /^user "([^"]*)" is member of community "([^"]*)"$/ do |username, community|
-  user = Person.find_by_username(username)
+  user = Person.find_by(username: username)
   community = Community.where(ident: community).first
   cm = CommunityMembership.find_by_person_id_and_community_id(user.id, community.id)
   CommunityMembership.create(:person_id => user.id, :community_id => community.id) unless cm
 end
 
 Given /^"([^"]*)" has admin rights in community "([^"]*)"$/ do |username, community|
-  user = Person.find_by_username(username)
+  user = Person.find_by(username: username)
   community = Community.where(ident: community).first
   CommunityMembership.find_by_person_id_and_community_id(user.id, community.id).update_attribute(:admin, true)
 end
 
 Given /^"([^"]*)" does not have admin rights in community "([^"]*)"$/ do |username, community|
-  user = Person.find_by_username(username)
+  user = Person.find_by(username: username)
   community = Community.where(ident: community).first
   CommunityMembership.find_by_person_id_and_community_id(user.id, community.id).update_attribute(:admin, false)
 end
@@ -214,7 +214,7 @@ Then /^I should not see my username$/ do
 end
 
 Then /^user "([^"]*)" (should|should not) have "([^"]*)" with value "([^"]*)"$/ do |username, verb, attribute, value|
-  user = Person.find_by_username(username)
+  user = Person.find_by(username: username)
   expect(user).not_to be_nil
   verb = verb.gsub(" ", "_")
   value = nil if value == "nil"
@@ -222,7 +222,7 @@ Then /^user "([^"]*)" (should|should not) have "([^"]*)" with value "([^"]*)"$/ 
 end
 
 Then /^user "(.*?)" should have email "(.*?)"$/ do |username, email|
-  p = Person.find_by_username(username)
+  p = Person.find_by(username: username)
   e = Email.find_by_person_id_and_address(p.id, email)
 
   expect(e).not_to be_nil
@@ -235,7 +235,7 @@ Then /^I should have (confirmed|unconfirmed) email "(.*?)"$/ do |conf, email|
 end
 
 Then /^user "(.*?)" should have (confirmed|unconfirmed) email "(.*?)"$/ do |username, conf, email|
-  p = Person.find_by_username(username)
+  p = Person.find_by(username: username)
   e = Email.find_by_person_id_and_address(p.id, email)
 
   expect(e).not_to be_nil
@@ -250,7 +250,7 @@ Then /^user "(.*?)" should have (confirmed|unconfirmed) email "(.*?)"$/ do |user
 end
 
 When /^"(.*?)" is authorized to post a new listing$/ do |username|
-  person = Person.find_by_username(username)
+  person = Person.find_by_username_and_community_id(username, @current_community.id)
   community_membership = CommunityMembership.find_by_person_id_and_community_id(person.id, @current_community.id)
   community_membership.update_attribute(:can_post_listings, true)
 end
@@ -262,13 +262,13 @@ Given(/^I have just received community updates email$/) do
 end
 
 Given(/^"(.*?)" follows "(.*?)"$/) do |follower, person|
-  person = Person.find_by_username(person)
-  follower = Person.find_by_username(follower)
+  person = Person.find_by(username: person)
+  follower = Person.find_by(username: follower)
   person.followers << follower unless follower.follows? person
 end
 
 Given(/^"(.*?)" follows everyone$/) do |person|
-  person = Person.find_by_username(person)
+  person = Person.find_by(username: person)
   person.followed_people = Person.all - [ person ]
 end
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -36,14 +36,6 @@ Given /^I am logged in(?: as "([^"]*)")?$/ do |person|
   login_user_without_browser(person.username)
 end
 
-Given /^I am logged in as organization(?: "([^"]*)")?$/ do |org_username|
-  username = org_username || "company"
-  person = Person.find_by(username: username) || FactoryGirl.create(:person, :username => username, :is_organization => true)
-  login_as(person, :scope => :person)
-  visit root_path(:locale => :en)
-  @logged_in_user = person
-end
-
 Given /^I log in(?: as "([^"]*)")?$/ do |person|
   logout_and_login_user(person)
 end

--- a/features/support/login_helpers.rb
+++ b/features/support/login_helpers.rb
@@ -13,7 +13,7 @@ module LoginHelpers
 
     # Warning! This sets @current_user even if the login fails.
     # This should be fixed.
-    @current_user = Person.find_by_username(username)
+    @current_user = Person.find_by(username: username)
   end
 
   def logout()
@@ -27,7 +27,7 @@ module LoginHelpers
 
   # No browser interaction
   def login_user_without_browser(username)
-    person = Person.find_by_username(username)
+    person = Person.find_by(username: username)
     login_as(person, :scope => :person)
     visit root_path(:locale => :en)
     @logged_in_user = person

--- a/features/support/transforms.rb
+++ b/features/support/transforms.rb
@@ -1,7 +1,7 @@
 Transform /^author "(.*?)"$/ do |username|
-  Person.find_by_username(username)
+  Person.find_by(username: username)
 end
 
 Transform /^starter "(.*?)"$/ do |username|
-  Person.find_by_username(username)
+  Person.find_by(username: username)
 end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -62,11 +62,12 @@ describe PeopleController, type: :controller do
   describe "#create" do
 
     it "creates a person" do
-      @request.host = "#{FactoryGirl.create(:community).ident}.lvh.me"
+      community = FactoryGirl.create(:community)
+      @request.host = "#{community.ident}.lvh.me"
       person_count = Person.count
       username = generate_random_username
       post :create, {:person => {:username => username, :password => "test", :email => "#{username}@example.com", :given_name => "", :family_name => ""}, :community => "test"}
-      expect(Person.find_by_username(username)).not_to be_nil
+      expect(Person.find_by_username_and_community_id(username, community.id)).not_to be_nil
       expect(Person.count).to eq(person_count + 1)
     end
 
@@ -79,7 +80,7 @@ describe PeopleController, type: :controller do
 
       post :create, {:person => {:username => username, :password => "test", :email => "#{username}@example.com", :given_name => "", :family_name => ""}}
 
-      expect(Person.find_by_username(username)).to be_nil
+      expect(Person.find_by_username_and_community_id(username, community.id)).to be_nil
       expect(flash[:error].to_s).to include("This email is not allowed")
     end
   end

--- a/spec/services/user_service/users_spec.rb
+++ b/spec/services/user_service/users_spec.rb
@@ -20,7 +20,7 @@ describe UserService::API::Users do
     it "should create a user" do
       u = create_user(PERSON_HASH)
       expect(u[:given_name]).to eql "Raymond"
-      expect(Person.find_by_username("raymondx").family_name).to eql "Xperiment"
+      expect(Person.find_by(username: "raymondx").family_name).to eql "Xperiment"
       expect(u[:locale]).to eql "fr"
     end
 


### PR DESCRIPTION
With the community specific user migration, user information has to be fetched by using user and community identifiers.