### PR TITLE
Update and remove some translation keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1639,9 +1639,6 @@ en:
       rideshare_offer: "Rideshare offer"
       rideshare_request: "Rideshare request"
       send_private_message: "Send private message"
-      share_types: "Share types"
-      share_types_offer: "Type of offer"
-      share_types_request: "Type of request"
       tags: Tags
       time: time
       times: times

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1295,7 +1295,7 @@ en:
       confirmation_link_is_wrong_or_used: "The confirmation link is already used or otherwise broken. Try logging in, or send feedback if the problem persists."
       additional_email_confirmed: "The email you entered is now confirmed."
       could_not_get_email_from_facebook: "Could not get email address from Facebook and can't create an account without email."
-      facebook_email_unconfirmed: "The email address '%{email}' in your Facebook account is been already taken but it's unconfirmed. Please confirm the email address before logging in with Facebook."
+      facebook_email_unconfirmed: "The email address '%{email}' associated with your Facebook account is already used but it hasn't been confirmed yet. Please confirm the email address before logging in with Facebook."
       create_new_listing: "Create another listing"
       create_one_here: "create one here"
       email_confirmation_sent_to_new_address: "Email confirmation is now sent to the new address."


### PR DESCRIPTION
The `facebook_email_unconfirmed` sentence was reported as a bit unclear by 3 translators.

Luis noticed that `share_types`, `share_types_offer` and `share_types_request` were no longer used so are useless noise for translation.