### PR TITLE
Unique community_memberships.person_id

### DIFF
--- a/app/models/community_membership.rb
+++ b/app/models/community_membership.rb
@@ -3,7 +3,7 @@
 # Table name: community_memberships
 #
 #  id                  :integer          not null, primary key
-#  person_id           :string(255)      not null
+#  person_id           :string(255)      default(""), not null
 #  community_id        :integer          not null
 #  admin               :boolean          default(FALSE)
 #  created_at          :datetime
@@ -17,7 +17,7 @@
 # Indexes
 #
 #  index_community_memberships_on_community_id  (community_id)
-#  memberships                                  (person_id,community_id) UNIQUE
+#  index_community_memberships_on_person_id     (person_id) UNIQUE
 #
 
 class CommunityMembership < ActiveRecord::Base

--- a/db/migrate/20160425144703_unique_community_memberships_person_id.rb
+++ b/db/migrate/20160425144703_unique_community_memberships_person_id.rb
@@ -1,0 +1,12 @@
+class UniqueCommunityMembershipsPersonId < ActiveRecord::Migration
+  def up
+    remove_index :community_memberships, name: :memberships
+    add_index :community_memberships, :person_id, unique: true
+  end
+
+  def down
+    remove_index :community_memberships, :person_id
+    add_index :community_memberships, [:person_id, :community_id], name: :memberships, unique: true
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422123211) do
+ActiveRecord::Schema.define(version: 20160425144703) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -246,7 +246,7 @@ ActiveRecord::Schema.define(version: 20160422123211) do
   add_index "community_customizations", ["community_id"], name: "index_community_customizations_on_community_id", using: :btree
 
   create_table "community_memberships", force: :cascade do |t|
-    t.string   "person_id",           limit: 255,                      null: false
+    t.string   "person_id",           limit: 255, default: "",         null: false
     t.integer  "community_id",        limit: 4,                        null: false
     t.boolean  "admin",                           default: false
     t.datetime "created_at"
@@ -259,7 +259,7 @@ ActiveRecord::Schema.define(version: 20160422123211) do
   end
 
   add_index "community_memberships", ["community_id"], name: "index_community_memberships_on_community_id", using: :btree
-  add_index "community_memberships", ["person_id", "community_id"], name: "memberships", unique: true, using: :btree
+  add_index "community_memberships", ["person_id"], name: "index_community_memberships_on_person_id", unique: true, using: :btree
 
   create_table "community_translations", force: :cascade do |t|
     t.integer  "community_id",    limit: 4,     null: false

--- a/features/organizations/user_adds_payment_information.feature
+++ b/features/organizations/user_adds_payment_information.feature
@@ -3,8 +3,7 @@ Feature: User adds payment information
   sell and receive any money
 
   Background:
-    Given there is an organization "company"
-    And "company" is a member of community "test"
+    Given there is an organization "company" in community "test"
     And community "test" has payments in use via Checkout
     And I am logged in as "company"
 

--- a/features/organizations/user_creates_a_new_listing_with_payment.feature
+++ b/features/organizations/user_creates_a_new_listing_with_payment.feature
@@ -1,8 +1,7 @@
 Feature: User creates a new listing with payments
 
   Background:
-    Given there is an organization "company"
-    And "company" is a member of community "test"
+    Given there is an organization "company" in community "test"
     And community "test" has payments in use via Checkout
     And I am logged in as "company"
 

--- a/features/settings/user_changes_email_address.feature
+++ b/features/settings/user_changes_email_address.feature
@@ -4,21 +4,19 @@ Feature: User changes email address
   I want to be able to change my email address
 
   Background:
-    Given there are following users:
-      | person      |
-      | sharetribe1 |
+    Given there are following communities:
+      | community             | allowed_emails |
+      | testcommunity         | @example.com   |
+    And there are following users:
+      | person      | community     |
+      | sharetribe1 | testcommunity |
     And there are following emails:
       | person      | address                 | send_notifications | confirmed_at        |
       | sharetribe1 | sharetribe@example.com  | false              | 2013-11-14 20:02:23 |
       | sharetribe1 | sharetribe2@example.com | true               | 2013-11-14 20:02:23 |
       | sharetribe1 | sharetribe@gmail.com    | false              | 2013-11-14 20:02:23 |
       | sharetribe1 | sharetribe@yahoo.com    | false              | nil                 |
-    And there are following communities:
-      | community             | allowed_emails |
-      | testcommunity         | @example.com   |
-      | anothertestcommunity  | @gmail.com     |
-    And "sharetribe1" is a member of community "testcommunity"
-    And "sharetribe1" is a member of community "anothertestcommunity"
+    When I move to community "testcommunity"
     And I am logged in as "sharetribe1"
     And I am on the account settings page
 
@@ -33,7 +31,6 @@ Feature: User changes email address
   Scenario: User removes an email
     Given I will confirm all following confirmation dialogs in this page if I am running PhantomJS
     Then I should not be able to remove email "sharetribe2@example.com"
-    Then I should not be able to remove email "sharetribe@gmail.com"
     When I remove email "sharetribe@example.com"
     Then I should not have email "sharetribe@example.com"
 

--- a/features/step_definitions/community_steps.rb
+++ b/features/step_definitions/community_steps.rb
@@ -61,13 +61,6 @@ Given /^the terms of community "([^"]*)" are changed to "([^"]*)"$/ do |communit
   Community.where(ident: community).first.update_attribute(:consent, terms)
 end
 
-Given /^"(.*?)" is a member of community "(.*?)"$/ do |username, community_name|
-  community = Community.where(ident: community_name).first
-  person = Person.find_by!(username: username)
-  membership = FactoryGirl.create(:community_membership, :person => person, :community => community)
-  membership.save!
-end
-
 Then /^Most recently created user should be member of "([^"]*)" community with(?: status "(.*?)" and)? its latest consent accepted(?: with invitation code "([^"]*)")?$/ do |community_ident, status, invitation_code|
     # Person.last seemed to return unreliable results for some reason
     # (kassi_testperson1 instead of the actual newest person, so changed

--- a/features/step_definitions/organization_steps.rb
+++ b/features/step_definitions/organization_steps.rb
@@ -26,8 +26,10 @@ Then /^I should see flash error$/ do
   expect(find(".flash-error")).to be_visible
 end
 
-Given /^there is an organization "(.*?)"$/ do |org_username|
-  FactoryGirl.create(:person, :username => org_username, :is_organization => true)
+Given /^there is an organization "(.*?)" in community "(.*?)"$/ do |org_username, community|
+  c = Community.find_by!(ident: community)
+  p = FactoryGirl.create(:person, :username => org_username, :is_organization => true, community_id: c.id)
+  FactoryGirl.create(:community_membership, person: p, community: c)
 end
 
 Given /^"(.*?)" is not an organization$/ do |username|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -90,7 +90,7 @@ end
 Given /^there are following users:$/ do |person_table|
   @people = {}
   person_table.hashes.each do |hash|
-    community = Community.first
+    community = Community.find_by(ident: hash['community']) || Community.first
 
     defaults = {
       password: "testi",
@@ -104,7 +104,7 @@ Given /^there are following users:$/ do |person_table|
 
     person_opts = defaults.merge({
       username: hash['person'],
-    }).merge(hash.except('person', 'membership_created_at'))
+    }).merge(hash.except('person', 'membership_created_at', 'community'))
 
     @hash_person, @hash_session = Person.find_by(username: username) || FactoryGirl.create(:person, person_opts)
     @hash_person.community_id = community.id
@@ -130,7 +130,7 @@ Given /^there are following users:$/ do |person_table|
                                     :status => "accepted")
     cm.update_attribute(:created_at, membership_created_at) if membership_created_at && !membership_created_at.empty?
 
-    attributes_to_update = hash.except('person','person_id', 'locale', 'membership_created_at')
+    attributes_to_update = hash.except('person','person_id', 'locale', 'membership_created_at', 'community')
     @hash_person.update_attributes(attributes_to_update) unless attributes_to_update.empty?
     @hash_person.set_default_preferences
     if hash['locale']
@@ -179,13 +179,6 @@ end
 Given /^"([^"]*)" is superadmin$/ do |username|
   user = Person.find_by(username: username)
   user.update_attribute(:is_admin, true)
-end
-
-Given /^user "([^"]*)" is member of community "([^"]*)"$/ do |username, community|
-  user = Person.find_by(username: username)
-  community = Community.where(ident: community).first
-  cm = CommunityMembership.find_by_person_id_and_community_id(user.id, community.id)
-  CommunityMembership.create(:person_id => user.id, :community_id => community.id) unless cm
 end
 
 Given /^"([^"]*)" has admin rights in community "([^"]*)"$/ do |username, community|

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -69,7 +69,6 @@ describe "CommunityMailer", type: :mailer do
       @p1.communities << @c1
       @p2 = FactoryGirl.create(:person)
       @p2.communities << @c1
-      @p2.communities << @c2
 
       @l1 = FactoryGirl.create(:listing,
           :title => "bike",
@@ -106,14 +105,13 @@ describe "CommunityMailer", type: :mailer do
       CommunityMailer.deliver_community_updates
       expect(include_all?(ActionMailer::Base.deliveries[0].to, @p2.confirmed_notification_email_addresses) || include_all?(ActionMailer::Base.deliveries[0].to, @p4.confirmed_notification_email_addresses)).to be_truthy
       expect(include_all?(ActionMailer::Base.deliveries[1].to, @p2.confirmed_notification_email_addresses) || include_all?(ActionMailer::Base.deliveries[1].to, @p4.confirmed_notification_email_addresses)).to be_truthy
-      expect(include_all?(ActionMailer::Base.deliveries[2].to, @p2.confirmed_notification_email_addresses) || include_all?(ActionMailer::Base.deliveries[2].to, @p4.confirmed_notification_email_addresses)).to be_truthy
-      expect(ActionMailer::Base.deliveries.size).to eq(3)
+      expect(ActionMailer::Base.deliveries.size).to eq(2)
     end
 
     it "should contain specific time information" do
       @p1.update_attribute(:community_updates_last_sent_at, 1.day.ago)
       CommunityMailer.deliver_community_updates
-      expect(ActionMailer::Base.deliveries.size).to eq(4)
+      expect(ActionMailer::Base.deliveries.size).to eq(3)
       email = find_email_body_for(@p1.emails.first)
       expect(email.body.include?("during the past 1 day")).to be_truthy
       email = find_email_body_for(@p2.emails.first)
@@ -127,10 +125,9 @@ describe "CommunityMailer", type: :mailer do
       @p5.communities << @c1
       @p5.update_attribute(:community_updates_last_sent_at, nil)
       CommunityMailer.deliver_community_updates
-      expect(ActionMailer::Base.deliveries.size).to eq(4)
+      expect(ActionMailer::Base.deliveries.size).to eq(3)
       email = find_email_body_for(@p5.emails.first)
       expect(email).not_to be_nil
-      #ActionMailer::Base.deliveries[3].to.include?(@p5.email).should be_truthy
       expect(email.body.include?("during the past 7 days")).to be_truthy
     end
 

--- a/spec/models/community_membership_spec.rb
+++ b/spec/models/community_membership_spec.rb
@@ -3,7 +3,7 @@
 # Table name: community_memberships
 #
 #  id                  :integer          not null, primary key
-#  person_id           :string(255)      not null
+#  person_id           :string(255)      default(""), not null
 #  community_id        :integer          not null
 #  admin               :boolean          default(FALSE)
 #  created_at          :datetime
@@ -17,7 +17,7 @@
 # Indexes
 #
 #  index_community_memberships_on_community_id  (community_id)
-#  memberships                                  (person_id,community_id) UNIQUE
+#  index_community_memberships_on_person_id     (person_id) UNIQUE
 #
 
 require 'spec_helper'

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -119,10 +119,11 @@ describe Listing, type: :model do
   describe "#visible_to?" do
     let(:community) { FactoryGirl.create(:community, private: true) }
     let(:community2) { FactoryGirl.create(:community) }
-    let(:person) { FactoryGirl.create(:person, communities: [community, community2]) }
+    let(:person) { FactoryGirl.create(:person, communities: [community]) }
     let(:listing) { FactoryGirl.create(:listing, community_id: community.id, listing_shape_id: 123) }
 
     it "is not visible, if the listing doesn't belong to the given community" do
+      expect(listing.visible_to?(person, community)).to be_truthy
       expect(listing.visible_to?(person, community2)).to be_falsey
     end
 


### PR DESCRIPTION
Person and CommunityMemberhips have 1-to-1 relationship. Thus, the `person_id`in `community_memberships` should be unique globally, not only per community.

- [X] Add unique index for `community_memberships.person_id`
- [X] Fix tests where user belongs to multiple communities
- [X] Remove step "user is a member of community". Instead, create the membership during the person creation.