### PR TITLE
ApplicationController shouldn't skip filters for subclasses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,12 +33,12 @@ class ApplicationController < ActionController::Base
     :warn_about_missing_payment_info,
     :set_homepage_path,
     :report_queue_size,
-    :maintenance_warning
-  before_filter :cannot_access_if_banned, :except => [ :confirmation_pending, :check_email_availability]
-  before_filter :cannot_access_without_confirmation, :except => [ :confirmation_pending, :check_email_availability]
-  before_filter :ensure_consent_given, except: [:confirmation_pending, :check_email_availability]
-  before_filter :ensure_user_belongs_to_community, except: [ :confirmation_pending, :check_email_availability]
-  before_filter :can_access_only_organizations_communities
+    :maintenance_warning,
+    :cannot_access_if_banned,
+    :cannot_access_without_confirmation,
+    :ensure_consent_given,
+    :ensure_user_belongs_to_community,
+    :can_access_only_organizations_communities
 
   # This updates translation files from WTI on every page load. Only useful in translation test servers.
   before_filter :fetch_translations if APP_CONFIG.update_translations_on_every_page_load == "true"

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,10 +7,16 @@ class PeopleController < Devise::RegistrationsController
   before_filter EnsureCanAccessPerson.new(
     :id, error_message_key: "layouts.notifications.you_are_not_authorized_to_view_this_content"), only: [:update, :destroy]
 
-  skip_filter :cannot_access_if_banned, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
-  skip_filter :cannot_access_without_confirmation, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
-  skip_filter :ensure_consent_given, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
-  skip_filter :ensure_user_belongs_to_community, :only => [ :check_email_availability_and_validity, :check_invitation_code ]
+  LOOSER_ACCESS_CONTROL = [
+    :check_email_availability,
+    :check_email_availability_and_validity,
+    :check_invitation_code
+  ]
+
+  skip_filter :cannot_access_if_banned,            only: LOOSER_ACCESS_CONTROL
+  skip_filter :cannot_access_without_confirmation, only: LOOSER_ACCESS_CONTROL
+  skip_filter :ensure_consent_given,               only: LOOSER_ACCESS_CONTROL
+  skip_filter :ensure_user_belongs_to_community,   only: LOOSER_ACCESS_CONTROL
 
   helper_method :show_closed?
 


### PR DESCRIPTION
ApplicationController now skips filters for methods that exist only in subclasses. This is bad OO desing, since the parent class shouldn't know anything about the subclass.

- [X] `:confirmation_pending`, no need to do anything, this is already skipped in SessionsController
- [X] `:check_email_availability`, skip it in `people_controller`.