### PR TITLE
Fix redirect roots

### DIFF
--- a/app/controllers/admin/getting_started_guide_controller.rb
+++ b/app/controllers/admin/getting_started_guide_controller.rb
@@ -5,7 +5,7 @@ class Admin::GettingStartedGuideController < ApplicationController
   rescue_from ReactOnRails::PrerenderError do |err|
     Rails.logger.error(err.message)
     Rails.logger.error(err.backtrace.join("\n"))
-    redirect_to root_path, flash: { error: I18n.t('error_messages.onboarding.server_rendering') }
+    redirect_to search_path, flash: { error: I18n.t('error_messages.onboarding.server_rendering') }
   end
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -170,6 +170,7 @@ class ApplicationController < ActionController::Base
 
   #Creates a URL for root path (i18n breaks root_path helper)
   def root
+    ActiveSupport::Deprecation.warn("Call to root is deprecated and will be removed in the future. Use search_path or landing_page_path instead.")
     "#{request.protocol}#{request.host_with_port}/#{params[:locale]}"
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -228,7 +228,7 @@ class ApplicationController < ActionController::Base
       session[:person_id] = nil
       flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
 
-      redirect_to root
+      redirect_to search_path
     end
   end
 
@@ -380,7 +380,7 @@ class ApplicationController < ActionController::Base
       # TODO Remove this. Find the issue that causes this and fix it, don't fix the symptoms.
       if @current_user.has_valid_email_for_community?(@current_community)
         @current_community.approve_pending_membership(@current_user)
-        redirect_to root and return
+        redirect_to search_path and return
       end
 
       redirect_to confirmation_pending_path
@@ -471,7 +471,7 @@ class ApplicationController < ActionController::Base
     clear_user_session
     flash[:error] = t("layouts.notifications.error_with_session")
     ApplicationHelper.send_error_notification("ASI session was unauthorized. This may be normal, if session just expired, but if this occurs frequently something is wrong.", "ASI session error", params)
-    redirect_to root_path and return
+    redirect_to search_path and return
   end
 
   def clear_user_session
@@ -489,14 +489,14 @@ class ApplicationController < ActionController::Base
   def ensure_is_admin
     unless @is_current_community_admin
       flash[:error] = t("layouts.notifications.only_kassi_administrators_can_access_this_area")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 
   def ensure_is_superadmin
     unless Maybe(@current_user).is_admin?.or_else(false)
       flash[:error] = t("layouts.notifications.only_kassi_administrators_can_access_this_area")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -43,7 +43,7 @@ class CommentsController < ApplicationController
 
     unless @comment.listing.visible_to?(@current_user, @current_community) || @current_user.has_admin_rights?
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -55,7 +55,7 @@ class CommunitiesController < ApplicationController
   end
 
   def ensure_no_communities
-    redirect_to root if communities_exist?
+    redirect_to landing_page_path if communities_exist?
   end
 
   def communities_exist?

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -72,7 +72,7 @@ class CommunityMembershipsController < ApplicationController
       Delayed::Job.enqueue(SendWelcomeEmail.new(@current_user.id, @current_community.id), priority: 5)
 
       flash[:notice] = t("layouts.notifications.you_are_now_member")
-      redirect_to root
+      redirect_to search_path
 
     }.on_error { |msg, data|
 
@@ -224,7 +224,7 @@ class CommunityMembershipsController < ApplicationController
   def ensure_membership_is_not_accepted
     if membership.accepted?
       flash[:notice] = t("layouts.notifications.you_are_already_member")
-      redirect_to root
+      redirect_to search_path
     end
   end
 
@@ -232,7 +232,7 @@ class CommunityMembershipsController < ApplicationController
     raise ArgumentError.new("Unknown state #{status}") unless CommunityMembership::VALID_STATUSES.include?(status)
 
     if membership.status != status
-      redirect_to root
+      redirect_to search_path
     end
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -66,7 +66,7 @@ class ConfirmationsController < Devise::ConfirmationsController
           redirect_to getting_started_admin_community_path(id: @current_community.id) and return
         end
       elsif @current_user # normal logged in user
-        redirect_to root and return
+        redirect_to search_path and return
       else # no logged in session
         redirect_to login_path and return
       end
@@ -76,7 +76,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     if @current_user
       redirect_to confirmation_pending_path
     else
-      redirect_to :root
+      redirect_to search_path
     end
   end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -17,7 +17,7 @@ class ConversationsController < ApplicationController
 
     if conversation.blank?
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
-      return redirect_to root
+      return redirect_to search_path
     end
 
     transaction = Transaction.find_by_conversation_id(conversation[:id])

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -41,7 +41,7 @@ class FeedbacksController < ApplicationController
     MailCarrier.deliver_later(PersonMailer.new_feedback(feedback, @current_community))
 
     flash[:notice] = t("layouts.notifications.feedback_saved")
-    redirect_to root
+    redirect_to search_path
   end
 
   private

--- a/app/controllers/free_transactions_controller.rb
+++ b/app/controllers/free_transactions_controller.rb
@@ -43,7 +43,7 @@ class FreeTransactionsController < ApplicationController
 
       unless transaction_response[:success]
         flash[:error] = t("layouts.notifications.message_not_sent")
-        return redirect_to root
+        return redirect_to search_path
       end
 
       transaction_id = transaction_response[:data][:transaction][:id]
@@ -54,10 +54,10 @@ class FreeTransactionsController < ApplicationController
 
       flash[:notice] = t("layouts.notifications.message_sent")
       Delayed::Job.enqueue(MessageSentJob.new(transaction.conversation.messages.last.id, @current_community.id))
-      redirect_to session[:return_to_content] || root
+      redirect_to session[:return_to_content] || search_path
     else
       flash[:error] = t("layouts.notifications.message_not_sent")
-      redirect_to root
+      redirect_to search_path
     end
   end
 
@@ -74,7 +74,7 @@ class FreeTransactionsController < ApplicationController
   def ensure_listing_author_is_not_current_user
     if @listing.author == @current_user
       flash[:error] = t("layouts.notifications.you_cannot_send_message_to_yourself")
-      redirect_to (session[:return_to_content] || root)
+      redirect_to (session[:return_to_content] || search_path)
     end
   end
 
@@ -82,14 +82,14 @@ class FreeTransactionsController < ApplicationController
   def ensure_authorized_to_reply
     unless @listing.visible_to?(@current_user, @current_community)
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 
   def ensure_listing_is_open
     if @listing.closed?
       flash[:error] = t("layouts.notifications.you_cannot_reply_to_a_closed_offer")
-      redirect_to (session[:return_to_content] || root)
+      redirect_to (session[:return_to_content] || search_path)
     end
   end
 

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -9,7 +9,7 @@ class HomepageController < ApplicationController
 
 
   def index
-    redirect_to root and return if no_current_user_in_private_clp_enabled_marketplace?
+    redirect_to landing_page_path and return if no_current_user_in_private_clp_enabled_marketplace?
 
     @homepage = true
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -77,7 +77,7 @@ class InvitationsController < ApplicationController
   def users_can_invite_new_users
     unless @current_community.allows_user_to_send_invitations?(@current_user)
       flash[:error] = t("layouts.notifications.inviting_new_users_is_not_allowed_in_this_community")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -78,7 +78,7 @@ class ListingsController < ApplicationController
 
           render :partial => "listings/profile_listings", :locals => {person: @person, limit: per_page, listings: listings}
         else
-          redirect_to root
+          redirect_to search_path
         end
       end
 
@@ -655,7 +655,7 @@ class ListingsController < ApplicationController
         else
           t("layouts.notifications.you_are_not_authorized_to_view_this_content")
         end
-        redirect_to root and return
+        redirect_to search_path and return
       else
         session[:return_to] = request.fullpath
         flash[:warning] = t("layouts.notifications.you_must_log_in_to_view_this_content")

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,7 +11,7 @@ class MessagesController < ApplicationController
   def create
     unless is_participant?(@current_user, params[:message][:conversation_id])
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_do_this")
-      return redirect_to root
+      return redirect_to search_path
     end
 
     message_params = params.require(:message).permit(

--- a/app/controllers/paypal_service/checkout_orders_controller.rb
+++ b/app/controllers/paypal_service/checkout_orders_controller.rb
@@ -24,7 +24,7 @@ class PaypalService::CheckoutOrdersController < ApplicationController
 
     if !proc_status[:success]
       flash[:error] = t("error_messages.paypal.generic_error")
-      return redirect_to root
+      return redirect_to search_path
     end
 
     render "paypal_service/success", layout: false, locals: {
@@ -78,7 +78,7 @@ class PaypalService::CheckoutOrdersController < ApplicationController
     pp_result = paypal_payments_service.request_cancel(@current_community.id, params[:token])
     if(!pp_result[:success])
       flash[:error] = t("error_messages.paypal.cancel_error")
-      return redirect_to root
+      return redirect_to search_path
     end
 
     flash[:notice] = t("paypal.cancel_succesful")

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -24,7 +24,7 @@ class PeopleController < Devise::RegistrationsController
     @person = Person.find_by!(username: params[:username], community_id: @current_community.id)
     raise PersonDeleted if @person.deleted?
 
-    redirect_to root and return if @current_community.private? && !@current_user
+    redirect_to landing_page_path and return if @current_community.private? && !@current_user
     @selected_tribe_navi_tab = "members"
     @community_membership = CommunityMembership.find_by_person_id_and_community_id_and_status(@person.id, @current_community.id, "accepted")
 
@@ -72,7 +72,7 @@ class PeopleController < Devise::RegistrationsController
 
   def new
     @selected_tribe_navi_tab = "members"
-    redirect_to root if logged_in?
+    redirect_to seach_path if logged_in?
     session[:invitation_code] = params[:code] if params[:code]
 
     @person = if params[:person] then
@@ -150,7 +150,7 @@ class PeopleController < Devise::RegistrationsController
     if APP_CONFIG.skip_email_confirmation
       email.confirm!
 
-      redirect_to root
+      redirect_to search_path
     else
       Email.send_confirmation(email, @current_community)
 
@@ -293,7 +293,7 @@ class PeopleController < Devise::RegistrationsController
     target_user = Person.find_by!(username: params[:id], community_id: @current_community.id)
 
     has_unfinished = TransactionService::Transaction.has_unfinished_transactions(target_user.id)
-    return redirect_to root if has_unfinished
+    return redirect_to search_path if has_unfinished
 
     # Do all delete operations in transaction. Rollback if any of them fails
     ActiveRecord::Base.transaction do
@@ -306,7 +306,7 @@ class PeopleController < Devise::RegistrationsController
     sign_out target_user
     report_analytics_event('user', "deleted", "by user")
     flash[:notice] = t("layouts.notifications.account_deleted")
-    redirect_to root
+    redirect_to search_path
   end
 
   def check_username_availability

--- a/app/controllers/person_messages_controller.rb
+++ b/app/controllers/person_messages_controller.rb
@@ -19,7 +19,7 @@ class PersonMessagesController < ApplicationController
       redirect_to @recipient
     }.on_error {
       flash[:error] = t("layouts.notifications.message_not_sent")
-      redirect_to root
+      redirect_to search_path
     }
   end
 
@@ -63,7 +63,7 @@ class PersonMessagesController < ApplicationController
     @recipient = Person.find_by!(username: username, community_id: @current_community.id)
     if @current_user == @recipient
       flash[:error] = t("layouts.notifications.you_cannot_send_message_to_yourself")
-      redirect_to root
+      redirect_to search_path
     end
   end
 end

--- a/app/controllers/post_pay_transactions_controller.rb
+++ b/app/controllers/post_pay_transactions_controller.rb
@@ -46,7 +46,7 @@ class PostPayTransactionsController < ApplicationController
 
       unless transaction_response[:success]
         flash[:error] = "Sending the message failed. Please try again."
-        return redirect_to root
+        return redirect_to search_path
       end
 
       transaction_id = transaction_response[:data][:transaction][:id]
@@ -62,10 +62,10 @@ class PostPayTransactionsController < ApplicationController
           :priority => 9, :run_at => send_interval.days.from_now)
       end
 
-      redirect_to session[:return_to_content] || root
+      redirect_to session[:return_to_content] || search_path
     else
       flash[:error] = "Sending the message failed. Please try again."
-      redirect_to root
+      redirect_to search_path
     end
   end
 
@@ -74,7 +74,7 @@ class PostPayTransactionsController < ApplicationController
   def ensure_listing_author_is_not_current_user
     if @listing.author == @current_user
       flash[:error] = t("layouts.notifications.you_cannot_send_message_to_yourself")
-      redirect_to (session[:return_to_content] || root)
+      redirect_to (session[:return_to_content] || search_path)
     end
   end
 
@@ -82,14 +82,14 @@ class PostPayTransactionsController < ApplicationController
   def ensure_authorized_to_reply
     unless @listing.visible_to?(@current_user, @current_community)
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 
   def ensure_listing_is_open
     if @listing.closed?
       flash[:error] = t("layouts.notifications.you_cannot_reply_to_a_closed_offer")
-      redirect_to (session[:return_to_content] || root)
+      redirect_to (session[:return_to_content] || search_path)
     end
   end
 
@@ -105,7 +105,7 @@ class PostPayTransactionsController < ApplicationController
     Maybe(@current_community).payment_gateway.each do |gateway|
       unless gateway.can_receive_payments?(@listing.author)
         flash[:error] = t("layouts.notifications.listing_author_payment_details_missing")
-        redirect_to (session[:return_to_content] || root)
+        redirect_to (session[:return_to_content] || search_path)
       end
     end
   end

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -401,7 +401,7 @@ class PreauthorizeTransactionsController < ApplicationController
   def ensure_listing_author_is_not_current_user
     if @listing.author == @current_user
       flash[:error] = t("layouts.notifications.you_cannot_send_message_to_yourself")
-      redirect_to(session[:return_to_content] || root)
+      redirect_to(session[:return_to_content] || search_path)
     end
   end
 
@@ -409,14 +409,14 @@ class PreauthorizeTransactionsController < ApplicationController
   def ensure_authorized_to_reply
     unless @listing.visible_to?(@current_user, @current_community)
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 
   def ensure_listing_is_open
     if @listing.closed?
       flash[:error] = t("layouts.notifications.you_cannot_reply_to_a_closed_offer")
-      redirect_to(session[:return_to_content] || root)
+      redirect_to(session[:return_to_content] || search_path)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -70,7 +70,7 @@ class SessionsController < ApplicationController
       redirect_to session[:return_to_content]
       session[:return_to_content] = nil
     else
-      redirect_to root_path
+      redirect_to search_path
     end
   end
 
@@ -78,7 +78,7 @@ class SessionsController < ApplicationController
     sign_out
     session[:person_id] = nil
     flash[:notice] = t("layouts.notifications.logout_successful")
-    redirect_to root
+    redirect_to search_path
   end
 
   def index
@@ -157,7 +157,7 @@ class SessionsController < ApplicationController
     error_message = params[:error_reason] || "login error"
     kind = env["omniauth.error.strategy"].name.to_s || "Facebook"
     flash[:error] = t("devise.omniauth_callbacks.failure",:kind => kind.humanize, :reason => error_message.humanize)
-    redirect_to root
+    redirect_to search_path
   end
 
   private

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -3,7 +3,7 @@ class TermsController < ApplicationController
   layout :choose_layout
 
   def show
-    redirect_to root_path and return unless session[:temp_cookie]
+    redirect_to search_path and return unless session[:temp_cookie]
     @current_community = Community.find(session[:temp_community_id])
     @current_user = nil
   end
@@ -35,7 +35,7 @@ class TermsController < ApplicationController
     session[:temp_community_id] = nil
     session[:consent_changed] = nil
     flash[:notice] = t("layouts.notifications.login_successful", :person_name => view_context.link_to(@current_user.given_name_or_username, person_path(@current_user))).html_safe
-    redirect_to (session[:return_to] || root)
+    redirect_to (session[:return_to] || search_path)
   end
 
   private

--- a/app/controllers/testimonials_controller.rb
+++ b/app/controllers/testimonials_controller.rb
@@ -85,7 +85,7 @@ class TestimonialsController < ApplicationController
 
     if @transaction.nil?
       flash[:error] = t("layouts.notifications.you_are_not_allowed_to_give_feedback_on_this_transaction")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 
@@ -95,7 +95,7 @@ class TestimonialsController < ApplicationController
 
     unless waiting
       flash[:error] = t("layouts.notifications.you_have_already_given_feedback_about_this_event")
-      redirect_to root and return
+      redirect_to search_path and return
     end
   end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -126,7 +126,7 @@ class TransactionsController < ApplicationController
 
     unless tx.present? && transaction_conversation.present?
       flash[:error] = t("layouts.notifications.you_are_not_authorized_to_view_this_content")
-      return redirect_to root
+      return redirect_to search_path
     end
 
     tx_model = Transaction.where(id: tx[:id]).first

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -698,6 +698,20 @@ module ApplicationHelper
     end
   end
 
+  def landing_page_path
+    non_default_locale = ->(locale) { locale != @current_community.default_locale.to_s}
+    not_present = ->(x) { !x.present? }
+
+    case [CustomLandingPage::LandingPageStore.enabled?(@current_community.id), @current_user, params[:locale]]
+    when matches([true, __, __])
+      landing_page_without_locale_path(locale: nil)
+    when matches([false, not_present, non_default_locale])
+      homepage_with_locale_path
+    else
+      homepage_without_locale_path(locale: nil)
+    end
+  end
+
   # Give an array of translation keys you need in JavaScript. The keys will be loaded and ready to be used in JS
   # with `ST.t` function
   def js_t(keys, run_js_immediately=false)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -346,7 +346,7 @@ module ApplicationHelper
       :topic => :general,
       :text => t("admin.left_hand_navigation.preview"),
       :icon_class => icon_class("eye"),
-      :path => root_path(big_cover_photo: true),
+      :path => search_path(big_cover_photo: true),
       :name => "preview",
     }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -698,6 +698,20 @@ module ApplicationHelper
     end
   end
 
+  def search_url(opts = {})
+    case [CustomLandingPage::LandingPageStore.enabled?(@current_community.id),
+          opts[:locale].present?]
+    when matches([true, true])
+      search_with_locale_url(opts)
+    when matches([true, false])
+      search_without_locale_url(opts.merge(locale: nil))
+    when matches([false, true])
+      homepage_with_locale_url(opts)
+    when matches([false, false])
+      homepage_without_locale_url(opts.merge(locale: nil))
+    end
+  end
+
   def landing_page_path
     non_default_locale = ->(locale) { locale != @current_community.default_locale.to_s}
     not_present = ->(x) { !x.present? }

--- a/app/views/community_mailer/community_updates.html.haml
+++ b/app/views/community_mailer/community_updates.html.haml
@@ -13,12 +13,12 @@
                       %td{:valign => "top", :width => "90%"}
                         %h1{:style => "font-family:Helvetica Neue, Helvetica, Arial, sans-serif;font-weight:400;font-size:18px;margin-top:20px;margin-bottom:5px; padding: 20px; background: #ebebeb;text-align: left;line-height:22px;"}
                           %span{:style => "color:#464646;"}
-                            = t("emails.community_updates.update_mail_title", :title_link => link_to(@title_link_text, root_url(@url_params))).html_safe
+                            = t("emails.community_updates.update_mail_title", :title_link => link_to(@title_link_text, search_url(@url_params))).html_safe
                         %div{:style => "font-family:Helvetica Neue, Helvetica, Arial, sans-serif;font-size:16px;line-height:22px; padding: 10px 0;text-align:left;"}
                           %p
                             = t("emails.newsletter.hi", :name => link_to(@recipient.given_name_or_username, person_url(@recipient, @url_params))).html_safe
                           %p
-                            = t("emails.community_updates.intro_paragraph", :community_link => link_to(t("emails.community_updates.intro_paragraph_link_text", :community_name => @community.full_name(I18n.locale)), root_url(@url_params)), :time_since_last_update => @time_since_last_update).html_safe
+                            = t("emails.community_updates.intro_paragraph", :community_link => link_to(t("emails.community_updates.intro_paragraph_link_text", :community_name => @community.full_name(I18n.locale)), search_url(@url_params)), :time_since_last_update => @time_since_last_update).html_safe
                       %td{:width => "5%"}
                     %tr
                       %td{:width => "5%"}

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -29,7 +29,7 @@
         = link_to listing_path(listing.url) do
           = listing.title
           - if @current_community.show_category_in_listing_list
-            %a.home-share-type-link{:href => root_path(:transaction_type => shape_name_map[listing.listing_shape_id], :view => :list)}
+            %a.home-share-type-link{:href => search_path(:transaction_type => shape_name_map[listing.listing_shape_id], :view => :list)}
               = icon_tag(listing.icon_name, ["icon-fix"])
               = shape_name(listing)
 

--- a/app/views/homepage/_list_item_with_distance.haml
+++ b/app/views/homepage/_list_item_with_distance.haml
@@ -31,7 +31,7 @@
           = link_to listing_path(listing.url) do
             = listing.title
             - if @current_community.show_category_in_listing_list
-              %a.browsing-list-item-share-type-link{ href: root_path( transaction_type: shape_name_map[listing.listing_shape_id], view: :list)}
+              %a.browsing-list-item-share-type-link{ href: search_path( transaction_type: shape_name_map[listing.listing_shape_id], view: :list)}
                 = icon_tag(listing.icon_name, ["icon-fix"])
                 = shape_name(listing)
         - distance = Maybe(listing.distance).or_else(nil)

--- a/app/views/layouts/_global_header.haml
+++ b/app/views/layouts/_global_header.haml
@@ -44,7 +44,7 @@
       If necessary, the buttons will overlap with the logo. Buttons should be on top, that's
       keep the logo here after buttons
     .header-left.header-logo-container
-      = link_to homepage_path, :class => "header-logo", :id => "header-logo" do
+      = link_to landing_page_path, :class => "header-logo", :id => "header-logo" do
         - if @current_community.logo.present?
           %i.header-square-logo.hidden-tablet
             -# Logo is here, it's a CSS background

--- a/app/views/settings/unsubscribe.haml
+++ b/app/views/settings/unsubscribe.haml
@@ -2,7 +2,7 @@
   - if unsubscribe_successful
     %h2
       = t("settings.notifications.unsubscribe_succesful")
-    = t("settings.notifications.unsubscribe_info_text", :settings_link => link_to(t("settings.notifications.settings_link"), notifications_person_settings_path(:person_id => target_user.username)), :homepage_link => link_to(t("settings.notifications.homepage_link"), root_path) ).html_safe
+    = t("settings.notifications.unsubscribe_info_text", :settings_link => link_to(t("settings.notifications.settings_link"), notifications_person_settings_path(:person_id => target_user.username)), :homepage_link => link_to(t("settings.notifications.homepage_link"), search_path) ).html_safe
   - else
     %h2
       = t("settings.notifications.unsubscribe_unsuccesful")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,8 +74,6 @@ Kassi::Application.routes.draw do
   get '/:locale/s', to: redirect('/%{locale}', status: 307), constraints: { locale: locale_matcher }
   get '/s', to: redirect('/', status: 307)
 
-  root :to => 'homepage#index'
-
   get '/_lp_preview' => 'landing_page#preview'
 
   # error handling: 3$: http://blog.plataformatec.com.br/2012/01/my-five-favorite-hidden-features-in-rails-3-2/

--- a/features/support/login_helpers.rb
+++ b/features/support/login_helpers.rb
@@ -29,7 +29,7 @@ module LoginHelpers
   def login_user_without_browser(username)
     person = Person.find_by(username: username)
     login_as(person, :scope => :person)
-    visit root_path(:locale => :en)
+    visit homepage_with_locale_path(:locale => :en)
     @logged_in_user = person
     @current_user = person
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -32,6 +32,6 @@ describe SessionsController, "POST create", type: :controller do
 
   it "redirects back to original community's domain" do
     post :create, {:person  => {:login => "testpersonusername", :password => "testi"}}
-    expect(response).to redirect_to "http://#{@request.host}/?locale=en"
+    expect(response).to redirect_to "http://#{@request.host}/"
   end
 end


### PR DESCRIPTION
- Replaces redirect roots with either landing page or search
- Deprecates root helper
- Replaces root_paths with search_path
- Replaces root_urls with search_urls
- Links to landing page instead of homepage in header icon 