### PR TITLE
Remove unused activate/deactivate feature

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -8,13 +8,8 @@ class PeopleController < Devise::RegistrationsController
     controller.ensure_authorized t("layouts.notifications.you_are_not_authorized_to_view_this_content")
   end
 
-  before_filter :ensure_is_admin, :only => [ :activate, :deactivate ]
-
   skip_filter :check_email_confirmation, :only => [ :update]
   skip_filter :cannot_access_without_joining, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
-
-  # Skip auth token check as current jQuery doesn't provide it automatically
-  skip_before_filter :verify_authenticity_token, :only => [:activate, :deactivate]
 
   helper_method :show_closed?
 
@@ -349,14 +344,6 @@ class PeopleController < Devise::RegistrationsController
     params[:closed] && params[:closed].eql?("true")
   end
 
-  def activate
-    change_active_status("activated")
-  end
-
-  def deactivate
-    change_active_status("deactivated")
-  end
-
   private
 
   # Create a new person by params and current community
@@ -389,22 +376,6 @@ class PeopleController < Devise::RegistrationsController
 
     respond_to do |format|
       format.json { render :json => available }
-    end
-  end
-
-  def change_active_status(status)
-    @person = Person.find(params[:id])
-    #@person.update_attribute(:active, 0)
-    @person.update_attribute(:active, (status.eql?("activated") ? true : false))
-    @person.listings.update_all(:open => false) if status.eql?("deactivated")
-    flash[:notice] = t("layouts.notifications.person_#{status}")
-    respond_to do |format|
-      format.html {
-        redirect_to @person
-      }
-      format.js {
-        render :layout => false
-      }
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -49,10 +49,6 @@ class SessionsController < ApplicationController
 
     session[:form_login] = nil
 
-    if @current_user
-      @current_user.update_attribute(:active, true) unless @current_user.active?
-    end
-
     unless @current_user && (!@current_user.communities.include?(@current_community) || @current_community.consent.eql?(@current_user.consent(@current_community)) || @current_user.is_admin?)
       # Either the user has succesfully logged in, but is not found in Sharetribe DB
       # or the user is a member of this community but the terms of use have changed.

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -11,7 +11,6 @@
 #  active_days_count                  :integer          default(0)
 #  last_page_load_date                :datetime
 #  test_group_number                  :integer          default(1)
-#  active                             :boolean          default(TRUE)
 #  username                           :string(255)
 #  email                              :string(255)
 #  encrypted_password                 :string(255)      default(""), not null
@@ -474,9 +473,9 @@ class Person < ActiveRecord::Base
     confirmed_email = !confirmed_notification_emails.empty?
     if email_type == "community_updates"
       # this is handled outside prefenrences so answer separately
-      return active && confirmed_email && min_days_between_community_updates < 100000
+      return confirmed_email && min_days_between_community_updates < 100000
     end
-    active && confirmed_email && preferences && preferences[email_type]
+    confirmed_email && preferences && preferences[email_type]
   end
 
   def profile_info_empty?

--- a/app/views/people/_edit_links.haml
+++ b/app/views/people/_edit_links.haml
@@ -1,4 +1,0 @@
-- if @person.active?
-  = link_to t(".deactivate"), deactivate_person_path(@person), :class => "deactivate_person", :method => :put, :remote => true
-- else
-  = link_to t(".activate"), activate_person_path(@person), :class => "activate_person", :method => :put, :remote => true

--- a/app/views/people/_inactive_notification.haml
+++ b/app/views/people/_inactive_notification.haml
@@ -1,4 +1,0 @@
-- unless @person.active
-  #inactive_notification_box
-    %h2= t(".this_person_is_not_active_in_kassi")
-    %p= t(".inactive_description")

--- a/app/views/people/activate.js.erb
+++ b/app/views/people/activate.js.erb
@@ -1,5 +1,0 @@
-/* Update edit links */
-$("#edit_links").html("<%= escape_javascript(render(:partial => 'people/edit_links')) %>");
-
-/* Update inactive notification */
-$("#inactive_notification").html("<%= escape_javascript(render(:partial => 'people/inactive_notification')) %>");

--- a/app/views/people/deactivate.js.erb
+++ b/app/views/people/deactivate.js.erb
@@ -1,5 +1,0 @@
-/* Update edit links */
-$("#edit_links").html("<%= escape_javascript(render(:partial => 'people/edit_links')) %>");
-
-/* Update inactive notification */
-$("#inactive_notification").html("<%= escape_javascript(render(:partial => 'people/inactive_notification')) %>");

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1333,8 +1333,6 @@ en:
       cannot_receive_payment: "The other party can't receive the payment due some error. Please contact the administrators to clarify the situation"
       payment_waiting_for_later_accomplishment: "When you have paid, we'll notify the seller and you will get a receipt in email"
       password_recovery_sent: "Instructions to change your password were sent to your email."
-      person_activated: "User activated"
-      person_deactivated: "User deactivated"
       person_updated_successfully: "Information updated"
       poll_answered: "Poll answered"
       poll_could_not_be_answered: "Poll could not be answered"
@@ -1791,18 +1789,12 @@ en:
     wait_while_loading: "Please wait."
     chatting_with_paypal: "We are chatting with PayPal."
   people:
-    edit_links:
-      activate: Activate
-      deactivate: Deactivate
     help_texts:
       feedback_description_title: Feedback
       help_invitation_code_title: "You need an invite to join"
       terms_title: "%{service_name} terms of use"
       invite_only_help_text: "Select this option if you want that new members can join only if they are invited by an existing user."
       invite_only_help_text_title: Invite-only
-    inactive_notification:
-      this_person_is_not_active_in_kassi: "This user is no longer active in %{service_name}"
-      inactive_description: "This user has stopped using %{service_name}. You cannot contact this user, give feedback to them or comment their listings."
     new:
       create_new_account: "Create account"
       email: "Email address"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,10 +305,6 @@ Kassi::Application.routes.draw do
       end
 
       resources :people, except: [:show], :path => "" do
-        member do
-          put :activate
-          put :deactivate
-        end
         resources :listings do
           member do
             put :close

--- a/db/migrate/20160407132641_remove_active_from_people.rb
+++ b/db/migrate/20160407132641_remove_active_from_people.rb
@@ -1,0 +1,5 @@
+class RemoveActiveFromPeople < ActiveRecord::Migration
+  def change
+    remove_column :people, :active, :boolean, after: :test_group_number, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160322103156) do
+ActiveRecord::Schema.define(version: 20160407132641) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -861,7 +861,6 @@ ActiveRecord::Schema.define(version: 20160322103156) do
     t.integer  "active_days_count",                  limit: 4,     default: 0
     t.datetime "last_page_load_date"
     t.integer  "test_group_number",                  limit: 4,     default: 1
-    t.boolean  "active",                                           default: true
     t.string   "username",                           limit: 255
     t.string   "email",                              limit: 255
     t.string   "encrypted_password",                 limit: 255,   default: "",    null: false

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -11,7 +11,6 @@
 #  active_days_count                  :integer          default(0)
 #  last_page_load_date                :datetime
 #  test_group_number                  :integer          default(1)
-#  active                             :boolean          default(TRUE)
 #  username                           :string(255)
 #  email                              :string(255)
 #  encrypted_password                 :string(255)      default(""), not null


### PR DESCRIPTION
Once upon a time we had a feature for activating and deactivating users. We don't have that anymore, so let's remove the code also.