### PR TITLE
Remove links to the developer flowdock chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ foreman start -f Procfile.hot
 
 Use these instructions to set up and deploy Sharetribe for production in different environments. They have been put together by the developer community, and are not officially maintained by the Sharetribe core team. The instructions might be somewhat out of date.
 
-If you have installation instructions that you would like to share, don't hesitate to [contact the team](https://www.flowdock.com/invitations/de227bdbe48d24c31a6b749933d3b4eca82e307c).
+If you have installation instructions that you would like to share, don't hesitate to share them at the [Sharetribe community forum](https://www.sharetribe.com/community).
 
 - [Deploying Sharetribe to Heroku](https://gist.github.com/svallory/d08e9baa88e18d691605) by [svallory](https://github.com/svallory)
 

--- a/TECHNICAL_ROADMAP.md
+++ b/TECHNICAL_ROADMAP.md
@@ -79,4 +79,4 @@ Sharetribe's user interface is currently intertwined with the core Sharetribe ap
 
 ## How can I affect these plans?
 
-Talk to us! These plans are formed based on an overall understanding of Sharetribe customer needs and the Sharetribe vision. Feedback can alter either of these, which will then lead to changes in plans. You can either contact us via [email](mailto:support@sharetribe.com), the Sharetribe [idea forum](http://support.sharetribe.com/forums/240322-sharetribe-development-ideas) or our [Flowdock developer chat room](https://www.flowdock.com/invitations/de227bdbe48d24c31a6b749933d3b4eca82e307c).
+Talk to us! These plans are formed based on an overall understanding of Sharetribe customer needs and the Sharetribe vision. Feedback can alter either of these, which will then lead to changes in plans. You can either contact us via [email](mailto:support@sharetribe.com), the Sharetribe [idea forum](http://support.sharetribe.com/forums/240322-sharetribe-development-ideas) or our [community forum](https://www.sharetribe.com/community).


### PR DESCRIPTION
A few references to the old developer Flowdock chat were found in the readmes.