### PR TITLE
Fix deprecation warnings of usage of community_memberships

### DIFF
--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -53,7 +53,7 @@ class Admin::CommunityMembershipsController < ApplicationController
   end
 
   def promote_admin
-    if removes_itself?(params[:remove_admin], @current_user, @current_community)
+    if removes_itself?(params[:remove_admin], @current_user)
       render nothing: true, status: 405
     else
       @current_community.community_memberships.where(person_id: params[:add_admin]).update_all("admin = 1")
@@ -113,9 +113,9 @@ class Admin::CommunityMembershipsController < ApplicationController
     end
   end
 
-  def removes_itself?(ids, current_admin_user, community)
+  def removes_itself?(ids, current_admin_user)
     ids ||= []
-    ids.include?(current_admin_user.id) && current_admin_user.is_admin_of?(community)
+    ids.include?(current_admin_user.id) && current_admin_user.is_marketplace_admin?
   end
 
   def sort_column

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -426,7 +426,7 @@ class ApplicationController < ActionController::Base
   end
 
   def fetch_community_admin_status
-    @is_current_community_admin = @current_user && @current_user.has_admin_rights_in?(@current_community)
+    @is_current_community_admin = @current_user && @current_user.has_admin_rights?
   end
 
   def fetch_community_plan_expiration_status

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -204,7 +204,9 @@ class ApplicationController < ActionController::Base
   # sessions which potentially had a person_id pointing to another
   # community are all expired.
   def ensure_user_belongs_to_community
-    if @current_user && !@current_user.is_admin? && !@current_user.communities.include?(@current_community)
+    return unless @current_user
+
+    if !@current_user.is_admin? && @current_user.accepted_community != @current_community
 
       logger.info(
         "Automatically logged out user that doesn't belong to community",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -389,21 +389,18 @@ class ApplicationController < ActionController::Base
   end
 
   def cannot_access_without_confirmation
-    if @current_user && !@current_community_memberships
-      existing_membership = @current_user.community_memberships.where(community_id: @current_community.id).first
-
-      if existing_membership && existing_membership.pending_email_confirmation?
-
-        # Check if requirements are already filled, but the membership just hasn't been updated yet
-        # (This might happen if unexpected error happens during page load and it shouldn't leave people in loop of of
-        # having email confirmed but not the membership)
-        if @current_user.has_valid_email_for_community?(@current_community)
-          @current_community.approve_pending_membership(@current_user)
-          redirect_to root and return
-        end
-
-        redirect_to confirmation_pending_path
+    if @current_user && @current_user.community_membership.pending_email_confirmation?
+      # Check if requirements are already filled, but the membership just hasn't been updated yet
+      # (This might happen if unexpected error happens during page load and it shouldn't leave people in loop of of
+      # having email confirmed but not the membership)
+      #
+      # TODO Remove this. Find the issue that causes this and fix it, don't fix the symptoms.
+      if @current_user.has_valid_email_for_community?(@current_community)
+        @current_community.approve_pending_membership(@current_user)
+        redirect_to root and return
       end
+
+      redirect_to confirmation_pending_path
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -382,7 +382,7 @@ class ApplicationController < ActionController::Base
   # Before filter to direct a banned user to access denied page
   def cannot_access_if_banned
     # Check if banned
-    if @current_user && @current_user.banned_at?(@current_community)
+    if @current_user && @current_user.banned?
       flash.keep
       redirect_to access_denied_tribe_memberships_path and return
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -185,9 +185,7 @@ class ApplicationController < ActionController::Base
   def ensure_consent_given
     return unless @current_user
 
-    current_membership = @current_user.community_memberships.find_by(community_id: @current_community.id)
-
-    if current_membership && current_membership.pending_consent?
+    if @current_user.community_membership.pending_consent?
       redirect_to controller: :community_memberships, action: :new
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,7 +21,7 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment = Comment.find(params[:id])
-    if current_user?(@comment.author) || @current_user.has_admin_rights_in?(@current_community)
+    if current_user?(@comment.author) || @current_user.has_admin_rights?
       @comment.destroy
       respond_to do |format|
         format.html { redirect_to listing_path(params[:listing_id]) }
@@ -41,7 +41,7 @@ class CommentsController < ApplicationController
       community_id: @current_community.id
     )
 
-    unless @comment.listing.visible_to?(@current_user, @current_community) || @current_user.has_admin_rights_in?(@current_community)
+    unless @comment.listing.visible_to?(@current_user, @current_community) || @current_user.has_admin_rights?
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
       redirect_to root and return
     end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -61,7 +61,7 @@ class ConfirmationsController < Devise::ConfirmationsController
       end
       flash[:notice] = t("layouts.notifications.additional_email_confirmed")
 
-      if @current_user && @current_user.has_admin_rights_in?(@current_community) #admins
+      if @current_user && @current_user.has_admin_rights?
         report_to_gtm({event: "admin_email_confirmed"})
         redirect_to getting_started_admin_community_path(:id => @current_community.id) and return
       elsif @current_user # normal logged in user

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -18,7 +18,7 @@ class InvitationsController < ApplicationController
 
     view_locals = {
       invitation_limit: invitation_limit,
-      has_admin_rights: @current_user.has_admin_rights_in?(@current_community)
+      has_admin_rights: @current_user.has_admin_rights?
     }
 
     render locals: onboarding_popup_locals.merge(view_locals)

--- a/app/controllers/listing_images_controller.rb
+++ b/app/controllers/listing_images_controller.rb
@@ -104,7 +104,7 @@ class ListingImagesController < ApplicationController
   def authorized_to_destroy?(image)
     if image.listing.present?
       # Listing is present: We are deleting image from saved listing
-      image.listing.author == @current_user || @current_user.has_admin_rights_in?(@current_community)
+      image.listing.author == @current_user || @current_user.has_admin_rights?
     else
       # Listing is not present: We are deleting image from a new unsaved listing
       image.author == @current_user
@@ -122,7 +122,7 @@ class ListingImagesController < ApplicationController
 
         if listing.nil?
           :not_found
-        elsif listing.author == @current_user || @current_user.has_admin_rights_in?(@current_community)
+        elsif listing.author == @current_user || @current_user.has_admin_rights?
           :authorized
         else
           :unauthorized

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -467,7 +467,7 @@ class ListingsController < ApplicationController
 
   def ensure_current_user_is_listing_author(error_message)
     @listing = Listing.find(params[:id])
-    return if current_user?(@listing.author) || @current_user.has_admin_rights_in?(@current_community)
+    return if current_user?(@listing.author) || @current_user.has_admin_rights?
     flash[:error] = error_message
     redirect_to @listing and return
   end
@@ -648,7 +648,7 @@ class ListingsController < ApplicationController
 
     raise ListingDeleted if @listing.deleted?
 
-    unless @listing.visible_to?(@current_user, @current_community) || (@current_user && @current_user.has_admin_rights_in?(@current_community))
+    unless @listing.visible_to?(@current_user, @current_community) || (@current_user && @current_user.has_admin_rights?)
       if @current_user
         flash[:error] = if @listing.closed?
           t("layouts.notifications.listing_closed")
@@ -749,7 +749,7 @@ class ListingsController < ApplicationController
 
   def is_authorized_to_post
     if @current_community.require_verification_to_post_listings?
-      unless @current_user.has_admin_rights_in?(@current_community) || @current_community_membership.can_post_listings?
+      unless @current_user.has_admin_rights? || @current_community_membership.can_post_listings?
         redirect_to verification_required_listings_path
       end
     end
@@ -793,7 +793,7 @@ class ListingsController < ApplicationController
     when matches([:paypal])
       can_post = PaypalHelper.community_ready_for_payments?(community.id)
       error_msg =
-        if user.has_admin_rights_in?(community)
+        if user.has_admin_rights?
           t("listings.new.community_not_configured_for_payments_admin",
             payment_settings_link: view_context.link_to(
               t("listings.new.payment_settings_link"),

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -109,7 +109,7 @@ class TransactionsController < ApplicationController
       .map { |tx_with_conv| [tx_with_conv, :participant] }
 
     m_admin =
-      Maybe(@current_user.has_admin_rights_in?(@current_community))
+      Maybe(@current_user.has_admin_rights?)
       .select { |can_show| can_show }
       .map {
         MarketplaceService::Transaction::Query.transaction_with_conversation(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -580,7 +580,7 @@ module ApplicationHelper
 
   def display_expiration_notice?
     ext_service_active = PlanService::API::Api.plans.active?
-    is_admin = Maybe(@current_user).has_admin_rights_in?(@current_community).or_else(false)
+    is_admin = Maybe(@current_user).has_admin_rights?.or_else(false)
     is_expired = Maybe(@current_plan)[:expired].or_else(false)
 
     ext_service_active && is_admin && is_expired
@@ -666,7 +666,7 @@ module ApplicationHelper
   end
 
   def with_invite_link(&block)
-    if @current_user && (@current_user.has_admin_rights_in?(@current_community) || @current_community.users_can_invite_new_users)
+    if @current_user && (@current_user.has_admin_rights? || @current_community.users_can_invite_new_users)
       block.call()
     end
   end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -401,7 +401,7 @@ class PersonMailer < ActionMailer::Base
       @url_params.freeze # to avoid accidental modifications later
       @test_email = test_email
 
-      subject = if @recipient.has_admin_rights_in?(community) && !@test_email
+      subject = if @recipient.has_admin_rights? && !@test_email
         t("emails.welcome_email.welcome_email_subject_for_marketplace_creator")
       else
         t("emails.welcome_email.welcome_email_subject", :community => community.full_name(recipient.locale), :person => person.given_name_or_username)

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -337,7 +337,7 @@ class Community < ActiveRecord::Base
   end
 
   def allows_user_to_send_invitations?(user)
-    (users_can_invite_new_users && user.member_of?(self)) || user.has_admin_rights_in?(self)
+    (users_can_invite_new_users && user.member_of?(self)) || user.has_admin_rights?
   end
 
   def has_customizations?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -476,9 +476,8 @@ class Person < ActiveRecord::Base
     #CommunityMembership.find_by_person_id_and_community_id(id, community.id).can_post_listings
   end
 
-  def banned_at?(community)
-    memberships = self.community_memberships.find_by_community_id(community.id)
-    !memberships.nil? && memberships.banned?
+  def banned?
+    community_membership.banned?
   end
 
   def has_email?(address)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -446,13 +446,12 @@ class Person < ActiveRecord::Base
     community_memberships.find_by_community_id(community.id).consent
   end
 
-  def is_admin_of?(community)
-    community_membership = community_memberships.find_by_community_id(community.id)
-    community_membership && community_membership.admin?
+  def is_marketplace_admin?
+    community_membership.admin?
   end
 
-  def has_admin_rights_in?(community)
-    is_admin? || is_admin_of?(community)
+  def has_admin_rights?
+    is_admin? || is_marketplace_admin?
   end
 
   def should_receive?(email_type)

--- a/app/views/admin/community_memberships/index.haml
+++ b/app/views/admin/community_memberships/index.haml
@@ -53,7 +53,7 @@
               %td= l(membership.created_at, :format => :short_date)
               - if @current_community.require_verification_to_post_listings
                 %td{:style => "text-align: center"}= check_box_tag "posting-allowed[#{member.id}]", member.id, membership.can_post_listings, :class => "admin-members-can-post-listings"
-              %td{:style => "text-align: center"}= check_box_tag "is_admin[#{member.id}]", member.id, member.is_admin_of?(@community), :class => "admin-members-is-admin", :disabled => member.eql?(@current_user)
+              %td{:style => "text-align: center"}= check_box_tag "is_admin[#{member.id}]", member.id, member.is_marketplace_admin?, :class => "admin-members-is-admin", :disabled => member.eql?(@current_user)
               %td{:style => "text-align: center"}
                 = link_to(icon_tag("cross"), ban_admin_community_community_membership_path(@current_community.id, membership.id), method: :put, :data => {:confirm => t("admin.communities.manage_members.ban_user_confirmation")}, :class => "admin-members-remove-user")
 

--- a/app/views/layouts/_header_menu.haml
+++ b/app/views/layouts/_header_menu.haml
@@ -27,7 +27,7 @@
         = icon_tag("redirect", ["icon-with-text"])
         = menu_link.title(I18n.locale)
 
-  - if @current_user && @current_community && @current_user.has_admin_rights_in?(@current_community)
+  - if @current_user && @current_community && @current_user.has_admin_rights?
     = link_to edit_details_admin_community_path(@current_community) do
       = icon_tag("admin", ["icon-with-text"])
       = t("layouts.logged_in.admin")

--- a/app/views/layouts/_mercury_editable_page.haml
+++ b/app/views/layouts/_mercury_editable_page.haml
@@ -1,4 +1,4 @@
-- if @current_user && @current_user.has_admin_rights_in?(@current_community)
+- if @current_user && @current_user.has_admin_rights?
   %p
     %a{:id => "edit_link", :href => "/editor" + request.path, :data => { :save_url => mercury_update_path }}
       .icon-with-text-container

--- a/app/views/listings/_comment.haml
+++ b/app/views/listings/_comment.haml
@@ -4,7 +4,7 @@
   %h3
     = link_to_unless comment.author.deleted?, PersonViewUtils.person_display_name(comment.author, @current_community), comment.author
   %small= time_ago(comment.created_at)
-  - if @current_user && (current_user?(comment.author) || @current_user.has_admin_rights_in?(@current_community))
+  - if @current_user && (current_user?(comment.author) || @current_user.has_admin_rights?)
     %small= link_to t('listings.comment.delete'), listing_comment_path(:listing_id => comment.listing.id, :id => comment.id), {method: :delete, data: { confirm: t('listings.comment.are_you_sure') }, :remote => :true}
   .comment-content
     - text_with_line_breaks do

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -1,5 +1,5 @@
 - is_author = current_user?(@listing.author)
-- is_marketplace_admin = Maybe(@current_user).has_admin_rights_in?(@current_community).or_else(false)
+- is_marketplace_admin = Maybe(@current_user).has_admin_rights?.or_else(false)
 - is_authorized = is_author || is_marketplace_admin
 
 - if @listing.closed?

--- a/app/views/person_mailer/welcome_email.html.haml
+++ b/app/views/person_mailer/welcome_email.html.haml
@@ -11,7 +11,7 @@
                     %tr
                       %td{:width => "7.5%"}
                       %td{:valign => "top", :width => "85%", :style => "font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-weight:400; font-size:14px; padding: 10px 0 40px 0; text-align: left; line-height:22px;"}
-                        - if @recipient.has_admin_rights_in?(@current_community) && !@test_email
+                        - if @recipient.has_admin_rights? && !@test_email
                           = render :partial => "admin/communities/welcome_email_for_marketplace_creator"
                         - else
                           %p= t("emails.common.hey", :name => @recipient.given_name_or_username)
@@ -21,7 +21,7 @@
                           - else
                             = render :partial => "admin/communities/default_welcome_email"
                       %td{:width => "7.5%"}
-            - unless @recipient.has_admin_rights_in?(@current_community) && !@test_email
+            - unless @recipient.has_admin_rights? && !@test_email
               %tr
                 %td{:style => "text-align: left;width:100%;max-width:602px;padding: 0 45px;"}
                   %p{:style => "margin-top:15px;margin-bottom:15px;font-family:helvetica,arial,sans-serif;font-size:12px;color:#464646;"}

--- a/app/views/sessions/_confirmation_form.haml
+++ b/app/views/sessions/_confirmation_form.haml
@@ -3,7 +3,7 @@
 
 - email_to_confirm = @current_user.latest_pending_email_address(@current_community)
 
-- if @current_user.has_admin_rights_in?(@current_community)
+- if @current_user.has_admin_rights?
   %h2= t("sessions.confirmation_pending.account_confirmation_instructions_title_admin")
   %p= t("sessions.confirmation_pending.your_marketplace_has_now_been_created")
   %p= t("sessions.confirmation_pending.account_confirmation_instructions_admin")

--- a/lib/mercury/authentication.rb
+++ b/lib/mercury/authentication.rb
@@ -4,7 +4,7 @@ module Mercury
     def can_edit?
       @current_user = current_person
       @current_community = ApplicationController.find_community(community_identifiers)
-      @current_user && @current_community && @current_user.has_admin_rights_in?(@current_community)
+      @current_user && @current_community && @current_user.has_admin_rights?
     end
 
     def community_identifiers


### PR DESCRIPTION
- [X] is_admin_of?
- [x] banned_at?
- [x] cannot_access_without_confirmation 
- [x] ensure_consent_given at 
- [x] ensure_user_belongs_to_community