### PR TITLE
Fix error in FB signup if email restriction is in use

### DIFF
--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -58,7 +58,7 @@ class CommunityMembershipsController < ApplicationController
         e =
           if @current_user.has_email?(params[:community_membership][:email])
             Email.find_by_address_and_community_id(params[:community_membership][:email], @current_community.id)
-          elsif
+          else
             Email.create(:person => @current_user, :address => params[:community_membership][:email], community_id: @current_community.id)
           end
 


### PR DESCRIPTION
- `elsif` should be `else`