### PR TITLE
Clean up Travis scripts

### DIFF
--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -1,38 +1,27 @@
 #!/bin/bash
 
+set -e
+
 echo "Running before_install"
-echo "SUITE: ${SUITE}"
 
-"echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+# Assert that the given SUITE is a known one
+case "$SUITE" in
+    rspec|rubocop|cucumber)
+        echo "SUITE: ${SUITE}"
+        ;;
+    *)
+        echo "Error: empty or unknown SUITE: $SUITE"
+        # This stops the whole build, and thus the SUITE check is not
+        # needed in other build phases
+        exit 1
+        ;;
+esac
 
-if [ "$SUITE" = "rspec" ]
-then
-	gem install nokogiri -- --use-system-libraries
-	gem install bundler specific_install
-	# Install a modified version of bundle_cache gem
-	# If the modifications get merged to bundle_cache use the upstream repo, not this one
-	gem specific_install https://github.com/sharetribe/bundle_cache
-	bundle_cache_install
-	exit
-elif [ "$SUITE" = "rubocop" ]
-then
-	gem install nokogiri -- --use-system-libraries
-	gem install bundler specific_install
-	# Install a modified version of bundle_cache gem
-	# If the modifications get merged to bundle_cache use the upstream repo, not this one
-	gem specific_install https://github.com/sharetribe/bundle_cache
-	bundle_cache_install
-	exit
-elif [ "$SUITE" = "cucumber" ]
-then
-	gem install nokogiri -- --use-system-libraries
-	gem install bundler specific_install
-	# Install a modified version of bundle_cache gem
-	# If the modifications get merged to bundle_cache use the upstream repo, not this one
-	gem specific_install https://github.com/sharetribe/bundle_cache
-	bundle_cache_install
-	exit
-else
-	echo -e "Error: SUITE is illegal or not set\n"
-	exit 1
-fi
+echo 'gem: --no-ri --no-rdoc' > ~/.gemrc
+
+gem install nokogiri -- --use-system-libraries
+gem install bundler specific_install
+# Install a modified version of bundle_cache gem
+# If the modifications get merged to bundle_cache use the upstream repo, not this one
+gem specific_install https://github.com/sharetribe/bundle_cache
+bundle_cache_install

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
 
+set -e
+
 echo "Running before_script"
 echo "SUITE: ${SUITE}"
 
-if [ "$SUITE" = "rspec" ]
-then
-	cp config/database.example.yml config/database.yml
-	mysql -e 'create database sharetribe_test;'
-	bundle exec rake db:test:load
-	exit
-elif [ "$SUITE" = "rubocop" ]
-then
-	exit
-elif [ "$SUITE" = "cucumber" ]
-then
-	cp config/database.example.yml config/database.yml
-	mysql -e 'create database sharetribe_test;'
-	bundle exec rake db:test:load
-	exit
-else
-	echo -e "Error: SUITE is illegal or not set\n"
-	exit 1
-fi
+case "$SUITE" in
+    rspec|cucumber)
+        echo "Setting up database for $SUITE"
+        cp config/database.example.yml config/database.yml
+        mysql -e 'create database sharetribe_test;'
+        bundle exec rake db:test:load
+        ;;
+esac

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
 
+set -e
+
 echo "Running install"
 echo "SUITE: ${SUITE}"
 
-if [ "$SUITE" = "rspec" ]
-then
-	bundle install --without development --path=~/.bundle
-	exit
-elif [ "$SUITE" = "rubocop" ]
-then
-  bundle install --without development --path=~/.bundle
-  exit
-elif [ "$SUITE" = "cucumber" ]
-then
-	bundle install --without development --path=~/.bundle
-	exit
-else
-	echo -e "Error: SUITE is illegal or not set\n"
-	exit 1
-fi
+bundle install --without development --path=~/.bundle

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "Running script"
 echo "SUITE: ${SUITE}"
 
@@ -18,7 +20,4 @@ then
   phantomjs --webdriver=8910 &
   PHANTOMJS=true bundle exec cucumber -ptravis 2>&1
   exit
-else
-  echo -e "Error: SUITE is illegal or not set\n"
-  exit 1
 fi


### PR DESCRIPTION
 - Use `set -e` in scripts to stop executing immediately after a failure.
 - Check `$SUITE` only in the first script. If that fails, the whole build is stopped.
 - Combine steps when several SUITEs run the same commands for less copy-paste duplication