### PR TITLE
Remove ensure_person_belongs_to_community method

### DIFF
--- a/app/view_utils/person_view_utils.rb
+++ b/app/view_utils/person_view_utils.rb
@@ -102,8 +102,4 @@ module PersonViewUtils
       first_name
     end
   end
-
-  def ensure_person_belongs_to_community!(person, community)
-    raise ActiveRecord::RecordNotFound.new('Not Found') unless person.communities.include?(community)
-  end
 end


### PR DESCRIPTION
This method is not used anymore as people are queried using username and
community id.