### PR TITLE
Extend railsContext with marketplaceId

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -471,6 +471,10 @@ class ApplicationController < ActionController::Base
     @minutes_to_maintenance = NextMaintenance.minutes_to(now)
   end
 
+  def current_community_id
+    Maybe(@current_community).id.or_else(nil)
+  end
+
   private
 
   # Override basic instrumentation and provide additional info for lograge to consume

--- a/app/helpers/cache_helper.rb
+++ b/app/helpers/cache_helper.rb
@@ -100,13 +100,15 @@ module CacheHelper
 
     locale = I18n.locale
     bundle_file = asset_path(ReactOnRails.configuration.server_bundle_js_file)
+    rails_context_extension = RailsContextExtension.custom_context(self)
 
     keys = [
       'react_component_cache',
       name,
       props,
       locale,
-      bundle_file
+      bundle_file,
+      rails_context_extension
     ]
 
     # We can skip the digest because we don't care if the .haml template changes.

--- a/client/app/components/OnboardingGuide/GuideCoverPhotoPage.js
+++ b/client/app/components/OnboardingGuide/GuideCoverPhotoPage.js
@@ -41,8 +41,7 @@ const GuideCoverPhotoPage = (props) => {
               target: '_blank',
               rel: 'noreferrer',
               alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),
-            }, t('web.admin.onboarding.guide.cover_photo.advice.link')) }))
-        ,
+            }, t('web.admin.onboarding.guide.cover_photo.advice.link')) })),
         br(),
         t('web.admin.onboarding.guide.cover_photo.advice.content2', { width: COVER_PHOTO_WIDTH, height: COVER_PHOTO_HEIGHT }),
       ]),

--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -1,12 +1,12 @@
-# module RenderingExtension
-#   # Return a Hash that contains custom values from the view context that will get passed to
-#   # all calls to react_component and redux_store for rendering
-#   def self.custom_context(view_context)
-#     {
-#       somethingUseful: view_context.session[:something_useful]
-#     }
-#   end
-# end
+module RailsContextExtension
+  # Return a Hash that contains custom values from the view context that will get passed to
+  # all calls to react_component and redux_store for rendering
+  def self.custom_context(view_context)
+    {
+      marketplaceId: view_context.controller.current_community_id
+    }
+  end
+end
 
 ReactOnRails.configure do |config|
   # Directory where your generated assets go. All generated assets must go to the same directory.
@@ -55,5 +55,5 @@ ReactOnRails.configure do |config|
 
   # This allows you to add additional values to the Rails Context. Implement one static method
   # called `custom_context(view_context)` and return a Hash.
-  # config.rendering_extension = RenderingExtension
+  config.rendering_extension = RailsContextExtension
 end


### PR DESCRIPTION
This Pull Request extends the `railsContext` with `marketplaceId`. It also changes the cache helper so that the extended `railsContext` will invalidate the cache, if needed. In addition, a new module `marketplaceId` is created to encapsulate the id. The module is globally available, so the id is globally available to all components. It's not passed via `props`.

Todo:

- [X] Extend `railsContext` with `marketplaceId`
- [X] Invalidate cache if `railsContext` changes
- [X] Implement `marketplaceId` module.

Review comments wanted:

- `marketplaceId` is now globally available. There's no need to pass it via `props`. Is that ok? It's admittedly less clean: components aren't so "pure" anymore. On the otherhand, it's more convenient: no need to pass it via `props` through the component hierarchy.