### PR TITLE
Assets are copied to public/webpack folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ client/node_modules
 !/client/app/i18n/.keep
 /client/app/routes/*
 !/client/app/routes/.keep
+
+# Generated assets
+/public/webpack/*

--- a/client/webpack.client.base.config.js
+++ b/client/webpack.client.base.config.js
@@ -13,10 +13,6 @@ const cssVariables = require('./app/assets/styles/variables');
 const devBuild = process.env.NODE_ENV !== 'production';
 const nodeEnv = devBuild ? 'development' : 'production';
 
-const { replacePercentChar } = require('./webpackConfigUtil');
-const assetHostEnv = typeof process.env.asset_host === 'string' ? `&asset_host=${process.env.asset_host}` : '';
-const assetHost = replacePercentChar(assetHostEnv);
-
 module.exports = {
   context: __dirname,
   entry: {
@@ -59,13 +55,6 @@ module.exports = {
       minChunks: Infinity,
     }),
   ],
-  module: {
-    loaders: [
-      { test: /\.(woff2?|svg)$/, loader: 'url?limit=10000' },
-      { test: /\.(ttf|eot)$/, loader: 'file' },
-      { test: /\.(jpe?g|png|gif|svg|ico)$/, loader: `customfile-loader?limit=10000&name=[name]-[hash].[ext]${assetHost}` },
-    ],
-  },
   postcss: [
     mixins({ mixinsFiles: path.join(__dirname, 'app/assets/styles/mixins.css') }),
     customProperties({ variables: cssVariables }),

--- a/client/webpack.client.config.js
+++ b/client/webpack.client.config.js
@@ -5,12 +5,18 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const config = require('./webpack.client.base.config');
 const devBuild = process.env.NODE_ENV !== 'production';
 
+const { replacePercentChar } = require('./webpackConfigUtil');
+const assetHostEnv = typeof process.env.asset_host === 'string' ? `&asset_host=${process.env.asset_host}` : '';
+const assetHost = replacePercentChar(assetHostEnv);
+
 config.output = {
   filename: '[name]-bundle.js',
   path: '../app/assets/webpack',
   publicPath: '/assets/',
 };
 
+config.module = config.module || {};
+config.module.loaders = config.module.loaders || [];
 config.module.loaders.push(
   {
     test: /\.js$/,
@@ -29,6 +35,18 @@ config.module.loaders.push(
   {
     test: require.resolve('react'),
     loader: 'imports?shim=es5-shim/es5-shim&sham=es5-shim/es5-sham',
+  },
+  {
+    test: /\.(woff2?|svg)$/,
+    loader: 'url?limit=10000',
+  },
+  {
+    test: /\.(ttf|eot)$/,
+    loader: 'file',
+  },
+  {
+    test: /\.(jpe?g|png|gif|svg|ico)$/,
+    loader: `customfile-loader?limit=10000&name=[name]-[hash].[ext]${assetHost}`,
   }
 );
 

--- a/client/webpack.storybook.config.js
+++ b/client/webpack.storybook.config.js
@@ -7,6 +7,8 @@ const config = require('../webpack.client.base.config');
 
 delete config.plugins;
 
+config.module = config.module || {};
+config.module.loaders = config.module.loaders || [];
 config.module.loaders.push(
   {
     test: /\.css$/,
@@ -16,8 +18,21 @@ config.module.loaders.push(
       'postcss-loader',
     ],
     include: path.resolve(__dirname, '../'),
+  },
+  {
+    test: /\.(woff2?|svg)$/,
+    loader: 'url?limit=10000',
+  },
+  {
+    test: /\.(ttf|eot)$/,
+    loader: 'file',
+  },
+  {
+    test: /\.(jpe?g|png|gif|svg|ico)$/,
+    loader: 'customfile-loader?limit=10000&name=[name]-[hash].[ext]&hotMode=true',
   }
 );
+
 config.output = {};
 config.output.publicPath = '/static/';
 


### PR DESCRIPTION
also in Rails + Webpack dev environment.

- small images are converted to data url (nothing changed)
- hotMode defined: (webpack server handles files - i.e. styleguide - we emit the file as before to webpack output directory.)
- asset_host defined: assets are copied to public/webpack and asset_host is used (lines are changed, behaviour stays the same)
- default (Rails is running and serving assets): assets are copied to public/webpack (previously they were copied to webpack output directory)
