### PR TITLE
Redirect to new onboarding straight from email confirmation

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -10,7 +10,7 @@ class Admin::CommunitiesController < ApplicationController
     @community = @current_community
 
     if(feature_enabled?(:onboarding_redesign_v1))
-      redirect_to getting_started_guide_admin_community_path(@current_community)
+      redirect_to getting_started_guide_admin_community_path(id: @current_community.id)
     else
       render locals: {paypal_enabled: PaypalHelper.paypal_active?(@current_community.id)}
     end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -61,9 +61,9 @@ class ConfirmationsController < Devise::ConfirmationsController
       if @current_user && @current_user.has_admin_rights?
         report_to_gtm({event: "admin_email_confirmed"})
         if feature_enabled?(:onboarding_redesign_v1)
-          redirect_to getting_started_guide_admin_community_path(@current_community) and return
+          redirect_to getting_started_guide_admin_community_path(id: @current_community.id) and return
         else
-          redirect_to getting_started_admin_community_path(:id => @current_community.id) and return
+          redirect_to getting_started_admin_community_path(id: @current_community.id) and return
         end
       elsif @current_user # normal logged in user
         redirect_to root and return

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -60,7 +60,11 @@ class ConfirmationsController < Devise::ConfirmationsController
 
       if @current_user && @current_user.has_admin_rights?
         report_to_gtm({event: "admin_email_confirmed"})
-        redirect_to getting_started_admin_community_path(:id => @current_community.id) and return
+        if feature_enabled?(:onboarding_redesign_v1)
+          redirect_to getting_started_guide_admin_community_path(@current_community) and return
+        else
+          redirect_to getting_started_admin_community_path(:id => @current_community.id) and return
+        end
       elsif @current_user # normal logged in user
         redirect_to root and return
       else # no logged in session


### PR DESCRIPTION
Multiple redirects lose session data, which messes up analytics.