### PR TITLE
Fix input styles leaking to global scope

### DIFF
--- a/client/app/components/SearchBar/SearchBar.css
+++ b/client/app/components/SearchBar/SearchBar.css
@@ -44,6 +44,16 @@
 
   -webkit-font-smoothing: antialiased;
 
+  &:only-of-type {
+    width: 100%;
+    padding: 0;
+    margin-right: var(--SearchBar_inputButtonMargin);
+
+    &:focus {
+      width: 100%;
+    }
+  }
+
   &::placeholder {
     color: var(--SearchBar_textColor);
     transition: color 0.1s ease-in;
@@ -89,16 +99,6 @@
 
 .locationInput {
   width: calc(100% - var(--SearchBar_keywordInputWidth));
-}
-
-input:only-of-type {
-  width: 100%;
-  padding: 0;
-  margin-right: var(--SearchBar_inputButtonMargin);
-
-  &:focus {
-    width: 100%;
-  }
 }
 
 /* Additional separating styles are added only when the two inputs are


### PR DESCRIPTION
CSS modules change class selectors to something unique, but element selectors stay intact and in the global scope (if not nested within another selector).

The input styles from PR #2069 leaked to the global scope, breaking search filters. This fixes the problem by scoping the selector in the proper place.

Tested in staging.