### PR TITLE
Add basic package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "repository": "sharetribe/sharetribe",
+  "license": "MIT",
+  "engines": {
+    "node": "5.10"
+  }
+}


### PR DESCRIPTION
Adding a Node.js buildpack to Heroku requires a package.json file to be
present. The buildpack is used in another branch, but must be also in
the master to enable deployments from both branches.