### PR TITLE
React component cache

### DIFF
--- a/app/controllers/admin/getting_started_guide_controller.rb
+++ b/app/controllers/admin/getting_started_guide_controller.rb
@@ -67,7 +67,6 @@ class Admin::GettingStartedGuideController < ApplicationController
         onboarding_data: sorted_steps,
         name: PersonViewUtils.person_display_name(@current_user, @current_community),
         info_icon: icon_tag("information"),
-        translations: I18n.t('admin.onboarding.guide')
       }
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -639,7 +639,6 @@ class ApplicationController < ActionController::Base
     community_id = @current_community.id
     onboarding_status = Admin::OnboardingWizard.new(community_id).setup_status
     {
-      translations: t('admin.onboarding.topbar'),
       guide_root: admin_getting_started_guide_path,
       progress: OnboardingViewUtils.progress(onboarding_status),
       next_step: OnboardingViewUtils.next_incomplete_step(onboarding_status)

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -94,7 +94,7 @@ module CacheHelper
   def react_component_cache(name, props, extra_keys = [], &block)
     if controller.perform_caching && !digest_assets
       Rails.logger.warn(
-        "'perform_caching' is turned on but the assets do not have digest. " +
+        "'perform_caching' is turned on but the assets do not have digest. " \
         "react_component_cache will not be invalidated correctly")
     end
 

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -73,6 +73,39 @@ module CacheHelper
     cache([type, listings_i18n_digest, @current_community, listing, listing.author, MoneyRails::Configuration.no_cents_if_whole], :expires_in => FRAGMENT_CACHE_EXPIRE_TIME, &block)
   end
 
+  # Cache helper for React components
+  #
+  # The cache key is generated from these values:
+  #
+  # - component name
+  # - props
+  # - locale
+  # - bundle file name (fingerprinted in production)
+  #
+  # All the dynamic values (like current locale) that are not passed
+  # to the component via props (but via railsContext for example)
+  # should be included in the list of values that is used to generate
+  # the cache key.
+  #
+  # Please note that if you turn on caching in development but do not run
+  # assets:precompile, the cache will not be invalidated because the server bundle
+  # filename doesn't change.
+  #
+  def react_component_cache(name, props, extra_keys = [], &block)
+    locale = I18n.locale
+    bundle_file = asset_path(ReactOnRails.configuration.server_bundle_js_file)
+
+    keys = [
+      'react_component_cache',
+      name,
+      props,
+      locale,
+      bundle_file
+    ]
+
+    cache(keys + extra_keys, &block)
+  end
+
   private
 
   def self.update_time_based_cache_key(key)

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -92,6 +92,12 @@ module CacheHelper
   # filename doesn't change.
   #
   def react_component_cache(name, props, extra_keys = [], &block)
+    if controller.perform_caching && !digest_assets
+      Rails.logger.warn(
+        "'perform_caching' is turned on but the assets do not have digest. " +
+        "react_component_cache will not be invalidated correctly")
+    end
+
     locale = I18n.locale
     bundle_file = asset_path(ReactOnRails.configuration.server_bundle_js_file)
 
@@ -103,7 +109,8 @@ module CacheHelper
       bundle_file
     ]
 
-    cache(keys + extra_keys, &block)
+    # We can skip the digest because we don't care if the .haml template changes.
+    cache(keys + extra_keys, {skip_digest: true}, &block)
   end
 
   private

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -10,7 +10,7 @@
     - with_feature(:onboarding_redesign_v1) do
       - props = onboarding_topbar_props
       - unless props[:next_step] == :all_done
-        - react_component_cache("onboarding_topbar", props, ["v1"]) do
+        - react_component_cache("onboarding_topbar", props) do
           = react_component("OnboardingTopBar", props: props, prerender: true)
 
   = render partial: 'layouts/global_header', locals: header_props()

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -10,7 +10,7 @@
     - with_feature(:onboarding_redesign_v1) do
       - props = onboarding_topbar_props
       - unless props[:next_step] == :all_done
-        - cache ['v1', 'onboarding_topbar', props] do
+        - react_component_cache("onboarding_topbar", props, ["v1"]) do
           = react_component("OnboardingTopBar", props: props, prerender: true)
 
   = render partial: 'layouts/global_header', locals: header_props()


### PR DESCRIPTION
Cache helper for React components

The cache key is generated from these values:

- component name
- props
- locale
- bundle file name (fingerprinted in production)

All the dynamic values (like current locale) that are not passed to the component via props (but via railsContext for example) should be included in the list of values that is used to generate the cache key.

Please note that if you turn on caching in development but do not run assets:precompile, the cache will not be invalidated because the server bundle filename doesn't change.