### PR TITLE
Correct Heroku buildpack instruction

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,7 +27,7 @@ A new worker is added to the Procfile to work for the new queue. If you're hosti
 This change doesn't require any changes if you are compiling the stylesheets synchronously using the `rake sharetribe:generate_customization_stylesheets_immediately` command during the deployment. However, if you are compiling the stylesheets asynchronously using the `rake sharetribe:generate_customization_stylesheets` command, then you need to make sure that you have at least one worker working for the "css_compile" queue.
 
 
-React on Rails build environment is added with this change. This means that build environment needs to have node set up. With Heroku this can be set with ```heroku buildpacks:set heroku/nodejs```. For other environments - see [npm instructions](https://docs.npmjs.com/getting-started/installing-node), [nvm](https://github.com/creationix/nvm), or [n](https://github.com/tj/n). In addition, production environments should have ```NODE_ENV=production`` set.
+React on Rails build environment is added with this change. This means that build environment needs to have node set up. With Heroku this can be set with ```heroku buildpacks:add --index 1 heroku/nodejs```. For other environments - see [npm instructions](https://docs.npmjs.com/getting-started/installing-node), [nvm](https://github.com/creationix/nvm), or [n](https://github.com/tj/n). In addition, production environments should have ```NODE_ENV=production`` set.
 
 After bundle install, you should also install npm packages:
 ```bash


### PR DESCRIPTION
We need both Node and Ruby buildpacks, so it's `buildpacks:add` instead of `buildpacks:set`