### PR TITLE
Remove unused communities.feedback_to_admin

### DIFF
--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -339,7 +339,7 @@ class PersonMailer < ActionMailer::Base
   end
 
   def mail_feedback_to(community, platform_admin_email)
-    if community.feedback_to_admin? && community.admin_emails.any?
+    if community.admin_emails.any?
       community.admin_emails.join(",")
     else
       platform_admin_email

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -14,7 +14,6 @@
 #  email_admins_about_new_members             :boolean          default(FALSE)
 #  use_fb_like                                :boolean          default(FALSE)
 #  real_name_required                         :boolean          default(TRUE)
-#  feedback_to_admin                          :boolean          default(TRUE)
 #  automatic_newsletters                      :boolean          default(TRUE)
 #  join_with_invite_only                      :boolean          default(FALSE)
 #  allowed_emails                             :text(65535)

--- a/db/migrate/20160408061218_remove_feedback_to_admin_from_communities.rb
+++ b/db/migrate/20160408061218_remove_feedback_to_admin_from_communities.rb
@@ -1,0 +1,5 @@
+class RemoveFeedbackToAdminFromCommunities < ActiveRecord::Migration
+  def change
+    remove_column :communities, :feedback_to_admin, :boolean, default: true, after: :real_name_required
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407132641) do
+ActiveRecord::Schema.define(version: 20160408061218) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -137,7 +137,6 @@ ActiveRecord::Schema.define(version: 20160407132641) do
     t.boolean  "email_admins_about_new_members",                           default: false
     t.boolean  "use_fb_like",                                              default: false
     t.boolean  "real_name_required",                                       default: true
-    t.boolean  "feedback_to_admin",                                        default: true
     t.boolean  "automatic_newsletters",                                    default: true
     t.boolean  "join_with_invite_only",                                    default: false
     t.text     "allowed_emails",                             limit: 65535

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -160,7 +160,7 @@ describe PersonMailer, type: :mailer do
 
   it "should send email to community admins of new feedback if that setting is on" do
     @feedback = FactoryGirl.create(:feedback)
-    @community = FactoryGirl.create(:community, :feedback_to_admin => 1)
+    @community = FactoryGirl.create(:community)
     m = CommunityMembership.create(:person_id => @test_person.id, :community_id => @community.id, :status => "accepted")
     m.update_attribute(:admin, true)
     email = MailCarrier.deliver_now(PersonMailer.new_feedback(@feedback, @community))

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -15,7 +15,6 @@
 #  email_admins_about_new_members             :boolean          default(FALSE)
 #  use_fb_like                                :boolean          default(FALSE)
 #  real_name_required                         :boolean          default(TRUE)
-#  feedback_to_admin                          :boolean          default(TRUE)
 #  automatic_newsletters                      :boolean          default(TRUE)
 #  join_with_invite_only                      :boolean          default(FALSE)
 #  allowed_emails                             :text(65535)


### PR DESCRIPTION
In the past we were able to select whether the messages to admins go to marketplace admins or to "platform admins", e.g. Sharetribe. That's no longer in use, all the messages to admins should marketplace admins.