### PR TITLE
Remove ampersand from the address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 ## [Unreleased]
 
 ### Fixed
+
 - Fix some React dependency issues caused startup timing/ordering [#2046](https://github.com/sharetribe/sharetribe/pull/2046) and [#2053](https://github.com/sharetribe/sharetribe/pull/2053)
+- Fix issue that caused Google Maps Geocoder to return wrong location if the listing address contained an ampersand (&) [#2075](https://github.com/sharetribe/sharetribe/pull/2075)
 
 ## [5.7.1] - 2016-05-12
 

--- a/app/assets/javascripts/googlemaps.js
+++ b/app/assets/javascripts/googlemaps.js
@@ -149,7 +149,7 @@ function googlemapMarkerInit(canvas,n_prefix,n_textfield,draggable,community_loc
 
 function update_map(field) {
   if (geocoder) {
-    geocoder.geocode({'address':field.value},
+    geocoder.geocode({'address':field.value.replace("&", "")},
       function(response,info) {
         if (info == google.maps.GeocoderStatus.OK){
           marker.setVisible(true);


### PR DESCRIPTION
Removes ampersand (&) from the address that is sent to Google for geocoding.

The ampersand was causing some issues. Apparently, Google splitted the string by the ampersand and didn't use the whole address for geocoding. For example:

1600 Amphitheatre Parkway, Suite I & G, Mountain View, CA

...uses only `G, Mountain View, CA` for the geocoding.

This pull request removes the ampersand and that seems to fix the issue.

Other solutions that I tried:

* I also tried to `encodeURIComponent` the address, but then I didn't get any results.
* In addition, I tried to encode only the & by replacing it with `%26` but the result was that Google tried to use also the number 26 for geocoding.