### PR TITLE
Show onboarding topbar only after email is confirmed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -602,6 +602,15 @@ class ApplicationController < ActionController::Base
     logger.add_metadata(metadata)
   end
 
+  def display_onboarding_topbar?
+    @current_user &&
+      @current_community &&
+      @current_user.has_admin_rights? &&
+      !@current_user.community_membership.pending_email_confirmation?
+  end
+
+  helper_method :display_onboarding_topbar?
+
   def onboarding_topbar_props
     community_id = @current_community.id
     onboarding_status = Admin::OnboardingWizard.new(community_id).setup_status

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -6,7 +6,7 @@
     .noscript-padding
       -# Noscript content will be positioned here
 
-  - if @current_user && @current_community && @current_user.has_admin_rights? && !@current_user.community_membership.pending_email_confirmation?
+  - if display_onboarding_topbar?
     - with_feature(:onboarding_redesign_v1) do
       - props = onboarding_topbar_props
       - unless props[:next_step] == :all_done

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -6,7 +6,7 @@
     .noscript-padding
       -# Noscript content will be positioned here
 
-  - if @current_user && @current_community && @current_user.has_admin_rights?
+  - if @current_user && @current_community && @current_user.has_admin_rights? && !@current_user.community_membership.pending_email_confirmation?
     - with_feature(:onboarding_redesign_v1) do
       - props = onboarding_topbar_props
       - unless props[:next_step] == :all_done


### PR DESCRIPTION
We had a small oversight in the new onboarding process: the user was prompted to do onboarding actions with the topbar already when their email wasn't confirmed. This is confusing, and something we didn't intend. This PR hides the topbar when email isn't confirmed.