### PR TITLE
Fix null pointer error if feedback form is sent without content

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -20,12 +20,13 @@ class FeedbacksController < ApplicationController
 
   def create
     feedback_form = FeedbackForm.new(params[:feedback])
-    return if ensure_not_spam!(params[:feedback], feedback_form)
 
     unless feedback_form.valid?
-      flash[:error] = t("layouts.notifications.feedback_not_saved") # feedback_form.errors.full_messages.join(", ")
+      flash[:error] = t("layouts.notifications.feedback_not_saved")
       return render_form(feedback_form)
     end
+
+    return if ensure_not_spam!(params[:feedback], feedback_form)
 
     author_id = Maybe(@current_user).id.or_else("Anonymous")
     email = current_user_email || feedback_form.email


### PR DESCRIPTION
- Fix null pointer error if feedback form is sent without content
- Not sure why this happen, may be a spam bot or something like that
- The error occurres in method `link_tags?(str)` is `str` is `nil`
- Move `ensure_not_spam!` after the form validation has validated that the `content` is present