### PR TITLE
Include rows when membership is missing

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -231,7 +231,7 @@ class Person < ActiveRecord::Base
   def self.username_available?(username, community_id)
     !username.in?(USERNAME_BLACKLIST) &&
       !Person
-        .joins(:community_memberships)
+        .joins("LEFT OUTER JOIN community_memberships ON community_memberships.person_id = people.id")
         .where("username = :username AND (is_admin = '1' OR community_memberships.community_id = :cid)", username: username, cid: community_id)
         .present?
   end


### PR DESCRIPTION
If superadmin is not part of any community, we still want to check the
username availability.