### PR TITLE
Set community membership consent on create

### DIFF
--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -25,8 +25,10 @@ class CommunityMembershipsController < ApplicationController
 
   def create
     # if there already exists one, modify that
-    existing = CommunityMembership.find_by_person_id_and_community_id(@current_user.id, @current_community.id)
-    @community_membership = existing || CommunityMembership.new(params[:community_membership].merge({status: "pending_email_confirmation"}))
+    @community_membership = CommunityMembership.where(person_id: @current_user.id, community_id: @current_community.id).first_or_create
+    request_params = params[:community_membership] || {}
+    @community_membership.update_attributes(request_params
+      .merge({consent: @current_community.consent, status: "pending_email_confirmation"}))
 
     # if invitation code is stored in session, use it here
     params[:invitation_code] ||= session[:invitation_code]

--- a/app/views/community_memberships/new.haml
+++ b/app/views/community_memberships/new.haml
@@ -50,9 +50,6 @@
           %input{:type => "checkbox", :id => "community_membership_consent", :name => "community_membership[consent]"}
           = form.label :consent, t('people.new.i_accept_the'), :class => "checkbox"
           = link_to t("people.new.terms"), "#", :tabindex => "-1", :id => "terms_link", :class => "form"
-    = form.hidden_field :community_id, :value => @current_community.id
-    = form.hidden_field :person_id, :value => @current_user.id
-    = form.hidden_field :consent, :value => @current_community.consent
     = button_tag(t('.join_community_button'), :class => "send_button")
 
 = render :partial => "people/help_texts", :collection => ["terms", "help_invitation_code"], :as => :field


### PR DESCRIPTION
Set consent to the one of current community on community membership
create. Also person id and community id read from session variables.