### PR TITLE
Fix missing legacy password data

### DIFF
--- a/db/migrate/20160427113446_fix_missing_password_data.rb
+++ b/db/migrate/20160427113446_fix_missing_password_data.rb
@@ -1,0 +1,17 @@
+class FixMissingPasswordData < ActiveRecord::Migration
+  def up
+    exec_update(
+      "UPDATE people
+       SET
+         people.legacy_encrypted_password = people.encrypted_password
+       WHERE
+         encrypted_password NOT LIKE '$2a$10%' AND
+         legacy_encrypted_password IS NULL",
+      "Update missing legacy passwords",
+      [])
+  end
+
+  def down
+    # no-op
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160425144703) do
+ActiveRecord::Schema.define(version: 20160427113446) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255


### PR DESCRIPTION
When we duplicated users based on community membersihps, we left out legacy encrypted password from the duplicates by accident.

This adds the data for users that haven't yet changed their password.