### PR TITLE
Wait for Webpack bundle files before starting Rails server

### DIFF
--- a/Procfile.hot
+++ b/Procfile.hot
@@ -1,6 +1,6 @@
 # Procfile for development with hot reloading of JavaScript and CSS
 
-rails: rails s -b 0.0.0.0
+rails: script/wait_for_server_js.sh && rails s -b 0.0.0.0
 
 # Run the React Storybook for client development
 storybook: cd client && npm run styleguide

--- a/Procfile.static
+++ b/Procfile.static
@@ -1,5 +1,5 @@
-# Run Rails without hot reloading (static assets).
-rails: REACT_ON_RAILS_ENV= rails s -b 0.0.0.0
+# Run Rails server after Webpack build is ready.
+rails: script/wait_for_server_js.sh && rails s -b 0.0.0.0
 
 # Build client assets, watching for changes.
 rails-client-assets: cd client && npm run build:dev:client

--- a/script/wait_for_file.sh
+++ b/script/wait_for_file.sh
@@ -1,0 +1,8 @@
+wait_for_file() {
+  local file="$1"; shift
+  local wait_seconds="${1:-10}"; shift # 10 seconds as default timeout
+
+  until [ $((wait_seconds--)) -eq 0 -o -f "$file" ] ; do sleep 1; done
+
+  [ "$wait_seconds" -ne -1 ]
+}

--- a/script/wait_for_server_js.sh
+++ b/script/wait_for_server_js.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+source 'script/wait_for_file.sh'
+
+server_js='app/assets/webpack/server-bundle.js'
+
+echo "Waiting for $server_js..."
+
+wait_for_file "$server_js" 30 || {
+  echo "Server JS bundle missing after waiting for 30 seconds: '$server_js'"
+  exit 1
+}
+
+echo "$server_js found"


### PR DESCRIPTION
Our Rails server depends on Webpack-built frontend bundles. When starting Rails server and Webpack builds in parallel we have no guarantees that the Webpack builds are actually completed before Rails gets interested in them, which results in timing dependent startup crashes.

This PR makes Rails server wait for Webpack to build server JS bundle before starting.

Fixes https://github.com/sharetribe/sharetribe/issues/2043 and partially https://github.com/sharetribe/sharetribe/issues/2037.