### PR TITLE
Show marketplace name if logo is missing

### DIFF
--- a/app/assets/stylesheets/mixins/default-colors.scss
+++ b/app/assets/stylesheets/mixins/default-colors.scss
@@ -58,10 +58,10 @@ $yellow:      #D1C905;
 
 $cover-photo-url: "cover_photos/header/default.jpg";
 $small-cover-photo-url: "cover_photos/header/default.jpg";
-$wide-logo-lowres-url: "logos/full/default.png";
-$wide-logo-highres-url: "logos/full/default-highres.png";
-$square-logo-lowres-url: "logos/mobile/default.png";
-$square-logo-highres-url: "logos/mobile/default-highres.png";
+$wide-logo-lowres-url: "";
+$wide-logo-highres-url: "";
+$square-logo-lowres-url: "";
+$square-logo-highres-url: "";
 $cover-photo-height: 453;
 $cover-photo-mobile-height: 365;
 $small-cover-photo-height: 96;

--- a/app/assets/stylesheets/mixins/type.scss
+++ b/app/assets/stylesheets/mixins/type.scss
@@ -34,6 +34,10 @@ $line-height: 24;
   @return ($pixels / $context-font-size) * 1em;
 }
 
+@function rem($pixels, $context-font-size: $font-size) {
+  @return ($pixels / $context-font-size) * 1rem;
+}
+
 @function lines($lines, $context-font-size: $font-size,  $context-line-height: $line-height) {
   @return $lines * ($context-line-height / $context-font-size) * 1em;
 }

--- a/app/assets/stylesheets/views/_header.css.scss
+++ b/app/assets/stylesheets/views/_header.css.scss
@@ -192,6 +192,29 @@ $elementSpacing: lines(0.5);
   margin-left: lines(0.5);
 }
 
+.header-wide-logo-text,
+.header-square-logo-text {
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+  line-height: 2.5rem;
+  height: 2.5rem;
+  font-size: em(28);
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+  font-weight: 800;
+}
+
+.header-wide-logo-text {
+  @include ellipsis;
+  width: rem(150);
+  height: rem(40);
+}
+
+.header-square-logo-text {
+  width: rem(40);
+  height: rem(40);
+}
+
 .header-wide-logo {
   background-image: url(image-path($wide-logo-lowres-url));
 

--- a/app/views/layouts/_global_header.haml
+++ b/app/views/layouts/_global_header.haml
@@ -45,7 +45,15 @@
       keep the logo here after buttons
     .header-left.header-logo-container
       = link_to homepage_path, :class => "header-logo", :id => "header-logo" do
-        %i.header-wide-logo.visible-tablet
-          -# Logo is here, it's a CSS background
-        %i.header-square-logo.hidden-tablet
-          -# Logo is here, it's a CSS background
+        - if @current_community.logo.present?
+          %i.header-square-logo.hidden-tablet
+            -# Logo is here, it's a CSS background
+        - else
+          %span.header-square-logo-text.hidden-tablet
+            = @current_community.name(I18n.locale)[0]
+        - if @current_community.wide_logo.present?
+          %i.header-wide-logo.visible-tablet
+            -# Logo is here, it's a CSS background
+        - else
+          %span.header-wide-logo-text.visible-tablet
+            = @current_community.name(I18n.locale)


### PR DESCRIPTION
To increase the whitelabel aspect of a newly created marketplace, show the marketplace name instead of a Sharetribe logo in the header when no custom logo is uploaded yet.