### PR TITLE
Skip ensure_user_belongs_to_community filter where it shouldn't be run

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,7 +1,8 @@
 class CommunitiesController < ApplicationController
   skip_filter :fetch_community,
               :cannot_access_if_banned,
-              :cannot_access_without_confirmation
+              :cannot_access_without_confirmation,
+              :ensure_user_belongs_to_community
 
   before_filter :ensure_no_communities
 

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -6,6 +6,7 @@ class CommunityMembershipsController < ApplicationController
 
   skip_filter :cannot_access_if_banned
   skip_filter :cannot_access_without_confirmation
+  skip_filter :ensure_user_belongs_to_community
   skip_filter :check_email_confirmation, :only => [:new, :create]
 
   def new

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,6 +1,9 @@
 class ConfirmationsController < Devise::ConfirmationsController
 
-  skip_filter :check_email_confirmation, :cannot_access_if_banned, :cannot_access_without_confirmation
+  skip_filter :check_email_confirmation,
+              :cannot_access_if_banned,
+              :cannot_access_without_confirmation,
+              :ensure_user_belongs_to_community
 
   # This is directly copied from Devise::ConfirmationsController
   # to be able to handle better the situations of resending confirmation and

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -3,6 +3,7 @@ class FeedbacksController < ApplicationController
   skip_filter :check_email_confirmation
   skip_filter :cannot_access_if_banned
   skip_filter :cannot_access_without_confirmation
+  skip_filter :ensure_user_belongs_to_community
 
   FeedbackForm = FormUtils.define_form("Feedback",
                                        :content,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -10,6 +10,7 @@ class PeopleController < Devise::RegistrationsController
   skip_filter :check_email_confirmation, :only => [ :update]
   skip_filter :cannot_access_if_banned, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
   skip_filter :cannot_access_without_confirmation, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
+  skip_filter :ensure_user_belongs_to_community, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
 
   helper_method :show_closed?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,6 +5,7 @@ class SessionsController < ApplicationController
   skip_filter :check_email_confirmation
   skip_filter :cannot_access_if_banned, :only => [ :destroy, :confirmation_pending ]
   skip_filter :cannot_access_without_confirmation, :only => [ :destroy, :confirmation_pending ]
+  skip_filter :ensure_user_belongs_to_community, :only => [ :destroy, :confirmation_pending ]
 
   # For security purposes, Devise just authenticates an user
   # from the params hash if we explicitly allow it to. That's


### PR DESCRIPTION
In `master` branch we have a filter `cannot_access_without_joining`. That filter was removed (because users can't "join" to other marketplaces anymore) and replaced by `cannot_access_if_banned` filter. However, if someone has an active session and tries to access marketplace in which she is not a member, instead of encouraging her to join the marketplace, we need to log her out. Thus, the `ensure_user_belongs_to_community` was added.

This PR skips the `ensure_user_belongs_to_community` in each place where `cannot_access_if_banned` is skipped.