### PR TITLE
Babel-polyfill somehow breaks build, use es6-object-assign instead

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
     "classnames": "2.2.5",
     "css-loader": "0.23.1",
     "es5-shim": "4.5.8",
+    "es6-object-assign": "1.0.2",
     "es6-promise": "3.2.1",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",

--- a/client/webpack.server.config.js
+++ b/client/webpack.server.config.js
@@ -14,7 +14,7 @@ const assetHost = replacePercentChar(assetHostEnv);
 module.exports = {
   context: __dirname,
   entry: [
-    'babel-polyfill',
+    'es6-object-assign',
     './app/startup/serverRegistration',
   ],
   output: {


### PR DESCRIPTION
Needs further investigation, but at least deployment works now