### PR TITLE
Missing translation behaviour: red warning in dev, guess in prod

### DIFF
--- a/Procfile.client-hot
+++ b/Procfile.client-hot
@@ -5,4 +5,4 @@ storybook: cd client && npm run styleguide
 rails-client-assets: cd client && npm run build:dev:client
 
 # Keep the JS fresh for server rendering. Remove if not server rendering
-rails-server-assets: cd client && npm run build:dev:server
+rails-server-assets: script/export_translations.sh && cd client && npm run build:dev:server

--- a/Procfile.client-static
+++ b/Procfile.client-static
@@ -2,4 +2,4 @@
 rails-client-assets: cd client && npm run build:dev:client
 
 # Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: cd client && npm run build:dev:server
+rails-server-assets: script/export_translations.sh && cd client && npm run build:dev:server

--- a/Procfile.hot
+++ b/Procfile.hot
@@ -9,4 +9,4 @@ storybook: cd client && npm run styleguide
 rails-client-assets: cd client && npm run build:dev:client
 
 # Keep the JS fresh for server rendering. Remove if not server rendering
-rails-server-assets: cd client && npm run build:dev:server
+rails-server-assets: script/export_translations.sh && cd client && npm run build:dev:server

--- a/Procfile.spec
+++ b/Procfile.spec
@@ -6,4 +6,4 @@
 rails-client-assets: cd client && npm run build:dev:client
 
 # Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: cd client && npm run build:dev:server
+rails-server-assets: script/export_translations.sh && cd client && npm run build:dev:server

--- a/Procfile.static
+++ b/Procfile.static
@@ -5,4 +5,4 @@ rails: script/wait_for_server_js.sh && rails s -b 0.0.0.0
 rails-client-assets: cd client && npm run build:dev:client
 
 # Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: cd client && npm run build:dev:server
+rails-server-assets: script/export_translations.sh && cd client && npm run build:dev:server

--- a/client/app/startup/OnboardingTopBarApp.js
+++ b/client/app/startup/OnboardingTopBarApp.js
@@ -3,7 +3,7 @@ import { initialize as initializeI18n } from '../utils/i18n';
 import OnboardingTopBar from '../components/OnboardingTopBar/OnboardingTopBar';
 
 export default (props, railsContext) => {
-  initializeI18n(railsContext);
+  initializeI18n(railsContext, process.env.NODE_ENV);
 
   return r(OnboardingTopBar, props);
 };

--- a/client/app/utils/i18n.js
+++ b/client/app/utils/i18n.js
@@ -13,6 +13,7 @@
 // The i18n-js library is able to read the language bundle from that global
 //
 
+import { span } from 'r-dom';
 import { bind } from 'lodash';
 
 function isServer() {
@@ -43,14 +44,18 @@ if (isServer()) {
 // library can use the existing I18n object
 const I18n = require('i18n-js');
 
+function missingTranslationMessage(scope) {
+  return `[missing "${scope}" translation]`;
+}
+
 function initialize(railsContext, env) {
   I18n.locale = railsContext.i18nLocale;
   I18n.defaultLocale = railsContext.i18nDefaultLocale;
   I18n.interpolationMode = 'split';
 
   if (env === 'development') {
-    I18n.missingTranslation = function throwMissingTranslation(scope) {
-      throw new Error(`Missing translation: ${scope}`);
+    I18n.missingTranslation = function displayMissingTranslation(scope) {
+      return span({className: "missing-translation", style: {backgroundColor: "red !important"}}, missingTranslationMessage(scope));
     };
   } else {
     I18n.missingTranslation = function guessMissingTranslation(scope) {

--- a/client/app/utils/i18n.js
+++ b/client/app/utils/i18n.js
@@ -55,7 +55,7 @@ function initialize(railsContext, env) {
 
   if (env === 'development') {
     I18n.missingTranslation = function displayMissingTranslation(scope) {
-      return span({className: "missing-translation", style: {backgroundColor: "red !important"}}, missingTranslationMessage(scope));
+      return span({ className: 'missing-translation', style: { backgroundColor: 'red !important' } }, missingTranslationMessage(scope));
     };
   } else {
     I18n.missingTranslation = function guessMissingTranslation(scope) {

--- a/client/app/utils/i18n.js
+++ b/client/app/utils/i18n.js
@@ -41,13 +41,35 @@ if (isServer()) {
 // translations from the global.I18n variable. This variable needs to
 // be initialized before loading the i18n-js library, so that the
 // library can use the existing I18n object
-
 const I18n = require('i18n-js');
 
-function initialize(railsContext) {
+function initialize(railsContext, env) {
   I18n.locale = railsContext.i18nLocale;
   I18n.defaultLocale = railsContext.i18nDefaultLocale;
   I18n.interpolationMode = 'split';
+
+  if (env === 'development') {
+    I18n.missingTranslation = function throwMissingTranslation(scope) {
+      throw new Error(`Missing translation: ${scope}`);
+    };
+  } else {
+    I18n.missingTranslation = function guessMissingTranslation(scope) {
+      // This is a sligthly modified guess function. Original:
+      // https://github.com/fnando/i18n-js/blob/2ca6d31365bb41db21e373d126cac00d38d15144/app/assets/javascripts/i18n.js#L536
+
+      // Get only the last portion of the scope
+      const s = scope.split('.').slice(-1)[0];
+
+      // Replace underscore with space && camelcase with space and lowercase letter
+      const guess = s
+              .replace(/_/g, ' ')
+              .replace(/([a-z])([A-Z])/g, (match, p1, p2) => `${p1} ${p2.toLowerCase()}`);
+
+      const uppercasedGuess = guess[0].toUpperCase() + guess.substr(1);
+
+      return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') + uppercasedGuess;
+    };
+  }
 }
 
 // Bind functions to I18n

--- a/docs/js-translations.md
+++ b/docs/js-translations.md
@@ -31,6 +31,103 @@ en:
     hello_world: "Hello JavaScript world!"
 ```
 
+### Fallbacks
+
+Fallbacks use the same fallback mapping as the Rails server.
+
+```yml
+# YML
+en:
+  hello_world: "Hello world!"
+
+fr:
+  hello_world: ~
+```
+
+```javascript
+# JS
+I18n.locale = "fr";
+I18n.t("hello_world") // => "Hello world!"
+```
+
+### Interpolation
+
+```yml
+# YML
+en:
+  click_here: "Click %{this_link} to read more."
+  this_link: "this link"
+  this_link_alt: "More useful information"
+```
+
+```javascript
+# JS
+I18n.t("click_here", {this_link: a({href: "http://example.com", alt: t("this_link_alt")}, t("this_link"))})
+```
+
+### Missing translations
+
+In **development** mode a missing translation message is shown with an easy to notice red background
+
+```javascript
+I18n.t("missing_key"); // span({className: "missing-translation", style: {backgroundColor: "red !important"}}, "[missing 'missing_key' translation]";
+```
+
+In **production** mode we try to "guess" the translation from the key:
+
+```javascript
+I18n.translate("this_key_is_missing"); // => "This key is missing"
+```
+
+### Pluralization, date/time localization, number localization etc.
+
+See [i18n-js documentation](https://github.com/fnando/i18n-js)
+
+### Dynamic translation keys
+
+Make sure that you always **type the translation key in its full form.**
+
+```javascript
+// BAD!
+t("listing_field." + type);
+
+// Good
+t("listing_field.dropdown");
+```
+
+Sometimes it is convenient to use dynamic keys. In this case, make sure that the full form is written somewhere near (i.e. in the same file at least) the `t` function call:
+
+```javascript
+const listing_field = {
+  title: "Brand",
+  type: "dropdown",
+  options: ["Nike", "Adidas", "Puma"],
+};
+
+// BAD!
+t(listing_field.type);
+
+// Good
+
+const types = {
+  checkbox: "listing_field.checkbox"
+  dropdown: "listing_field.dropdown",
+  number: "listing_field.number",
+}
+
+t(types[listing_field.type]);
+```
+
+Why? Because of greppability. If we ever decide to remove e.g. the checkbox type and we want to remove the translation for `listing_field.checkbox` we need to be able to search for `listing_field.checkbox` in order to know where it is used.
+
+### Cleaning up
+
+`assets:clobber` deletes all the compiled language bundles.
+
+```bash
+rake assets:clobber
+```
+
 ## Implementation details
 
 ### I18n-js
@@ -54,8 +151,14 @@ In production mode, you should see two `<script>` tags, one for the language bun
 
 ## Server-side rendering
 
-When doing server-side rendering, the `all.js` file is bundled to the `server.js` bundle. The `utils/i18n.js` file takes care of loading the translation bundle `all.js`.
+When doing server-side rendering, the `client/i18n/all.js` file is bundled to the `server.js` bundle. The `utils/i18n.js` file takes care of requiring the `client/i18n/all.js`.
 
 ### Deployment to production
 
 `rake i18n:js:export` task is configured so that it's always called before `rake assets:precompile`. So no extra steps are needed during the deployment.
+
+## Troubleshooting
+
+### Server rendered translations are out-of-date
+
+Run `rake i18n:js:export`, wait until new `server-bundle.js` is compiled and refresh the browser.

--- a/script/export_translations.sh
+++ b/script/export_translations.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+FILE="./client/app/i18n/all.js"
+
+if [ -f $FILE ];
+then
+    echo "Skipping translation export task. Translation bundle ${FILE} exists already."
+else
+    echo "Exporting translations..."
+    bundle exec rake i18n:js:export
+    echo "Translations exported to ${FILE}"
+fi


### PR DESCRIPTION
This PR changes the way how we handle missing translations. In production mode, we try to guess the translations (i.e. t("this_translation_is_missing") => "This translation is missing" and in development mode, we show a red warning message. This is the same behaviour what we have on the Rails side.

<img width="1198" alt="screen shot 2016-05-18 at 16 29 55" src="https://cloud.githubusercontent.com/assets/429876/15360325/cd31b0e0-1d15-11e6-8959-30a3d9e3e8f3.png">

Todo:

- [X] Missing translation behaviour in prod
- [X] Missing translation behaviour in dev
- [X] How to (automatically) handle the `rake i18n:js:export` compilation