### PR TITLE
Deprecate communities and community_memberships

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -112,6 +112,10 @@ class Person < ActiveRecord::Base
 
   has_and_belongs_to_many :followed_listings, :class_name => "Listing", :join_table => "listing_followers"
 
+  deprecate communities: "Use community instead.",
+            community_memberships: "Use community_membership instead.",
+            deprecator: MethodDeprecator.new
+
   def to_param
     username
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -103,6 +103,8 @@ class Person < ActiveRecord::Base
   has_many :authored_comments, :class_name => "Comment", :foreign_key => "author_id", :dependent => :destroy
   has_many :community_memberships, :dependent => :destroy
   has_many :communities, -> { where("community_memberships.status = 'accepted'") }, :through => :community_memberships
+  has_one  :community_membership, :dependent => :destroy
+  has_one  :accepted_community, -> { where("community_memberships.status= 'accepted'") }, through: :community_membership, source: :community
   has_many :invitations, :foreign_key => "inviter_id", :dependent => :destroy
   has_many :auth_tokens, :dependent => :destroy
   has_many :follower_relationships
@@ -112,7 +114,7 @@ class Person < ActiveRecord::Base
 
   has_and_belongs_to_many :followed_listings, :class_name => "Listing", :join_table => "listing_followers"
 
-  deprecate communities: "Use community instead.",
+  deprecate communities: "Use accepted_community instead.",
             community_memberships: "Use community_membership instead.",
             deprecator: MethodDeprecator.new
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,9 @@ require File.expand_path('../available_locales', __FILE__)
 # Load the logger
 require File.expand_path('../../lib/sharetribe_logger', __FILE__)
 
+# Load the deprecator
+require File.expand_path('../../lib/method_deprecator', __FILE__)
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/docs/method-deprecator.md
+++ b/docs/method-deprecator.md
@@ -1,0 +1,45 @@
+# MethodDeprecator
+
+## Basics
+
+MethodDeprecator is an implementation of class
+[`ActiveSupport::Deprecation`](http://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html). [`ActiveSupport`](http://guides.rubyonrails.org/active_support_core_extensions.html)
+is the Ruby on Rails component providing core extensions for basic Ruby functionality. Ruby on Rails requires all of this functionality by default.
+
+In addition, every [`Class`](http://ruby-doc.org/core-2.2.0/Class.html) has as a superclass a [`Module`](http://ruby-doc.org/core-2.2.0/Module.html). `ActiveSupport` provides an extension to `Module`, which defines a method [`deprecate`](http://api.rubyonrails.org/classes/Module.html#method-i-deprecate).
+
+Therefore, `deprecate` can be called from every class and module inside the Sharetribe application that inherits from those two aforementioned classes.
+
+By default, `deprecate` will print a notification about method being deprecated in the next Rails version. It takes as a named parameter an optional `:deprecator`, where we can define our own functionality. This is provided by `MethodDeprecator`.
+
+`MethodDeprecator` is included in `config/application.rb` and is therefore usable everywhere in the app.
+
+## Examples
+
+``` ruby
+class LaunchControl
+  def launch_apollo
+    puts "Apollo, lift-off!!"
+  end
+
+  def launch_shuttle
+    puts "Shuttle, lift-off!"
+  end
+
+  def launch_soyuz
+    puts "Союз, отрываться"
+  end
+
+
+  deprecate_method launch_apollo: "Apollo hasn't gone to the moon for a while, use launch_soyuz instead.",
+                   launch_shuttle: "Shuttle isn't in service anymore. Use launch_soyuz instead.",
+                   deprecator: MethodDeprecator.new
+end
+
+
+lctl = LaunchControl.new
+lctl.launch_apollo   # => DEPRECATION WARNING: launch_apollo is deprecated and will be removed in future. |
+                     #    Apollo hasn't gone to the moon for a while, use launch_soyuz instead. (called from <main> at (pry):41
+lctl.launch_shuttle  # => DEPRECATION WARNING: launch_apollo is deprecated and will be removed in future. |
+                     #    Shuttle isn't in service anymore. Use launch_soyuz instead. (called from <main> at (pry):43
+```

--- a/lib/method_deprecator.rb
+++ b/lib/method_deprecator.rb
@@ -1,0 +1,8 @@
+class MethodDeprecator < ActiveSupport::Deprecation
+
+  def deprecation_warning(deprecated_method_name, message, caller_backtrace = nil)
+    caller_backtrace ||= caller(2)
+    message = "#{deprecated_method_name} is deprecated and will be removed in future. | #{message}"
+    warn(message, caller_backtrace)
+  end
+end


### PR DESCRIPTION
Deprecate has_many relationships, these will be transformed to has_one
or replaced with person.community_id.

This pull request also introduces a common method for deprecating methods inside the app. Calling a deprecated method will produce following log message:
`DEPRECATION WARNING: community_memberships is deprecated and will be removed in future. | Use community_membership instead. (called from <main> at (pry):11)`