### PR TITLE
Add uniqueness constraints for facebook_id and email

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -4,6 +4,7 @@
 #
 #  id                   :integer          not null, primary key
 #  person_id            :string(255)
+#  community_id         :integer
 #  address              :string(255)
 #  confirmed_at         :datetime
 #  confirmation_sent_at :datetime
@@ -14,8 +15,9 @@
 #
 # Indexes
 #
-#  index_emails_on_address    (address)
-#  index_emails_on_person_id  (person_id)
+#  index_emails_on_address                   (address)
+#  index_emails_on_address_and_community_id  (address,community_id) UNIQUE
+#  index_emails_on_person_id                 (person_id)
 #
 
 class Email < ActiveRecord::Base

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,6 +3,7 @@
 # Table name: people
 #
 #  id                                 :string(22)       not null, primary key
+#  community_id                       :integer
 #  created_at                         :datetime
 #  updated_at                         :datetime
 #  is_admin                           :integer          default(0)
@@ -42,16 +43,15 @@
 #  organization_name                  :string(255)
 #  deleted                            :boolean          default(FALSE)
 #  cloned_from                        :string(22)
-#  community_id                       :integer
 #
 # Indexes
 #
-#  index_people_on_authentication_token       (authentication_token)
-#  index_people_on_email                      (email) UNIQUE
-#  index_people_on_facebook_id                (facebook_id)
-#  index_people_on_id                         (id)
-#  index_people_on_reset_password_token       (reset_password_token) UNIQUE
-#  index_people_on_username_and_community_id  (username,community_id) UNIQUE
+#  index_people_on_authentication_token          (authentication_token)
+#  index_people_on_email                         (email) UNIQUE
+#  index_people_on_facebook_id_and_community_id  (facebook_id,community_id) UNIQUE
+#  index_people_on_id                            (id)
+#  index_people_on_reset_password_token          (reset_password_token) UNIQUE
+#  index_people_on_username_and_community_id     (username,community_id) UNIQUE
 #
 
 require 'json'

--- a/db/migrate/20160308133020_add_community_id_to_emails.rb
+++ b/db/migrate/20160308133020_add_community_id_to_emails.rb
@@ -1,0 +1,6 @@
+class AddCommunityIdToEmails < ActiveRecord::Migration
+  def change
+    add_column :emails, :community_id, :integer, after: :person_id
+  end
+end
+

--- a/db/migrate/20160308134050_add_community_id_values_to_emails.rb
+++ b/db/migrate/20160308134050_add_community_id_values_to_emails.rb
@@ -1,0 +1,15 @@
+class AddCommunityIdValuesToEmails < ActiveRecord::Migration
+  def up
+    execute("
+      UPDATE emails AS e, community_memberships AS cm
+      SET e.community_id = cm.community_id
+      WHERE cm.person_id = e.person_id
+    ")
+  end
+  def down
+    execute("
+      UPDATE emails
+      SET community_id = NULL
+   ")
+  end
+end

--- a/db/migrate/20160308134100_add_unique_indecies_on_facebook_id_and_email.rb
+++ b/db/migrate/20160308134100_add_unique_indecies_on_facebook_id_and_email.rb
@@ -1,0 +1,10 @@
+class AddUniqueIndeciesOnFacebookIdAndEmail < ActiveRecord::Migration
+  def change
+    remove_index :people, column: :facebook_id
+    add_index :people, [:facebook_id, :community_id], unique: true
+
+    # Don't remove existing index on 'address'. We still do searches
+    # with the address only
+    add_index :emails, [:address, :community_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -388,6 +388,7 @@ ActiveRecord::Schema.define(version: 20160324065708) do
 
   create_table "emails", force: :cascade do |t|
     t.string   "person_id",            limit: 255
+    t.integer  "community_id",         limit: 4
     t.string   "address",              limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
@@ -397,6 +398,7 @@ ActiveRecord::Schema.define(version: 20160324065708) do
     t.boolean  "send_notifications"
   end
 
+  add_index "emails", ["address", "community_id"], name: "index_emails_on_address_and_community_id", unique: true, using: :btree
   add_index "emails", ["address"], name: "index_emails_on_address", using: :btree
   add_index "emails", ["person_id"], name: "index_emails_on_person_id", using: :btree
 
@@ -853,6 +855,7 @@ ActiveRecord::Schema.define(version: 20160324065708) do
 
   create_table "people", id: false, force: :cascade do |t|
     t.string   "id",                                 limit: 22,                    null: false
+    t.integer  "community_id",                       limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "is_admin",                           limit: 4,     default: 0
@@ -892,12 +895,11 @@ ActiveRecord::Schema.define(version: 20160324065708) do
     t.string   "organization_name",                  limit: 255
     t.boolean  "deleted",                                          default: false
     t.string   "cloned_from",                        limit: 22
-    t.integer  "community_id",                       limit: 4
   end
 
   add_index "people", ["authentication_token"], name: "index_people_on_authentication_token", using: :btree
   add_index "people", ["email"], name: "index_people_on_email", unique: true, using: :btree
-  add_index "people", ["facebook_id"], name: "index_people_on_facebook_id", using: :btree
+  add_index "people", ["facebook_id", "community_id"], name: "index_people_on_facebook_id_and_community_id", unique: true, using: :btree
   add_index "people", ["id"], name: "index_people_on_id", using: :btree
   add_index "people", ["reset_password_token"], name: "index_people_on_reset_password_token", unique: true, using: :btree
   add_index "people", ["username", "community_id"], name: "index_people_on_username_and_community_id", unique: true, using: :btree

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                   :integer          not null, primary key
 #  person_id            :string(255)
+#  community_id         :integer
 #  address              :string(255)
 #  confirmed_at         :datetime
 #  confirmation_sent_at :datetime
@@ -14,8 +15,9 @@
 #
 # Indexes
 #
-#  index_emails_on_address    (address)
-#  index_emails_on_person_id  (person_id)
+#  index_emails_on_address                   (address)
+#  index_emails_on_address_and_community_id  (address,community_id) UNIQUE
+#  index_emails_on_person_id                 (person_id)
 #
 
 require 'spec_helper'

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -3,6 +3,7 @@
 # Table name: people
 #
 #  id                                 :string(22)       not null, primary key
+#  community_id                       :integer
 #  created_at                         :datetime
 #  updated_at                         :datetime
 #  is_admin                           :integer          default(0)
@@ -42,16 +43,15 @@
 #  organization_name                  :string(255)
 #  deleted                            :boolean          default(FALSE)
 #  cloned_from                        :string(22)
-#  community_id                       :integer
 #
 # Indexes
 #
-#  index_people_on_authentication_token       (authentication_token)
-#  index_people_on_email                      (email) UNIQUE
-#  index_people_on_facebook_id                (facebook_id)
-#  index_people_on_id                         (id)
-#  index_people_on_reset_password_token       (reset_password_token) UNIQUE
-#  index_people_on_username_and_community_id  (username,community_id) UNIQUE
+#  index_people_on_authentication_token          (authentication_token)
+#  index_people_on_email                         (email) UNIQUE
+#  index_people_on_facebook_id_and_community_id  (facebook_id,community_id) UNIQUE
+#  index_people_on_id                            (id)
+#  index_people_on_reset_password_token          (reset_password_token) UNIQUE
+#  index_people_on_username_and_community_id     (username,community_id) UNIQUE
 #
 
 require 'spec_helper'


### PR DESCRIPTION
- Add emails.community_id column
- Populate that column
- Set unique index on people.facebook_id and people.community_id
- Set unique index on emails.address and emails.community_id