### PR TITLE
Stylelint setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - SUITE="rspec"
   - SUITE="rubocop"
   - SUITE="cucumber"
-  - SUITE="eslint"
+  - SUITE="lint"
   global:
     - BUNDLE_ARCHIVE="travis-bundle-cache"
     - AWS_S3_REGION="us-east-1"

--- a/client/.stylelintrc.js
+++ b/client/.stylelintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: 'stylelint-config-standard',
+  rules: {
+    'shorthand-property-no-redundant-values': null,
+  },
+};

--- a/client/.stylelintrc.js
+++ b/client/.stylelintrc.js
@@ -1,6 +1,36 @@
 module.exports = {
   extends: 'stylelint-config-standard',
   rules: {
+    // stylelint-config-standard overrides
     'shorthand-property-no-redundant-values': null,
+
+    // Single quotes everywhere
+    'font-family-name-quotes': 'single-where-recommended',
+    'function-url-quotes': 'single',
+    'string-quotes': 'single',
+
+    // Disallow using vendor prefixes to let Autoprefixer handle them
+    'at-rule-no-vendor-prefix': true,
+    'media-feature-name-no-vendor-prefix': true,
+    'property-no-vendor-prefix': true,
+    'selector-no-vendor-prefix': true,
+    'value-no-vendor-prefix': true,
+
+    // Warn about TODO comments
+    'comment-word-blacklist': [['/TODO\\b/', '/FIXME\\b/', '/XXX\\b/'], {
+      severity: 'warning',
+    }],
+
+    'selector-no-id': true,
+    'selector-no-qualifying-type': [true, { ignore: ['attribute'] }],
+    'selector-no-universal': true,
+
+    // Allow only camelCased class selectors that can be used without
+    // quoting within JavaScript with CSS modules
+    'selector-class-pattern': /^[a-zA-Z_]+$/,
+
+    'custom-property-no-outside-root': true,
+    'selector-root-no-composition': true,
+    'no-browser-hacks': true,
   },
 };

--- a/client/README.md
+++ b/client/README.md
@@ -46,21 +46,21 @@ New React components can be included to HAML and ERB files with '_react_componen
 <%= react_component("ExampleApp", props: @app_props_server_render, prerender: true, trace: true) %>
 ```
 
-_webpack.server.rails.build.config.js_ creates a _server-bundle.js_ file which is used by react_on_rails gem to create server-side rendering.
+_webpack.server.config.js_ creates a _server-bundle.js_ file which is used by react_on_rails gem to create server-side rendering.
 
-_webpack.client.rails.build.config.js_ defines how component specific styles are extracted using ExtractTextPlugin (if you have imported style.css file in your React component). These generated files (_app-bundle.js_, _vendor-bundle.js_, and _app-bundle.css_) and they are saved to _sharetribe/app/assets/webpack_ folder.
+_webpack.client.config.js_ defines how component specific styles are extracted using ExtractTextPlugin (if you have imported style.css file in your React component). These generated files (_app-bundle.js_, _vendor-bundle.js_, and _app-bundle.css_) and they are saved to _sharetribe/app/assets/webpack_ folder.
 
-We are using [CSS Modules](https://github.com/css-modules/css-modules) and preprocessors like SASS-loader and [PostCSS](https://github.com/postcss/postcss) loader.
-**N.B. we are likely to remove SASS loader quite soon and configure PostCSS better.**
+For stylesheets, we are using [CSS Modules](https://github.com/css-modules/css-modules) and [PostCSS](https://github.com/postcss/postcss) with [cssnext](http://cssnext.io/).
 
 We use [React Storybook](https://github.com/kadirahq/react-storybook) for a hot reloading component development environment, in `http://localhost:9001/`. See [instructions for writing stories](https://github.com/kadirahq/react-storybook#writing-stories), for example story see [OnboardingTopBar.story.js](app/components/OnboardingTopBar/OnboardingTopBar.story.js).
 
-ESLint
-==========================
-The `.eslintrc` file is based on the AirBnb [eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc).
+Linting JavaScript and CSS files
+================================
 
-It also includes many eslint defaults that the AirBnb eslint does not include.
+For static code linting, we use [ESLint](http://eslint.org/) for JavaScript code and [stylelint](http://stylelint.io/) for CSS code. The configuration can be found in `.eslintrc.js` and `.stylelintrc.js`, respectively.
 
 You can run the linting with:
 
-    npm run lint
+    npm run lint       # run both ESLint and stylelint
+    npm run eslint     # run only ESLint
+    npm run stylelint  # run only stylelint

--- a/client/app/assets/styles/mixins.css
+++ b/client/app/assets/styles/mixins.css
@@ -1,5 +1,5 @@
 @define-mixin guideStepListCheckbox {
-  background-image: url(../../assets/images/iconSquare@2x.png);
+  background-image: url('../../assets/images/iconSquare@2x.png');
   background-repeat: no-repeat;
   background-size: 100%;
   background-position-y: 1px;

--- a/client/app/assets/styles/mixins.css
+++ b/client/app/assets/styles/mixins.css
@@ -34,5 +34,5 @@
   height: auto;
   position: relative;
   overflow: hidden;
-  padding: 40.30% 0 0 0; /* 40.30% = 100 / (w / h) = 100 / (732 / 295) */
+  padding: 40.3% 0 0 0; /* 40.30% = 100 / (w / h) = 100 / (732 / 295) */
 }

--- a/client/app/components/OnboardingGuide/OnboardingGuide.css
+++ b/client/app/components/OnboardingGuide/OnboardingGuide.css
@@ -4,6 +4,7 @@
   color: var(--colorTitle);
   line-height: var(--lineHeightTitle);
 }
+
 .description {
   font-size: var(--fontSize);
   font-weight: 400;
@@ -17,7 +18,7 @@
 .sectionSeparator {
   margin: var(--verticalSpaceElementBig) 0;
   height: 1px;
-  border-bottom: solid 1px rgba(0,0,0,0.1);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.1);
 }
 
 /* GuideStatusPage */
@@ -26,7 +27,8 @@
   margin-bottom: var(--verticalSpaceText);
 }
 
-.stepListItem, .stepListItemDone {
+.stepListItem,
+.stepListItemDone {
   list-style: none;
 }
 
@@ -40,6 +42,7 @@
   height: var(--fontSize);
   margin-right: 0.5em;
 }
+
 .stepListItemDone .stepListCheckbox {
   @mixin guideStepListCheckbox;
   background-image: url('../../assets/images/iconSquareChecked@2x.png');
@@ -55,6 +58,7 @@
     color: var(--colorActionTextHover);
   }
 }
+
 .stepListItemDone .stepListLink {
   text-decoration: line-through;
   color: var(--colorCompleted);
@@ -79,8 +83,10 @@
     color: var(--colorButtonGhost);
   }
 }
+
 .buttonSeparator {
   margin-right: var(--gutter);
+
   @media (max-width: 600px) {
     display: none;
   }
@@ -121,6 +127,7 @@
 .sloganImageContainer {
   @mixin guideSloganImageContainer;
 }
+
 .sloganImageContainerBig {
   @mixin guideSloganImageContainer;
   padding: 73.68% 0 0 0; /* 73.68% = 100 / (w / h) = 100 / (722 / 532) */

--- a/client/app/components/OnboardingTopBar/OnboardingTopBar.css
+++ b/client/app/components/OnboardingTopBar/OnboardingTopBar.css
@@ -50,7 +50,7 @@
   }
   display: inline-block;
   background-color: rgb(76, 152, 138);
-  box-shadow: inset 0px 3px 8px 0px rgba(0, 0, 0, 0.17);
+  box-shadow: inset 0 3px 8px 0 rgba(0, 0, 0, 0.17);
   height: 1em;
   position: relative;
   border-radius: 0.5em;
@@ -74,12 +74,12 @@
   display: inline-block;
   font-weight: 600;
   padding: 0.6em 1em;
-  border: 1px solid rgba(255,255,255,0.5);
+  border: 1px solid rgba(255, 255, 255, 0.5);
   border-radius: 5px;
   text-decoration: none;
   color: white;
   &:hover {
     color: white;
-    border: 1px solid rgba(255,255,255,1);
+    border: 1px solid rgba(255, 255, 255, 1);
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "repository": "sharetribe/sharetribe",
   "license": "MIT",
   "engines": {
-    "node": "5.10"
+    "node": "6.1"
   },
   "scripts": {
     "lint": "npm run eslint && npm run stylelint",

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,9 @@
     "node": "5.10"
   },
   "scripts": {
-    "lint": "eslint .",
+    "lint": "npm run eslint && npm run stylelint",
+    "eslint": "eslint .",
+    "stylelint": "stylelint **/*.css",
     "build:client": "webpack --config webpack.client.config.js",
     "build:server": "webpack --config webpack.server.config.js",
     "build:production:client": "NODE_ENV=production webpack --config webpack.client.config.js",
@@ -64,6 +66,8 @@
     "eslint-plugin-react": "5.1.1",
     "phantomjs-prebuilt": "2.1.7",
     "react-transform-hmr": "1.0.4",
+    "stylelint": "6.3.3",
+    "stylelint-config-standard": "7.0.0",
     "webpack-dev-server": "1.14.1"
   },
   "browser": {

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -6,7 +6,7 @@ echo "Running before_install"
 
 # Assert that the given SUITE is a known one
 case "$SUITE" in
-    rspec|rubocop|cucumber|eslint)
+    rspec|rubocop|cucumber|lint)
         echo "SUITE: ${SUITE}"
         ;;
     *)

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -13,7 +13,7 @@ case "$SUITE" in
 esac
 
 case "$SUITE" in
-    cucumber|eslint)
+    cucumber|lint)
         echo "Installing and selecting Node.js version with nvm for suite: $SUITE"
         # shellcheck source=/dev/null
         . "$HOME/.nvm/nvm.sh"

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -19,6 +19,7 @@ case "$SUITE" in
         . "$HOME/.nvm/nvm.sh"
         nvm install
         nvm use
+        nvm alias default "$(cat .nvmrc)"
 
         echo "Node.js version:"
         node --version

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -5,6 +5,14 @@ set -e
 echo "Running script"
 echo "SUITE: ${SUITE}"
 
+# Somehow Travis uses a different version of Node.js even after
+# running install.sh if we don't set up nvm again here.
+
+# shellcheck source=/dev/null
+. "$HOME/.nvm/nvm.sh"
+nvm install
+nvm use
+
 if [ "$SUITE" = "rspec" ]
 then
     bundle exec rspec spec 2>&1

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -31,7 +31,7 @@ then
     (cd client && npm run start-phantomjs) &
     PHANTOMJS=true bundle exec cucumber -ptravis 2>&1
     exit
-elif [ "$SUITE" = "eslint" ]
+elif [ "$SUITE" = "lint" ]
 then
     cd client && npm run lint 2>&1
     exit


### PR DESCRIPTION
This PR enables [stylelint](http://stylelint.io/) for linting CSS code within the `client/` directory.

The setup extends the [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard) configuration with the [suggested additions](https://github.com/stylelint/stylelint-config-standard#suggested-additions).

The `.css` files can be linted by running `npm run stylelint` within the `client/` directory or together with ESLint by running `npm run lint`.