### PR TITLE
Add new filter cannot_access_without_confirmation

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,6 +1,7 @@
 class CommunitiesController < ApplicationController
   skip_filter :fetch_community,
-              :cannot_access_if_banned
+              :cannot_access_if_banned,
+              :cannot_access_without_confirmation
 
   before_filter :ensure_no_communities
 

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -5,6 +5,7 @@ class CommunityMembershipsController < ApplicationController
   end
 
   skip_filter :cannot_access_if_banned
+  skip_filter :cannot_access_without_confirmation
   skip_filter :check_email_confirmation, :only => [:new, :create]
 
   def new
@@ -13,16 +14,6 @@ class CommunityMembershipsController < ApplicationController
     if existing_membership && existing_membership.accepted?
       flash[:notice] = t("layouts.notifications.you_are_already_member")
       redirect_to root and return
-    elsif existing_membership && existing_membership.pending_email_confirmation?
-      # Check if requirements are already filled, but the membership just hasn't been updated yet
-      # (This might happen if unexpected error happens during page load and it shouldn't leave people in loop of of
-      # having email confirmed but not the membership)
-      if @current_user.has_valid_email_for_community?(@current_community)
-        @current_community.approve_pending_membership(@current_user)
-        redirect_to root and return
-      end
-
-      redirect_to confirmation_pending_path and return
     elsif existing_membership && existing_membership.banned?
       redirect_to access_denied_tribe_memberships_path and return
     end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,6 +1,6 @@
 class ConfirmationsController < Devise::ConfirmationsController
 
-  skip_filter :check_email_confirmation, :cannot_access_if_banned
+  skip_filter :check_email_confirmation, :cannot_access_if_banned, :cannot_access_without_confirmation
 
   # This is directly copied from Devise::ConfirmationsController
   # to be able to handle better the situations of resending confirmation and

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -2,6 +2,7 @@ class FeedbacksController < ApplicationController
 
   skip_filter :check_email_confirmation
   skip_filter :cannot_access_if_banned
+  skip_filter :cannot_access_without_confirmation
 
   FeedbackForm = FormUtils.define_form("Feedback",
                                        :content,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -9,6 +9,7 @@ class PeopleController < Devise::RegistrationsController
 
   skip_filter :check_email_confirmation, :only => [ :update]
   skip_filter :cannot_access_if_banned, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
+  skip_filter :cannot_access_without_confirmation, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
 
   helper_method :show_closed?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,7 @@ class SessionsController < ApplicationController
 
   skip_filter :check_email_confirmation
   skip_filter :cannot_access_if_banned, :only => [ :destroy, :confirmation_pending ]
+  skip_filter :cannot_access_without_confirmation, :only => [ :destroy, :confirmation_pending ]
 
   # For security purposes, Devise just authenticates an user
   # from the params hash if we explicitly allow it to. That's


### PR DESCRIPTION
The old code (the before filter `cannot_access_without_joining`) redirected user that didn't have accepted membership to `new_tribe_membership_path`, which points to `CommunityMemberships#new`. This method had some logic which checked if the user account was confirmed and if not, it redirected the user to the correct page. When `cannot_access_without_joining` was removed, this logic was also removed. This PR brings it back.