### PR TITLE
SearchBar location autocompletion

### DIFF
--- a/client/.storybook/head.html
+++ b/client/.storybook/head.html
@@ -1,1 +1,2 @@
 <script>window.I18n = {};</script>
+<script src="https://maps.googleapis.com/maps/api/js?libraries=places"></script>

--- a/client/app/components/composites/SearchBar/SearchBar.css
+++ b/client/app/components/composites/SearchBar/SearchBar.css
@@ -1,3 +1,29 @@
+/* The Google Maps Places Autocomplete dropdown box is added in the
+   end of the document body, and we must scope the global style
+   overrides within a class generated from the SearchBar component.
+
+   Classes available for customization can be seen at:
+
+   https://developers.google.com/maps/documentation/javascript/places-autocomplete#style_autocomplete
+*/
+.topLevelBody {
+  /* stylelint-disable selector-class-pattern */
+  & :global(.pac-container[style]) {
+    /* Generated autocompletion has inline styles, thus the ugly override.
+       See: https://css-tricks.com/override-inline-styles-with-css/ */
+    width: 20em !important;
+    margin-top: 10px;
+  }
+
+  & :global(.pac-item) {
+    line-height: 40px;
+  }
+  & :global(.pac-icon) {
+    margin-top: 10px;
+  }
+  /* stylelint-enable selector-class-pattern */
+}
+
 .root {
   display: inline-flex;
   width: 28.3em;

--- a/client/app/components/composites/SearchBar/SearchBar.js
+++ b/client/app/components/composites/SearchBar/SearchBar.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-set-state */
+
 import { Component, PropTypes } from 'react';
 import { form, input, button, span } from 'r-dom';
 
@@ -13,16 +15,139 @@ const SEARCH_MODES = [
   SEARCH_MODE_KEYWORD_AND_LOCATION,
 ];
 
+const coordinates = (place) => {
+  if (place && place.geometry) {
+    return place.geometry.location.toUrlValue();
+  }
+  return null;
+};
+
+const getDetails = (placeId) => new Promise((resolve, reject) => {
+  const serviceStatus = window.google.maps.places.PlacesServiceStatus;
+  const div = document.createElement('div');
+  const service = new window.google.maps.places.PlacesService(div);
+
+  service.getDetails({ placeId }, (place, status) => {
+    if (status !== serviceStatus.OK) {
+      reject(new Error(`Could not get details for place id "${placeId}"`));
+    } else {
+      resolve(place);
+    }
+  });
+});
+
+const getPrediction = (location) => new Promise((resolve, reject) => {
+  const serviceStatus = window.google.maps.places.PlacesServiceStatus;
+  const service = new window.google.maps.places.AutocompleteService();
+
+  service.getPlacePredictions({ input: location }, (predictions, status) => {
+    if (status !== serviceStatus.OK) {
+      reject(new Error(`Prediction service status not OK: ${status}`));
+    } else if (predictions.length === 0) {
+      reject(new Error(`No predictions found for location "${location}"`));
+    } else {
+      resolve(getDetails(predictions[0].place_id));
+    }
+  });
+});
+
 class SearchBar extends Component {
   constructor(props) {
     super(props);
 
-    // The values of the inputs are synced to the component state
-    // until the form is submitted.
-    this.state = {
-      keyword: '',
-      location: '',
-    };
+    // Bind `this` within methods
+    this.handleSubmit = this.handleSubmit.bind(this);
+
+    this.state = { selectedPlace: null };
+  }
+  componentDidMount() {
+    document.body.classList.add(css.topLevelBody);
+    if (!this.locationInput) {
+      return;
+    }
+    const bounds = { north: -90, east: -180, south: 90, west: 180 };
+    const autocomplete = new window.google.maps.places.Autocomplete(this.locationInput, { bounds });
+    autocomplete.setTypes(['geocode']);
+    this.placeChangedListener = window.google.maps.event.addListener(
+      autocomplete,
+      'place_changed',
+      () => this.setState({ selectedPlace: autocomplete.getPlace() })
+    );
+  }
+  componentWillUnmount() {
+    document.body.classList.remove(css.topLevelBody);
+
+    if (this.placeChangedListener) {
+      this.placeChangedListener.remove();
+    }
+
+    // Clean up the generated autocompletion UI. Assumes there is only one.
+    const container = document.body.querySelector('.pac-container');
+
+    if (container) {
+      document.body.removeChild(container);
+    }
+  }
+  handleSubmit() {
+    if (!this.keywordInput && !this.locationInput) {
+      throw new Error('No input refs saved to submit SearchBar form');
+    }
+
+    const keywordValueStr = this.keywordInput ? this.keywordInput.value.trim() : '';
+    const locationValueStr = this.locationInput ? this.locationInput.value.trim() : '';
+
+    if ((keywordValueStr + locationValueStr).length === 0) {
+      // Skip submit when all inputs are empty
+      return;
+    }
+
+    const onSubmit = this.props.onSubmit;
+
+    if (!this.locationInput) {
+      // Only keyword input, submitting current input value
+      onSubmit({
+        keyword: keywordValueStr,
+        location: null,
+        coordinates: null,
+      });
+      return;
+    }
+
+    const keywordValue = this.keywordInput ? this.keywordInput.value : null;
+    const coords = coordinates(this.state.selectedPlace);
+
+    if (coords) {
+      // Place already selected, submitting selected value
+      onSubmit({
+        keyword: keywordValue,
+        location: locationValueStr,
+        coordinates: coords,
+      });
+    } else if (locationValueStr) {
+      // Predict location from the typed value
+      getPrediction(locationValueStr)
+        .then((place) => {
+          const predictedCoords = coordinates(place);
+          if (!predictedCoords) {
+            throw new Error(`Could not get coordinates from place predicted from location "${locationValueStr}"`);
+          }
+          onSubmit({
+            keyword: keywordValue,
+            location: locationValueStr,
+            coordinates: predictedCoords,
+          });
+        })
+        .catch((e) => {
+          console.error('failed to predict location:', e); // eslint-disable-line no-console
+        });
+    } else if (this.keywordInput) {
+      // Only keyword value present, submit that
+      onSubmit({
+        keyword: keywordValue,
+        location: '',
+        coords: null,
+      });
+    }
   }
   render() {
     const { mode, keywordPlaceholder, locationPlaceholder } = this.props;
@@ -31,14 +156,24 @@ class SearchBar extends Component {
       type: 'search',
       className: css.keywordInput,
       placeholder: keywordPlaceholder,
-      onChange: (e) => this.setState({ keyword: e.target.value }), // eslint-disable-line react/no-set-state
+      ref: (c) => {
+        this.keywordInput = c;
+      },
     });
     const locationInput = input({
       type: 'search',
       className: css.locationInput,
       placeholder: locationPlaceholder,
       autoComplete: 'off',
-      onChange: (e) => this.setState({ location: e.target.value }), // eslint-disable-line react/no-set-state
+
+      // When the user edits the selected location value, the fetched
+      // place object is not up to date anymore and has to be cleared.
+      onChange: () => this.setState({ selectedPlace: null }),
+
+      ref: (c) => {
+        this.locationInput = c;
+      },
+
     });
 
     const hasKeywordInput = mode === SEARCH_MODE_KEYWORD || mode === SEARCH_MODE_KEYWORD_AND_LOCATION;
@@ -48,7 +183,7 @@ class SearchBar extends Component {
       classSet: { [css.root]: true },
       onSubmit: (e) => {
         e.preventDefault();
-        this.props.onSubmit(this.state);
+        this.handleSubmit();
       },
     }, [
       hasKeywordInput ? keywordInput : null,


### PR DESCRIPTION
Add Google Maps location autocompletion to the `SearchBar` React component. The selected location comes as coordinates in the `onSubmit` callback value.

## Example 1: Selecting a location and submitting form

After selecting location:

<img width="400" alt="screen shot 2016-06-13 at 15 18 26" src="https://cloud.githubusercontent.com/assets/53923/16007264/20a8227c-317a-11e6-8dd8-7a8484508c82.png">

`onSubmit` yields

```javascript
{
  keyword: null,
  location: "Hellevoetsluis, Netherlands",
  coordinates: "51.831863,4.13181"
}
```

## Example 2: Submitting form without selecting location

<img width="402" alt="screen shot 2016-06-13 at 15 15 42" src="https://cloud.githubusercontent.com/assets/53923/16007207/bb5e0d1e-3179-11e6-84be-f9091b856614.png">

`onSubmit` yields

```javascript
{
  keyword: null,
  location: "hell",
  coordinates: "60.167215,24.965187" // first place predicted from the "hell" query
}
```

## Example 3: keyword only

<img width="401" alt="screen shot 2016-06-13 at 15 20 13" src="https://cloud.githubusercontent.com/assets/53923/16007320/662e646e-317a-11e6-80dd-c15cedde60a2.png">

`onSubmit` yields

```javascript
{
  keyword: "bicycle",
  location: "",
  coords: null
}
```

The `onSubmit` is **not** called if all the inputs are empty.

## Styleguide

See the [interactive component](https://sharetribe.github.io/sharetribe/topbar-location-autocomplete/?selectedKind=Top%20bar&selectedStory=With%20location%20search) in the Styleguide.
