### PR TITLE
Correctly reset legacy password and salt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Updated Paperclip gem [#1836](https://github.com/sharetribe/sharetribe/pull/1836)
 - Unauthorized users were able to upload new listing images [#1866](https://github.com/sharetribe/sharetribe/pull/1866)
 - Change session expiration time from one year to one month [#1877](https://github.com/sharetribe/sharetribe/pull/1877)
+- Correctly reset old password and salt [#1961](https://github.com/sharetribe/sharetribe/pull/1961)
 
 ## [5.6.0] - 2016-03-11
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -628,6 +628,14 @@ class Person < ActiveRecord::Base
 
   # Overrides method injected from Devise::DatabaseAuthenticatable
   # Removes legacy pashsword and salt.
+  def password=(*args)
+    self.legacy_encrypted_password = nil
+    self.password_salt = nil
+    super
+  end
+
+  # Overrides method injected from Devise::DatabaseAuthenticatable
+  # Removes legacy pashsword and salt.
   def reset_password!(*args)
     self.legacy_encrypted_password = nil
     self.password_salt

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -634,14 +634,6 @@ class Person < ActiveRecord::Base
     super
   end
 
-  # Overrides method injected from Devise::DatabaseAuthenticatable
-  # Removes legacy pashsword and salt.
-  def reset_password!(*args)
-    self.legacy_encrypted_password = nil
-    self.password_salt
-    super
-  end
-
   private
 
   def digest(password, salt)


### PR DESCRIPTION
If legacy password and salt is present, password recovery works but logging in with the new password doesn't after that. 

This correctly resets the legacy password and salt in order for the new password to work.

Steps to reproduce:

1. Have a user with legacy_encrypted_password in database (not logged in)
2. Click forgot my password
3. Enter email address and change password according to instructions
4. Try to log in with new password

Other option:

1. Have a user with legacy_encrypted_password in database (logged in, with persistent session, don't use the log in functionality)
2. Go to profile
3. Change password
4. Log out
5. Try to log in with new password

`reset_password!` is not called and thus the old passwords are not reset properly.