### PR TITLE
Fix specs of deprecated calls

### DIFF
--- a/app/services/user_service/api/users.rb
+++ b/app/services/user_service/api/users.rb
@@ -88,7 +88,7 @@ module UserService::API
         person.inverse_follower_relationships.destroy_all
 
         # Delete memberships
-        person.community_memberships.update_all(status: "deleted_user")
+        person.community_membership.update_attributes(status: "deleted_user")
 
         # Delte auth tokens
         person.auth_tokens.destroy_all

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -49,7 +49,7 @@ describe ListingsController, type: :controller do
     @c2 = FactoryGirl.create(:community)
 
     @p1 = FactoryGirl.create(:person)
-    @p1.communities << @c1
+    @p1.accepted_community = @c1
 
     @category_item      = FactoryGirl.create(:category, :community => @c1)
     @category_item.translations << FactoryGirl.create(:category_translation, :name => "Tavarat", :locale => "fi", :category => @category_item)

--- a/spec/mailers/community_mailer_spec.rb
+++ b/spec/mailers/community_mailer_spec.rb
@@ -19,7 +19,7 @@ describe "CommunityMailer", type: :mailer do
       @c1.community_customizations.first.update_attribute(:name, "MarketTestPlace")
 
       @p1 = FactoryGirl.create(:person, :emails => [ FactoryGirl.create(:email, :address => "update_tester@example.com") ])
-      @p1.communities << @c1
+      @p1.accepted_community = @c1
       @l2 = FactoryGirl.create(:listing,
           :title => "hammer",
           :created_at => 2.days.ago,
@@ -32,7 +32,7 @@ describe "CommunityMailer", type: :mailer do
 
       @email = CommunityMailer.community_updates(
         recipient: @p1,
-        community: @p1.communities.first,
+        community: @p1.accepted_community,
         listings: [@l2],
         unsubscribe_token: @p1_unsubscribe_token
       )
@@ -66,9 +66,9 @@ describe "CommunityMailer", type: :mailer do
       @c1 = FactoryGirl.create(:community)
       @c2 = FactoryGirl.create(:community)
       @p1 = FactoryGirl.create(:person)
-      @p1.communities << @c1
+      @p1.accepted_community = @c1
       @p2 = FactoryGirl.create(:person)
-      @p2.communities << @c1
+      @p2.accepted_community = @c1
 
       @l1 = FactoryGirl.create(:listing,
           :title => "bike",
@@ -86,9 +86,9 @@ describe "CommunityMailer", type: :mailer do
           :author => @p2)
 
       @p3 = FactoryGirl.create(:person)
-      @p3.communities << @c1
+      @p3.accepted_community = @c1
       @p4 = FactoryGirl.create(:person)
-      @p4.communities << @c1
+      @p4.accepted_community = @c1
 
       @p1.update_attribute(:community_updates_last_sent_at, 8.hours.ago)
       @p2.update_attribute(:community_updates_last_sent_at, 14.days.ago)
@@ -122,7 +122,7 @@ describe "CommunityMailer", type: :mailer do
 
     it "should send with default 7 days to those with nil as last time sent" do
       @p5 = FactoryGirl.create(:person)
-      @p5.communities << @c1
+      @p5.accepted_community = @c1
       @p5.update_attribute(:community_updates_last_sent_at, nil)
       CommunityMailer.deliver_community_updates
       expect(ActionMailer::Base.deliveries.size).to eq(3)

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -184,11 +184,11 @@ describe PersonMailer, type: :mailer do
       @c1 = FactoryGirl.create(:community)
       @p1 = FactoryGirl.create(:person, :emails => [ FactoryGirl.create(:email, :address => "update_tester@example.com") ])
 
-      @p1.communities << @c1
+      @p1.accepted_community = @c1
     end
 
     it "should welcome a regular member" do
-      @email = PersonMailer.welcome_email(@p1, @p1.communities.first)
+      @email = PersonMailer.welcome_email(@p1, @p1.accepted_community)
       expect(@email).to deliver_to("update_tester@example.com")
       expect(@email).to have_subject("Welcome to Sharetribe")
       expect(@email).to have_body_text "Welcome to Sharetribe! Glad to have you on board."
@@ -197,7 +197,7 @@ describe PersonMailer, type: :mailer do
 
     it "should contain custom content if that is defined for the community" do
       @c1.community_customizations.first.update_attribute(:welcome_email_content, "Custom email")
-      @email = PersonMailer.welcome_email(@p1, @p1.communities.first)
+      @email = PersonMailer.welcome_email(@p1, @p1.accepted_community)
       expect(@email).to have_body_text "Custom email"
       expect(@email).not_to have_body_text "Add something you could offer to others."
       expect(@email).not_to have_body_text "You have now admin rights in this community."

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -149,7 +149,7 @@ describe Community, type: :model do
 
     before(:each) do
       @p1 = FactoryGirl.create(:person, :emails => [ FactoryGirl.create(:email, :address => "update_tester@example.com") ])
-      @p1.communities << @community
+      @p1.accepted_community = @community
       @l1 = get_listing(2,2)
       @l2 = get_listing(3,3)
       @l3 = get_listing(12,12)

--- a/spec/services/user_service/users_spec.rb
+++ b/spec/services/user_service/users_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 class TransactionMailer; end
 
 describe UserService::API::Users do
@@ -75,7 +77,7 @@ describe UserService::API::Users do
       expect(new_user.given_name).not_to be_nil
       expect(new_user.family_name).not_to be_nil
       expect(new_user.emails).not_to be_empty
-      expect(new_user.community_memberships).not_to be_empty
+      expect(new_user.community_membership).not_to be_nil
       expect(new_user.braintree_account).not_to be_nil
       expect(new_user.checkout_account).not_to be_nil
       expect(new_user.auth_tokens).not_to be_nil
@@ -91,7 +93,7 @@ describe UserService::API::Users do
       expect(deleted_user.given_name).to be_nil
       expect(deleted_user.family_name).to be_nil
       expect(deleted_user.emails).to be_empty
-      expect(deleted_user.community_memberships.map(&:status).all? { |status| status == "deleted_user" }).to eq(true)
+      expect(deleted_user.community_membership.status).to eq("deleted_user")
       expect(deleted_user.braintree_account).to be_nil
       expect(deleted_user.checkout_account).to be_nil
       expect(deleted_user.auth_tokens).to be_empty


### PR DESCRIPTION
Removes and fixes logic that previously referred to has_many relationships in person.rb. Now, we refer to `accepted_community` and `community_membership` and rely on the fact that these are has_one relationships.

Updates:
  - Specs:
    * listing_controller_spec
    * community_mailer_spec
    * person_mailer_spec
    * community_spec
    * users_spec
  - Other:
    * User service api: update only the single community membership on delete
    * People controller: destroy paypal account from the single community user belongs to 