### PR TITLE
Remove unused email check

### DIFF
--- a/app/controllers/amazon_bounces_controller.rb
+++ b/app/controllers/amazon_bounces_controller.rb
@@ -1,6 +1,6 @@
 class AmazonBouncesController < ApplicationController
   skip_before_filter :verify_authenticity_token, :only => :notification
-  skip_filter :fetch_community, :check_email_confirmation
+  skip_filter :fetch_community
 
   before_filter :check_sns_token
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,6 @@ class ApplicationController < ActionController::Base
     :maintenance_warning
   before_filter :cannot_access_without_joining, :except => [ :confirmation_pending, :check_email_availability]
   before_filter :can_access_only_organizations_communities
-  before_filter :check_email_confirmation, :except => [ :confirmation_pending, :check_email_availability_and_validity]
 
   # This updates translation files from WTI on every page load. Only useful in translation test servers.
   before_filter :fetch_translations if APP_CONFIG.update_translations_on_every_page_load == "true"
@@ -348,15 +347,6 @@ class ApplicationController < ActionController::Base
       sign_out @current_user
       flash[:warning] = t("layouts.notifications.can_not_login_with_private_user")
       redirect_to login_path
-    end
-  end
-
-  def check_email_confirmation
-    # If confirmation is required, but not done, redirect to confirmation pending announcement page
-    # (but allow confirmation to come through)
-    if @current_community && @current_user && @current_user.pending_email_confirmation_to_join?(@current_community_membership)
-      flash[:warning] = t("layouts.notifications.you_need_to_confirm_your_account_first")
-      redirect_to :controller => "sessions", :action => "confirmation_pending" unless params[:controller] == 'devise/confirmations'
     end
   end
 

--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -1,7 +1,6 @@
 class BraintreeWebhooksController < ApplicationController
 
   skip_before_filter :verify_authenticity_token
-  skip_filter :check_email_confirmation
 
   before_filter do
     unless @current_community.braintree_in_use?

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -5,7 +5,6 @@ class CommunityMembershipsController < ApplicationController
   end
 
   skip_filter :cannot_access_without_joining
-  skip_filter :check_email_confirmation, :only => [:new, :create]
 
   def new
     existing_membership = @current_user.community_memberships.where(:community_id => @current_community.id).first

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,6 +1,6 @@
 class ConfirmationsController < Devise::ConfirmationsController
 
-  skip_filter :check_email_confirmation, :cannot_access_without_joining
+  skip_filter :cannot_access_without_joining
 
   # This is directly copied from Devise::ConfirmationsController
   # to be able to handle better the situations of resending confirmation and

--- a/app/controllers/domain_validation_controller.rb
+++ b/app/controllers/domain_validation_controller.rb
@@ -1,7 +1,6 @@
 class DomainValidationController < ApplicationController
 
   skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community_membership
-  skip_filter :check_email_confirmation
 
   def index
     if params[:dv_file] == @current_community.dv_test_file_name

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,6 +1,5 @@
 class FeedbacksController < ApplicationController
 
-  skip_filter :check_email_confirmation
   skip_filter :cannot_access_without_joining
 
   FeedbackForm = FormUtils.define_form("Feedback",

--- a/app/controllers/infos_controller.rb
+++ b/app/controllers/infos_controller.rb
@@ -1,7 +1,5 @@
 class InfosController < ApplicationController
 
-  skip_filter :check_email_confirmation
-
   def about
     @selected_tribe_navi_tab = "about"
     @selected_left_navi_link = "about"

--- a/app/controllers/paypal_ipn_controller.rb
+++ b/app/controllers/paypal_ipn_controller.rb
@@ -4,7 +4,6 @@ class PaypalIpnController < ApplicationController
   include PaypalService::IPNInjector
 
   skip_before_filter :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :fetch_community_membership, :check_http_auth
-  skip_filter :check_email_confirmation
 
   IPNDataTypes = PaypalService::DataTypes::IPN
 

--- a/app/controllers/paypal_service/checkout_orders_controller.rb
+++ b/app/controllers/paypal_service/checkout_orders_controller.rb
@@ -1,6 +1,5 @@
 class PaypalService::CheckoutOrdersController < ApplicationController
   skip_before_filter :verify_authenticity_token
-  skip_filter :check_email_confirmation
 
   before_filter do
     unless PaypalHelper.community_ready_for_payments?(@current_community.id)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,7 +7,6 @@ class PeopleController < Devise::RegistrationsController
   before_filter EnsureCanAccessPerson.new(
     :id, error_message_key: "layouts.notifications.you_are_not_authorized_to_view_this_content"), only: [:update, :destroy]
 
-  skip_filter :check_email_confirmation, :only => [ :update]
   skip_filter :cannot_access_without_joining, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
 
   helper_method :show_closed?

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,6 +1,5 @@
 class PlansController < ApplicationController
   skip_before_filter :check_http_auth, :verify_authenticity_token, :fetch_logged_in_user, :fetch_community, :fetch_community_membership
-  skip_filter :check_email_confirmation
   before_filter :ensure_external_plan_service_in_use!
 
   # Request data types

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,6 @@ require 'rest_client'
 
 class SessionsController < ApplicationController
 
-  skip_filter :check_email_confirmation
   skip_filter :cannot_access_without_joining, :only => [ :destroy, :confirmation_pending ]
 
   # For security purposes, Devise just authenticates an user

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -601,14 +601,6 @@ class Person < ActiveRecord::Base
     conversation.requires_payment?(community) && conversation.status.eql?("accepted") && id.eql?(conversation.buyer.id)
   end
 
-  def pending_email_confirmation_to_join?(membership)
-    if membership
-      return (membership.status == "pending_email_confirmation")
-    else
-      return false
-    end
-  end
-
   # Returns and email that is pending confirmation
   # If community is given as parameter, in case of many pending
   # emails the one required by the community is returned


### PR DESCRIPTION
It seems that the `check_email_confirmation` filter is not useful. The filter
`cannot_access_without_joining` already takes care of checking the email
confirmation status.