### PR TITLE
Save community id for new emails

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -194,6 +194,11 @@ class Person < ActiveRecord::Base
 
   # Creates a new email
   def email_attributes=(attributes)
+    ActiveSupport::Deprecation.warn(
+      ["Person.email_attributes is deprecated.",
+       "Instead of using nested attributes, build each associated",
+       "model individually inside a DB transaction in the controller."].join(" "))
+
     emails.build(attributes)
   end
 


### PR DESCRIPTION
- Save community id for new emails
- Don't use nested attributes
- Deprecate `email_attributes` method