### PR TITLE
Remove find by username from application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :root, :logged_in?, :current_user?
 
+  attr_reader :current_user
+
   def redirect_removed_locale
     if params[:locale] && Kassi::Application.config.REMOVED_LOCALES.include?(params[:locale])
       fallback = Kassi::Application.config.REMOVED_LOCALE_FALLBACKS[params[:locale]]
@@ -178,18 +180,6 @@ class ApplicationController < ActionController::Base
     session[:return_to] = request.fullpath
     flash[:warning] = warning_message
     redirect_to login_path and return
-  end
-
-  # A before filter for views that only authorized users can access
-  def ensure_authorized(error_message)
-    if logged_in?
-      @person = Person.find(params[:person_id] || params[:id])
-      return if current_user?(@person)
-    end
-
-    # This is reached only if not authorized
-    flash[:error] = error_message
-    redirect_to root and return
   end
 
   def logged_in?

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,9 +6,7 @@ class MessagesController < ApplicationController
     controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_send_a_message")
   end
 
-  before_filter do |controller|
-    controller.ensure_authorized t("layouts.notifications.you_are_not_authorized_to_do_this")
-  end
+  before_filter EnsureCanAccessPerson.new(:person_id, error_message_key: "layouts.notifications.you_are_not_authorized_to_do_this")
 
   def create
     unless is_participant?(@current_user, params[:message][:conversation_id])

--- a/app/filters/ensure_can_access_person.rb
+++ b/app/filters/ensure_can_access_person.rb
@@ -1,0 +1,17 @@
+class EnsureCanAccessPerson
+
+  def initialize(param_name, opts = {})
+    @param_name = param_name
+    @error_message_key = opts[:error_message_key] || "layouts.notifications.you_are_not_authorized_to_do_this"
+  end
+
+  def before(controller)
+    current_user = controller.current_user
+    username = controller.params[@param_name]
+
+    unless current_user && current_user.username == username
+      controller.flash[:error] = I18n.t(@error_message_key)
+      controller.redirect_to controller.root and return
+    end
+  end
+end

--- a/app/views/people/_googlemap.haml
+++ b/app/views/people/_googlemap.haml
@@ -1,7 +1,0 @@
-.googlemap
-  .jsmap{:id => "map_canvas"}
-  - content_for :extra_javascript do
-    :javascript
-      $(document).ready(function() {
-        googlemapMarkerInit('map_canvas',"location", undefined, undefined, #{tribe_latitude}, #{tribe_longitude}, "#{@person.location.address}");
-      });

--- a/app/views/settings/_community_updates_radiobutton.haml
+++ b/app/views/settings/_community_updates_radiobutton.haml
@@ -1,3 +1,3 @@
 .checkbox-container
-  = radio_button_tag("person[min_days_between_community_updates]", options[1], @person.min_days_between_community_updates == options[1], :id => options[0])
+  = radio_button_tag("person[min_days_between_community_updates]", options[1], target_user.min_days_between_community_updates == options[1], :id => options[0])
   = label_tag options[0], t("settings.notifications.#{options[0]}").html_safe, :class => "radio"

--- a/app/views/settings/_notification_checkbox.haml
+++ b/app/views/settings/_notification_checkbox.haml
@@ -1,3 +1,3 @@
 .checkbox-container
-  = check_box_tag "person[preferences][#{notification_type}]", "true", @person.preferences[notification_type] ? true : false, :id => notification_type
+  = check_box_tag "person[preferences][#{notification_type}]", "true", target_user.preferences[notification_type] ? true : false, :id => notification_type
   = label_tag notification_type, t("settings.notifications.#{notification_type}")

--- a/app/views/settings/account.haml
+++ b/app/views/settings/account.haml
@@ -4,7 +4,7 @@
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")
 
-= render :partial => "layouts/left_hand_navigation", :locals => { :links => settings_links_for(@current_user, @current_community) }
+= render :partial => "layouts/left_hand_navigation", :locals => { :links => settings_links_for(target_user, @current_community) }
 
 #person_settings_form.left-navi-section.settings-section.account-settings
   -# Username
@@ -13,11 +13,11 @@
     .account-settings-text
       %b
         = username_label + ":"
-      = @person.username
+      = target_user.username
 
   -# Email
   .account-settings-row
-    = form_for @person, :html => {:id => 'email_form'} do |form|
+    = form_for target_user, :html => {:id => 'email_form'} do |form|
       .ss-mail.account-settings-icon
       .account-settings-text#account_email_content
         .account-settings-title
@@ -37,16 +37,16 @@
             %b
               = t(".email.confirmation_title_desktop")
         .account-settings-email-content-rows#account-settings-email-content-rows
-          - @person.emails.each_with_index do |email, index|
+          - target_user.emails.each_with_index do |email, index|
             - unless email.new_record?
               .account-settings-email-row{:class => ((index % 2 == 0) ? "account-settings-email-row-highlight" : "")}
                 .account-settings-email-row-address
                   = email.address
                 .account-settings-email-row-delete
-                  - can_delete = @person.can_delete_email(email)
+                  - can_delete = target_user.can_delete_email(email)
                   - disabled_class = can_delete ? "" : "disabled"
                   - if can_delete
-                    = link_to person_email_path(@person.id, email.id), :method => :delete, :data => {:confirm => t(".email.remove_confirmation")}, :class => "account-settings-email-row-delete-link" do
+                    = link_to person_email_path(target_user.username, email.id), :method => :delete, :data => {:confirm => t(".email.remove_confirmation")}, :class => "account-settings-email-row-delete-link" do
                       .settings-email-mobile-label-container
                         .visible-desktop.settings-email-mobile-label
                           = icon_tag("cross", ["account-settings-email-row-delete-cross", disabled_class])
@@ -74,7 +74,7 @@
                         = icon_tag("check", ["icon-fix"])
                     - else
                       = t(".email.status_pending")
-                      %small= link_to(t(".email.confirmation_resend"), send_confirmation_person_email_path(@current_user, email), :method => :post, :class => "account-settings-email-row-resend-link")
+                      %small= link_to(t(".email.confirmation_resend"), send_confirmation_person_email_path(target_user, email), :method => :post, :class => "account-settings-email-row-resend-link")
 
         .account-settings-email-row.account-new-email-link
           = link_to t(".email.add_new_with_plus"), "#", id: "account-new-email"
@@ -108,7 +108,7 @@
       = "********"
       = link_to t(".change"), "#", :id => "account_password_link", :class => "change-link"
     #account_password_form.password-form
-      = form_for @person, :html => {:id => 'password_form'} do |form|
+      = form_for target_user, :html => {:id => 'password_form'} do |form|
         = form.password_field :password, :class => :text_field_account, :maxlength => "255", :placeholder => t(".new_password")
         = form.password_field :password2, :class => :text_field_account, :maxlength => "255", :placeholder => t(".confirm_new_password")
         = form.button t(".save"), :class => "send_button_account", :id => "password_submit"
@@ -128,7 +128,7 @@
     %p
       = t("settings.account.delete_information_others_involved")
 
-    = form_tag url_for(:controller => :people, :action => :destroy, :id => @current_user.id), :method => :delete do
+    = form_tag url_for(:controller => :people, :action => :destroy, :id => target_user.username), :method => :delete do
       = button_tag t('.delete_account_button'), :class => (has_unfinished ? 'disabled-button' : ''), :disabled => has_unfinished, :id => "delete_account_button", :data => {:confirm => t('.delete_account_confirmation_popup')}
 
     - if has_unfinished

--- a/app/views/settings/notifications.haml
+++ b/app/views/settings/notifications.haml
@@ -1,21 +1,21 @@
 - content_for :javascript do
-  initialize_update_notification_settings_form("#{I18n.locale}","#{@person.id.to_s}");
+  initialize_update_notification_settings_form("#{I18n.locale}","#{target_user.id.to_s}");
 
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")
 
-= render :partial => "layouts/left_hand_navigation", :locals => { :links => settings_links_for(@current_user, @current_community) }
+= render :partial => "layouts/left_hand_navigation", :locals => { :links => settings_links_for(target_user, @current_community) }
 
 #person_settings_form.left-navi-section.settings-section.notification-settings
-  = form_for @person do |form|
+  = form_for target_user do |form|
 
     %h2= t(".community_updates")
-    = render :partial => "community_updates_radiobutton", :collection => [["email_daily_community_updates", 1], ["email_weekly_community_updates", 7], ["do_not_email_community_updates", 100000]], :as => :options
+    = render :partial => "community_updates_radiobutton", :collection => [["email_daily_community_updates", 1], ["email_weekly_community_updates", 7], ["do_not_email_community_updates", 100000]], :as => :options, locals: {target_user: target_user}
 
     %h2.lower= t(".newsletters")
-    = render :partial => "notification_checkbox", :collection => Person::EMAIL_NEWSLETTER_TYPES, :as => :notification_type
+    = render :partial => "notification_checkbox", :collection => Person::EMAIL_NEWSLETTER_TYPES, :as => :notification_type, locals: {target_user: target_user}
 
     %h2.lower= t(".i_want_to_get_email_notification_when")
-    = render :partial => "notification_checkbox", :collection => @current_community.email_notification_types, :as => :notification_type
+    = render :partial => "notification_checkbox", :collection => @current_community.email_notification_types, :as => :notification_type, locals: {target_user: target_user}
 
     = form.button t("settings.save_information"), :class => "send_button_notifications"

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -1,5 +1,5 @@
 - content_for :javascript do
-  initialize_update_profile_info_form("#{I18n.locale}","#{@person.id.to_s}", #{@current_community.real_name_required?});
+  initialize_update_profile_info_form("#{I18n.locale}","#{target_user.id.to_s}", #{@current_community.real_name_required?});
 
 - content_for :extra_javascript do
   = javascript_include_tag "https://maps.google.com/maps/api/js?sensor=true"
@@ -7,15 +7,15 @@
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")
 
-= render :partial => "layouts/left_hand_navigation", :locals => { :links => settings_links_for(@current_user, @current_community) }
+= render :partial => "layouts/left_hand_navigation", :locals => { :links => settings_links_for(target_user, @current_community) }
 
 #person_settings_form.left-navi-section.settings-section
   %p
     = t("settings.profile.these_fields_are_shown_in_your")
-    = link_to(t("settings.profile.profile_page"), @person) + "."
+    = link_to(t("settings.profile.profile_page"), target_user) + "."
 
-  = form_for @person do |form|
-    - unless @person.is_organization
+  = form_for target_user do |form|
+    - unless target_user.is_organization
       = form.label :given_name, t("settings.profile.given_name")
       = form.text_field :given_name, :class => "text_field", :maxlength => "30"
       .inline-label-container
@@ -56,8 +56,8 @@
     = form.label :description, t("settings.profile.about_you"), :class => "input"
     = form.text_area :description, :class => "update_profile_description_text_area"
     = form.fields_for :location do |loc|
-      = loc.hidden_field :address, :value => @person.location.address
-      = loc.hidden_field :google_address, :value => @person.location.google_address
-      = loc.hidden_field :latitude, :value => @person.location.latitude
-      = loc.hidden_field :longitude, :value => @person.location.longitude
+      = loc.hidden_field :address, :value => target_user.location.address
+      = loc.hidden_field :google_address, :value => target_user.location.google_address
+      = loc.hidden_field :latitude, :value => target_user.location.latitude
+      = loc.hidden_field :longitude, :value => target_user.location.longitude
     = form.button t("settings.save_information"), :class => "send_button"

--- a/app/views/settings/unsubscribe.haml
+++ b/app/views/settings/unsubscribe.haml
@@ -1,8 +1,8 @@
 .centered-section
-  - if @unsubscribe_successful
+  - if unsubscribe_successful
     %h2
       = t("settings.notifications.unsubscribe_succesful")
-    = t("settings.notifications.unsubscribe_info_text", :settings_link => link_to(t("settings.notifications.settings_link"), notifications_person_settings_path(:person_id => @person_to_unsubscribe.id)), :homepage_link => link_to(t("settings.notifications.homepage_link"), root_path) ).html_safe
+    = t("settings.notifications.unsubscribe_info_text", :settings_link => link_to(t("settings.notifications.settings_link"), notifications_person_settings_path(:person_id => target_user.username)), :homepage_link => link_to(t("settings.notifications.homepage_link"), root_path) ).html_safe
   - else
     %h2
       = t("settings.notifications.unsubscribe_unsuccesful")

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -92,16 +92,17 @@ describe PeopleController, type: :controller do
       @person = FactoryGirl.create(:person)
       @community.members << @person
       @id = @person.id
-      expect(Person.find_by_id(@id)).not_to be_nil
+      @username = @person.username
+      expect(Person.find_by_username_and_community_id(@username, @community.id)).not_to be_nil
     end
 
     it "deletes the person" do
       sign_in_for_spec(@person)
 
-      delete :destroy, {:person_id => @id}
+      delete :destroy, {:id => @username}
       expect(response.status).to eq(302)
 
-      expect(Person.find_by_id(@id).deleted?).to eql(true)
+      expect(Person.find_by_username_and_community_id(@username, @community.id).deleted?).to eql(true)
     end
 
     it "doesn't delete if not logged in as target person" do
@@ -109,10 +110,10 @@ describe PeopleController, type: :controller do
       @community.members << b
       sign_in_for_spec(b)
 
-      delete :destroy, {:person_id => @id}
+      delete :destroy, {:id => @username}
       expect(response.status).to eq(302)
 
-      expect(Person.find_by_id(@id)).not_to be_nil
+      expect(Person.find_by_username_and_community_id(@username, @community.id)).not_to be_nil
     end
 
   end


### PR DESCRIPTION
Remove the Person.find(username) calls from ApplicationController. This PR aims to apply the lessons learnt from https://github.com/sharetribe/sharetribe/pull/1870.