### PR TITLE
Any custom field is considered as success in onboarding flow

### DIFF
--- a/app/services/admin/onboarding_wizard.rb
+++ b/app/services/admin/onboarding_wizard.rb
@@ -81,8 +81,7 @@ module Admin
     end
 
     def custom_field_created(setup_status, custom_field)
-      if !setup_status[:filter] &&
-         Maybe(custom_field).search_filter.or_else(false)
+      unless setup_status[:filter]
         :filter
       end
     end


### PR DESCRIPTION
Previously, adding a text field didn't count as success.