### PR TITLE
Facebook email unconfirmed

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1293,6 +1293,7 @@ en:
       confirmation_link_is_wrong_or_used: "The confirmation link is already used or otherwise broken. Try logging in, or send feedback if the problem persists."
       additional_email_confirmed: "The email you entered is now confirmed."
       could_not_get_email_from_facebook: "Could not get email address from Facebook and can't create an account without email."
+      facebook_email_unconfirmed: "The email address '%{email}' in your Facebook account is been already taken but it's unconfirmed. Please confirm the email address before logging in with Facebook."
       create_new_listing: "Create another listing"
       create_one_here: "create one here"
       email_confirmation_sent_to_new_address: "Email confirmation is now sent to the new address."


### PR DESCRIPTION
`emails.community_id` and `emails.address` pair should be unique. The same email address can not be used twice in the same community (because address is an identifier we use for logging people in).

With Facebook login, it's possible to create duplicated emails.

Steps to reproduce:

1. Make sure there are no user in the DB that uses the `facebook_id` of your account.
1. Make sure there are no email address in the DB that uses the email address of your Facebook account.
1. Create a new user with the email account that you have in your Facebook account.
1. Don't confirm the email address
1. Log out
1. Create a new user with your Facebook account

Expected: Error message, that says that the email address is already been taken but it's not confirmed.

Actual: New account successfully created. There are 2 email rows with the same address in the DB.