### PR TITLE
Fix customer analytics custom events

### DIFF
--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -201,8 +201,8 @@ function report_analytics_event(category, action, opt_label) {
   if (typeof _gaq !== 'undefined' && Array.isArray(_gaq)) {
     _gaq.push(['_trackEvent'].concat(params_array));
   }
-  if (typeof ST.customer_report_event === 'function') {
-    ST.customer_report_event(category, action, opt_label);
+  if (typeof ST.customerReportEvent === 'function') {
+    ST.customerReportEvent(category, action, opt_label);
   }
 }
 


### PR DESCRIPTION
An incomplete snake case <-> camel case conversion prevented custom events from being sent to customer GA.

Other end: https://github.com/sharetribe/sharetribe/blob/0b5f4cc02412601615c80042447ae753ce4c1655/app/views/analytics/_customer_analytics.haml#L19