### PR TITLE
Add custom media queries for fixed breakpoints

### DIFF
--- a/client/app/assets/styles/media-queries.js
+++ b/client/app/assets/styles/media-queries.js
@@ -1,0 +1,13 @@
+/* eslint-env node */
+const variables = require('./variables');
+
+const medium = variables['--breakpointMedium'];
+const large = variables['--breakpointLarge'];
+
+module.exports = {
+
+  // Variable expansion from the generated media queries doesn't work,
+  // so we must add those manually to the output.
+  '--medium-viewport': `(min-width: ${medium})`,
+  '--large-viewport': `(min-width: ${large})`,
+};

--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -1,6 +1,32 @@
 /* eslint-env node */
 
 module.exports = {
+
+  /*
+   By default content based media queries should be used for
+   responsiveness. However, some designs are based on certain fixed
+   breakpoints.
+
+   These breakpoints should not be used straight from variables. Use
+   them with the custom media queries defined in media-queries.js.
+
+   Example:
+
+   .container {
+     font-size: 2rem;
+
+     @media (--medium-viewport) {
+       font-size: 1.6rem;
+     }
+
+     @media (--large-viewport) {
+       font-size: 1.4rem;
+     }
+   }
+   */
+  '--breakpointMedium': '601px',
+  '--breakpointLarge': '1024px',
+
   '--fontSizeSmall': '0.875rem',
   '--fontSize': '1rem',
   '--fontSizeBig': '1.125rem',

--- a/client/webpack.client.base.config.js
+++ b/client/webpack.client.base.config.js
@@ -9,6 +9,8 @@ const cssnext = require('postcss-cssnext');
 const mixins = require('postcss-mixins');
 const customProperties = require('postcss-custom-properties');
 const cssVariables = require('./app/assets/styles/variables');
+const customMedia = require('postcss-custom-media');
+const mediaQueries = require('./app/assets/styles/media-queries');
 
 const devBuild = process.env.NODE_ENV !== 'production';
 const nodeEnv = devBuild ? 'development' : 'production';
@@ -57,6 +59,7 @@ module.exports = {
   ],
   postcss: [
     mixins({ mixinsFiles: path.join(__dirname, 'app/assets/styles/mixins.css') }),
+    customMedia({ extensions: mediaQueries }),
     customProperties({ variables: cssVariables }),
     cssnext({ browsers: ['last 2 versions', 'not ie < 11', 'not ie_mob < 11', 'ie >= 11'] }),
   ],


### PR DESCRIPTION
By default content based media queries should be used for responsiveness. However, some designs are based on certain fixed breakpoints.

These breakpoints should not be used straight from variables. Use them with the custom media queries defined in media-queries.js.

Example:

```css
.container {
  font-size: 2rem;

  @media (--medium-viewport) {
    font-size: 1.6rem;
  }

  @media (--large-viewport) {
    font-size: 1.4rem;
  }
}
```