### PR TITLE
Use I18n-js to export translation bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ client/node_modules
 # Generated js bundles
 /app/assets/webpack/*
 
+# Generated i18n-js bundles
+/app/assets/javascripts/i18n/*
+/client/app/i18n/*

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,15 @@ gem 'faraday_middleware', '~> 0.10.0'
 
 gem "react_on_rails", "~> 5.1.1"
 
+# Use latest from master
+#
+# The latest master is needed because it contains the I18n.extend configuration
+# See: https://github.com/fnando/i18n-js/pull/397
+gem "i18n-js",
+    git: "git://github.com/fnando/i18n-js.git",
+    branch: "master",
+    ref: "2ca6d31365bb41db21e373d126cac00d38d15144"
+
 group :staging, :production do
   gem 'newrelic_rpm', '~> 3.9.1.236'
   gem 'rails_12factor', '~> 0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: git://github.com/fnando/i18n-js.git
+  revision: 2ca6d31365bb41db21e373d126cac00d38d15144
+  ref: 2ca6d31365bb41db21e373d126cac00d38d15144
+  branch: master
+  specs:
+    i18n-js (3.0.0.rc12)
+      i18n (~> 0.6, >= 0.6.6)
+
+GIT
   remote: git://github.com/intridea/oauth2.git
   revision: e0006cb5099bf392f011eb5c49cbec4f893bbdba
   ref: e0006cb5099bf392f011eb5c49cbec4f893bbdba
@@ -540,6 +549,7 @@ DEPENDENCIES
   flying-sphinx (~> 1.2.0)
   guard-rspec (~> 4.6.5)
   haml (~> 4.0.5)
+  i18n-js!
   jquery-rails (= 3.1.3)
   jwt (~> 1.5.2)
   kgio (~> 2.9.2)
@@ -594,4 +604,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.2
+   1.12.3

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -61,6 +61,12 @@
   -# load Facebook SDK for the whole page
   = render :partial => "layouts/facebook_sdk"
 
+  -# Initialize global I18n variable and load translations there
+  :javascript
+    window.I18n = {};
+
+  = javascript_include_tag "i18n/#{I18n.locale}"
+
   = javascript_include_tag 'application'
 
   :javascript

--- a/app/views/layouts/styleguide.html.erb
+++ b/app/views/layouts/styleguide.html.erb
@@ -9,6 +9,14 @@
                               hot: 'application_hot',
                               media: 'all') %>
 
+
+  <!-- Initialize global I18n variable and load translations there -->
+  <script>
+    window.I18n = {};
+  </script>
+
+  <%= javascript_include_tag "i18n/#{I18n.locale}" %>
+
   <!-- This is to load the hot assets. -->
   <% domain = APP_CONFIG.domain.split(':').first %>
   <%= env_javascript_include_tag(hot: ["http://#{domain}:3500/vendor-bundle.js",

--- a/client/app/components/OnboardingTopBar/OnboardingTopBar.js
+++ b/client/app/components/OnboardingTopBar/OnboardingTopBar.js
@@ -1,25 +1,54 @@
 import { Component, PropTypes } from 'react';
-import { translate } from '../../utils/i18nUtils';
 import { div, span, a } from 'r-dom';
+import { t } from '../../utils/i18n';
 
 import css from './OnboardingTopBar.scss';
 
-const next = function next(nextStep, guideRoot, t) {
-  return t(nextStep) ? {
-    title: t(nextStep),
-    link: `${guideRoot}/${nextStep}`,
-  } : null;
+const next = function next(nextStep, guideRoot) {
+  switch (nextStep) {
+    case 'slogan_and_description':
+      return {
+        title: t('admin.onboarding.topbar.slogan_and_description'),
+        link: `${guideRoot}/${nextStep}`,
+      };
+    case 'cover_photo':
+      return {
+        title: t('admin.onboarding.topbar.cover_photo'),
+        link: `${guideRoot}/${nextStep}`,
+      };
+    case 'filter':
+      return {
+        title: t('admin.onboarding.topbar.filter'),
+        link: `${guideRoot}/${nextStep}`,
+      };
+    case 'paypal':
+      return {
+        title: t('admin.onboarding.topbar.paypal'),
+        link: `${guideRoot}/${nextStep}`,
+      };
+    case 'listing':
+      return {
+        title: t('admin.onboarding.topbar.listing'),
+        link: `${guideRoot}/${nextStep}`,
+      };
+    case 'invitation':
+      return {
+        title: t('admin.onboarding.topbar.invitation'),
+        link: `${guideRoot}/${nextStep}`,
+      };
+    default:
+      return null;
+  }
 };
 
 class OnboardingTopBar extends Component {
 
   nextElement() {
-    const t = translate(this.props.translations);
-    const nextStep = next(this.props.next_step, this.props.guide_root, t);
+    const nextStep = next(this.props.next_step, this.props.guide_root);
     if (nextStep) {
       return (
         div({ className: css.nextContainer }, [
-          div({ className: css.nextLabel }, t('next_step')),
+          div({ className: css.nextLabel }, t('admin.onboarding.topbar.next_step')),
           a({ href: nextStep.link, className: css.nextButton }, [
             span(nextStep.title),
           ]),
@@ -30,12 +59,11 @@ class OnboardingTopBar extends Component {
   }
 
   render() {
-    const t = translate(this.props.translations);
     const currentProgress = this.props.progress;
     return div({ className: css.topbarContainer }, [
       div({ className: css.topbar }, [
         a({ className: css.progressLabel, href: this.props.guide_root }, [
-          t('progress_label'),
+          t('admin.onboarding.topbar.progress_label'),
           span({ className: css.progressLabelPercentage },
                `${Math.floor(currentProgress)} %`),
         ]),
@@ -49,7 +77,6 @@ class OnboardingTopBar extends Component {
 }
 
 OnboardingTopBar.propTypes = {
-  translations: PropTypes.objectOf(PropTypes.string).isRequired,
   guide_root: PropTypes.string.isRequired,
   progress: PropTypes.number.isRequired,
   next_step: PropTypes.string.isRequired,

--- a/client/app/startup/OnboardingTopBarApp.js
+++ b/client/app/startup/OnboardingTopBarApp.js
@@ -1,0 +1,10 @@
+import r from 'r-dom';
+import { I18n } from '../utils/i18n';
+import OnboardingTopBar from '../components/OnboardingTopBar/OnboardingTopBar';
+
+export default (props, railsContext) => {
+  I18n.locale = railsContext.i18nLocale;
+  I18n.defaultLocale = railsContext.i18nDefaultLocale;
+
+  return r(OnboardingTopBar, props);
+};

--- a/client/app/startup/clientRegistration.js
+++ b/client/app/startup/clientRegistration.js
@@ -2,9 +2,8 @@ import ReactOnRails from 'react-on-rails';
 import Promise from 'es6-promise';
 Promise.polyfill();
 
-import OnboardingTopBar from '../components/OnboardingTopBar/OnboardingTopBar';
+import OnboardingTopBar from './OnboardingTopBarApp';
 import OnboardingGuideApp from './OnboardingGuideApp';
-
 
 ReactOnRails.register({
   OnboardingGuideApp,

--- a/client/app/startup/serverRegistration.js
+++ b/client/app/startup/serverRegistration.js
@@ -2,7 +2,7 @@
 import ReactOnRails from 'react-on-rails';
 
 import OnboardingGuideApp from './OnboardingGuideApp';
-import OnboardingTopBar from '../components/OnboardingTopBar/OnboardingTopBar';
+import OnboardingTopBar from './OnboardingTopBarApp';
 
 ReactOnRails.register({
   OnboardingGuideApp,

--- a/client/app/utils/i18n.js
+++ b/client/app/utils/i18n.js
@@ -1,0 +1,53 @@
+// This file has three tasks:
+//
+// 1. Initialize global.I18n if we are in server environment
+// 1. Load the language bundle if we are in server environment
+// 2. Require the i18n-js library and export it
+//
+// The language bundle is loaded in a global I18n variable like this:
+//
+// `global.I18n.translations["en"] = <translation json>`
+//
+// The i18n-js library is able to read the language bundle from that global
+//
+
+import { bind } from 'lodash';
+
+function isServer() {
+  return typeof window === 'undefined';
+}
+
+if (isServer()) {
+
+  // Initialize global.I18n
+  // In browser we initialize this in a script-tag manually
+  global.I18n = {}; // eslint-disable-line no-undef
+
+  // Load the translation bundle in the global.I18n variable.
+  // In browser the bundle is loaded in a separate script-tag.
+
+  try {
+    // The translation bundle will be loaded to the global I18n
+    // variable. Initialize the variable here.
+    require('../i18n/all.js'); // eslint-disable-line no-undef
+  } catch (e) {
+    console.warn("Can't load language bundle all.js"); // eslint-disable-line no-console
+  }
+}
+
+// Load the i18n-js library. The library is able to read the
+// translations from the global.I18n variable. This variable needs to
+// be initialized before loading the i18n-js library, so that the
+// library can use the existing I18n object
+
+const I18n = require('i18n-js'); // eslint-disable-line no-undef
+
+// Bind functions to I18n
+const translate = bind(I18n.translate, I18n);
+const localize = bind(I18n.localize, I18n);
+const pluralize = bind(I18n.pluralize, I18n);
+const t = bind(I18n.t, I18n);
+const l = bind(I18n.l, I18n);
+const p = bind(I18n.p, I18n);
+
+export { I18n, translate, localize, pluralize, t, l, p };

--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,8 @@
     "sass-resources-loader": "1.0.2",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
-    "webpack": "1.13.0"
+    "webpack": "1.13.0",
+    "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz"
   },
   "devDependencies": {
     "babel-eslint": "6.0.4",

--- a/client/webpack.client.base.config.js
+++ b/client/webpack.client.base.config.js
@@ -33,6 +33,8 @@ module.exports = {
     },
   },
   plugins: [
+    new webpack.IgnorePlugin(/i18n\/all.js/),
+
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(nodeEnv),

--- a/client/webpack.server.rails.build.config.js
+++ b/client/webpack.server.rails.build.config.js
@@ -29,7 +29,11 @@ module.exports = {
   ],
   module: {
     loaders: [
-      { test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/ },
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: [/node_modules/, /i18n\/all.js/],
+      },
       {
         test: /\.css$/,
         loaders: [

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,7 +57,15 @@ module Kassi
     config.assets.paths << VENDOR_CSS_PATH
 
     # Define here additional Assset Pipeline Manifests to include to precompilation
-    config.assets.precompile += ['markerclusterer.js', 'communities/custom-style-*', 'ss-*', 'modernizr.min.js', 'mercury.js','jquery-1.7.js']
+    config.assets.precompile += [
+      'markerclusterer.js',
+      'communities/custom-style-*',
+      'ss-*',
+      'modernizr.min.js',
+      'mercury.js',
+      'jquery-1.7.js',
+      'i18n/*.js'
+    ]
 
     # Read the config from the config.yml
     APP_CONFIG = ConfigLoader.load_app_config

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -291,6 +291,11 @@ default: &default_settings
   #
   next_maintenance_at:
 
+  # Use I18n::JS::Middleware to compile the translation bundle for
+  # client-side JS code during the request. Should be true for
+  # development and false otherwise.
+  use_i18n_js_middleware: false
+
 production: &production_settings
   <<: *default_settings
 
@@ -316,6 +321,8 @@ development:
   secret_key_base: "fd1af50b59b5e27776941b3205f92aca0f704c2252225cf93e3d97ae53f4774d25736cbdb19c1580839a2f68e15009209227e966003f53932c1bcc5d65616948"
 
   log_level: DEBUG
+
+  use_i18n_js_middleware: true
 
 test:
   <<: *default_settings

--- a/config/environments/common.rb
+++ b/config/environments/common.rb
@@ -12,7 +12,8 @@ Kassi::Application.configure do
     [:asset_host, :string, :optional],
     [:eager_load, :bool, :mandatory, :str_to_bool],
     [:serve_static_files, :bool, :optional, :str_to_bool],
-    [:log_level, transform_with: str_to_lowercase_sym, one_of: [:debug, :info, :warn, :error]]
+    [:log_level, transform_with: str_to_lowercase_sym, one_of: [:debug, :info, :warn, :error]],
+    [:use_i18n_js_middleware, :bool, :optional, :str_to_bool],
   )
 
   m_config = Maybe(Config.call(APP_CONFIG.to_h))
@@ -31,5 +32,9 @@ Kassi::Application.configure do
 
   m_config[:log_level].each { |log_level|
     config.log_level = log_level
+  }
+
+  m_config[:use_i18n_js_middleware].each { |use_middleware|
+    config.middleware.use I18n::JS::Middleware if use_middleware
   }
 end

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -1,0 +1,37 @@
+# Configure translations that are passed to JavaScript
+
+# Don't export the i18n.js file.
+# We get that file via webpack and npm
+export_i18n_js: false
+
+# By default the exported files contains call to I18n.extend.
+# We don't want to call that because in our case I18n is not library
+# is not yet available when we are loading the translations.
+js_extend: false
+
+translations:
+
+  # Bundles per language
+  #
+  # Per language bundles are used in frontend because we don't
+  # want to send too big language bundles over the wire
+  #
+  # Use a custom namespace that uses either global (in node) or window (in browser)
+
+  - file: "app/assets/javascripts/i18n/%{locale}.js"
+    only: ["*.web", "*.admin.onboarding"]
+    namespace: "(typeof(window) === 'undefined' ? global : window).I18n"
+    pretty_print: true # can be turned on for debugging
+
+  # Bundle for all languages
+  #
+  # This bundle is used for server rendering. We can bundle
+  # all languages in on file because we don't need to care
+  # about the filesize
+  #
+  # Use a custom namespace that uses either global (in node) or window (in browser)
+
+  - file: "client/app/i18n/all.js"
+    only: ["*.web", "*.admin.onboarding"]
+    namespace: "(typeof(window) === 'undefined' ? global : window).I18n"
+    pretty_print: false # can be turned on for debugging

--- a/config/initializers/i18n-js.rb
+++ b/config/initializers/i18n-js.rb
@@ -1,0 +1,42 @@
+# This file monkey-patches an open issue in I18n-js
+#
+# I18n-js doesn't work well with I18n::Backend::Chain backend
+#
+# See: https://github.com/fnando/i18n-js/issues/59
+
+module I18n
+  module JS
+
+    def self.translations
+      all_translations = {}
+      selected_backends = []
+      current_backend = ::I18n.backend
+
+      case current_backend
+      when I18n::Backend::Chain
+        current_backend.backends.each do |backend_in_chain|
+          if backend_in_chain.respond_to?(:translations, true)
+            selected_backends << backend_in_chain
+          end
+        end
+      else
+        if current_backend.respond_to?(:translations, true)
+          selected_backends = [current_backend]
+        end
+      end
+
+      selected_backends.each do |selected_backend|
+        selected_backend.instance_eval do
+          # all `selected_backends` are `::I18n::Backend::Simple`
+          if defined?(:initialized?) && defined?(:init_translations)
+            init_translations unless initialized?
+          end
+        end
+        all_translations.deep_merge!(selected_backend.send(:translations))
+      end
+
+      all_translations
+    end
+
+  end
+end

--- a/docs/js-translations.md
+++ b/docs/js-translations.md
@@ -1,0 +1,61 @@
+# Client-side translations
+
+_This documentation describes how to use translations in the client-side JavaScript code. The document applied only to the new React based JavaScript code._
+
+_The mechanism described in this document **does not work with marketplace specific translations.**_
+
+## Usage
+
+In the React component, you need to import `t` function from the `i18n` module. After that you can use all the translation keys from the `en.js.*` scope:
+
+```js
+// MyReactComponent.js
+
+import { t } from '../../utils/i18n';
+
+class MyReactComponent extends Component {
+  render() {
+    return span({className: "hello-world"}, t("js.hello_world"))
+  }
+}
+```
+
+The example above assumed that there's a `js.hello_world` key in the translation YML file, e.g.:
+
+```yml
+
+# en.yml
+
+en:
+  js:
+    hello_world: "Hello JavaScript world!"
+```
+
+## Implementation details
+
+### I18n-js
+
+The client-side translations are powered by [i18n-js](https://github.com/fnando/i18n-js/) gem. The gem provides three important utilities:
+
+* `rake i18n:js:export` task to export the translations to `.js` bundle
+* `i18n-js` npm package, which helpers for translations, pluralizations, etc.
+* `I18n::JS::Middleware` which compiles the `.js` bundle every request in development mode
+
+## Client-side rendering
+
+The translation bundle for all languages is big, so it makes sense to split it per language for client-side rendering purposes. In addition, the translation bundle can be cached because it doesn't change between deploys.
+
+In production mode, you should see two `<script>` tags, one for the language bundle and one for the `application.js` with the fingerprint in the filename:
+
+```html
+<script src="https://your_cdn.com/assets/i18n/en-9b9ce41ada0d1b7ad028dda2c64c23d8.js"></script>
+<script src="https://your_cdn.com/assets/application-6e9fbeebcaa14c12939b47fab1e53769.js"></script>
+```
+
+## Server-side rendering
+
+When doing server-side rendering, the `all.js` file is bundled to the `server.js` bundle. The `utils/i18n.js` file takes care of loading the translation bundle `all.js`.
+
+### Deployment to production
+
+`rake i18n:js:export` task is configured so that it's always called before `rake assets:precompile`. So no extra steps are needed during the deployment.

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -4,7 +4,7 @@
 # This is the secret sauce for how a Heroku deployment knows to create the webpack generated JavaScript files.
 Rake::Task["assets:precompile"]
   .clear_prerequisites
-  .enhance(["assets:compile_environment"])
+  .enhance(["i18n:js:export", "assets:compile_environment"])
 
 namespace :assets do
   # In this task, set prerequisites for the assets:precompile task
@@ -21,6 +21,11 @@ namespace :assets do
   end
 
   task :clobber do
+    # Remove compiled webpack files
     rm_r Dir.glob(Rails.root.join("app/assets/webpack/*"))
+
+    # Remove compiled language bundles
+    rm_r Dir.glob(Rails.root.join("app/assets/javascripts/i18n/*"))
+    rm_r Dir.glob(Rails.root.join("client/app/i18n/*"))
   end
 end


### PR DESCRIPTION
Purpose: This PR tries to solve the problem of passing translations to front-end code (JavaScript) and using interpolation, pluralization, date formatting e.g. in JS.

# Client-side translations

_This documentation describes how to use translations in the client-side JavaScript code. The document applied only to the new React based JavaScript code._

## Usage

In the React component, you need to import `t` function from the `i18n` module. After that you can use all the translation keys from the `en.js.*` scope:

```js
// MyReactComponent.js

import { t } from '../../utils/i18n';

class MyReactComponent extends Component {
  render() {
    return span({className: "hello-world"}, t("js.hello_world")
  }
}
```

The example above assumed that there's a `js.hello_world` key in the translation YML file, e.g.:

```yml

# en.yml

en:
  js:
    hello_world: "Hello JavaScript world!"
```

## Implementation details

### I18n-js

The client-side translations are powered by [i18n-js](https://github.com/fnando/i18n-js/) gem. The gem provides three important utilities:

* `rake i18n:js:export` task to export the translations to `.js` bundle
* `i18n-js` npm package, which helpers for translations, pluralizations, etc.
* `I18n::JS::Middleware` which compiles the `.js` bundle every request in development mode

## Client-side rendering

The translation bundle for all languages is big, so it makes sense to split it per language for client-side rendering purposes. In addition, the translation bundle can be cached because it doesn't change between deploys.

In production mode, you should see two `<script>` tags, one for the language bundle and one for the `application.js` with the fingerprint in the filename:

```html
<script src="https://your_cdn.com/assets/i18n/en-9b9ce41ada0d1b7ad028dda2c64c23d8.js"></script>
<script src="https://your_cdn.com/assets/application-6e9fbeebcaa14c12939b47fab1e53769.js"></script>
```

## Server-side rendering

When doing server-side rendering, the `utils/i18n.js` file takes care of loading the translation bundle `all.js`.

### Deployment to production

`rake i18n:js:export` task is configured so that it's always called before `rake assets:precompile`. So no extra steps are needed during the deployment.

Todo:

- [X] Create bundles per language
- [X] In development environment, create bundles on fly
- [X] Run `rake i18n:js:export` every time before `assets:precompile`
- [X] Include global `I18n` library
- [X] Change Onboarding topbar to use `I18n`
- [x] Server rendering
- [x] Documentation
- [ ] Remove `utils/i18nUtils.js`
- [ ] Change the guide to use `I18n`
- [x] Consider changing the `i18n.js` utility so that we can also export only the `t` function.
- [x] App configuration (middleware)