### PR TITLE
Autoprefixer config

### DIFF
--- a/client/app/components/OnboardingTopBar/OnboardingTopBar.scss
+++ b/client/app/components/OnboardingTopBar/OnboardingTopBar.scss
@@ -7,7 +7,7 @@ $gradientEnd: rgb(89,165,179);
   color: white;
   padding-top: 1.2em;
   padding-bottom: 1.2em;
-  background-image: linear-gradient( 180deg, $gradientStart 0%, $gradientEnd 100%);
+  background-image: linear-gradient( 90deg, $gradientStart 0%, $gradientEnd 100%);
   box-shadow: $topbarShadow;
 }
 

--- a/client/webpack.client.base.config.js
+++ b/client/webpack.client.base.config.js
@@ -59,7 +59,9 @@ module.exports = {
     ],
   },
 
-  postcss: [autoprefixer],
+  postcss: [
+    autoprefixer({ browsers: ['last 2 versions', 'not ie < 11', 'not ie_mob < 11', 'ie >= 11'] }),
+  ],
 
   // Place here all SASS files with variables, mixins etc.
   // And sass-resources-loader will load them in every CSS Module (SASS file) for you


### PR DESCRIPTION
Configure autoprefixer to target our supported browsers, and a surprise gradient fix

```
> browserslist('last 2 versions, not ie < 11, not ie_mob < 11, ie >= 11')
[ 'chrome 50',
  'chrome 49',
  'edge 13',
  'edge 12',
  'firefox 45',
  'firefox 44',
  'ie 11',
  'ie_mob 11',
  'ios_saf 9.0-9.2',
  'ios_saf 8.1-8.4',
  'opera 36',
  'opera 35',
  'safari 9.1',
  'safari 9' ]
```