### PR TITLE
Landing page fixes

### DIFF
--- a/app/assets/stylesheets/landing_page/development.scss
+++ b/app/assets/stylesheets/landing_page/development.scss
@@ -1,0 +1,7 @@
+
+// Enabled this to see all the click areas
+/*
+a {
+  outline: 1px solid red;
+}
+*/

--- a/app/assets/stylesheets/landing_page/mixins/_all.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_all.scss
@@ -1,2 +1,3 @@
 @import "breakpoints";
 @import "prefixes";
+@import "flex-shrink-fix";

--- a/app/assets/stylesheets/landing_page/mixins/_all.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_all.scss
@@ -1,1 +1,2 @@
 @import "breakpoints";
+@import "prefixes";

--- a/app/assets/stylesheets/landing_page/mixins/_flex-shrink-fix.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_flex-shrink-fix.scss
@@ -1,0 +1,10 @@
+// See https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
+
+@mixin enable-flex-shrink-fix {
+  @include prefix-prop(flex-shrink, 0);
+}
+
+
+@mixin disable-flex-shrink-fix {
+  @include prefix-prop(flex-shrink, 1);
+}

--- a/app/assets/stylesheets/landing_page/mixins/_prefixes.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_prefixes.scss
@@ -1,0 +1,24 @@
+/// Mixin to prefix a property
+/// @author Hugo Giraudel
+/// @param {String} $property - Property name
+/// @param {*} $value - Property value
+@mixin prefix-prop($property, $value) {
+  $prefixes: webkit moz ms o;
+
+  @each $prefix in $prefixes {
+    #{'-' + $prefix + '-' + $property}: $value;
+  }
+
+  // Output standard non-prefixed declaration
+  #{$property}: $value;
+}
+
+@mixin prefix-val($property, $value) {
+  $prefixes: webkit moz ms o;
+  @each $prefix in $prefixes {
+    #{$property}: #{'-' + $prefix + '-' + $value};
+  }
+
+  // Output standard non-prefixed declaration
+  #{$property}: $value;
+}

--- a/app/assets/stylesheets/landing_page/reset.scss
+++ b/app/assets/stylesheets/landing_page/reset.scss
@@ -26,9 +26,3 @@ a {
 hr {
   margin: 0;
 }
-
-* {
-  // See https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
-  @include prefix-prop(flex-shrink, 0);
-  @include prefix-prop(flex-basis, auto);
-}

--- a/app/assets/stylesheets/landing_page/reset.scss
+++ b/app/assets/stylesheets/landing_page/reset.scss
@@ -1,3 +1,5 @@
+@import "./mixins/all";
+
 /* ************************************************************************************ */
 /* Own resets                                                                           */
 /* ************************************************************************************ */
@@ -23,4 +25,10 @@ a {
 
 hr {
   margin: 0;
+}
+
+* {
+  // See https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored
+  @include prefix-prop(flex-shrink, 0);
+  @include prefix-prop(flex-basis, auto);
 }

--- a/app/assets/stylesheets/landing_page/sections/footer.scss
+++ b/app/assets/stylesheets/landing_page/sections/footer.scss
@@ -54,7 +54,7 @@ $footer__clickarea-y-padding-mobile: 12px;
   }
 }
 
-.footer__links-container--no-social {
+.footer__links-container--center {
   @extend .footer__links-container;
   @include prefix-prop(justify-content, center);
 }

--- a/app/assets/stylesheets/landing_page/sections/footer.scss
+++ b/app/assets/stylesheets/landing_page/sections/footer.scss
@@ -28,19 +28,27 @@
   }
 }
 
+$footer__clickarea-y-padding-desktop: 16px;
+$footer__clickarea-y-padding-tablet: 12px;
+$footer__clickarea-y-padding-mobile: 12px;
+
 .footer__links-container {
   @include prefix-val(display, flex);
   @include prefix-prop(justify-content, space-between);
   @include prefix-prop(flex-direction, column-reverse);
 
-  margin-bottom: 18px;
+  /* mobile */
+  @include prefix-prop(align-items, center);
+  margin-bottom: 24px - $footer__clickarea-y-padding-mobile;
 
   @media #{$tablet}  {
-    margin-bottom: 18px;
+    @include prefix-prop(align-items, center);
+    margin-bottom: 30px - $footer__clickarea-y-padding-tablet;
   }
 
   @media #{$desktop} {
-    margin-bottom: 48px;
+    @include prefix-prop(align-items, baseline);
+    margin-bottom: 48px - $footer__clickarea-y-padding-desktop;
     @include prefix-prop(flex-direction, row);
     max-width: 1140px + (2 * 24px);
   }
@@ -95,26 +103,25 @@ $footer__link-margin-tablet: 16px;
     }
   }
 
+  margin: 0;
+
   // mobile
   font-size: 13px;
   letter-spacing: 0px;
-
-  margin: 0 $footer__link-margin-mobile;
-  margin-bottom: 12px;
+  padding: $footer__clickarea-y-padding-mobile $footer__link-margin-mobile;
 
   @media #{$tablet} {
     font-size: 16px;
     letter-spacing: 0px;
 
-    margin: 0px $footer__link-margin-tablet;
-    margin-bottom: 12px;
+    padding: $footer__clickarea-y-padding-tablet $footer__link-margin-tablet;
   }
 
   @media #{$desktop} {
     font-size: 16px;
     letter-spacing: 0px;
 
-    margin: 0px $footer__link-margin-tablet;
+    padding: $footer__clickarea-y-padding-desktop $footer__link-margin-tablet;
   }
 }
 
@@ -179,14 +186,8 @@ $footer__social-media-margin: 18px;
   }
 }
 
-.footer__social-media-icon {
-  // The color is defined in footer.erb partial
-  margin: 0 $footer__social-media-margin;
-  margin-bottom: 12px;
-
-  @media #{$desktop} {
-    margin-bottom: 0;
-  }
+.footer__social-media-link {
+  padding: $footer__clickarea-y-padding-desktop $footer__social-media-margin;
 }
 
 .footer__facebook-icon {

--- a/app/assets/stylesheets/landing_page/sections/footer.scss
+++ b/app/assets/stylesheets/landing_page/sections/footer.scss
@@ -46,6 +46,11 @@
   }
 }
 
+.footer__links-container--no-social {
+  @extend .footer__links-container;
+  @include prefix-prop(justify-content, center);
+}
+
 $footer__link-margin-mobile: 12px;
 $footer__link-margin-tablet: 16px;
 

--- a/app/assets/stylesheets/landing_page/sections/footer.scss
+++ b/app/assets/stylesheets/landing_page/sections/footer.scss
@@ -12,9 +12,9 @@
   min-height: 279px;
   margin: 0 auto;
 
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
+  @include prefix-val(display, flex);
+  @include prefix-prop(justify-content, center);
+  @include prefix-prop(flex-direction, column);
 
   padding: 36px;
 
@@ -29,10 +29,11 @@
 }
 
 .footer__links-container {
-  display: flex;
-  justify-content: space-between;
+  @include prefix-val(display, flex);
+  @include prefix-prop(justify-content, space-between);
+  @include prefix-prop(flex-direction, column-reverse);
+
   margin-bottom: 18px;
-  flex-direction: column-reverse;
 
   @media #{$tablet}  {
     margin-bottom: 18px;
@@ -40,7 +41,7 @@
 
   @media #{$desktop} {
     margin-bottom: 48px;
-    flex-direction: row;
+    @include prefix-prop(flex-direction, row);
     max-width: 1140px + (2 * 24px);
   }
 }

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -91,6 +91,7 @@
 
 .hero__search-bar {
   @include prefix-val(display, flex);
+  @include prefix-prop(flex-shrink, 1);
   margin: 0 auto;
   max-width: 532px;
 }
@@ -157,7 +158,7 @@
   padding: 0;
   border-radius: 0px 29.5px 29.5px 0px;
 
-  padding: 14px 28px;
+  padding: 14px 32px 14px 28px;
 
   line-height: 32px;
 

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -127,6 +127,8 @@
   color: #525961;
 
   &:focus {
+    // The input element has already the blinking cursor
+    // indicating that the element is selected
     outline: none;
   }
 
@@ -167,6 +169,8 @@
   color: #FFFFFF;
   letter-spacing: 0px;
 
+  // Hover color is used to indicate tab focus.
+  // The hover color is set in the layout
   outline: none;
 
   @include enable-flex-shrink-fix;

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -169,6 +169,8 @@
 
   outline: none;
 
+  @include enable-flex-shrink-fix;
+
   /* mobile */
   display: none;
 
@@ -205,6 +207,8 @@
 
 
 .hero__search-icon {
+  @include enable-flex-shrink-fix;
+
   background: #FFF;
 
   /* mobile */

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -9,8 +9,8 @@
   min-height: 80vh;
   background-size: cover;
   background-position: center;
-  display: flex;
-  align-items: center;
+  @include prefix-val(display, flex);
+  @include prefix-prop(align-items, center);
   box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.5); /* is there any cleaner way? */
 }
 
@@ -90,13 +90,13 @@
 }
 
 .hero__search-bar {
-  display: flex;
+  @include prefix-val(display, flex);
   margin: 0 auto;
   max-width: 532px;
 }
 
 .hero__search-input-container {
-  display: flex;
+  @include prefix-val(display, flex);
   width: 100%;
   background-color: #FFF;
 
@@ -104,17 +104,17 @@
   overflow: hidden; // add overflow hidden so that children's borders are also rounded
 
   /* mobile */
-  flex-direction: row-reverse;
+  @include prefix-prop(flex-direction, row-reverse);
   padding: 0px 0px 0px 24px;
 
   @media #{$tablet} {
     border-radius: 29.5px 0px 0px 29.5px;
-    flex-direction: row;
+    @include prefix-prop(flex-direction, row);
   }
 
   @media #{$desktop} {
     border-radius: 29.5px 0px 0px 29.5px;
-    flex-direction: row;
+    @include prefix-prop(flex-direction, row);
   }
 }
 

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -167,6 +167,8 @@
   color: #FFFFFF;
   letter-spacing: 0px;
 
+  outline: none;
+
   /* mobile */
   display: none;
 

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -179,6 +179,10 @@
   @media #{$desktop} {
     display: block;
   }
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .hero__search-icon-svg {

--- a/app/assets/stylesheets/landing_page/styles.scss
+++ b/app/assets/stylesheets/landing_page/styles.scss
@@ -1,3 +1,4 @@
 //= require ./normalize
 //= require ./reset
 //= require_tree ./sections
+//= require ./development

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -54,6 +54,8 @@ class LandingPageController < ActionController::Metal
   private
 
   def denormalizer(cid, locale, sitename)
+    return @_denormalizer if @_denormalizer
+
     # Application paths
     paths = { "search" => "/", # FIXME. Remove hardcoded URL. Add search path here when we get one
               "signup" => sign_up_path,
@@ -63,7 +65,7 @@ class LandingPageController < ActionController::Metal
 
     marketplace_data = CLP::MarketplaceDataStore.marketplace_data(cid, locale)
 
-    CLP::Denormalizer.new(
+    @_denormalizer = CLP::Denormalizer.new(
       link_resolvers: {
         "path" => CLP::LinkResolver::PathResolver.new(paths),
         "marketplace_data" => CLP::LinkResolver::MarketplaceDataResolver.new(marketplace_data),
@@ -71,6 +73,8 @@ class LandingPageController < ActionController::Metal
         "translation" => CLP::LinkResolver::TranslationResolver.new(locale)
       }
     )
+
+    @_denormalizer
   end
 
   def parse_int(int_str_or_nil)
@@ -93,7 +97,8 @@ class LandingPageController < ActionController::Metal
                      javascripts: {
                        location_search: location_search_js
                      },
-                     sections: denormalizer(cid, locale, sitename).to_tree(structure) }
+                     settings: denormalizer(cid, locale, sitename).to_tree(structure, root: "settings"),
+                     sections: denormalizer(cid, locale, sitename).to_tree(structure, root: "composition") }
   end
 
   def render_not_found(msg = "Not found")
@@ -107,7 +112,8 @@ class LandingPageController < ActionController::Metal
   "settings": {
     "marketplace_id": 9999,
     "locale": "en",
-    "sitename": "turbobikes"
+    "sitename": "turbobikes",
+    "marketplace_name": {"type": "marketplace_data", "id": "name"}
   },
 
   "sections": [

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -175,7 +175,7 @@ JSON
   end
 
   def landing_page_styles
-    Rails.application.assets.find_asset("landing_page/styles.scss").to_s
+    Rails.application.assets.find_asset("landing_page/styles.scss").to_s.html_safe
   end
 
   def location_search_js

--- a/app/services/custom_landing_page/denormalizer.rb
+++ b/app/services/custom_landing_page/denormalizer.rb
@@ -1,13 +1,12 @@
 module CustomLandingPage
   class Denormalizer
 
-    def initialize(root: "composition", link_resolvers: {})
-      @root = root
+    def initialize(link_resolvers: {})
       @link_resolvers = link_resolvers
     end
 
-    def to_tree(normalized_data)
-      root = normalized_data[@root]
+    def to_tree(normalized_data, root:)
+      root = normalized_data[root]
 
       deep_map(root) { |k, v|
         case v

--- a/app/services/custom_landing_page/marketplace_data_store.rb
+++ b/app/services/custom_landing_page/marketplace_data_store.rb
@@ -18,6 +18,8 @@ module CustomLandingPage
                            .pluck(:name, :slogan, :description, :search_placeholder)
                            .first
 
+      search_placeholder ||= I18n.t("landing_page.hero.search_placeholder", locale: locale)
+
       main_search = MarketplaceConfigurations
                     .where(community_id: cid)
                     .pluck(:main_search)

--- a/app/services/custom_landing_page/marketplace_data_store.rb
+++ b/app/services/custom_landing_page/marketplace_data_store.rb
@@ -1,6 +1,8 @@
 module CustomLandingPage
   module MarketplaceDataStore
 
+    DEFAULT_COLOR = "A64C5D";
+
     module_function
 
     def marketplace_data(cid, locale)
@@ -30,8 +32,10 @@ module CustomLandingPage
           "keyword_search"
         end
 
-      { "primary_color" => primary_color.present? ? "#" + primary_color : nil,
-        "primary_color_darken" => primary_color.present? ? "#" + ColorUtils.darken(primary_color, 15) : nil,
+      color = primary_color.present? ? primary_color : DEFAULT_COLOR
+
+      { "primary_color" => "##{color}",
+        "primary_color_darken" => "##{ColorUtils.darken(color, 15)}",
         "name" => name,
         "slogan" => slogan,
         "description" => description,

--- a/app/views/landing_page/_footer.erb
+++ b/app/views/landing_page/_footer.erb
@@ -1,14 +1,14 @@
 <% content_for :footer_css, flush: true do %>
-  .footer__container--dark .footer__social-media-icon {
+  .footer__container--dark .footer__social-media-link > svg {
     fill: #FFFFFF;
   }
-  .footer__container--dark .footer__social-media-icon:hover {
+  .footer__container--dark .footer__social-media-link:hover > svg {
     fill: #D9D9D9;
   }
-  .footer__container--light .footer__social-media-icon {
+  .footer__container--light .footer__social-media-link > svg {
     fill: <%= s['social_media_icon_color']['value'] %>;
   }
-  .footer__container--light .footer__social-media-icon:hover {
+  .footer__container--light .footer__social-media-link:hover > svg {
     fill: <%= s['social_media_icon_color_hover']['value'] %>;
   }
 <% end %>
@@ -33,7 +33,7 @@
 
           <% s["social"].each do |social| %>
 
-            <a href="<%= social['url'] %>" target="_blank" rel="noreferrer">
+            <a class="footer__social-media-link" href="<%= social['url'] %>" target="_blank" rel="noreferrer">
 
               <% case social["service"] %>
               <% when "facebook" %>

--- a/app/views/landing_page/_footer.erb
+++ b/app/views/landing_page/_footer.erb
@@ -15,7 +15,10 @@
 
 <footer id="<%= section_id %>" class="footer__container--<%= s['theme'] %>">
   <div class="footer__content">
-    <div class="footer__links-container">
+
+    <% container_modifier = s["social"].length == 0 ? "--no-social" : "" %>
+
+    <div class="footer__links-container<%= container_modifier %>">
       <% if s['links'].length > 0 %>
         <ul class="footer__link-list">
           <% s['links'].each do |link| %>

--- a/app/views/landing_page/_footer.erb
+++ b/app/views/landing_page/_footer.erb
@@ -13,13 +13,17 @@
   }
 <% end %>
 
+<%
+  has_links = s["links"].present?
+  has_social = s["social"].present?
+  container_modifier = has_links && has_social ? "" : "--center"
+%>
+
 <footer id="<%= section_id %>" class="footer__container--<%= s['theme'] %>">
   <div class="footer__content">
 
-    <% container_modifier = s["social"].length == 0 ? "--no-social" : "" %>
-
     <div class="footer__links-container<%= container_modifier %>">
-      <% if s['links'].length > 0 %>
+      <% if has_links %>
         <ul class="footer__link-list">
           <% s['links'].each do |link| %>
             <li class="footer__link-list-item"><a class="footer__link" href="<%= link['href']['path'] %>"><%= link["label"] %></a></li>
@@ -27,7 +31,7 @@
         </ul>
       <% end %>
 
-      <% if s["social"].length > 0 %>
+      <% if has_social %>
 
         <div class="footer__social-media">
 

--- a/app/views/landing_page/_hero.erb
+++ b/app/views/landing_page/_hero.erb
@@ -4,13 +4,17 @@
   }
 
   .hero__search-button,
-  .hero__signup-button
+  .hero__search-button:active,
+  .hero__signup-button,
+  .hero__signup-button:active
   {
     background-color: <%= s["search_button_color"]["value"] %>;
   }
 
   .hero__search-button:hover,
-  .hero__signup-button:hover {
+  .hero__search-button:focus,
+  .hero__signup-button:hover,
+  .hero__signup-button:focus {
     background-color: <%= s["search_button_color_hover"]["value"] %>;
   }
 <% end %>

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -29,7 +29,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Custom Landing Page</title>
+  <title><%= settings["marketplace_name"]["value"] %></title>
 
   <!-- SEO Meta -->
   <!--

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -29,7 +29,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= settings["marketplace_name"]["value"] %></title>
+  <title><%= page["title"]["value"] %></title>
 
   <!-- SEO Meta -->
   <!--

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1226,6 +1226,7 @@ en:
     hero:
       search: Search
       signup: "Sign up"
+      search_placeholder: "What are you looking for?"
   layouts:
     admin:
       admin: "%{service_name} admin panel"


### PR DESCRIPTION
General fixes:

- [X] Flexbox browser prefixes
- [X] Add marketplace default color if the marketplace color is not set
- [X] Marketplace name as page title

Hero fixes:

- [X] Mark normalize.css content to be HTML safe so that it will be printed as is and not escaped. This will fix the issue where the search input had default layout (borders) enabled
- [X] Default search placeholder text
- [X] Hide default borders when search button is clicked
- [X] Cursor pointer when hovering search button
- [X] Fix [flexbox issues](https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored) with Safari

Footer fixes:

- [X] Bigger click area for links footer links
- [X] Center footer links if there are no social media icons
- [X] Center social media icons if there are no links