### PR TITLE
Show branding info in transaction emails

### DIFF
--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -258,6 +258,7 @@ class TransactionMailer < ActionMailer::Base
     @current_community = community
     @recipient = recipient
     @url_params = build_url_params(community, recipient)
+    @show_branding_info = !PlanService::API::Api.plans.get_current(community_id: community.id).data[:features][:whitelabel]
   end
 
   def mail_params(recipient, community, subject)


### PR DESCRIPTION
Some of the transactional emails such as payment receipts are set up differently from the rest. This causes `@show_branding_info` to be nil and inconsistency in the emails.

This pull request sets up the `@show_branding_info` properly for those emails.