### PR TITLE
Add POST resource for prospect emails

### DIFF
--- a/app/controllers/int_api/marketplace_api.md
+++ b/app/controllers/int_api/marketplace_api.md
@@ -45,3 +45,13 @@ Response 200 Ok, body:
 }
 ```
 
+## POST /int_api/prospect_emails
+
+Request body:
+
+```ruby
+{ email: "eddie.ejemplo@example.com"
+}
+```
+
+Response 200 OK, empty body

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -54,8 +54,9 @@ class IntApi::MarketplacesController < ApplicationController
     render status: 201, json: {"marketplace_url" => url, "marketplace_id" => marketplace[:id]}
   end
 
-  # This could be more logical in different controller, but as implementing
-  # at this point only tiny int-api with 2 methods, using one controller
+  # TODO Remove this resource once the
+  # marketings site starts using the
+  # create_prospect_email resource
   def check_email_availability
     email = params[:email]
     render :json => ["email parameter missing"], :status => 400 and return if email.blank?
@@ -65,11 +66,16 @@ class IntApi::MarketplacesController < ApplicationController
 
     response.status = 200
 
-    # TODO Remove response body
-    #
-    # Now that the email is always available there's no need for response body
-    #
     render :json => {:email => email, :available => true} and return
+  end
+
+  def create_prospect_email
+    email = params[:email]
+    render json: [ "Email missing from payload" ], :status => 400 and return if email.blank?
+
+    ProspectEmail.create(:email => email)
+
+    head 200, content_type: "application/json"
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Kassi::Application.routes.draw do
   namespace :int_api do
     post "/create_trial_marketplace" => "marketplaces#create"
     get "/check_email_availability" => "marketplaces#check_email_availability"
+    post "/prospect_emails" => "marketplaces#create_prospect_email"
   end
 
   locale_matcher = Regexp.new(Sharetribe::AVAILABLE_LOCALES.map { |l| l[:ident] }.concat(Sharetribe::REMOVED_LOCALES.to_a).join("|"))

--- a/spec/controllers/int_api/marketplaces_controller_spec.rb
+++ b/spec/controllers/int_api/marketplaces_controller_spec.rb
@@ -181,6 +181,23 @@ describe IntApi::MarketplacesController, type: :controller do
 
       expect(ProspectEmail.last.email).to eql "something.not.used@example.com"
     end
+  end
 
+  describe "#create_prospect_email" do
+    it "should add given email as prospect email" do
+      post :create_prospect_email, {:email => "something.not.used@example.com" }
+
+      expect(response.status).to eql 200
+      expect(response.body).to eql ""
+      expect(ProspectEmail.last.email).to eql "something.not.used@example.com"
+    end
+    it "should return with an error when an email is not provided" do
+      post :create_prospect_email, {}
+
+      expect(response.status).to eql 400
+      r = JSON.parse(response.body)
+      expect(r[0]).to eql "Email missing from payload"
+      expect(ProspectEmail.last).to be_nil
+    end
   end
 end

--- a/spec/requests/http_basic_auth_spec.rb
+++ b/spec/requests/http_basic_auth_spec.rb
@@ -34,6 +34,11 @@ describe "HTTP basic auth", type: :request do
     expect(response.status).to eq(200)
   end
 
+  it "is bypassed for internal API" do
+    post "/int_api/prospect_emails", email: "test123@example.com"
+    expect(response.status).to eq(200)
+  end
+
   it "is not required when disabled" do
     APP_CONFIG.use_http_auth = false
     get "/"


### PR DESCRIPTION
Adds a resource where prospect emails can be posted.

The old `int_api/check_email_availability` resource can be removed once the marketing site uses the `int_api/prospect_email` resource.