### PR TITLE
Add search and post a new listing paths

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -61,9 +61,12 @@ class LandingPageController < ActionController::Metal
 
   def build_denormalizer(cid:, locale:, sitename:, lp_enabled:)
 
-    path_to_search = lp_enabled ?
-                       search_with_locale_path(locale: locale) :
-                       homepage_without_locale_path(locale: nil)
+    path_to_search =
+      if lp_enabled
+        search_with_locale_path(locale: locale)
+      else
+        homepage_without_locale_path(locale: nil)
+      end
 
     # Application paths
     paths = { "search" => path_to_search,

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -26,7 +26,11 @@ class LandingPageController < ActionController::Metal
     begin
       structure = CLP::LandingPageStore.load_structure(cid, version)
 
-      render_landing_page(cid, structure)
+      # We know for sure that landing page is enabled
+      # Otherwise an exception would have been thrown
+      lp_enabled = true
+
+      render_landing_page(cid, structure, lp_enabled)
     rescue CLP::LandingPageContentNotFound
       render_not_found()
     end
@@ -38,13 +42,15 @@ class LandingPageController < ActionController::Metal
 
     begin
       structure = CLP::LandingPageStore.load_structure(cid, preview_version)
+      lp_enabled = CLP::LandingPageStore.enabled?(cid)
 
       # Uncomment for dev purposes
       # structure = JSON.parse(data_str)
+      # lp_enabled = true
 
       # Tell robots to not index and to not follow any links
       headers["X-Robots-Tag"] = "none"
-      render_landing_page(cid, structure)
+      render_landing_page(cid, structure, lp_enabled)
     rescue CLP::LandingPageContentNotFound
       render_not_found()
     end
@@ -53,12 +59,18 @@ class LandingPageController < ActionController::Metal
 
   private
 
-  def build_denormalizer(cid, locale, sitename)
+  def build_denormalizer(cid:, locale:, sitename:, lp_enabled:)
+
+    path_to_search = lp_enabled ?
+                       search_with_locale_path(locale: locale) :
+                       homepage_without_locale_path(locale: nil)
+
     # Application paths
-    paths = { "search" => "/", # FIXME. Remove hardcoded URL. Add search path here when we get one
+    paths = { "search" => path_to_search,
               "signup" => sign_up_path,
               "about" => about_infos_path,
-              "contact_us" => new_user_feedback_path
+              "contact_us" => new_user_feedback_path,
+              "post_a_new_listing" => new_listing_path
             }
 
     marketplace_data = CLP::MarketplaceDataStore.marketplace_data(cid, locale)
@@ -83,11 +95,16 @@ class LandingPageController < ActionController::Metal
     request.env[:current_marketplace]&.id
   end
 
-  def render_landing_page(cid, structure)
+  def render_landing_page(cid, structure, lp_enabled)
     locale, sitename = structure["settings"].values_at("locale", "sitename")
     font_path = APP_CONFIG[:font_proximanovasoft_url].present? ? APP_CONFIG[:font_proximanovasoft_url] : "/landing_page/fonts"
 
-    denormalizer = build_denormalizer(cid, locale, sitename)
+    denormalizer = build_denormalizer(
+      cid: cid,
+      locale: locale,
+      sitename: sitename,
+      lp_enabled: lp_enabled
+    )
 
     render :landing_page,
            locals: { font_path: font_path,
@@ -145,7 +162,7 @@ class LandingPageController < ActionController::Metal
       "button_color": {"type": "marketplace_data", "id": "primary_color"},
       "button_color_hover": {"type": "marketplace_data", "id": "primary_color_darken"},
       "button_title": "Section link",
-      "button_path": {"value": "https://google.com"},
+      "button_path": {"type": "path", "id": "post_a_new_listing"},
       "background_image": {"type": "assets", "id": "myinfoimage"}
     },
     {


### PR DESCRIPTION
Add two new paths to path resolver:

- `search`
- `post_a_new_listing`

Search path is conditional. If the landing page is enabled, it redirects to root, otherwise to search.