### PR TITLE
Add Storybook deploy script

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -54,6 +54,13 @@ For stylesheets, we are using [CSS Modules](https://github.com/css-modules/css-m
 
 We use [React Storybook](https://github.com/kadirahq/react-storybook) for a hot reloading component development environment, in `http://localhost:9001/`. See [instructions for writing stories](https://github.com/kadirahq/react-storybook#writing-stories), for example story see [OnboardingTopBar.story.js](app/components/OnboardingTopBar/OnboardingTopBar.story.js).
 
+Publishing styleguide for preview
+---------------------------------
+
+Styleguide can be published as a static build, to be used for e.g. reviews by other team members. Running `npm run deploy-storybook` in `client` directory publishes styleguide from your branch to `https://sharetribe.github.io/sharetribe/[BRANCH_NAME]/`.
+
+We're using a [custom fork](https://github.com/mporkola/storybook-deployer) of [Storybook deployer](https://github.com/kadirahq/storybook-deployer), modified to output different branches to different directories. The goal is to get it merged upstream, but it still requires some work.
+
 Linting JavaScript and CSS files
 ================================
 

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "build:dev:server": "webpack -w --config webpack.server.config.js",
     "print-phantomjs-version": "phantomjs --version",
     "start-phantomjs": "phantomjs --webdriver=8910",
-    "styleguide": "start-storybook -p 9001"
+    "styleguide": "start-storybook -p 9001",
+    "deploy-storybook": "storybook-to-ghpages"
   },
   "dependencies": {
     "babel": "6.5.2",
@@ -58,6 +59,7 @@
   },
   "devDependencies": {
     "@kadira/storybook": "1.27.0",
+    "@kadira/storybook-deployer": "github:mporkola/storybook-deployer",
     "babel-eslint": "6.0.4",
     "babel-plugin-react-transform": "2.0.2",
     "body-parser": "1.15.1",


### PR DESCRIPTION
Easily deploy styleguide to Github Pages for review, by running `npm run deploy-storybook` in `client` subdirectory.

Example: http://sharetribe.github.io/sharetribe/topbar-logo/

The deploy script dependency is a fork of the original https://github.com/kadirahq/storybook-deployer, adding support for different branches. I'll make a PR upstream after the script is more suitable for general use.