### PR TITLE
In the map listing bubble, use icon_tag instead of font's classname

### DIFF
--- a/app/views/homepage/_listing_bubble_multiple.haml
+++ b/app/views/homepage/_listing_bubble_multiple.haml
@@ -1,7 +1,7 @@
 .bubble-navi-container
   .bubble-navi
     %a
-      %i.bubble-navi-left.ss-navigateleft
+      = icon_tag("directleft", ["bubble-navi-left"])
     .bubble-navi-header
       %span.buble-navi-selected-item
         = "1"
@@ -9,6 +9,6 @@
       %span.buble-navi-total-items
         = "2"
     %a
-      %i.bubble-navi-right.ss-navigateright
+      = icon_tag("directright", ["bubble-navi-right"])
   .bubble-multi-content
     =render :partial => "homepage/listing_bubble", :collection => @listings, :as => :listing


### PR DESCRIPTION
Fixes #1871

Before:

![screen shot 2016-04-07 at 09 02 17](https://cloud.githubusercontent.com/assets/429876/14342060/8e32cb36-fc9f-11e5-87a3-111e957dea37.png)

After:

![screen shot 2016-04-07 at 09 00 19](https://cloud.githubusercontent.com/assets/429876/14342068/97640a62-fc9f-11e5-9aef-b5e6ddac80aa.png)

