### PR TITLE
Marketplace resolver

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,3 @@
-# Yes, we know this is too long class
-# rubocop:disable ClassLength
-
 require 'will_paginate/array'
 
 class ApplicationController < ActionController::Base

--- a/app/controllers/braintree_webhooks_controller.rb
+++ b/app/controllers/braintree_webhooks_controller.rb
@@ -77,7 +77,7 @@ class BraintreeWebhooksController < ApplicationController
 
   # This method overrides the default behaviour defined in ApplicationController
   # Instead of taking the ident/domain from the URL host part, take it from the community_id parameter
-  def community_identifiers
-    {id: params[:community_id]}
+  def resolve_community
+    CurrentMarketplaceResolver.resolve_from_id(params[:community_id])
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -35,12 +35,7 @@ class ErrorsController < ActionController::Base
   private
 
   def current_community
-    @current_community ||= ApplicationController.find_community(community_identifiers)
-  end
-
-  def community_identifiers
-    app_domain = URLUtils.strip_port_from_host(APP_CONFIG.domain)
-    ApplicationController.parse_community_identifiers_from_host(request.host, app_domain)
+    @current_community ||= CurrentMarketplaceResolver.resolve_from_host(request.host, URLUtils.strip_port_from_host(APP_CONFIG.domain))
   end
 
   def title(status)

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -587,29 +587,6 @@ class Community < ActiveRecord::Base
     favicon.processing?
   end
 
-  # Finds a community by the given identifier(s)
-  #
-  # Communities have 3 values that can used individually to
-  # uniquely identify a community.
-  #
-  # Those are (in the order of priority):
-  #
-  # - id
-  # - ident
-  # - domain
-  #
-  def self.find_by_identifier(identifiers)
-    priority = [:id, :ident, :domain]
-
-    identifier_to_use = priority.find { |identifier| identifiers[identifier].present? }
-
-    if identifier_to_use.nil?
-      nil
-    else
-      Community.where({ identifier_to_use => identifiers[identifier_to_use]}).first
-    end
-  end
-
   private
 
   def initialize_settings

--- a/app/utils/current_marketplace_resolver.rb
+++ b/app/utils/current_marketplace_resolver.rb
@@ -1,0 +1,38 @@
+module CurrentMarketplaceResolver
+
+  module_function
+
+  def resolve_from_host(host, app_domain)
+    sole_community_or do
+      ident = ident_from_host(host, app_domain)
+      Community.find_by(ident: ident) || Community.find_by(domain: host)
+    end
+  end
+
+  def resolve_from_id(id)
+    sole_community_or do
+      Community.find_by(id: id)
+    end
+  end
+
+  # private
+
+  def sole_community_or(&block)
+    if Community.count == 1
+      Community.first
+    else
+      block.call
+    end
+  end
+
+  def ident_from_host(host, app_domain)
+    ident_with_www = /^www\.(.+)\.#{app_domain}$/.match(host)
+    ident_without_www = /^(.+)\.#{app_domain}$/.match(host)
+
+    if ident_with_www
+      ident_with_www[1]
+    elsif ident_without_www
+      ident_without_www[1]
+    end
+  end
+end

--- a/lib/mercury/authentication.rb
+++ b/lib/mercury/authentication.rb
@@ -3,14 +3,8 @@ module Mercury
 
     def can_edit?
       @current_user = current_person
-      @current_community = ApplicationController.find_community(community_identifiers)
+      @current_community = CurrentMarketplaceResolver.resolve_from_host(request.host, URLUtils.strip_port_from_host(APP_CONFIG.domain))
       @current_user && @current_community && @current_user.has_admin_rights?
     end
-
-    def community_identifiers
-      app_domain = URLUtils.strip_port_from_host(APP_CONFIG.domain)
-      ApplicationController.parse_community_identifiers_from_host(request.host, app_domain)
-    end
-
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -128,18 +128,4 @@ describe ApplicationController, type: :controller do
       expect(ApplicationController.fetch_temp_flags(false, params, session)).to eq [].to_set
     end
   end
-
-  describe "#parse_community_identifiers_from_request" do
-    it "parses ident from host" do
-      expect(ApplicationController.parse_community_identifiers_from_host("market.sharetribe.com", "sharetribe.com")).to eq({ident: "market"})
-    end
-
-    it "parses ident (with www) from host" do
-      expect(ApplicationController.parse_community_identifiers_from_host("www.market.sharetribe.com", "sharetribe.com")).to eq({ident: "market"})
-    end
-
-    it "parses domain from host" do
-      expect(ApplicationController.parse_community_identifiers_from_host("www.market.com", "sharetribe.com")).to eq({domain: "www.market.com"})
-    end
-  end
 end

--- a/spec/utils/current_marketplace_resolver_spec.rb
+++ b/spec/utils/current_marketplace_resolver_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe CurrentMarketplaceResolver do
+
+  describe "#resolve_from_host" do
+
+    it "returns community by ident" do
+      foo = FactoryGirl.create(:community, ident: "foo")
+      bar = FactoryGirl.create(:community, ident: "bar")
+
+      expect(CurrentMarketplaceResolver.resolve_from_host("foo.sharetribe.com", "sharetribe.com"))
+        .to eq(foo)
+      expect(CurrentMarketplaceResolver.resolve_from_host("bar.sharetribe.com", "sharetribe.com"))
+        .to eq(bar)
+      expect(CurrentMarketplaceResolver.resolve_from_host("foobar.sharetribe.com", "sharetribe.com"))
+        .to eq(nil)
+    end
+
+    it "returns community by domain" do
+      foo = FactoryGirl.create(:community, domain: "foo.com")
+      bar = FactoryGirl.create(:community, domain: "bar.com")
+
+      expect(CurrentMarketplaceResolver.resolve_from_host("foo.com", "sharetribe.com"))
+        .to eq(foo)
+      expect(CurrentMarketplaceResolver.resolve_from_host("bar.com", "sharetribe.com"))
+        .to eq(bar)
+      expect(CurrentMarketplaceResolver.resolve_from_host("foobar.com", "sharetribe.com"))
+        .to eq(nil)
+    end
+  end
+
+  describe "#resolve_from_id" do
+
+    it "returns community by id" do
+      foo = FactoryGirl.create(:community, id: 111)
+      bar = FactoryGirl.create(:community, id: 222)
+
+      expect(CurrentMarketplaceResolver.resolve_from_id(222))
+        .to eq(bar)
+    end
+  end
+end


### PR DESCRIPTION
This PR extracts the logic for finding current marketplace in a new module, `MarketplaceResolver`. In the future, if we decide to do dynamic routing, which requires us to fetch the marketplace in the Rack middleware, this module can be used there.\

Needs testing:

- [x] Braintree
- [ ] Mercury editor
- [x] Errors controller