### PR TITLE
Add non-breaking space to avoid widows

### DIFF
--- a/app/views/landing_page/_hero.erb
+++ b/app/views/landing_page/_hero.erb
@@ -19,11 +19,18 @@
   }
 <% end %>
 
+<%
+# Add non-breaking space to prevent widows
+subtitle_splitted = s["subtitle"]["value"].split(" ")
+last_three = subtitle_splitted.pop(3)
+subtitle = (subtitle_splitted + [last_three.join("&nbsp;")]).join(" ").html_safe
+%>
+
 <section id="<%= section_id %>" class="hero__section">
   <div class="hero__content">
     <div class="hero__content-container">
       <h1 class="hero__title"><%= s["title"]["value"] %></h1>
-      <h3 class="hero__subtitle"><%= s["subtitle"]["value"] %></h3>
+      <h3 class="hero__subtitle"><%= subtitle %></h3>
 
       <% case s["variation"]["value"] %>
       <% when "keyword_search", "location_search" %>

--- a/app/views/landing_page/_hero.erb
+++ b/app/views/landing_page/_hero.erb
@@ -19,18 +19,11 @@
   }
 <% end %>
 
-<%
-# Add non-breaking space to prevent widows
-subtitle_splitted = s["subtitle"]["value"].split(" ")
-last_three = subtitle_splitted.pop(3)
-subtitle = (subtitle_splitted + [last_three.join("&nbsp;")]).join(" ").html_safe
-%>
-
 <section id="<%= section_id %>" class="hero__section">
   <div class="hero__content">
     <div class="hero__content-container">
       <h1 class="hero__title"><%= s["title"]["value"] %></h1>
-      <h3 class="hero__subtitle"><%= subtitle %></h3>
+      <h3 class="hero__subtitle"><%= render partial: "prevent_widows", locals: { text: s["subtitle"]["value"]} %></h3>
 
       <% case s["variation"]["value"] %>
       <% when "keyword_search", "location_search" %>

--- a/app/views/landing_page/_prevent_widows.erb
+++ b/app/views/landing_page/_prevent_widows.erb
@@ -1,0 +1,7 @@
+<%=
+  # Add non-breaking space to prevent widows
+  splitted = text.split(" ")
+  last_two = splitted.pop(2)
+
+  (splitted + ["<span style=\"white-space: nowrap\">#{last_two.join(" ")}</span>"]).join(" ").html_safe
+%>


### PR DESCRIPTION
Same as this https://css-tricks.com/snippets/jquery/add-non-breaking-space-on-title-to-prevent-widows/ but done with Ruby on the server side. Also, we add the non-breaking space to last three words so that there's always at least three words in the last line.