### PR TITLE
Monkey-patch the using_i18n_fallbacks_module? method

### DIFF
--- a/config/initializers/i18n-js.rb
+++ b/config/initializers/i18n-js.rb
@@ -7,23 +7,23 @@
 module I18n
   module JS
 
-    def self.translations
-      all_translations = {}
-      selected_backends = []
+    def self.selected_backends
       current_backend = ::I18n.backend
 
       case current_backend
       when I18n::Backend::Chain
-        current_backend.backends.each do |backend_in_chain|
-          if backend_in_chain.respond_to?(:translations, true)
-            selected_backends << backend_in_chain
-          end
+        current_backend.backends.select do |backend_in_chain|
+          backend_in_chain.respond_to?(:translations, true)
         end
       else
         if current_backend.respond_to?(:translations, true)
-          selected_backends = [current_backend]
+          [current_backend]
         end
       end
+    end
+
+    def self.translations
+      all_translations = {}
 
       selected_backends.each do |selected_backend|
         selected_backend.instance_eval do
@@ -38,5 +38,16 @@ module I18n
       all_translations
     end
 
+    class FallbackLocales
+      def using_i18n_fallbacks_module?
+        I18n::JS.selected_backends.any? do |backend|
+          backend.class.included_modules.include?(I18n::Backend::Fallbacks)
+        end
+      end
+
+      def ensure_valid_locales!(locales)
+        locales.delete_if { |locale| !::I18n.available_locales.include?(locale) }
+      end
+    end
   end
 end

--- a/config/initializers/i18n-js.rb
+++ b/config/initializers/i18n-js.rb
@@ -35,7 +35,7 @@ module I18n
         all_translations.deep_merge!(selected_backend.send(:translations))
       end
 
-      all_translations
+      all_translations.slice(*::I18n.available_locales)
     end
 
     class FallbackLocales

--- a/config/initializers/i18n-js.rb
+++ b/config/initializers/i18n-js.rb
@@ -7,6 +7,12 @@
 module I18n
   module JS
 
+    # Returns a list of backends that are in use and respond to `translations`
+    # method.
+    #
+    # In practice, the SimpleBackend is the only backend that responds to
+    # the `translations` method.
+    #
     def self.selected_backends
       current_backend = ::I18n.backend
 

--- a/config/initializers/i18n-js.rb
+++ b/config/initializers/i18n-js.rb
@@ -50,10 +50,6 @@ module I18n
           backend.class.included_modules.include?(I18n::Backend::Fallbacks)
         end
       end
-
-      def ensure_valid_locales!(locales)
-        locales.delete_if { |locale| !::I18n.available_locales.include?(locale) }
-      end
     end
   end
 end

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,7 +1,68 @@
+# Add fallbacks module to the current backend (which in this point is Simple backend)
 I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
 
+# Configure the available locales
 I18n.available_locales = Sharetribe::AVAILABLE_LOCALES.map { |locale| locale[:ident] }
 
+# Implement a custom Tag implementation.
+#
+# The default I18n::Locale::Tag::Simple implementation splits the locale by dashes
+# and returns an array. For example:
+#
+# I18n.fallbacks["da-DK"] #=> [:"da-DK", :da, :en]
+#
+# This is a problem for us, because we have manually defined what locales are available.
+# We do have "da-DK" locale, but we don't have "da" locale.
+#
+# The I18n::Locale::Tag::DefinedFallbacksOnly is a slightly modified version of Simple
+# implementation. The only difference is that the `to_a` method returns the current
+# tag only (in an array) without splitting it:
+#
+# I18n::Locale::Tag.implementation = I18n::Locale::Tag::DefinedFallbacksOnly
+# I18n.fallbacks["da-DK"] #=> [:"da-DK", :en]
+#
+# Read more:
+#
+# - The Simple implementation: https://github.com/svenfuchs/i18n/blob/aee7b3f6072fba3f54798a280bd6007536b039cd/lib/i18n/locale/tag/simple.rb
+# - RFC 4646 standard compliance: https://github.com/svenfuchs/i18n/wiki/Fallbacks#rfc-4646-standard-compliance
+#
+module I18n
+  module Locale
+    module Tag
+      class DefinedFallbacksOnly
+        class << self
+          def tag(tag)
+            new(tag)
+          end
+        end
+
+        include Parents
+
+        attr_reader :tag
+
+        def initialize(*tag)
+          @tag = tag.join('-').to_sym
+        end
+
+        def to_sym
+          tag
+        end
+
+        def to_s
+          tag.to_s
+        end
+
+        def to_a
+          [tag.to_s]
+        end
+      end
+    end
+  end
+end
+
+I18n::Locale::Tag.implementation = I18n::Locale::Tag::DefinedFallbacksOnly
+
+# Set the fallback mapping
 Sharetribe::AVAILABLE_LOCALES
   .select { |locale| locale[:fallback].present? }
   .each { |locale| I18n.fallbacks.map(locale[:ident] => locale[:fallback]) }

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,5 +1,7 @@
 I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
 
+I18n.available_locales = Sharetribe::AVAILABLE_LOCALES.map { |locale| locale[:ident] }
+
 Sharetribe::AVAILABLE_LOCALES
   .select { |locale| locale[:fallback].present? }
   .each { |locale| I18n.fallbacks.map(locale[:ident] => locale[:fallback]) }

--- a/config/initializers/i18n_backend.rb
+++ b/config/initializers/i18n_backend.rb
@@ -2,7 +2,11 @@ module I18n
   module Backend
 
     # A simple and minimal wrapper to KeyValue store, that allows
-    # storing per community translations
+    # storing per community translations.
+    #
+    # Does NOT include the default Fallbacks module but instead
+    # implements its own fallback logic in `lookup`, which doesn't
+    # rely on the fallback mapping.
     #
     # Usage:
     #
@@ -12,7 +16,6 @@ module I18n
     # `instance` method returns the singleton instance
     #
     class CommunityBackend < KeyValue
-      include Fallbacks
 
       class << self
         attr_accessor(:translation_service_backend_instance)

--- a/spec/i18n/defined_fallbacks_only_tag_spec.rb
+++ b/spec/i18n/defined_fallbacks_only_tag_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+# The I18n::Locale::Tag::Simple is NOT implemented by us. In that
+# sense, this test is useless. It's here to demonstrate the difference
+# between the default implementation and the `DefinedFallbacksOnly`
+# implementation
+describe I18n::Locale::Tag::Simple do
+  it "returns the locale and splitted subparts" do
+    tag_impl = I18n::Locale::Tag::Simple
+    expect(tag_impl.tag("fi-FI-helsinki").self_and_parents.map(&:to_s)).to eq(["fi-FI-helsinki", "fi-FI", "fi"])
+  end
+end
+
+describe I18n::Locale::Tag::DefinedFallbacksOnly do
+  it "returns the locale as is" do
+    tag_impl = I18n::Locale::Tag::DefinedFallbacksOnly
+    expect(tag_impl.tag("fi-FI-helsinki").self_and_parents.map(&:to_s)).to eq(["fi-FI-helsinki"])
+  end
+end


### PR DESCRIPTION
This Pull Request fixes an issue with fallbacks in JS translations. The fallbacks are not currently working. You can verify this by using `fr-CA` locale (Canadian French), which should fallback to `fr` but it falls back to `en`.

- [X] Correctly configure `I18n.available_locales`
- [X] Don't include the `Fallbacks` module to the `CommuityBackend`. It implements its own fallback logic in the `lookup` method
- [X] Add a new `Tag` implementation that returns the locale fallbacks without splitting the locale
- [X] Monkey-patch the `FallbackLocales.using_i18n_fallbacks_module?` so that it returns `true` if any of the backend in the backend chain has `Fallbacks` module included

### using_i18n_fallbacks_module?

We are using a chained I18n backend. Because of this, the `using_i18n_fallbacks_module?` was always returning `false`, because the chain backend doesn't have the `Fallbacks` module, instead, one of the backend in the backed chain may have the `Fallbacks` module included. This monkey-patch changes the method so that instead of asking from the Chain backend if the `Fallbacks` module is included, it iterates the whole chain and returns `true` if any of the backends has `Fallbacks` included.

See more: https://github.com/fnando/i18n-js/issues/406

### I18n::Locale::Tag::DefinedFallbacksOnly

`I18n::Locale::Tag::DefinedFallbacksOnly` is a `Tag` implementation which returns the locale fallbacks without splitting the locale. Here's the difference between this and the default `Simple` implementation:

```ruby
# Simple
tag_impl = I18n::Locale::Tag::Simple
expect(tag_impl.tag("fi-FI-helsinki").self_and_parents.map(&:to_s)).to eq(["fi-FI-helsinki", "fi-FI", "fi"])

# DefinedFallbacksOnly
tag_impl = I18n::Locale::Tag::DefinedFallbacksOnly
expect(tag_impl.tag("fi-FI-helsinki").self_and_parents.map(&:to_s)).to eq(["fi-FI-helsinki"])
```

The problem with the default implementation is that we have locales such as `da-DK`, but we don't have a locale `da`. Thus, the default implementation returns fallback locales that we don't have. Rails doesn't seem to care about this, but the I18nJs gem does.