### PR TITLE
Check listing shapes when initialising onboarding status

### DIFF
--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -87,7 +87,7 @@ class Admin::ListingShapesController < ApplicationController
 
       # Onboarding wizard step recording
       state_changed = Admin::OnboardingWizard.new(@current_community.id)
-        .update_from_event(:listing_shape_updated, update_result.data)
+        .update_from_event(:listing_shape_updated, [update_result.data])
       if state_changed
         report_to_gtm([{event: "km_record", km_event: "Onboarding payments setup"},
                        {event: "km_record", km_event: "Onboarding payment disabled"}])

--- a/app/services/admin/onboarding_wizard.rb
+++ b/app/services/admin/onboarding_wizard.rb
@@ -115,13 +115,12 @@ module Admin
       end
     end
 
-    def listing_shape_updated(setup_status, listing_shape)
-      if !setup_status[:paypal] && listing_shape &&
-         !listing_shape[:price_enabled]
+    def listing_shape_updated(setup_status, listing_shapes)
+      if !setup_status[:paypal] && listing_shapes.present? &&
+         listing_shapes.any? {|shape| !shape[:price_enabled] }
         :paypal
       end
     end
-
 
     # Helpers and setup logic
     #
@@ -137,6 +136,7 @@ module Admin
       custom_field = CustomField.find_by(community_id: community.id)
       listing = Listing.find_by(community_id: community.id)
       invitation = Invitation.find_by(community_id: community.id)
+      listing_shapes = ListingShape.where(community_id: community.id)
 
       m = MarketplaceSetupSteps.find_or_create_by(community_id: community_id)
       setup_status = to_setup_status(m)
@@ -147,7 +147,8 @@ module Admin
         custom_field_created(setup_status, custom_field),
         paypal_preferences_updated(setup_status, community),
         listing_created(setup_status, listing),
-        invitation_created(setup_status, invitation)
+        invitation_created(setup_status, invitation),
+        listing_shape_updated(setup_status, listing_shapes)
       ].compact.map { |status| [status, true] }.to_h
 
       m.update_attributes(updates)


### PR DESCRIPTION
Listing shapes need to be checked now as well, as we consider a listing shape without payments a successful "configure payments" step.

After this commit an existing marketplace getting new onboarding enabled would have all the onboarding step statuses detected correctly. This is mostly required for more predictable behaviour and possible future changes, and doesn't really affect the current onboarding experiment. 