### PR TITLE
Remove HTML from translations

### DIFF
--- a/app/views/admin/getting_started_guide/index.haml
+++ b/app/views/admin/getting_started_guide/index.haml
@@ -10,4 +10,4 @@
       = render :partial => "admin/left_hand_navigation", :locals => { :links => admin_links_for(@current_community) }
     .col-9
       - cache ['v1', 'onboarding_guide', props] do
-        = react_component("OnboardingGuideApp", props: props)
+        = react_component("OnboardingGuideApp", props: props, prerender: false)

--- a/app/views/admin/getting_started_guide/index.haml
+++ b/app/views/admin/getting_started_guide/index.haml
@@ -10,4 +10,4 @@
       = render :partial => "admin/left_hand_navigation", :locals => { :links => admin_links_for(@current_community) }
     .col-9
       - cache ['v1', 'onboarding_guide', props] do
-        = react_component("OnboardingGuideApp", props: props, prerender: false)
+        = react_component("OnboardingGuideApp", props: props)

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -23,6 +23,11 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
+    commonjs: true
+  },
+  globals: {
+    // Webpack plugin adds `process` global
+    process: false
   },
   rules: {
     // See http://eslint.org/docs/rules/ for documentation for

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -26,7 +26,8 @@ module.exports = {
     commonjs: true
   },
   globals: {
-    // Webpack plugin adds `process` global
+    // `process` global is added by Webpack plugin.
+    // Tell the existence of `process` to ESLint
     process: false
   },
   rules: {

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    commonjs: true
   },
   globals: {
     // `process` global is added by Webpack plugin.

--- a/client/app/components/OnboardingTopBar/OnboardingTopBar.js
+++ b/client/app/components/OnboardingTopBar/OnboardingTopBar.js
@@ -8,32 +8,32 @@ const next = function next(nextStep, guideRoot) {
   switch (nextStep) {
     case 'slogan_and_description':
       return {
-        title: t('admin.onboarding.topbar.slogan_and_description'),
+        title: t('web.admin.onboarding.topbar.slogan_and_description'),
         link: `${guideRoot}/${nextStep}`,
       };
     case 'cover_photo':
       return {
-        title: t('admin.onboarding.topbar.cover_photo'),
+        title: t('web.admin.onboarding.topbar.cover_photo'),
         link: `${guideRoot}/${nextStep}`,
       };
     case 'filter':
       return {
-        title: t('admin.onboarding.topbar.filter'),
+        title: t('web.admin.onboarding.topbar.filter'),
         link: `${guideRoot}/${nextStep}`,
       };
     case 'paypal':
       return {
-        title: t('admin.onboarding.topbar.paypal'),
+        title: t('web.admin.onboarding.topbar.paypal'),
         link: `${guideRoot}/${nextStep}`,
       };
     case 'listing':
       return {
-        title: t('admin.onboarding.topbar.listing'),
+        title: t('web.admin.onboarding.topbar.listing'),
         link: `${guideRoot}/${nextStep}`,
       };
     case 'invitation':
       return {
-        title: t('admin.onboarding.topbar.invitation'),
+        title: t('web.admin.onboarding.topbar.invitation'),
         link: `${guideRoot}/${nextStep}`,
       };
     default:
@@ -48,7 +48,7 @@ class OnboardingTopBar extends Component {
     if (nextStep) {
       return (
         div({ className: css.nextContainer }, [
-          div({ className: css.nextLabel }, t('admin.onboarding.topbar.next_step')),
+          div({ className: css.nextLabel }, t('web.admin.onboarding.topbar.next_step')),
           a({ href: nextStep.link, className: css.nextButton }, [
             span(nextStep.title),
           ]),
@@ -63,7 +63,7 @@ class OnboardingTopBar extends Component {
     return div({ className: css.topbarContainer }, [
       div({ className: css.topbar }, [
         a({ className: css.progressLabel, href: this.props.guide_root }, [
-          t('admin.onboarding.topbar.progress_label'),
+          t('web.admin.onboarding.topbar.progress_label'),
           span({ className: css.progressLabelPercentage },
                `${Math.floor(currentProgress)} %`),
         ]),

--- a/client/app/components/onboardingGuide/GuideBackToTodoLink.js
+++ b/client/app/components/onboardingGuide/GuideBackToTodoLink.js
@@ -1,6 +1,7 @@
 import { PropTypes } from 'react';
 import { a } from 'r-dom';
 import css from './styles.scss';
+import { t } from '../../utils/i18n';
 
 const GuideBackToTodoLink = (props) => {
   const handleClick = function handleClick(e, path) {
@@ -12,13 +13,12 @@ const GuideBackToTodoLink = (props) => {
     className: css.backLink,
     onClick: (e) => handleClick(e, ''),
     href: props.initialPath,
-  }, `‹ ${props.t('back_to_todo')}`);
+  }, `‹ ${t('web.admin.onboarding.guide.back_to_todo')}`);
 };
 
 GuideBackToTodoLink.propTypes = {
   changePage: PropTypes.func.isRequired,
   initialPath: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
 };
 
 export default GuideBackToTodoLink;

--- a/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
+++ b/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
@@ -1,5 +1,5 @@
 import { PropTypes } from 'react';
-import r, { div, h2, p, img, a, span, br } from 'r-dom';
+import r, { div, h2, p, img, a, br } from 'r-dom';
 import css from './styles.scss';
 import { t } from '../../utils/i18n';
 
@@ -31,17 +31,14 @@ const GuideCoverPhotoPage = (props) => {
       div({
         className: css.infoTextContent,
       }, [
-        span(
-          t('web.admin.onboarding.guide.cover_photo.advice.content1',
-            { link: a({
-              href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
-              target: '_blank',
-              alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
-            }, t('web.admin.onboarding.guide.cover_photo.advice.link')) })),
+        t('web.admin.onboarding.guide.cover_photo.advice.content1',
+          { link: a({
+            href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
+            target: '_blank',
+            alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
+          }, t('web.admin.onboarding.guide.cover_photo.advice.link')) }),
         br(),
-        span(
-          t('web.admin.onboarding.guide.cover_photo.advice.content2', { width: 1920, height: 450 })
-        ),
+        t('web.admin.onboarding.guide.cover_photo.advice.content2', { width: 1920, height: 450 }),
       ]),
     ]),
 

--- a/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
+++ b/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
@@ -35,6 +35,7 @@ const GuideCoverPhotoPage = (props) => {
           { link: a({
             href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
             target: '_blank',
+            rel: 'noreferrer',
             alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
           }, t('web.admin.onboarding.guide.cover_photo.advice.link')) }),
         br(),

--- a/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
+++ b/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
@@ -5,6 +5,9 @@ import { t } from '../../utils/i18n';
 
 import GuideBackToTodoLink from './GuideBackToTodoLink';
 
+const COVER_PHOTO_WIDTH = 1920;
+const COVER_PHOTO_HEIGHT = 450;
+
 const GuideCoverPhotoPage = (props) => {
   const { changePage, initialPath, pageData, infoIcon } = props;
 
@@ -39,7 +42,7 @@ const GuideCoverPhotoPage = (props) => {
             alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
           }, t('web.admin.onboarding.guide.cover_photo.advice.link')) }),
         br(),
-        t('web.admin.onboarding.guide.cover_photo.advice.content2', { width: 1920, height: 450 }),
+        t('web.admin.onboarding.guide.cover_photo.advice.content2', { width: COVER_PHOTO_WIDTH, height: COVER_PHOTO_HEIGHT }),
       ]),
     ]),
 

--- a/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
+++ b/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
@@ -8,15 +8,6 @@ import GuideBackToTodoLink from './GuideBackToTodoLink';
 const GuideCoverPhotoPage = (props) => {
   const { changePage, initialPath, pageData, infoIcon } = props;
 
-  const val = t('web.admin.onboarding.guide.cover_photo.advice.content1',
-            {link: a({
-              href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
-              target: '_blank',
-              alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
-            }, t('web.admin.onboarding.guide.cover_photo.advice.link'))});
-
-  console.log(val);
-
   return div({ className: 'container' }, [
     r(GuideBackToTodoLink, { changePage, initialPath }),
     h2({ className: css.title }, t('web.admin.onboarding.guide.cover_photo.title')),
@@ -42,14 +33,14 @@ const GuideCoverPhotoPage = (props) => {
       }, [
         span(
           t('web.admin.onboarding.guide.cover_photo.advice.content1',
-            {link: a({
+            { link: a({
               href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
               target: '_blank',
               alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
-            }, t('web.admin.onboarding.guide.cover_photo.advice.link'))})),
+            }, t('web.admin.onboarding.guide.cover_photo.advice.link')) })),
         br(),
         span(
-          t('web.admin.onboarding.guide.cover_photo.advice.content2', {width: 1920, height: 450})
+          t('web.admin.onboarding.guide.cover_photo.advice.content2', { width: 1920, height: 450 })
         ),
       ]),
     ]),

--- a/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
+++ b/client/app/components/onboardingGuide/GuideCoverPhotoPage.js
@@ -1,23 +1,33 @@
 import { PropTypes } from 'react';
-import r, { div, h2, p, img, a } from 'r-dom';
+import r, { div, h2, p, img, a, span, br } from 'r-dom';
 import css from './styles.scss';
+import { t } from '../../utils/i18n';
 
 import GuideBackToTodoLink from './GuideBackToTodoLink';
 
 const GuideCoverPhotoPage = (props) => {
-  const { changePage, initialPath, t, pageData, infoIcon } = props;
+  const { changePage, initialPath, pageData, infoIcon } = props;
+
+  const val = t('web.admin.onboarding.guide.cover_photo.advice.content1',
+            {link: a({
+              href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
+              target: '_blank',
+              alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
+            }, t('web.admin.onboarding.guide.cover_photo.advice.link'))});
+
+  console.log(val);
 
   return div({ className: 'container' }, [
-    r(GuideBackToTodoLink, { changePage, initialPath, t }),
-    h2({ className: css.title }, t('title')),
-    p({ className: css.description }, t('description')),
+    r(GuideBackToTodoLink, { changePage, initialPath }),
+    h2({ className: css.title }, t('web.admin.onboarding.guide.cover_photo.title')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.cover_photo.description')),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainer }, [
         img({
           className: css.sloganImage,
           src: pageData.info_image,
-          alt: t('info_image_alt'),
+          alt: t('web.admin.onboarding.guide.cover_photo.info_image_alt'),
         }),
       ]) :
       null,
@@ -29,18 +39,28 @@ const GuideCoverPhotoPage = (props) => {
       }),
       div({
         className: css.infoTextContent,
-        dangerouslySetInnerHTML: { __html: t('advice') }, // eslint-disable-line react/no-danger
-      }),
+      }, [
+        span(
+          t('web.admin.onboarding.guide.cover_photo.advice.content1',
+            {link: a({
+              href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
+              target: '_blank',
+              alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
+            }, t('web.admin.onboarding.guide.cover_photo.advice.link'))})),
+        br(),
+        span(
+          t('web.admin.onboarding.guide.cover_photo.advice.content2', {width: 1920, height: 450})
+        ),
+      ]),
     ]),
 
-    a({ className: css.nextButton, href: pageData.cta }, t('add_your_own')),
+    a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.cover_photo.add_your_own')),
   ]);
 };
 
 GuideCoverPhotoPage.propTypes = {
   changePage: PropTypes.func.isRequired,
   initialPath: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
   infoIcon: PropTypes.string.isRequired,
   pageData: PropTypes.shape({
     cta: PropTypes.string.isRequired,

--- a/client/app/components/onboardingGuide/GuideFilterPage.js
+++ b/client/app/components/onboardingGuide/GuideFilterPage.js
@@ -1,25 +1,28 @@
 import { PropTypes } from 'react';
-import r, { div, h2, p, img, a } from 'r-dom';
+import r, { div, h2, p, img, a, span, i } from 'r-dom';
 import css from './styles.scss';
+import { t } from '../../utils/i18n';
 
 import GuideBackToTodoLink from './GuideBackToTodoLink';
 
 const GuideFilterPage = (props) => {
-  const { changePage, initialPath, t, pageData, infoIcon } = props;
+  const { changePage, initialPath, pageData, infoIcon } = props;
 
   return div({ className: 'container' }, [
-    r(GuideBackToTodoLink, { changePage, initialPath, t }),
-    h2({ className: css.title }, t('title')),
-    p({ className: css.description,
-      dangerouslySetInnerHTML: { __html: props.t('description') }, // eslint-disable-line react/no-danger
-     }),
+    r(GuideBackToTodoLink, { changePage, initialPath }),
+    h2({ className: css.title }, t('web.admin.onboarding.guide.filter.title')),
+    p({ className: css.description }, [
+        span(
+          t('web.admin.onboarding.guide.filter.description.content',
+            {display_on_homepage: i(t('web.admin.onboarding.guide.filter.description.display_on_homepage'))}))
+      ]),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainerBig }, [
         img({
           className: css.sloganImage,
           src: pageData.info_image,
-          alt: t('info_image_alt'),
+          alt: t('web.admin.onboarding.guide.filter.info_image_alt'),
         }),
       ]) :
       null,
@@ -30,19 +33,22 @@ const GuideFilterPage = (props) => {
         dangerouslySetInnerHTML: { __html: infoIcon }, // eslint-disable-line react/no-danger
       }),
       div({
-        className: css.infoTextContent,
-        dangerouslySetInnerHTML: { __html: t('advice') }, // eslint-disable-line react/no-danger
-      }),
+        className: css.infoTextContent }, [
+        span(t('web.admin.onboarding.guide.filter.advice.content',
+               {not_too_many_link: a({
+                 target: '_blank',
+                 href: 'https://www.sharetribe.com/academy/how-to-help-your-customers-find-the-right-product-or-service',
+               }, t('web.admin.onboarding.guide.filter.advice.not_too_many_link'))}))
+      ]),
     ]),
 
-    a({ className: css.nextButton, href: pageData.cta }, t('add_fields_and_filters')),
+    a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.filter.add_fields_and_filters')),
   ]);
 };
 
 GuideFilterPage.propTypes = {
   changePage: PropTypes.func.isRequired,
   initialPath: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
   infoIcon: PropTypes.string.isRequired,
   pageData: PropTypes.shape({
     cta: PropTypes.string.isRequired,

--- a/client/app/components/onboardingGuide/GuideFilterPage.js
+++ b/client/app/components/onboardingGuide/GuideFilterPage.js
@@ -36,6 +36,7 @@ const GuideFilterPage = (props) => {
           t('web.admin.onboarding.guide.filter.advice.content',
             { not_too_many_link: a({
               target: '_blank',
+              rel: 'noreferrer',
               href: 'https://www.sharetribe.com/academy/how-to-help-your-customers-find-the-right-product-or-service',
             }, t('web.admin.onboarding.guide.filter.advice.not_too_many_link')) }),
         ]),

--- a/client/app/components/onboardingGuide/GuideFilterPage.js
+++ b/client/app/components/onboardingGuide/GuideFilterPage.js
@@ -12,10 +12,10 @@ const GuideFilterPage = (props) => {
     r(GuideBackToTodoLink, { changePage, initialPath }),
     h2({ className: css.title }, t('web.admin.onboarding.guide.filter.title')),
     p({ className: css.description }, [
-        span(
-          t('web.admin.onboarding.guide.filter.description.content',
-            {display_on_homepage: i(t('web.admin.onboarding.guide.filter.description.display_on_homepage'))}))
-      ]),
+      span(
+        t('web.admin.onboarding.guide.filter.description.content',
+          { display_on_homepage: i(t('web.admin.onboarding.guide.filter.description.display_on_homepage')) })),
+    ]),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainerBig }, [
@@ -34,12 +34,12 @@ const GuideFilterPage = (props) => {
       }),
       div({
         className: css.infoTextContent }, [
-        span(t('web.admin.onboarding.guide.filter.advice.content',
-               {not_too_many_link: a({
+          span(t('web.admin.onboarding.guide.filter.advice.content',
+               { not_too_many_link: a({
                  target: '_blank',
                  href: 'https://www.sharetribe.com/academy/how-to-help-your-customers-find-the-right-product-or-service',
-               }, t('web.admin.onboarding.guide.filter.advice.not_too_many_link'))}))
-      ]),
+               }, t('web.admin.onboarding.guide.filter.advice.not_too_many_link')) })),
+        ]),
     ]),
 
     a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.filter.add_fields_and_filters')),

--- a/client/app/components/onboardingGuide/GuideFilterPage.js
+++ b/client/app/components/onboardingGuide/GuideFilterPage.js
@@ -1,5 +1,5 @@
 import { PropTypes } from 'react';
-import r, { div, h2, p, img, a, span, i } from 'r-dom';
+import r, { div, h2, p, img, a, i } from 'r-dom';
 import css from './styles.scss';
 import { t } from '../../utils/i18n';
 
@@ -12,9 +12,8 @@ const GuideFilterPage = (props) => {
     r(GuideBackToTodoLink, { changePage, initialPath }),
     h2({ className: css.title }, t('web.admin.onboarding.guide.filter.title')),
     p({ className: css.description }, [
-      span(
-        t('web.admin.onboarding.guide.filter.description.content',
-          { display_on_homepage: i(t('web.admin.onboarding.guide.filter.description.display_on_homepage')) })),
+      t('web.admin.onboarding.guide.filter.description.content',
+          { display_on_homepage: i(t('web.admin.onboarding.guide.filter.description.display_on_homepage')) }),
     ]),
 
     pageData.info_image ?
@@ -34,11 +33,11 @@ const GuideFilterPage = (props) => {
       }),
       div({
         className: css.infoTextContent }, [
-          span(t('web.admin.onboarding.guide.filter.advice.content',
-               { not_too_many_link: a({
-                 target: '_blank',
-                 href: 'https://www.sharetribe.com/academy/how-to-help-your-customers-find-the-right-product-or-service',
-               }, t('web.admin.onboarding.guide.filter.advice.not_too_many_link')) })),
+          t('web.admin.onboarding.guide.filter.advice.content',
+            { not_too_many_link: a({
+              target: '_blank',
+              href: 'https://www.sharetribe.com/academy/how-to-help-your-customers-find-the-right-product-or-service',
+            }, t('web.admin.onboarding.guide.filter.advice.not_too_many_link')) }),
         ]),
     ]),
 

--- a/client/app/components/onboardingGuide/GuideInvitationPage.js
+++ b/client/app/components/onboardingGuide/GuideInvitationPage.js
@@ -12,11 +12,11 @@ const GuideInvitationPage = (props) => {
     r(GuideBackToTodoLink, { changePage, initialPath }),
     h2({ className: css.title }, t('web.admin.onboarding.guide.invitation.title')),
     p({ className: css.description }, t('web.admin.onboarding.guide.invitation.description.content', {
-        preview_link: a({
-          href: '/?big_cover_photo=true',
-          alt: t('web.admin.onboarding.guide.invitation.description.preview_link_alt'),
-          target: '_blank'},
-                        t('web.admin.onboarding.guide.invitation.description.preview_link'))})),
+      preview_link: a({
+        href: '/?big_cover_photo=true',
+        alt: t('web.admin.onboarding.guide.invitation.description.preview_link_alt'),
+        target: '_blank',
+      }, t('web.admin.onboarding.guide.invitation.description.preview_link')) })),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainer }, [

--- a/client/app/components/onboardingGuide/GuideInvitationPage.js
+++ b/client/app/components/onboardingGuide/GuideInvitationPage.js
@@ -15,6 +15,7 @@ const GuideInvitationPage = (props) => {
       preview_link: a({
         href: '/?big_cover_photo=true',
         alt: t('web.admin.onboarding.guide.invitation.description.preview_link_alt'),
+        rel: 'noreferrer',
         target: '_blank',
       }, t('web.admin.onboarding.guide.invitation.description.preview_link')) })),
 

--- a/client/app/components/onboardingGuide/GuideInvitationPage.js
+++ b/client/app/components/onboardingGuide/GuideInvitationPage.js
@@ -1,26 +1,29 @@
 import { PropTypes } from 'react';
 import r, { div, h2, p, img, a } from 'r-dom';
 import css from './styles.scss';
+import { t } from '../../utils/i18n';
 
 import GuideBackToTodoLink from './GuideBackToTodoLink';
 
 const GuideInvitationPage = (props) => {
-  const { changePage, initialPath, t, pageData, infoIcon } = props;
+  const { changePage, initialPath, pageData, infoIcon } = props;
 
   return div({ className: 'container' }, [
-    r(GuideBackToTodoLink, { changePage, initialPath, t }),
-    h2({ className: css.title }, t('title')),
-    p({
-      className: css.description,
-      dangerouslySetInnerHTML: { __html: t('description') }, // eslint-disable-line react/no-danger }
-    }),
+    r(GuideBackToTodoLink, { changePage, initialPath }),
+    h2({ className: css.title }, t('web.admin.onboarding.guide.invitation.title')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.invitation.description.content', {
+        preview_link: a({
+          href: '/?big_cover_photo=true',
+          alt: t('web.admin.onboarding.guide.invitation.description.preview_link_alt'),
+          target: '_blank'},
+                        t('web.admin.onboarding.guide.invitation.description.preview_link'))})),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainer }, [
         img({
           className: css.sloganImage,
           src: pageData.info_image,
-          alt: t('info_image_alt'),
+          alt: t('web.admin.onboarding.guide.invitation.info_image_alt'),
         }),
       ]) :
       null,
@@ -30,20 +33,16 @@ const GuideInvitationPage = (props) => {
         className: css.infoTextIcon,
         dangerouslySetInnerHTML: { __html: infoIcon }, // eslint-disable-line react/no-danger
       }),
-      div({
-        className: css.infoTextContent,
-        dangerouslySetInnerHTML: { __html: t('advice') }, // eslint-disable-line react/no-danger
-      }),
+      div({ className: css.infoTextContent }, t('web.admin.onboarding.guide.invitation.advice')),
     ]),
 
-    a({ className: css.nextButton, href: pageData.cta }, t('invite_users')),
+    a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.invitation.invite_users')),
   ]);
 };
 
 GuideInvitationPage.propTypes = {
   changePage: PropTypes.func.isRequired,
   initialPath: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
   infoIcon: PropTypes.string.isRequired,
   pageData: PropTypes.shape({
     cta: PropTypes.string.isRequired,

--- a/client/app/components/onboardingGuide/GuideListingPage.js
+++ b/client/app/components/onboardingGuide/GuideListingPage.js
@@ -30,7 +30,7 @@ const GuideListingPage = (props) => {
         dangerouslySetInnerHTML: { __html: infoIcon }, // eslint-disable-line react/no-danger
       }),
       div({ className: css.infoTextContent },
-          t('web.admin.onboarding.guide.listing.advice.content', {close_listing: i(t('web.admin.onboarding.guide.listing.advice.close_listing'))})),
+          t('web.admin.onboarding.guide.listing.advice.content', { close_listing: i(t('web.admin.onboarding.guide.listing.advice.close_listing')) })),
     ]),
 
     a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.listing.post_your_first_listing')),

--- a/client/app/components/onboardingGuide/GuideListingPage.js
+++ b/client/app/components/onboardingGuide/GuideListingPage.js
@@ -1,23 +1,25 @@
 import { PropTypes } from 'react';
-import r, { div, h2, p, img, a } from 'r-dom';
+import r, { div, h2, p, img, a, i } from 'r-dom';
 import css from './styles.scss';
+
+import { t } from '../../utils/i18n';
 
 import GuideBackToTodoLink from './GuideBackToTodoLink';
 
 const GuideListingPage = (props) => {
-  const { changePage, initialPath, t, pageData, infoIcon } = props;
+  const { changePage, initialPath, pageData, infoIcon } = props;
 
   return div({ className: 'container' }, [
-    r(GuideBackToTodoLink, { changePage, initialPath, t }),
-    h2({ className: css.title }, t('title')),
-    p({ className: css.description }, t('description')),
+    r(GuideBackToTodoLink, { changePage, initialPath }),
+    h2({ className: css.title }, t('web.admin.onboarding.guide.listing.title')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.listing.description')),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainerBig }, [
         img({
           className: css.sloganImage,
           src: pageData.info_image,
-          alt: t('info_image_alt'),
+          alt: t('web.admin.onboarding.guide.listing.info_image_alt'),
         }),
       ]) :
       null,
@@ -27,20 +29,17 @@ const GuideListingPage = (props) => {
         className: css.infoTextIcon,
         dangerouslySetInnerHTML: { __html: infoIcon }, // eslint-disable-line react/no-danger
       }),
-      div({
-        className: css.infoTextContent,
-        dangerouslySetInnerHTML: { __html: t('advice') }, // eslint-disable-line react/no-danger
-      }),
+      div({ className: css.infoTextContent },
+          t('web.admin.onboarding.guide.listing.advice.content', {close_listing: i(t('web.admin.onboarding.guide.listing.advice.close_listing'))})),
     ]),
 
-    a({ className: css.nextButton, href: pageData.cta }, t('post_your_first_listing')),
+    a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.listing.post_your_first_listing')),
   ]);
 };
 
 GuideListingPage.propTypes = {
   changePage: PropTypes.func.isRequired,
   initialPath: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
   infoIcon: PropTypes.string.isRequired,
   pageData: PropTypes.shape({
     cta: PropTypes.string.isRequired,

--- a/client/app/components/onboardingGuide/GuidePaypalPage.js
+++ b/client/app/components/onboardingGuide/GuidePaypalPage.js
@@ -1,24 +1,25 @@
 import { PropTypes } from 'react';
 import r, { div, h2, p, img, a, span } from 'r-dom';
 import css from './styles.scss';
+import { t } from '../../utils/i18n';
 
 import GuideBackToTodoLink from './GuideBackToTodoLink';
 
 const GuidePaypalPage = (props) => {
-  const { changePage, initialPath, t, pageData, infoIcon } = props;
+  const { changePage, initialPath, pageData, infoIcon } = props;
 
   return div({ className: 'container' }, [
-    r(GuideBackToTodoLink, { changePage, initialPath, t }),
-    h2({ className: css.title }, t('title')),
-    p({ className: css.description }, t('description_p1')),
-    p({ className: css.description }, t('description_p2')),
+    r(GuideBackToTodoLink, { changePage, initialPath }),
+    h2({ className: css.title }, t('web.admin.onboarding.guide.paypal.title')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.paypal.description_p1')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.paypal.description_p2')),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainer }, [
         img({
           className: css.sloganImage,
           src: pageData.info_image,
-          alt: t('info_image_alt'),
+          alt: t('web.admin.onboarding.guide.paypal.info_image_alt'),
         }),
       ]) :
       null,
@@ -28,16 +29,19 @@ const GuidePaypalPage = (props) => {
         className: css.infoTextIcon,
         dangerouslySetInnerHTML: { __html: infoIcon }, // eslint-disable-line react/no-danger
       }),
-      div({
-        className: css.infoTextContent,
-        dangerouslySetInnerHTML: { __html: t('advice') }, // eslint-disable-line react/no-danger
-      }),
+      div({ className: css.infoTextContent }, t('web.admin.onboarding.guide.paypal.advice.content',
+                                                { disable_payments_link: a(
+                                                  { href: 'http://support.sharetribe.com/knowledgebase/articles/470085',
+                                                    target: '_blank',
+                                                    alt: t('web.admin.onboarding.guide.paypal.advice.disable_payments_alt')
+                                                  },
+                                                  t('web.admin.onboarding.guide.paypal.advice.disable_payments_link')) }))
     ]),
 
     div(null, [
-      a({ className: css.nextButton, href: pageData.cta }, t('setup_payments')),
-      span({ className: css.buttonSeparator }, t('cta_separator')),
-      a({ className: css.nextButtonGhost, href: pageData.alternative_cta }, t('disable_payments')),
+      a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.paypal.setup_payments')),
+      span({ className: css.buttonSeparator }, t('web.admin.onboarding.guide.paypal.cta_separator')),
+      a({ className: css.nextButtonGhost, href: pageData.alternative_cta }, t('web.admin.onboarding.guide.paypal.disable_payments')),
     ]),
   ]);
 };
@@ -45,7 +49,6 @@ const GuidePaypalPage = (props) => {
 GuidePaypalPage.propTypes = {
   changePage: PropTypes.func.isRequired,
   initialPath: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
   infoIcon: PropTypes.string.isRequired,
   pageData: PropTypes.shape({
     cta: PropTypes.string.isRequired,

--- a/client/app/components/onboardingGuide/GuidePaypalPage.js
+++ b/client/app/components/onboardingGuide/GuidePaypalPage.js
@@ -29,13 +29,14 @@ const GuidePaypalPage = (props) => {
         className: css.infoTextIcon,
         dangerouslySetInnerHTML: { __html: infoIcon }, // eslint-disable-line react/no-danger
       }),
-      div({ className: css.infoTextContent }, t('web.admin.onboarding.guide.paypal.advice.content',
-                                                { disable_payments_link: a(
-                                                  { href: 'http://support.sharetribe.com/knowledgebase/articles/470085',
-                                                    target: '_blank',
-                                                    alt: t('web.admin.onboarding.guide.paypal.advice.disable_payments_alt')
-                                                  },
-                                                  t('web.admin.onboarding.guide.paypal.advice.disable_payments_link')) }))
+      div({ className: css.infoTextContent }, t('web.admin.onboarding.guide.paypal.advice.content', {
+        disable_payments_link: a(
+          { href: 'http://support.sharetribe.com/knowledgebase/articles/470085',
+            target: '_blank',
+            alt: t('web.admin.onboarding.guide.paypal.advice.disable_payments_alt'),
+          },
+          t('web.admin.onboarding.guide.paypal.advice.disable_payments_link')),
+      })),
     ]),
 
     div(null, [

--- a/client/app/components/onboardingGuide/GuidePaypalPage.js
+++ b/client/app/components/onboardingGuide/GuidePaypalPage.js
@@ -33,6 +33,7 @@ const GuidePaypalPage = (props) => {
         disable_payments_link: a(
           { href: 'http://support.sharetribe.com/knowledgebase/articles/470085',
             target: '_blank',
+            rel: 'noreferrer',
             alt: t('web.admin.onboarding.guide.paypal.advice.disable_payments_alt'),
           },
           t('web.admin.onboarding.guide.paypal.advice.disable_payments_link')),

--- a/client/app/components/onboardingGuide/GuideSloganAndDescriptionPage.js
+++ b/client/app/components/onboardingGuide/GuideSloganAndDescriptionPage.js
@@ -1,40 +1,47 @@
 import { PropTypes } from 'react';
-import r, { div, h2, p, img, a } from 'r-dom';
+import r, { div, h2, p, img, a, i } from 'r-dom';
 import css from './styles.scss';
+import { t } from '../../utils/i18n';
 
 import GuideBackToTodoLink from './GuideBackToTodoLink';
 
 const GuideSloganAndDescriptionPage = (props) => {
-  const { changePage, initialPath, t, infoIcon, pageData } = props;
+  const { changePage, initialPath, infoIcon, pageData } = props;
 
   return div({ className: 'container' }, [
-    r(GuideBackToTodoLink, { changePage, initialPath, t }),
-    h2({ className: css.title }, t('title')),
-    p({ className: css.description }, t('description')),
+    r(GuideBackToTodoLink, { changePage, initialPath }),
+    h2({ className: css.title }, t('web.admin.onboarding.guide.slogan_and_description.title')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.slogan_and_description.description')),
 
     pageData.info_image ?
       div({ className: css.sloganImageContainer }, [
         img({
           className: css.sloganImage,
           src: props.pageData.info_image,
-          alt: t('info_image_alt'),
+          alt: t('web.admin.onboarding.guide.slogan_and_description.info_image_alt'),
         }),
       ]) :
       null,
 
     div({ className: css.infoTextContainer }, [
       div({ className: css.infoTextIcon, dangerouslySetInnerHTML: { __html: infoIcon } }),
-      div({ className: css.infoTextContent, dangerouslySetInnerHTML: { __html: t('advice') } }),
+      div({ className: css.infoTextContent },
+          t('web.admin.onboarding.guide.slogan_and_description.advice.content',
+            {
+              food_from_locals_slogan: i(t('web.admin.onboarding.guide.slogan_and_description.advice.food_from_locals_slogan')),
+              food_from_locals_description: i(t('web.admin.onboarding.guide.slogan_and_description.advice.food_from_locals_description')),
+              guitar_lessons_slogan: i(t('web.admin.onboarding.guide.slogan_and_description.advice.guitar_lessons_slogan')),
+              guitar_lessons_description: i(t('web.admin.onboarding.guide.slogan_and_description.advice.guitar_lessons_description')),
+            })),
     ]),
 
-    a({ className: css.nextButton, href: pageData.cta }, t('add_your_own')),
+    a({ className: css.nextButton, href: pageData.cta }, t('web.admin.onboarding.guide.slogan_and_description.add_your_own')),
   ]);
 };
 
 GuideSloganAndDescriptionPage.propTypes = {
   changePage: PropTypes.func.isRequired,
   initialPath: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
   infoIcon: PropTypes.string.isRequired,
   pageData: PropTypes.shape({
     cta: PropTypes.string.isRequired,

--- a/client/app/components/onboardingGuide/GuideStatusPage.js
+++ b/client/app/components/onboardingGuide/GuideStatusPage.js
@@ -13,7 +13,7 @@ const GuideStatusPage = (props) => {
   const onboardingData = props.onboarding_data;
 
   const title = props.nextStep ?
-        t('web.admin.onboarding.guide.status_page.title', {name : props.name}) :
+        t('web.admin.onboarding.guide.status_page.title', { name: props.name }) :
         t('web.admin.onboarding.guide.status_page.title_done');
 
   const todoDescPartial = div([
@@ -22,28 +22,32 @@ const GuideStatusPage = (props) => {
   ]);
 
   const doneDescPartial = div([
-    p({
-      className: css.description,
-    }, t('web.admin.onboarding.guide.status_page.congratulation_p1.content',
-         {knowledge_base_link: a(
-           { href: 'http://support.sharetribe.com/knowledgebase/articles/892140-what-to-do-after-the-basic-setup-of-your-marketpla',
-             target: '_blank',
-             alt: t('web.admin.onboarding.guide.status_page.congratulation_p1.knowledge_base_alt'),
-           })})),
-    p({ className: css.description }, t('web.admin.onboarding.guide.status_page.congratulation_p2.content',
-                                        { marketplace_guide_link: a(
-                                          { href: "https://www.sharetribe.com/academy/guide/",
-                                            target: "_blank",
-                                            alt: t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_alt')
-                                          }, t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_link'))
-                                        })),
-    p({ className: css.description }, t('web.admin.onboarding.guide.status_page.congratulation_p3.content',
+    p({ className: css.description },
+      t('web.admin.onboarding.guide.status_page.congratulation_p1.content',
+        { knowledge_base_link: a(
+          { href: 'http://support.sharetribe.com/knowledgebase/articles/892140-what-to-do-after-the-basic-setup-of-your-marketpla',
+            target: '_blank',
+            alt: t('web.admin.onboarding.guide.status_page.congratulation_p1.knowledge_base_alt'),
+          }),
+        })),
+    p({ className: css.description },
+      t('web.admin.onboarding.guide.status_page.congratulation_p2.content',
+        { marketplace_guide_link: a(
+          { href: 'https://www.sharetribe.com/academy/guide/',
+            target: '_blank',
+            alt: t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_alt'),
+          },
+          t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_link')),
+        })),
+    p({ className: css.description },
+      t('web.admin.onboarding.guide.status_page.congratulation_p3.content',
          { contact_support_link: a(
            { 'data-uv-trigger': 'contact',
              href: 'mailto:support@sharetribe.com',
-             title: t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_title')},
-           t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_link')
-         )})),
+             title: t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_title'),
+           },
+           t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_link')),
+         })),
   ]);
 
   const description = props.nextStep ? todoDescPartial : doneDescPartial;
@@ -67,12 +71,12 @@ const GuideStatusPage = (props) => {
               css.stepListItem;
 
       const titles = {
-        slogan_and_description: "web.admin.onboarding.guide.status_page.slogan_and_description",
-        cover_photo: "web.admin.onboarding.guide.status_page.cover_photo",
-        filter: "web.admin.onboarding.guide.status_page.filter",
-        paypal: "web.admin.onboarding.guide.status_page.paypal",
-        listing: "web.admin.onboarding.guide.status_page.listing",
-        invitation: "web.admin.onboarding.guide.status_page.invitation",
+        slogan_and_description: 'web.admin.onboarding.guide.status_page.slogan_and_description',
+        cover_photo: 'web.admin.onboarding.guide.status_page.cover_photo',
+        filter: 'web.admin.onboarding.guide.status_page.filter',
+        paypal: 'web.admin.onboarding.guide.status_page.paypal',
+        listing: 'web.admin.onboarding.guide.status_page.listing',
+        invitation: 'web.admin.onboarding.guide.status_page.invitation',
       };
 
       return li({ className: stepListItem, key }, [
@@ -105,9 +109,9 @@ GuideStatusPage.propTypes = {
   name: string.isRequired,
   infoIcon: string.isRequired,
   nextStep: shape({
-      title: string.isRequired,
-      link: string.isRequired,
-    }),
+    title: string.isRequired,
+    link: string.isRequired,
+  }),
   onboarding_data: arrayOf(shape({
     step: oneOf([
       'slogan_and_description',

--- a/client/app/components/onboardingGuide/GuideStatusPage.js
+++ b/client/app/components/onboardingGuide/GuideStatusPage.js
@@ -1,5 +1,6 @@
 import { PropTypes } from 'react';
 import { div, p, h2, hr, ul, li, span, a } from 'r-dom';
+import { t } from '../../utils/i18n';
 
 import css from './styles.scss';
 
@@ -11,29 +12,38 @@ const GuideStatusPage = (props) => {
 
   const onboardingData = props.onboarding_data;
 
-  // TODO: interpolating translation strings needs more thinking
   const title = props.nextStep ?
-    props.t('title').replace(/%\{(\w+)\}/g, props.name) :
-    props.t('title_done');
+        t('web.admin.onboarding.guide.status_page.title', {name : props.name}) :
+        t('web.admin.onboarding.guide.status_page.title_done');
 
   const todoDescPartial = div([
-    p({ className: css.description }, props.t('description_p1')),
-    p({ className: css.description }, props.t('description_p2')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.status_page.description_p1')),
+    p({ className: css.description }, t('web.admin.onboarding.guide.status_page.description_p2')),
   ]);
 
   const doneDescPartial = div([
     p({
       className: css.description,
-      dangerouslySetInnerHTML: { __html: props.t('congratulation_p1') }, // eslint-disable-line react/no-danger
-    }),
-    p({
-      className: css.description,
-      dangerouslySetInnerHTML: { __html: props.t('congratulation_p2') }, // eslint-disable-line react/no-danger
-    }),
-    p({
-      className: css.description,
-      dangerouslySetInnerHTML: { __html: props.t('congratulation_p3') }, // eslint-disable-line react/no-danger
-    }),
+    }, t('web.admin.onboarding.guide.status_page.congratulation_p1.content',
+         {knowledge_base_link: a(
+           { href: 'http://support.sharetribe.com/knowledgebase/articles/892140-what-to-do-after-the-basic-setup-of-your-marketpla',
+             target: '_blank',
+             alt: t('web.admin.onboarding.guide.status_page.congratulation_p1.knowledge_base_alt'),
+           })})),
+    p({ className: css.description }, t('web.admin.onboarding.guide.status_page.congratulation_p2.content',
+                                        { marketplace_guide_link: a(
+                                          { href: "https://www.sharetribe.com/academy/guide/",
+                                            target: "_blank",
+                                            alt: t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_alt')
+                                          }, t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_link'))
+                                        })),
+    p({ className: css.description }, t('web.admin.onboarding.guide.status_page.congratulation_p3.content',
+         { contact_support_link: a(
+           { 'data-uv-trigger': 'contact',
+             href: 'mailto:support@sharetribe.com',
+             title: t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_title')},
+           t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_link')
+         )})),
   ]);
 
   const description = props.nextStep ? todoDescPartial : doneDescPartial;
@@ -47,7 +57,7 @@ const GuideStatusPage = (props) => {
       li({ className: css.stepListItemDone }, [
         span({ className: css.stepListLink }, [
           span({ className: css.stepListCheckbox }),
-          props.t('create_your_marketplace'),
+          t('web.admin.onboarding.guide.status_page.create_your_marketplace'),
         ]),
       ]),
     ].concat(onboardingData.map((step) => {
@@ -56,6 +66,15 @@ const GuideStatusPage = (props) => {
               css.stepListItemDone :
               css.stepListItem;
 
+      const titles = {
+        slogan_and_description: "web.admin.onboarding.guide.status_page.slogan_and_description",
+        cover_photo: "web.admin.onboarding.guide.status_page.cover_photo",
+        filter: "web.admin.onboarding.guide.status_page.filter",
+        paypal: "web.admin.onboarding.guide.status_page.paypal",
+        listing: "web.admin.onboarding.guide.status_page.listing",
+        invitation: "web.admin.onboarding.guide.status_page.invitation",
+      };
+
       return li({ className: stepListItem, key }, [
         a({
           className: css.stepListLink,
@@ -63,7 +82,7 @@ const GuideStatusPage = (props) => {
           href: `${props.initialPath}/${step.sub_path}`,
         }, [
           span({ className: css.stepListCheckbox }),
-          props.t(key),
+          t(titles[key]),
         ]),
       ]);
     }))),
@@ -85,13 +104,10 @@ GuideStatusPage.propTypes = {
   initialPath: string.isRequired,
   name: string.isRequired,
   infoIcon: string.isRequired,
-  nextStep: oneOf([
-    shape({
+  nextStep: shape({
       title: string.isRequired,
       link: string.isRequired,
     }),
-    bool.isRequired,
-  ]).isRequired,
   onboarding_data: arrayOf(shape({
     step: oneOf([
       'slogan_and_description',
@@ -106,7 +122,6 @@ GuideStatusPage.propTypes = {
     cta: string,
     complete: bool.isRequired,
   })).isRequired,
-  t: func.isRequired,
 };
 
 export default GuideStatusPage;

--- a/client/app/components/onboardingGuide/GuideStatusPage.js
+++ b/client/app/components/onboardingGuide/GuideStatusPage.js
@@ -27,6 +27,7 @@ const GuideStatusPage = (props) => {
         { knowledge_base_link: a(
           { href: 'http://support.sharetribe.com/knowledgebase/articles/892140-what-to-do-after-the-basic-setup-of-your-marketpla',
             target: '_blank',
+            rel: 'noreferrer',
             alt: t('web.admin.onboarding.guide.status_page.congratulation_p1.knowledge_base_alt'),
           }),
         })),
@@ -35,6 +36,7 @@ const GuideStatusPage = (props) => {
         { marketplace_guide_link: a(
           { href: 'https://www.sharetribe.com/academy/guide/',
             target: '_blank',
+            rel: 'noreferrer',
             alt: t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_alt'),
           },
           t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_link')),

--- a/client/app/components/onboardingGuide/OnboardingGuide.js
+++ b/client/app/components/onboardingGuide/OnboardingGuide.js
@@ -44,12 +44,12 @@ const nextStep = function nextStep(data) {
   const nextStepData = data.find((step) => !step.complete);
 
   const titles = {
-    slogan_and_description: "web.admin.onboarding.guide.next_step.slogan_and_description",
-    cover_photo: "web.admin.onboarding.guide.next_step.cover_photo",
-    filter: "web.admin.onboarding.guide.next_step.filter",
-    paypal: "web.admin.onboarding.guide.next_step.paypal",
-    listing: "web.admin.onboarding.guide.next_step.listing",
-    invitation: "web.admin.onboarding.guide.next_step.invitation",
+    slogan_and_description: 'web.admin.onboarding.guide.next_step.slogan_and_description',
+    cover_photo: 'web.admin.onboarding.guide.next_step.cover_photo',
+    filter: 'web.admin.onboarding.guide.next_step.filter',
+    paypal: 'web.admin.onboarding.guide.next_step.paypal',
+    listing: 'web.admin.onboarding.guide.next_step.listing',
+    invitation: 'web.admin.onboarding.guide.next_step.invitation',
   };
 
   if (nextStepData) {

--- a/client/app/startup/OnboardingGuideApp.js
+++ b/client/app/startup/OnboardingGuideApp.js
@@ -1,6 +1,7 @@
 import r from 'r-dom';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
 import { Provider } from 'react-redux';
+import { initialize as initializeI18n } from '../utils/i18n';
 import middleware from 'redux-thunk';
 
 // Uses the index
@@ -10,6 +11,8 @@ import composeInitialState from '../store/composeInitialState';
 import OnboardingGuideContainer from '../components/onboardingGuide/OnboardingGuideContainer';
 
 export default (props, railsContext) => {
+  initializeI18n(railsContext, process.env.NODE_ENV);
+
   const combinedReducer = combineReducers(reducers);
   const combinedProps = composeInitialState(props, railsContext);
 

--- a/client/app/startup/OnboardingTopBarApp.js
+++ b/client/app/startup/OnboardingTopBarApp.js
@@ -1,10 +1,9 @@
 import r from 'r-dom';
-import { I18n } from '../utils/i18n';
+import { initialize as initializeI18n } from '../utils/i18n';
 import OnboardingTopBar from '../components/OnboardingTopBar/OnboardingTopBar';
 
 export default (props, railsContext) => {
-  I18n.locale = railsContext.i18nLocale;
-  I18n.defaultLocale = railsContext.i18nDefaultLocale;
+  initializeI18n(railsContext);
 
   return r(OnboardingTopBar, props);
 };

--- a/client/app/utils/i18n.js
+++ b/client/app/utils/i18n.js
@@ -21,7 +21,7 @@ if (isServer()) {
 
   // Initialize global.I18n
   // In browser we initialize this in a script-tag manually
-  global.I18n = {}; // eslint-disable-line no-undef
+  global.I18n = {};
 
   // Load the translation bundle in the global.I18n variable.
   // In browser the bundle is loaded in a separate script-tag.
@@ -29,7 +29,7 @@ if (isServer()) {
   try {
     // The translation bundle will be loaded to the global I18n
     // variable. Initialize the variable here.
-    require('../i18n/all.js'); // eslint-disable-line no-undef
+    require('../i18n/all.js');
   } catch (e) {
     console.warn("Can't load language bundle all.js"); // eslint-disable-line no-console
   }
@@ -40,7 +40,13 @@ if (isServer()) {
 // be initialized before loading the i18n-js library, so that the
 // library can use the existing I18n object
 
-const I18n = require('i18n-js'); // eslint-disable-line no-undef
+const I18n = require('i18n-js');
+
+function initialize(railsContext) {
+  I18n.locale = railsContext.i18nLocale;
+  I18n.defaultLocale = railsContext.i18nDefaultLocale;
+  I18n.interpolationMode = 'split';
+}
 
 // Bind functions to I18n
 const translate = bind(I18n.translate, I18n);
@@ -50,4 +56,4 @@ const t = bind(I18n.t, I18n);
 const l = bind(I18n.l, I18n);
 const p = bind(I18n.p, I18n);
 
-export { I18n, translate, localize, pluralize, t, l, p };
+export { initialize, translate, localize, pluralize, t, l, p };

--- a/client/app/utils/i18n.js
+++ b/client/app/utils/i18n.js
@@ -1,3 +1,5 @@
+/* eslint-env commonjs */
+
 // This file has three tasks:
 //
 // 1. Initialize global.I18n if we are in server environment

--- a/client/app/utils/i18nUtils.js
+++ b/client/app/utils/i18nUtils.js
@@ -1,7 +1,0 @@
-function translate(translations) {
-  return function translateKey(translationKey) {
-    return translations[translationKey];
-  };
-}
-
-export { translate };

--- a/client/package.json
+++ b/client/package.json
@@ -52,7 +52,7 @@
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
     "webpack": "1.13.0",
-    "i18n-js": "http://github.com/fnando/i18n-js/archive/v3.0.0.rc12.tar.gz"
+    "i18n-js": "http://github.com/sharetribe/i18n-js/archive/interpolation-mode.tar.gz"
   },
   "devDependencies": {
     "@kadira/storybook": "1.25.0",

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -19,7 +19,7 @@ translations:
   # Use a custom namespace that uses either global (in node) or window (in browser)
 
   - file: "app/assets/javascripts/i18n/%{locale}.js"
-    only: ["*.web", "*.admin.onboarding"]
+    only: ["*.web"]
     namespace: "(typeof(window) === 'undefined' ? global : window).I18n"
     pretty_print: true # can be turned on for debugging
 
@@ -32,6 +32,6 @@ translations:
   # Use a custom namespace that uses either global (in node) or window (in browser)
 
   - file: "client/app/i18n/all.js"
-    only: ["*.web", "*.admin.onboarding"]
+    only: ["*.web"]
     namespace: "(typeof(window) === 'undefined' ? global : window).I18n"
     pretty_print: false # can be turned on for debugging

--- a/config/locales/onboarding/en.yml
+++ b/config/locales/onboarding/en.yml
@@ -1,105 +1,136 @@
 en:
-  admin:
-    onboarding:
-      guide:
-        cover_photo:
-          title: "Step 3: Add a cover photo"
-          description: "A good cover photo can make the difference between a new visitor joining or leaving your marketplace."
-          info_image_alt: "A screenshot of homepage with big cover photo"
-          add_your_own: "Add cover photo"
-          advice: "Check out <a href=\"http://support.sharetribe.com/knowledgebase/articles/744438\" target=\"_blank\" alt=\"How to get good-looking cover photos, logos, favicon, profiles and listing pictures?\">our guide</a> on where to find good-looking images that are free to use. <br/>Note: the photo will be resized to 1920x450 pixels. The top and bottom sections of images that are taller will be cropped."
-        filter:
-          title: "Step 4: Add listing fields & filters"
-          description: "Listing fields determine the structure of your marketplace. For example, if you are building a marketplace for selling used shoes, you probably want to add a field for shoe size. The seller will then need to add the size of their shoes when creating a new shoe listing. If you wish to allow your customers to filter listings based on shoe size, you can check the box <i>Display a filter based on this field on the homepage</i> when creating the field."
-          info_image_alt: "A screenshot from fields and filters page"
-          add_fields_and_filters: "Add fields & filters"
-          advice: "Filters are very handy, but <a target=\"_blank\" href=\"https://www.sharetribe.com/academy/how-to-help-your-customers-find-the-right-product-or-service/\">you shouldn't add too many</a>. Customers will be overwhelmed by having too many filters, and each filter is an additional field for your suppliers to fill in."
-        invitation:
-          title: "Step 7: Inviting users"
-          description: "Happy with what marketplace looks like and how it works? Maybe <a href='/?big_cover_photo=true' alt='Check preview' target='_blank'>one last preview</a>? If you're ready, let's start inviting users!"
-          info_image_alt: "Users illustration"
-          invite_users: "Invite users"
-          advice: "Invite your friends first and gather feedback from them."
-        listing:
-          title: "Step 6: Add your first listing"
-          description: "Listings are the content of your marketplace: the products or services your providers are offering. To make your marketplace look less empty and test how the process of creating a new listing works, add one yourself!"
-          info_image_alt: "A screenshot from Post a new listing page"
-          post_your_first_listing: "Post your first listing"
-          advice: "Removing a listing is easy: simply click on the listing and choose <i>Close listing</i>."
-        next_step:
-          slogan_and_description: "Add a slogan & description"
-          cover_photo: "Add a cover photo"
-          filter: "Add fields & filters"
-          paypal: "Accept payments"
-          listing: "Post your first listing"
-          invitation: "Invite users"
-        paypal:
-          title: "Step 5: Set up online payments"
-          description_p1: "If you want to allow your providers to accept online payments, you need to connect your PayPal account (you will receive a fee from each transaction). Once connected, you need to choose a minimum transaction size and your transaction fee."
-          description_p2: "Alternatively, you can disable online payments for now."
-          info_image_alt: "A screenshot from payments page"
-          disable_payments: "Disable payments"
-          setup_payments: "Set up payments"
-          cta_separator: "or"
-          advice: "You can read more about disabling payments from <a href=\"http://support.sharetribe.com/knowledgebase/articles/470085\" target=\"_blank\" alt=\"How to disable payments or add free listings to your marketplace\">this article</<a>."
-        slogan_and_description:
-          title: "Step 2: Slogan & Description"
-          description: "The slogan & description help new visitors understand what your marketplace is about. They are the first thing your users notice when they enter your site, so try to make them descriptive but succinct."
-          info_image_alt: "A screenshot of homepage showing slogan and description."
-          add_your_own: "Add slogan & description"
-          advice: "Use the slogan to tell quickly what your marketplace is about. <i>\"Buy food from locals\"</i> or <i>\"Get guitar lessons from a pro\"</i> are good examples. In the description text you can then expand on your main value proposition. <i>\"FoodMarket is the easiest way to order produce directly from local providers\"</i> or <i>\"GuitarPro is the best place to compare music teachers\"</i> are good examples."
-        status_page:
-          title: "Welcome to your marketplace, %{name}"
-          title_done: "All done!"
-          description_p1: "To get your marketplace up and running, there are a few essential steps you need to take, as listed below."
-          description_p2: "Once finished, your marketplace will be ready to receive its first visitors!"
-          congratulation_p1: "You did it! Your marketplace is now up and running. However, this is just the beginning. You've only seen a fraction of the customization options that Sharetribe offers. To read more about how to customize your marketplace further, check out <a href='http://support.sharetribe.com/knowledgebase/articles/892140-what-to-do-after-the-basic-setup-of-your-marketpla' alt='knowledge base' target='_blank'>our knowledge base</a>."
-          congratulation_p2: "If you wish to learn more about how to build your marketplace business, we recommend our <a href='https://www.sharetribe.com/academy/guide/' alt='link to marketplace academy' target='_blank'>practical guide for building an online marketplace business</a>."
-          congratulation_p3: "If you have any questions, don't hesitate to <a data-uv-trigger='contact' href='mailto:support@sharetribe.com' title='Support'>contact our support</a>, we're always happy to help!"
-          create_your_marketplace: "Create your marketplace"
+  web:
+    admin:
+      onboarding:
+        guide:
+          cover_photo:
+            title: "Step 3: Add a cover photo"
+            description: "A good cover photo can make the difference between a new visitor joining or leaving your marketplace."
+            info_image_alt: "A screenshot of homepage with big cover photo"
+            add_your_own: "Add cover photo"
+            advice:
+              content1: "Check out %{link} on where to find good-looking images that are free to use."
+              content2: "Note: the photo will be resized to %{width}x%{height} pixels. The top and bottom sections of images that are taller will be cropped."
+              link: "our guide"
+              alt: "How to get good-looking cover photos, logos, favicon, profiles and listing pictures?"
+          filter:
+            title: "Step 4: Add listing fields & filters"
+            description:
+              content: "Listing fields determine the structure of your marketplace. For example, if you are building a marketplace for selling used shoes, you probably want to add a field for shoe size. The seller will then need to add the size of their shoes when creating a new shoe listing. If you wish to allow your customers to filter listings based on shoe size, you can check the box %{display_on_homepage} when creating the field."
+              display_on_homepage: "Display a filter based on this field on the homepage"
+            info_image_alt: "A screenshot from fields and filters page"
+            add_fields_and_filters: "Add fields & filters"
+            advice:
+              content: "Filters are very handy, but %{not_too_many_link}. Customers will be overwhelmed by having too many filters, and each filter is an additional field for your suppliers to fill in."
+              not_too_many_link: "you shouldn't add too many"
+          invitation:
+            title: "Step 7: Inviting users"
+            description:
+              content: "Happy with what marketplace looks like and how it works? Maybe %{preview_link}? If you're ready, let's start inviting users!"
+              preview_link: "one last preview"
+              preview_link_alt: "Check preview"
+            info_image_alt: "Users illustration"
+            invite_users: "Invite users"
+            advice: "Invite your friends first and gather feedback from them."
+          listing:
+            title: "Step 6: Add your first listing"
+            description: "Listings are the content of your marketplace: the products or services your providers are offering. To make your marketplace look less empty and test how the process of creating a new listing works, add one yourself!"
+            info_image_alt: "A screenshot from Post a new listing page"
+            post_your_first_listing: "Post your first listing"
+            advice:
+              content: "Removing a listing is easy: simply click on the listing and choose %{close_listing}."
+              close_listing: "Close listing"
+          next_step:
+            slogan_and_description: "Add a slogan & description"
+            cover_photo: "Add a cover photo"
+            filter: "Add fields & filters"
+            paypal: "Accept payments"
+            listing: "Post your first listing"
+            invitation: "Invite users"
+          paypal:
+            title: "Step 5: Set up online payments"
+            description_p1: "If you want to allow your providers to accept online payments, you need to connect your PayPal account (you will receive a fee from each transaction). Once connected, you need to choose a minimum transaction size and your transaction fee."
+            description_p2: "Alternatively, you can disable online payments for now."
+            info_image_alt: "A screenshot from payments page"
+            disable_payments: "Disable payments"
+            setup_payments: "Set up payments"
+            cta_separator: "or"
+            advice:
+              content: "You can read more about disabling payments from %{disable_payments_link}."
+              disable_payments_link: "this article"
+              disable_payments_alt: "How to disable payments or add free listings to your marketplace"
+          slogan_and_description:
+            title: "Step 2: Slogan & Description"
+            description: "The slogan & description help new visitors understand what your marketplace is about. They are the first thing your users notice when they enter your site, so try to make them descriptive but succinct."
+            info_image_alt: "A screenshot of homepage showing slogan and description."
+            add_your_own: "Add slogan & description"
+            advice:
+              content: "Use the slogan to tell quickly what your marketplace is about. %{food_from_locals_slogan} or %{guitar_lessons_slogan} are good examples. In the description text you can then expand on your main value proposition. %{food_from_locals_description} or %{guitar_lessons_description} are good examples."
+              food_from_locals_slogan: "\"Buy food from locals\""
+              guitar_lessons_slogan: "\"Get guitar lessons from a pro\""
+              food_from_locals_description: "\"FoodMarket is the easiest way to order produce directly from local providers\""
+              guitar_lessons_description: "\"GuitarPro is the best place to compare music teachers\""
+          status_page:
+            title: "Welcome to your marketplace, %{name}"
+            title_done: "All done!"
+            description_p1: "To get your marketplace up and running, there are a few essential steps you need to take, as listed below."
+            description_p2: "Once finished, your marketplace will be ready to receive its first visitors!"
+            congratulation_p1:
+              content: "You did it! Your marketplace is now up and running. However, this is just the beginning. You've only seen a fraction of the customization options that Sharetribe offers. To read more about how to customize your marketplace further, check out %{knowledge_base_link}."
+              knowledge_base_link: "our knowledge base"
+              knowledge_base_alt: "knowledge base"
+            congratulation_p2:
+              content: "If you wish to learn more about how to build your marketplace business, we recommend our %{marketplace_guide_link}."
+              marketplace_guide_link: "practical guide for building an online marketplace business"
+              marketplace_guide_alt: "link to marketplace academy"
+            congratulation_p3:
+              content: "If you have any questions, don't hesitate to %{contact_support_link}, we're always happy to help!"
+              contact_support_link: "contact our support"
+              contact_support_title: "Support"
+            create_your_marketplace: "Create your marketplace"
+            slogan_and_description: "Add a slogan & description"
+            cover_photo: "Upload a cover photo"
+            filter: "Add fields & filters"
+            paypal: "Set up online payments"
+            listing: "Post a listing"
+            invitation: "Invite users"
+          back_to_todo: "Back to to-do list"
+        popup:
+          slogan_and_description:
+            title: "Woohoo, task completed!"
+            body: "Fantastic! Up next: the slogan and description are the best way to tell new visitors understand what your marketplace is about."
+            button: "Write your own!"
+          cover_photo:
+            title: "Woohoo, task completed!"
+            body: "Well done, let's keep going! A good cover photo has a huge impact on the initial impression left on new visitors. It's time to add yours!"
+            button: "Upload a cover photo"
+          filter:
+            title: "Looking good!"
+            body: "Now let's focus on some functionality. Listing fields and filters give structure to your marketplace and help your customers find what they are looking for."
+            button: "Add fields & filters"
+          paypal:
+            title: "Well done! "
+            body: "Next, set up your marketplace for online payments! To allow your providers to accept payments, you need to connect your PayPal account. Alternative, you can disable online payments for now."
+            button: "Set up payments"
+          listing:
+            title: "Good job!"
+            body: "The basics of your marketplace have now been set up, but the site is quite empty. It's time to add the first product or service by posting a new listing."
+            button: "Post your first listing"
+          invitation:
+            title: "...and now the final step - share your marketplace!"
+            body: "Happy with your marketplace? Then let's start inviting users!"
+            button: "Invite users"
+          all_done:
+            title: "Brilliant, you made it!"
+            body: "Fantastic, you did it! Your marketplace is now up and running. However, this is just the beginning. We're here to help you on every step of your journey."
+            button: "See what to do next"
+          button_later: "I'll do it later, thanks"
+        topbar:
+          progress_label: "Marketplace progress"
+          next_step: "Next"
           slogan_and_description: "Add a slogan & description"
           cover_photo: "Upload a cover photo"
           filter: "Add fields & filters"
-          paypal: "Set up online payments"
+          paypal: "Accept payments"
           listing: "Post a listing"
           invitation: "Invite users"
-        back_to_todo: "Back to to-do list"
-      popup:
-        slogan_and_description:
-          title: "Woohoo, task completed!"
-          body: "Fantastic! Up next: the slogan and description are the best way to tell new visitors understand what your marketplace is about."
-          button: "Write your own!"
-        cover_photo:
-          title: "Woohoo, task completed!"
-          body: "Well done, let's keep going! A good cover photo has a huge impact on the initial impression left on new visitors. It's time to add yours!"
-          button: "Upload a cover photo"
-        filter:
-          title: "Looking good!"
-          body: "Now let's focus on some functionality. Listing fields and filters give structure to your marketplace and help your customers find what they are looking for."
-          button: "Add fields & filters"
-        paypal:
-          title: "Well done! "
-          body: "Next, set up your marketplace for online payments! To allow your providers to accept payments, you need to connect your PayPal account. Alternative, you can disable online payments for now."
-          button: "Set up payments"
-        listing:
-          title: "Good job!"
-          body: "The basics of your marketplace have now been set up, but the site is quite empty. It's time to add the first product or service by posting a new listing."
-          button: "Post your first listing"
-        invitation:
-          title: "...and now the final step - share your marketplace!"
-          body: "Happy with your marketplace? Then let's start inviting users!"
-          button: "Invite users"
-        all_done:
-          title: "Brilliant, you made it!"
-          body: "Fantastic, you did it! Your marketplace is now up and running. However, this is just the beginning. We're here to help you on every step of your journey."
-          button: "See what to do next"
-        button_later: "I'll do it later, thanks"
-      topbar:
-        progress_label: "Marketplace progress"
-        next_step: "Next"
-        slogan_and_description: "Add a slogan & description"
-        cover_photo: "Upload a cover photo"
-        filter: "Add fields & filters"
-        paypal: "Accept payments"
-        listing: "Post a listing"
-        invitation: "Invite users"

--- a/docs/js-translations.md
+++ b/docs/js-translations.md
@@ -6,7 +6,7 @@ _The mechanism described in this document **does not work with marketplace speci
 
 ## Usage
 
-In the React component, you need to import `t` function from the `i18n` module. After that you can use all the translation keys from the `en.js.*` scope:
+In the React component, you need to import `t` function from the `i18n` module. After that you can use all the translation keys from the `en.web.*` scope:
 
 ```js
 // MyReactComponent.js
@@ -15,12 +15,12 @@ import { t } from '../../utils/i18n';
 
 class MyReactComponent extends Component {
   render() {
-    return span({className: "hello-world"}, t("js.hello_world"))
+    return span({className: "hello-world"}, t("web.hello_world"))
   }
 }
 ```
 
-The example above assumed that there's a `js.hello_world` key in the translation YML file, e.g.:
+The example above assumed that there's a `web.hello_world` key in the translation YML file, e.g.:
 
 ```yml
 


### PR DESCRIPTION
- Guide uses new t function and interpolation
- Change the onboarding guide to use the new `t` function
- Remove all markup from translations
- Use forked version of i18n-js, with interpolationMode
- Move all the JS translations under `web.*` scope
- Remove `i18nUtils.js` as it's not needed anymore
- ESLint: Add global `process` and `commonjs` environment

Might be also good idea to review the forked i18n-js: https://github.com/fnando/i18n-js/compare/master...sharetribe:interpolation-mode