### PR TITLE
Raise a RecordNotFound when needed

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -198,7 +198,7 @@ class PeopleController < Devise::RegistrationsController
   end
 
   def update
-    target_user = Person.find_by_username_and_community_id(params[:id], @current_community.id)
+    target_user = Person.find_by_username_and_community_id!(params[:id], @current_community.id)
     # If setting new location, delete old one first
     if params[:person] && params[:person][:location] && (params[:person][:location][:address].empty? || params[:person][:street_address].blank?)
       params[:person].delete("location")
@@ -279,7 +279,7 @@ class PeopleController < Devise::RegistrationsController
   end
 
   def destroy
-    target_user = Person.find_by_username_and_community_id(params[:id], @current_community.id)
+    target_user = Person.find_by_username_and_community_id!(params[:id], @current_community.id)
     has_unfinished = TransactionService::Transaction.has_unfinished_transactions(target_user.id)
     return redirect_to root if has_unfinished
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -7,7 +7,7 @@ class SettingsController < ApplicationController
   before_filter EnsureCanAccessPerson.new(:person_id, error_message_key: "layouts.notifications.you_are_not_authorized_to_view_this_content"), except: :unsubscribe
 
   def show
-    target_user = Person.find_by_username_and_community_id(params[:person_id], @current_community.id)
+    target_user = Person.find_by_username_and_community_id!(params[:person_id], @current_community.id)
     add_location_to_person!(target_user)
     flash.now[:notice] = t("settings.profile.image_is_processing") if target_user.image.processing?
     @selected_left_navi_link = "profile"
@@ -15,7 +15,7 @@ class SettingsController < ApplicationController
   end
 
   def account
-    target_user = Person.find_by_username_and_community_id(params[:person_id], @current_community.id)
+    target_user = Person.find_by_username_and_community_id!(params[:person_id], @current_community.id)
     @selected_left_navi_link = "account"
     target_user.emails.build
     marketplaces = target_user.community_memberships
@@ -27,7 +27,7 @@ class SettingsController < ApplicationController
   end
 
   def notifications
-    target_user = Person.find_by_username_and_community_id(params[:person_id], @current_community.id)
+    target_user = Person.find_by_username_and_community_id!(params[:person_id], @current_community.id)
     @selected_left_navi_link = "notifications"
     render locals: {target_user: target_user}
   end


### PR DESCRIPTION
Use the method Person.find_by_username_and_community_id! to raise a
RecordNotFound when a person is not found.