### PR TITLE
Remove :new_login feature flag

### DIFF
--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -64,7 +64,12 @@ class IntApi::MarketplacesController < ApplicationController
     ProspectEmail.create(:email => params[:email])
 
     response.status = 200
-    render :json => {:email => email, :available => (Email.email_available?(email, nil))} and return
+
+    # TODO Remove response body
+    #
+    # Now that the email is always available there's no need for response body
+    #
+    render :json => {:email => email, :available => true} and return
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -116,29 +116,18 @@ class SessionsController < ApplicationController
       person.update_facebook_data(data.id)
       flash[:notice] = t("devise.omniauth_callbacks.success", :kind => "Facebook")
       sign_in_and_redirect person, :event => :authentication
+    elsif data.email.blank?
+      flash[:error] = t("layouts.notifications.could_not_get_email_from_facebook")
+      redirect_to sign_up_path and return
     else
-      # TODO: Remove also the surrounding if check when removing the feature check
-      # Afterwards, only the logic for creating user is needed
-      # rubocop:disable Style/IfInsideElse
-      if feature_enabled?(:new_login) || persons.empty?
-        if data.email.blank?
-          flash[:error] = t("layouts.notifications.could_not_get_email_from_facebook")
-          redirect_to sign_up_path and return
-        end
+      facebook_data = {"email" => data.email,
+                       "given_name" => data.first_name,
+                       "family_name" => data.last_name,
+                       "username" => data.username,
+                       "id"  => data.id}
 
-        facebook_data = {"email" => data.email,
-                         "given_name" => data.first_name,
-                         "family_name" => data.last_name,
-                         "username" => data.username,
-                         "id"  => data.id}
-
-        session["devise.facebook_data"] = facebook_data
-        redirect_to :action => :create_facebook_based, :controller => :people
-      else
-        flash[:error] = "Cannot create a new user, user already exists with Facebook account."
-        redirect_to sign_up_path
-      end
-      # rubocop:enable StyleIfInsideElse
+      session["devise.facebook_data"] = facebook_data
+      redirect_to :action => :create_facebook_based, :controller => :people
     end
   end
 

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -14,22 +14,12 @@ module Form
     :credit_card_expiration_year
   )
 
-  class EmailAvailableValidator < ActiveModel::Validator
-    def validate(form)
-      options[:fields].each do |f|
-        email_address = form.send(f)
-        form.errors.add(f, "Email address #{email_address} is not available.") unless Email.email_available?(email_address, nil)
-      end
-    end
-  end
-
   NewMarketplace = FormUtils.define_form("NewMarketplaceForm",
     :admin_email, :admin_first_name, :admin_last_name, :admin_password,
     :marketplace_country, :marketplace_language, :marketplace_name, :marketplace_type
   ).with_validations do
     validates_presence_of :admin_email, :admin_first_name, :admin_last_name, :admin_password
     validates_format_of   :admin_email, with: /\A[A-Z0-9._%\-\+\~\/]+@([A-Z0-9-]+\.)+[A-Z]+\z/i
-    validates_with        EmailAvailableValidator, fields: [:admin_email]
     validates_length_of   :admin_password, minimum: 8
     validates_length_of   :admin_first_name, in: 1..255
     validates_length_of   :admin_last_name, in: 1..255

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -48,14 +48,10 @@ class Email < ActiveRecord::Base
 
   # Email already in use for current user or someone else
   def self.email_available?(email, community_id)
-    if FeatureFlagService::API::Api.features.enabled?(community_id: community_id, feature: :new_login).data
-     !Email
-       .joins(person: :community_memberships)
-       .where("address = ? AND community_memberships.community_id = ?", email, community_id)
-       .present?
-    else
-      !Email.find_by(address: email)
-    end
+   !Email
+     .joins(person: :community_memberships)
+     .where("address = ? AND community_memberships.community_id = ?", email, community_id)
+     .present?
   end
 
   def self.send_confirmation(email, community)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -223,16 +223,12 @@ class Person < ActiveRecord::Base
   end
 
   def self.username_available?(username, community_id)
-    if FeatureFlagService::API::Api.features.enabled?(community_id: community_id, feature: :new_login).data
-     !username.in?(USERNAME_BLACKLIST) &&
-     !Person
-       .joins(:community_memberships)
-       .where("username = :username AND (is_admin = '1' OR community_memberships.community_id = :cid)", username: username, cid: community_id)
-       .present?
-    else
-      !username.in?(USERNAME_BLACKLIST) && !Person.find_by(username: username).present?
-    end
-   end
+    !username.in?(USERNAME_BLACKLIST) &&
+      !Person
+        .joins(:community_memberships)
+        .where("username = :username AND (is_admin = '1' OR community_memberships.community_id = :cid)", username: username, cid: community_id)
+        .present?
+  end
 
   # Deprecated: This is view logic (how to display name) and thus should not be in model layer
   # Consider using PersonViewUtils

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -8,8 +8,7 @@ module FeatureFlagService::Store
       [:features, :mandatory, :set])
 
     FLAGS = [
-      :export_transactions_as_csv,
-      :new_login
+      :export_transactions_as_csv
     ].to_set
 
     def initialize(additional_flags:)


### PR DESCRIPTION
Remove the `:new_login` feature flag. This will mean that users are able to create new users with usernames/emails/facebook IDs that are already associated to other marketplaces.