### PR TITLE
Render railsContext separately

### DIFF
--- a/app/views/admin/getting_started_guide/index.haml
+++ b/app/views/admin/getting_started_guide/index.haml
@@ -9,5 +9,5 @@
     .col-3
       = render :partial => "admin/left_hand_navigation", :locals => { :links => admin_links_for(@current_community) }
     .col-9
-      - cache ['v1', 'onboarding_guide', props] do
+      - react_component_cache(name: "onboarding_guide", props: props) do
         = react_component("OnboardingGuideApp", props: props)

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -2,6 +2,9 @@
 
 %body
 
+  -# Render railsContext here before any react component gets rendered
+  = prepend_render_rails_context("")
+
   %noscript
     .noscript-padding
       -# Noscript content will be positioned here
@@ -10,7 +13,7 @@
     - with_feature(:onboarding_redesign_v1) do
       - props = onboarding_topbar_props
       - unless props[:next_step] == :all_done
-        - react_component_cache("onboarding_topbar", props) do
+        - react_component_cache(name: "onboarding_topbar", props: props) do
           = react_component("OnboardingTopBar", props: props, prerender: true)
 
   = render partial: 'layouts/global_header', locals: header_props()


### PR DESCRIPTION
This PR fixes an issue with caching that caused outdated data to appear in `railsContext`.

**Steps to reproduce:**

1. Turn on `config.action_controller.perform_caching` in `development.rb`
1. Start `rails s` in development mode
1. Go to homepage (URL /)
1. Go to some other page
1. Open the source code of that page and search for `pathname`

Expected result: Pathname reflects current URL

Actual result: Pathname is "/"

**Reason**

The data for `railsContext` is rendered in the `react_component` call. When `react_component_cache` is added around the `react_component` call, also the `railsContext` will be cached.

Example:

```ruby
- react_component_cache(name: "component", props: props) do
  # The next line will render the `railsContext` and the component
  = react_component("MyComponent")
```

Now if some data in the `railsContext` changes, e.g. `pathname`, the old cached `railsContext` is still rendered.

**How to fix?**

There are few ways to fix the issue:

1. **Include the `railsContext` to the cache key.** This would be bullet-proof solution: the cache would be always invalidated then the data in the `railsContext` changes. However, this would result invalidating the cache even when it's not needed. For example, the Onboarding Topbar is shown in multiple pages and the rendered result doesn't depend on `pathname`, so invalidating the cache always when data in the context changes would result in over invalidation.
2. **Render `railsContext` outside of cache block.** Another option would be to render the `railsContext` data outside the cache block. For example:

  ```ruby
  = prepend_render_rails_context("")

  - react_component_cache(name: "component", props: props) do
    # The next line will render ONLY the component, because the `railsContext` is rendered already
    = react_component("MyComponent")
  ```

  The problem with this solution is that even if the `railsContext` contains now the correct data, the cache is not invalidated if the server rendered view depends on the data in `railsContext`.
3. **Render `railsContext` outside of cache block and pass list of `railsContext` keys to the `react_component_cache`**: This solution is same as previous solution, but fixes the issue of not invalidation the cache by adding a list of keys that should invalidate the cache, if the data in the `railsContext` changes.

  ```ruby
  = prepend_render_rails_context("")

  -# If the server rendered part of the component depends on "pathname", pass it to the cache function
  - react_component_cache(name: "component", props: props, rails_context_keys: [:pathname]) do
    # The next line will render ONLY the component, because the `railsContext` is rendered already
    = react_component("MyComponent")
  ```

This PR implements the strategy 3.

Additional reading:

- [rails_context implementation](https://github.com/shakacode/react_on_rails/blob/7adc8663dd84f6e350097bf7d0e8d685f88101e7/app/helpers/react_on_rails_helper.rb#L344)
- [prepend_render_rails_context implementation](https://github.com/shakacode/react_on_rails/blob/7adc8663dd84f6e350097bf7d0e8d685f88101e7/app/helpers/react_on_rails_helper.rb#L226)