### PR TITLE
Harmonize CLP json

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -163,12 +163,8 @@ class LandingPageController < ActionController::Metal
   ],
 
   "composition": [
-    { "section": {"type": "sections", "id": "myhero1"},
-      "disabled": false},
-    { "section": {"type": "sections", "id": "footer"},
-      "disabled": false},
-    { "section": {"type": "sections", "id": "myhero1"},
-      "disabled": true}
+    { "section": {"type": "sections", "id": "myhero1"}},
+    { "section": {"type": "sections", "id": "footer"}}
   ],
 
   "assets": [

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -14,7 +14,7 @@ module CustomLandingPage
         if path.nil?
           raise LinkResolvingError.new("Couldn't find path '#{id}'.")
         else
-          { "id" => id, "type" => type, "path" => path }
+          { "id" => id, "type" => type, "value" => path }
         end
       end
     end

--- a/app/services/custom_landing_page/marketplace_data_store.rb
+++ b/app/services/custom_landing_page/marketplace_data_store.rb
@@ -1,7 +1,7 @@
 module CustomLandingPage
   module MarketplaceDataStore
 
-    DEFAULT_COLOR = "A64C5D";
+    DEFAULT_COLOR = "A64C5D"
 
     module_function
 

--- a/app/views/landing_page/_footer.erb
+++ b/app/views/landing_page/_footer.erb
@@ -26,7 +26,7 @@
       <% if has_links %>
         <ul class="footer__link-list">
           <% s['links'].each do |link| %>
-            <li class="footer__link-list-item"><a class="footer__link" href="<%= link['href']['path'] %>"><%= link["label"] %></a></li>
+            <li class="footer__link-list-item"><a class="footer__link" href="<%= link['href']['value'] %>"><%= link["label"] %></a></li>
           <% end %>
         </ul>
       <% end %>

--- a/app/views/landing_page/_hero.erb
+++ b/app/views/landing_page/_hero.erb
@@ -29,7 +29,7 @@
       <% when "keyword_search", "location_search" %>
 
         <div class="hero__search-bar-padding">
-          <form method="get" id="<%= section_id %>__search-form" class="hero__search-bar" action="<%= s["search_path"]["path"] %>">
+          <form method="get" id="<%= section_id %>__search-form" class="hero__search-bar" action="<%= s["search_path"]["value"] %>">
             <div class="hero__search-input-container">
               <div class="hero__search-icon">
 
@@ -68,7 +68,7 @@
 
       <% when "private" %>
 
-        <a class="hero__signup-button" href="<%= s["signup_path"]["path"] %>"><%= s["signup_button"]["value"] %></a>
+        <a class="hero__signup-button" href="<%= s["signup_path"]["value"] %>"><%= s["signup_button"]["value"] %></a>
 
       <% end %>
     </div>

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -6,10 +6,8 @@
   # If we'd render the sections after the <head> elements, the section specific
   # styles would be empty
 %>
-<% enabled_sections = sections.reject { |section| section["disabled"] } %>
-
 <% content_for :sections do %>
-  <% enabled_sections.each do |section| %>
+  <% sections.each do |section| %>
 
     <% s = section["section"] %>
     <% section_id = "#{s['kind']}__#{s['id']}" %>
@@ -21,7 +19,7 @@
       <%= render partial: "footer", locals: {section_id: section_id, s: s} %>
     <% end %>
 
-  <% end # enabled_sections#each %>
+  <% end # sections#each %>
 <% end # capture %>
 
 <html lang="en">
@@ -111,7 +109,7 @@
 
 <% # Add javascript libraries %>
 
-<% if enabled_sections.any? { |s| s["section"]["kind"] == "hero" && s["section"]["variation"]["value"] == "location_search" } %>
+<% if sections.any? { |s| s["section"]["kind"] == "hero" && s["section"]["variation"]["value"] == "location_search" } %>
   <script src="https://maps.googleapis.com/maps/api/js?libraries=places"></script>
   <script>
     <%= javascripts[:location_search] %>


### PR DESCRIPTION
For synthetically resolved links always use the format `{ type: <type>, id: <id>, value: <value> }`. For paths it used to be `{ type: <type>, id: <id>, path: <value> }`.

For assets keep the different format (key is src) because that is manually inputted and makes more sense for JSON author to refer to files via src instead of value.

Drop the disabled support from compositions. This is extra complexity that can be achieved by deleting the row from the composition array.