### PR TITLE
Fix resend confirmation

### DIFF
--- a/app/assets/javascripts/sharetribe_common.js
+++ b/app/assets/javascripts/sharetribe_common.js
@@ -4,8 +4,8 @@ function initialize_confirmation_pending_form(locale, email_in_use_message) {
     $("html, body").animate({ scrollTop: $(document).height() }, 1000);
     $('input.email').focus();
   });
-  var form_id = "#change_mistyped_email_form";
-  $(form_id).validate({
+  var change_form_id = "#change_mistyped_email_form";
+  $(change_form_id).validate({
      errorPlacement: function(error, element) {
        error.insertAfter(element);
      },
@@ -17,8 +17,12 @@ function initialize_confirmation_pending_form(locale, email_in_use_message) {
      },
      onkeyup: false, //Only do validations when form focus changes to avoid exessive calls
      submitHandler: function(form) {
-       disable_and_submit(form_id, form, "false", locale);
+       disable_and_submit(change_form_id, form, "false", locale);
      }
+  });
+  var resend_form_id = "#resend_email_confirmation";
+  $(resend_form_id).submit(function(e) {
+    disable_submit_button(resend_form_id, locale);
   });
 }
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -30,11 +30,9 @@ class ConfirmationsController < Devise::ConfirmationsController
         flash[:error] = t("people.new.email_is_in_use")
         redirect_to :controller => "sessions", :action => "confirmation_pending" and return
       end
-    end
-
-    # Resend confirmation
-    if email_param_present
-      email = Email.find_by_address_and_community_id(params[:person][:email], @current_community.id)
+    else
+      email_to_confirm = @current_user.latest_pending_email_address(@current_community)
+      email = Email.find_by_address_and_community_id(email_to_confirm, @current_community.id)
       Email.send_confirmation(email, @current_community)
       flash[:notice] = t("sessions.confirmation_pending.check_your_email")
       redirect_to :controller => "sessions", :action => "confirmation_pending" and return

--- a/app/views/sessions/_confirmation_form.haml
+++ b/app/views/sessions/_confirmation_form.haml
@@ -13,12 +13,16 @@
 %br/
 
 %p
-  = form_for(Person, :as => "person", :url => confirmation_path(:locale => I18n.locale), :html => { :method => :put, :id => "change_mistyped_email_form"} ) do |form|
+  = form_for(Person, :as => "person", :url => confirmation_path(:locale => I18n.locale), :html => { :method => :put, :id => "resend_email_confirmation"} ) do |form|
     .form_field_container
       = form.hidden_field :id, :value => @current_user.id
       = form.button t("sessions.confirmation_pending.resend_confirmation_instructions"), :class => "resend_email_confirmation_button send_button"
-    %p
-      = t("sessions.confirmation_pending.your_current_email_is", :email => email_to_confirm).html_safe
-      = link_to t('sessions.confirmation_pending.change_email'), "#", :id => "mistyped_email_link", :class => "green_part_link"
-      #password_forgotten
+%p
+  = t("sessions.confirmation_pending.your_current_email_is", :email => email_to_confirm).html_safe
+  = link_to t('sessions.confirmation_pending.change_email'), "#", :id => "mistyped_email_link", :class => "green_part_link"
+  #password_forgotten
+
+    = form_for(Person, :as => "person", :url => confirmation_path(:locale => I18n.locale), :html => { :method => :put, :id => "change_mistyped_email_form"} ) do |form|
+      .form_field_container
+        = form.hidden_field :id, :value => @current_user.id
         = render :partial => "sessions/change_mistyped_email", :locals => {:email_to_confirm => email_to_confirm}


### PR DESCRIPTION
Steps to reproduce:

1. Create a new user (with the normal sign up form, not Facebook)
2. In the confirmation page, click "Resend confirmation" button.

Expected: User sees "Please wait..." text that indicates that something is happened. Also, a new confirmation email is sent.

Actual: Nothing happens when user clicks the button