### PR TITLE
Email.find_by_address_and_community_id

### DIFF
--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -62,7 +62,7 @@ class CommunityMembershipsController < ApplicationController
 
         # no confirmed allowed email found. Check if there is unconfirmed or should we add one.
         if @current_user.has_email?(params[:community_membership][:email])
-          e = Email.find_by_address(params[:community_membership][:email])
+          e = Email.find_by_address_and_community_id(params[:community_membership][:email], @current_community.id)
         elsif
           e = Email.create(:person => @current_user, :address => params[:community_membership][:email])
         end
@@ -74,7 +74,7 @@ class CommunityMembershipsController < ApplicationController
       # we need to resend the confirmation email and update membership status to "pending_email_confirmation"
       elsif @current_user.community_memberships.size > 0
         Maybe(@current_user.latest_pending_email_address(@current_community)).map { |email_address|
-          Email.send_confirmation(Email.find_by_address(email_address), @current_community)
+          Email.send_confirmation(Email.find_by_address_and_community_id(email_address, @current_community.id), @current_community)
         }
       end
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -31,7 +31,7 @@ class ConfirmationsController < Devise::ConfirmationsController
 
     # Resend confirmation
     if email_param_present
-      email = Email.find_by_address(params[:person][:email])
+      email = Email.find_by_address_and_community_id(params[:person][:email], @current_community.id)
       Email.send_confirmation(email, @current_community)
       flash[:notice] = t("sessions.confirmation_pending.check_your_email")
       redirect_to :controller => "sessions", :action => "confirmation_pending" and return

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -97,7 +97,7 @@ class SessionsController < ApplicationController
   end
 
   def request_new_password
-    if person = Person.find_by_email(params[:email])
+    if person = Person.find_by_email_address_and_community_id(params[:email], @current_community.id)
       token = person.reset_password_token_if_needed
       MailCarrier.deliver_later(PersonMailer.reset_password_instructions(person, params[:email], token, @current_community))
       flash[:notice] = t("layouts.notifications.password_recovery_sent")

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -45,10 +45,6 @@ class Email < ActiveRecord::Base
     self.save
   end
 
-  def self.confirmed?(email)
-    Email.find_by_address(email).confirmed_at.present?
-  end
-
   # Email already in use for current user or someone else
   def self.email_available?(email)
     !Email.find_by_address(email).present?
@@ -62,5 +58,12 @@ class Email < ActiveRecord::Base
 
   def self.send_confirmation(email, community)
     MailCarrier.deliver_later(PersonMailer.email_confirmation(email, community))
+  end
+
+  def self.find_by_address_and_community_id(address, community_id)
+    Email
+      .joins("INNER JOIN community_memberships ON community_memberships.person_id = emails.person_id")
+      .where(address: address, community_memberships: { community_id: community_id })
+      .first
   end
 end

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -63,7 +63,6 @@ class Email < ActiveRecord::Base
   def self.find_by_address_and_community_id(address, community_id)
     Email
       .joins("INNER JOIN community_memberships ON community_memberships.person_id = emails.person_id")
-      .where(address: address, community_memberships: { community_id: community_id })
-      .first
+      .find_by(address: address, community_memberships: { community_id: community_id })
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -564,6 +564,12 @@ class Person < ActiveRecord::Base
     end
   end
 
+  def self.find_by_email_address_and_community_id(email_address, community_id)
+    Maybe(
+      Email.find_by_address_and_community_id(email_address, community_id)
+    ).person.or_else(nil)
+  end
+
   def reset_password_token_if_needed
     # Devise 3.1.0 doesn't expose methods to generate reset_password_token without
     # sending the email, so this code is copy-pasted from Recoverable module

--- a/app/services/marketplace_service/person.rb
+++ b/app/services/marketplace_service/person.rb
@@ -31,8 +31,9 @@ module MarketplaceService
       module_function
 
       def unsubscribe_email_from_community_updates(email_address)
-        person = Maybe(Email.find_by_address(email_address)).person.or_else(nil)
-        Helper.unsubscribe_from_community_updates(person)
+        Email.where(address: email_address).map(&:person).each { |person|
+          Helper.unsubscribe_from_community_updates(person)
+        }
       end
 
       def unsubscribe_person_from_community_updates(person_id)

--- a/features/step_definitions/settings_steps.rb
+++ b/features/step_definitions/settings_steps.rb
@@ -101,11 +101,11 @@ Then /^I should be able to remove notifications from "(.*?)"$/ do |email|
 end
 
 Then /^I should receive notifications for email "(.*?)"$/ do |email|
-  expect(Email.find_by_address(email).send_notifications).to be_truthy
+  expect(Email.find_by_address_and_community_id(email, @current_community.id).send_notifications).to be_truthy
 end
 
 Then /^I should not receive notifications for email "(.*?)"$/ do |email|
-  expect(Email.find_by_address(email).send_notifications).to be_falsey
+  expect(Email.find_by_address_and_community_id(email, @current_community.id).send_notifications).to be_falsey
 end
 
 Then /^I should not be able to resend confirmation for "(.*?)"$/ do |email|


### PR DESCRIPTION
Currently email addresses are globally unique. However, this will change soon, and emails will be unique per community. That's why we can't use `Email.find_by_address` anymore, instead we need to use `Email.find_by_address_and_community_id`.

Some controllers that are related to login/signup or email availability still use `find_by_address`, because these will change in the #1753 PR.

One controller (Amazon Bounce) needs to find all emails by address, so `find_by_address` is changed to `where(address: address)