### PR TITLE
On boarding guide backend

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -231,8 +231,10 @@ class Admin::CommunitiesController < ApplicationController
     update(@current_community,
            community_params.merge(stylesheet_needs_recompile: regenerate_css?(params, @current_community)),
            edit_look_and_feel_admin_community_path(@current_community),
-           :edit_look_and_feel) {
+           :edit_look_and_feel) { |community|
       Delayed::Job.enqueue(CompileCustomStylesheetJob.new(@current_community.id), priority: 3)
+      Admin::OnboardingWizard.new(community.id)
+        .update_from_event(:community_updated, community)
     }
   end
 
@@ -343,7 +345,7 @@ class Admin::CommunitiesController < ApplicationController
   def update(model, params, path, action, &block)
     if model.update_attributes(params)
       flash[:notice] = t("layouts.notifications.community_updated")
-      yield if block_given? #on success, call optional block
+      block.call(model) if block_given? #on success, call optional block
       redirect_to path
     else
       flash.now[:error] = t("layouts.notifications.community_update_failed")

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -232,7 +232,7 @@ class Admin::CommunitiesController < ApplicationController
            community_params.merge(stylesheet_needs_recompile: regenerate_css?(params, @current_community)),
            edit_look_and_feel_admin_community_path(@current_community),
            :edit_look_and_feel) { |community|
-      Delayed::Job.enqueue(CompileCustomStylesheetJob.new(@current_community.id), priority: 3)
+      Delayed::Job.enqueue(CompileCustomStylesheetJob.new(community.id), priority: 3)
       Admin::OnboardingWizard.new(community.id)
         .update_from_event(:community_updated, community)
     }

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -114,6 +114,8 @@ class Admin::CustomFieldsController < ApplicationController
 
     success = if valid_categories?(@current_community, params[:custom_field][:category_attributes])
       @custom_field.save
+      Admin::OnboardingWizard.new(@current_community.id)
+        .update_from_event(:custom_field_created, @custom_field)
     end
 
     if success

--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -84,6 +84,8 @@ class Admin::PaypalPreferencesController < ApplicationController
                               minimum_price_cents: paypal_prefs_form.minimum_listing_price.cents,
                               minimum_transaction_fee_cents: paypal_prefs_form.minimum_transaction_fee.cents})
 
+      Admin::OnboardingWizard.new(@current_community.id)
+        .update_from_event(:paypal_preferences_updated, @current_community)
       flash[:notice] = t("admin.paypal_accounts.preferences_updated")
     else
       flash[:error] = paypal_prefs_form.errors.full_messages.join(", ")

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -36,6 +36,8 @@ class InvitationsController < ApplicationController
 
       if invitation.save
         Delayed::Job.enqueue(InvitationCreatedJob.new(invitation.id, @current_community.id))
+        Admin::OnboardingWizard.new(@current_community.id)
+          .update_from_event(:invitation_created, invitation)
       else
         sending_problems = true
       end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -303,6 +303,8 @@ class ListingsController < ApplicationController
           "layouts.notifications.listing_created_successfully",
           :new_listing_link => view_context.link_to(t("layouts.notifications.create_new_listing"),new_listing_path)
         ).html_safe
+        Admin::OnboardingWizard.new(@current_community.id)
+          .update_from_event(:listing_created, @listing)
         redirect_to @listing, status: 303 and return
       else
         logger.error("Errors in creating listing: #{@listing.errors.full_messages.inspect}")

--- a/app/models/checkout_account.rb
+++ b/app/models/checkout_account.rb
@@ -7,8 +7,8 @@
 #  merchant_id               :string(255)      not null
 #  merchant_key              :string(255)      not null
 #  person_id                 :string(255)      not null
-#  created_at                :datetime         default(NULL), not null
-#  updated_at                :datetime         default(NULL), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 
 class CheckoutAccount < ActiveRecord::Base

--- a/app/models/marketplace_setup_steps.rb
+++ b/app/models/marketplace_setup_steps.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: marketplace_setup_steps
+#
+#  id                     :integer          not null, primary key
+#  community_id           :integer          not null
+#  slogan_and_description :boolean          default(FALSE), not null
+#  cover_photo            :boolean          default(FALSE), not null
+#  filter                 :boolean          default(FALSE), not null
+#  paypal                 :boolean          default(FALSE), not null
+#  listing                :boolean          default(FALSE), not null
+#  invitation             :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_marketplace_setup_steps_on_community_id  (community_id) UNIQUE
+#
+
+class MarketplaceSetupSteps < ActiveRecord::Base
+  validates_presence_of(:community_id)
+end

--- a/app/services/admin/onboarding_wizard.rb
+++ b/app/services/admin/onboarding_wizard.rb
@@ -1,0 +1,104 @@
+module Admin
+  class OnboardingWizard
+
+    MarketplaceSetupSteps = ::MarketplaceSetupSteps
+
+    KNOWN_STATUSES = [
+      :slogan_and_description, :cover_photo, :filter, :paypal, :listing, :invitation
+    ].to_set
+
+    EVENT_TYPES = [
+      :community_customizations_updated, :community_updated
+    ].to_set
+
+    SetupStatus = EntityUtils.define_builder(
+      [:community_id, :fixnum, :mandatory],
+      [:slogan_and_description, :bool, :mandatory],
+      [:cover_photo, :bool, :mandatory],
+      [:filter, :bool, :mandatory],
+      [:paypal, :bool, :mandatory],
+      [:listing, :bool, :mandatory],
+      [:invitation, :bool, :mandatory])
+
+    def initialize(community_id)
+      @community_id = community_id
+    end
+
+    # Get the status as a SetupStatus hash
+    def setup_status
+      load_setup_status(@community_id)
+    end
+
+    # Imperative shell. Process the given event_type with *args
+    # arguments. If the event leads to a state change apply it and
+    # return true. Otherwise return false.
+    def update_from_event(event_type, *args)
+      setup_status = load_setup_status(@community_id)
+      completed_status = process_event(event_type, setup_status, args)
+
+      if completed_status
+        update_completed(@community_id, completed_status)
+        true
+      else
+        false
+      end
+    end
+
+
+    private
+
+    def process_event(event_type, setup_status, args)
+      unless EVENT_TYPES.include?(event_type)
+        raise ArgumentError.new("Unkown event type: #{event_type}")
+      end
+
+      # Dispatch to event handler method of same name as event_type
+      method(event_type).call(setup_status, *args)
+    end
+
+    # Update events
+
+    def community_customizations_updated(setup_status, community_customizations)
+      if !setup_status[:slogan_and_description] &&
+         community_customizations.all? { |c| c.slogan.present? } &&
+         community_customizations.all? { |c| c.description.present? }
+        :slogan_and_description
+      end
+    end
+
+    def community_updated
+    end
+
+    def filter_created
+    end
+
+    def paypal_connected
+    end
+
+    def listing_created
+    end
+
+    def invitation_created
+    end
+
+    def load_setup_status(community_id)
+      m = Maybe(MarketplaceSetupSteps.find_by(community_id: community_id))
+          .or_else { MarketplaceSetupSteps.new(community_id: community_id) }
+
+      to_setup_status(m)
+    end
+
+    def update_completed(community_id, status)
+      unless KNOWN_STATUSES.include?(status)
+        raise ArgumentError.new("Unkown status: #{status}")
+      end
+
+      m = MarketplaceSetupSteps.find_or_create_by(community_id: community_id)
+      m.update(status => true)
+    end
+
+    def to_setup_status(model)
+      SetupStatus.call(EntityUtils.model_to_hash(model))
+   end
+  end
+end

--- a/app/services/admin/onboarding_wizard.rb
+++ b/app/services/admin/onboarding_wizard.rb
@@ -39,8 +39,7 @@ module Admin
     # arguments. If the event leads to a state change apply it and
     # return true. Otherwise return false.
     def update_from_event(event_type, *args)
-      setup_status = to_setup_status(load_setup_steps(@community_id))
-      completed_status = process_event(event_type, setup_status, args)
+      completed_status = process_event(event_type, setup_status(), args)
 
       if completed_status
         update_completed(@community_id, completed_status)
@@ -55,7 +54,7 @@ module Admin
 
     def process_event(event_type, setup_status, args)
       unless EVENT_TYPES.include?(event_type)
-        raise ArgumentError.new("Unkown event type: #{event_type}")
+        raise ArgumentError.new("Unknown event type: #{event_type}")
       end
 
       # Dispatch to event handler method of same name as event_type
@@ -150,7 +149,7 @@ module Admin
 
     def update_completed(community_id, status)
       unless KNOWN_STATUSES.include?(status)
-        raise ArgumentError.new("Unkown status: #{status}")
+        raise ArgumentError.new("Unknown status: #{status}")
       end
 
       m = load_setup_steps(community_id)

--- a/app/services/admin/onboarding_wizard.rb
+++ b/app/services/admin/onboarding_wizard.rb
@@ -66,7 +66,11 @@ module Admin
       end
     end
 
-    def community_updated
+    def community_updated(setup_status, community)
+      if !setup_status[:cover_photo] &&
+         Maybe(community).map { |c| c.cover_photo_file_name.present? }.or_else(false)
+        :cover_photo
+      end
     end
 
     def filter_created

--- a/app/view_utils/paypal_helper.rb
+++ b/app/view_utils/paypal_helper.rb
@@ -108,6 +108,6 @@ module PaypalHelper
   end
 
   def accounts_api
-    PaypalService::API::Api.accounts_api
+    PaypalService::API::Api.accounts
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,7 +182,6 @@ Kassi::Application.routes.draw do
       end
       resources :custom_fields do
         collection do
-          get :add_option
           get :edit_price
           get :edit_location
           post :order

--- a/db/migrate/20160407103437_create_marketplace_setup_steps.rb
+++ b/db/migrate/20160407103437_create_marketplace_setup_steps.rb
@@ -1,0 +1,15 @@
+class CreateMarketplaceSetupSteps < ActiveRecord::Migration
+  def change
+    create_table :marketplace_setup_steps do |t|
+      t.integer :community_id, null: false
+      t.boolean :slogan_and_description, null: false, default: false
+      t.boolean :cover_photo, null: false, default: false
+      t.boolean :filter, null: false, default: false
+      t.boolean :paypal, null: false, default: false
+      t.boolean :listing, null: false, default: false
+      t.boolean :invitation, null: false, default: false
+    end
+
+    add_index :marketplace_setup_steps, :community_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -609,6 +609,18 @@ ActiveRecord::Schema.define(version: 20160408061218) do
 
   add_index "marketplace_sender_emails", ["community_id"], name: "index_marketplace_sender_emails_on_community_id", using: :btree
 
+  create_table "marketplace_setup_steps", force: :cascade do |t|
+    t.integer "community_id",           limit: 4,                 null: false
+    t.boolean "slogan_and_description",           default: false, null: false
+    t.boolean "cover_photo",                      default: false, null: false
+    t.boolean "filter",                           default: false, null: false
+    t.boolean "paypal",                           default: false, null: false
+    t.boolean "listing",                          default: false, null: false
+    t.boolean "invitation",                       default: false, null: false
+  end
+
+  add_index "marketplace_setup_steps", ["community_id"], name: "index_marketplace_setup_steps_on_community_id", unique: true, using: :btree
+
   create_table "marketplace_trials", force: :cascade do |t|
     t.integer  "community_id", limit: 4, null: false
     t.datetime "expires_at"


### PR DESCRIPTION
This design intentionally puts all logic in one place and operates directly on existing AR models. This has the downside that it couples the implementation tightly to domain classes in a non-obvious way. There's couple of reasons to this choice:

* Make it easy to change the wizard logic, add steps, remove steps, or even remote the entire wizard. It's now an experimental feature
* Minimize the impact on controllers; it's just one event call here and there, no need to care what it does.
* There's no good other place to put it or other way to do it. Preferrably this should be coupled with the domain logic but since we don't have the service layer in place for the admin actions to configure marketplace the his domain logic is scattered across several controllers. I don't want to spread the wizard checks across controllers because those are not correct places in any scenario and that would eliminate the easy of change & delete for on boarding wizard logic.