### PR TITLE
Fix transaction confirmation email

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -151,7 +151,7 @@ class TransactionsController < ApplicationController
       transaction: tx,
       listing: listing,
       transaction_model: tx_model,
-      conversation_other_party: person_entity_with_url(conversation[:other_person]),
+      conversation_other_party: person_entity_with_url(other_party(conversation)),
       is_author: is_author,
       role: role,
       message_form: MessageForm.new({sender_id: @current_user.id, conversation_id: conversation[:id]}),
@@ -187,6 +187,14 @@ class TransactionsController < ApplicationController
   end
 
   private
+
+  def other_party(conversation)
+    if @current_user.id == conversation[:other_person][:id]
+      conversation[:starter_person]
+    else
+      conversation[:other_person]
+    end
+  end
 
   def ensure_can_start_transactions(listing_model:, current_user:, current_community:)
     error =

--- a/app/views/person_mailer/transaction_confirmed.html.haml
+++ b/app/views/person_mailer/transaction_confirmed.html.haml
@@ -11,13 +11,6 @@
     %font{body_font}
       = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username)
 
-- Maybe(@conversation).conversation.last_message.content.each do |content|
-  %tr
-    %td{:align => "left", :style => "padding-top: 15px;"}
-      %font{body_font}
-        = t("emails.transaction_confirmed.here_is_a_message_from", :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username)
-  = render :partial => "quote", :locals => { :quote => content }
-
 = render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username), :url => url}
 
 %tr


### PR DESCRIPTION
When a buyer aborts a transaction after payment, the seller is sent an email with the last message quoted from the conversation, assigned as being written by the buyer. However, sometimes (always?) the author of the last message can be either participant of the conversation, ending up in a situation where an email is sent to the seller quoting a message from that seller, but marking that message as being written by the buyer. Therefore we just drop the quoted message from the email in this PR.

Another change is to fix the transaction conversation titles that both had the same title "Conversation with X" where X the user that did not start the conversation.