### PR TITLE
Pull topbar props out of app ctrl. Fix some bugs.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,3 @@
-# Yes, we know this is too long class
-# rubocop:disable ClassLength
-
 require 'will_paginate/array'
 
 class ApplicationController < ActionController::Base

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -610,7 +610,8 @@ class ApplicationController < ActionController::Base
       community: @current_community,
       user: @current_user,
       community_locales: available_locales(),
-      path_after_locale_change: @return_to)
+      path_after_locale_change: @return_to,
+      locale_param: params[:locale])
   end
 
   helper_method :topbar_props

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -104,6 +104,7 @@ class LandingPageController < ActionController::Metal
     self.response_body = msg
   end
 
+  # rubocop:disable Metrics/MethodLength
   def data_str
     <<JSON
 {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -676,54 +676,15 @@ module ApplicationHelper
   end
 
   def search_path(opts = {})
-    o = opts.dup.to_hash
-    o.delete("controller")
-    o.delete("action")
-    o.delete("locale")
-
-    non_default_locale = ->(locale) { locale != @current_community.default_locale.to_s}
-    not_present = ->(x) { !x.present? }
-
-    case [CustomLandingPage::LandingPageStore.enabled?(@current_community.id),
-          @current_user,
-          params[:locale]]
-    when matches([true, not_present, non_default_locale])
-      search_with_locale_path(o)
-    when matches([true, __, __])
-      search_without_locale_path(o.merge(locale: nil))
-    when matches([false, not_present, non_default_locale])
-      homepage_with_locale_path(o)
-    when matches([false, __, __])
-      homepage_without_locale_path(o.merge(locale: nil))
-    end
+    PathHelpers.search_path(@current_community, @current_user, params[:locale], opts)
   end
 
   def search_url(opts = {})
-    case [CustomLandingPage::LandingPageStore.enabled?(@current_community.id),
-          opts[:locale].present?]
-    when matches([true, true])
-      search_with_locale_url(opts)
-    when matches([true, false])
-      search_without_locale_url(opts.merge(locale: nil))
-    when matches([false, true])
-      homepage_with_locale_url(opts)
-    when matches([false, false])
-      homepage_without_locale_url(opts.merge(locale: nil))
-    end
+    PathHelpers.search_url(@current_community, opts)
   end
 
   def landing_page_path
-    non_default_locale = ->(locale) { locale != @current_community.default_locale.to_s}
-    not_present = ->(x) { !x.present? }
-
-    case [CustomLandingPage::LandingPageStore.enabled?(@current_community.id), @current_user, params[:locale]]
-    when matches([true, __, __])
-      landing_page_without_locale_path(locale: nil)
-    when matches([false, not_present, non_default_locale])
-      homepage_with_locale_path
-    else
-      homepage_without_locale_path(locale: nil)
-    end
+    PathHelpers.landing_page_path(@current_community, @current_user, params[:locale])
   end
 
   # Give an array of translation keys you need in JavaScript. The keys will be loaded and ready to be used in JS

--- a/app/view_utils/common_styles_helper.rb
+++ b/app/view_utils/common_styles_helper.rb
@@ -1,0 +1,11 @@
+module CommonStylesHelper
+
+  module_function
+
+  def marketplace_colors(community)
+    {
+      marketplace_color1: community ? "##{community.custom_color1}" : "#a64c5d",
+      marketplace_color2: community ? "##{community.custom_color2}" : "#00a26c"
+    }
+  end
+end

--- a/app/view_utils/path_helpers.rb
+++ b/app/view_utils/path_helpers.rb
@@ -15,11 +15,11 @@ module PathHelpers
           user,
           locale_param]
     when matches([true, not_present, non_default_locale])
-      paths.search_with_locale_path(o)
+      paths.search_with_locale_path(o.merge(locale: locale_param))
     when matches([true, __, __])
       paths.search_without_locale_path(o.merge(locale: nil))
     when matches([false, not_present, non_default_locale])
-      paths.homepage_with_locale_path(o)
+      paths.homepage_with_locale_path(o.merge(locale: locale_param))
     when matches([false, __, __])
       paths.homepage_without_locale_path(o.merge(locale: nil))
     end
@@ -47,7 +47,7 @@ module PathHelpers
     when matches([true, __, __])
       paths.landing_page_without_locale_path(locale: nil)
     when matches([false, not_present, non_default_locale])
-      paths.homepage_with_locale_path
+      paths.homepage_with_locale_path(locale: locale_param)
     else
       paths.homepage_without_locale_path(locale: nil)
     end

--- a/app/view_utils/path_helpers.rb
+++ b/app/view_utils/path_helpers.rb
@@ -1,0 +1,61 @@
+module PathHelpers
+
+  module_function
+
+  def search_path(community, user, locale_param, opts = {})
+    o = opts.dup.to_hash
+    o.delete("controller")
+    o.delete("action")
+    o.delete("locale")
+
+    non_default_locale = ->(locale) { locale.present? && locale != community.default_locale.to_s}
+    not_present = ->(x) { !x.present? }
+
+    case [CustomLandingPage::LandingPageStore.enabled?(community.id),
+          user,
+          locale_param]
+    when matches([true, not_present, non_default_locale])
+      paths.search_with_locale_path(o)
+    when matches([true, __, __])
+      paths.search_without_locale_path(o.merge(locale: nil))
+    when matches([false, not_present, non_default_locale])
+      paths.homepage_with_locale_path(o)
+    when matches([false, __, __])
+      paths.homepage_without_locale_path(o.merge(locale: nil))
+    end
+  end
+
+  def search_url(community, opts = {})
+    case [CustomLandingPage::LandingPageStore.enabled?(community.id),
+          opts[:locale].present?]
+    when matches([true, true])
+      paths.search_with_locale_url(opts)
+    when matches([true, false])
+      paths.search_without_locale_url(opts.merge(locale: nil))
+    when matches([false, true])
+      paths.homepage_with_locale_url(opts)
+    when matches([false, false])
+      paths.homepage_without_locale_url(opts.merge(locale: nil))
+    end
+  end
+
+  def landing_page_path(community, user, locale_param)
+    non_default_locale = ->(locale) { locale && locale != community.default_locale.to_s}
+    not_present = ->(x) { !x.present? }
+
+    case [CustomLandingPage::LandingPageStore.enabled?(community.id), user, locale_param]
+    when matches([true, __, __])
+      paths.landing_page_without_locale_path(locale: nil)
+    when matches([false, not_present, non_default_locale])
+      paths.homepage_with_locale_path
+    else
+      paths.homepage_without_locale_path(locale: nil)
+    end
+  end
+
+
+  def paths
+    Rails.application.routes.url_helpers
+  end
+
+end

--- a/app/view_utils/topbar_helper.rb
+++ b/app/view_utils/topbar_helper.rb
@@ -1,0 +1,87 @@
+module TopbarHelper
+
+  module_function
+
+  def topbar_props(community:, user: nil, community_locales:, path_after_locale_change:)
+
+    links = [
+      {
+        link: "/", # FIXME
+        title: I18n.t("header.home")
+      },
+      {
+        link: paths.about_infos_path,
+        title: I18n.t("header.about")
+      },
+      {
+        link: paths.new_user_feedback_path,
+        title: I18n.t("header.contact_us"),
+      }
+    ]
+
+    if user&.has_admin_rights? || community.users_can_invite_new_users
+      links << {
+        link: paths.new_invitation_path,
+        title: I18n.t("header.invite"),
+      }
+    end
+
+    links.concat(Maybe(community.menu_links)
+      .map { |menu_links|
+        menu_links.map { |menu_link|
+          {
+            link: menu_link.url(I18n.locale),
+            title: menu_link.title(I18n.locale)
+          }
+        }
+      }.or_else([]))
+
+    {
+      logo: {
+        href: '/',
+        text: community.name(I18n.locale),
+        image: community.wide_logo.present? ? community.wide_logo.url(:header) : nil,
+        image_highres: community.wide_logo.present? ? community.wide_logo.url(:header_highres) : nil
+      },
+      search: {
+        mode: 'keyword-and-location',
+        keyword_placeholder: (@community_customization && @community_customization.search_placeholder) || I18n.t("web.topbar.search_placeholder"),
+        location_placeholder: 'Location'
+      },
+      menu: {
+        links: links,
+      },
+      locales: locale_props(I18n.locale, community_locales, path_after_locale_change),
+      avatarDropdown: {
+        customColor: CommonStylesHelper.marketplace_colors(community)[:marketplace_color1],
+        avatar: {
+          imageHeight: '44px',
+          image: Maybe(user).image.url(:thumb).or_else(missing_profile_image_path()),
+        }
+      }
+    }
+  end
+
+
+  def locale_props(current_locale, community_locales, path_after_locale_change)
+    {
+      current_locale_ident: I18n.locale,
+      current_locale: Maybe(Sharetribe::AVAILABLE_LOCALES.find { |l| l[:ident] == current_locale.to_s })[:language].or_else(current_locale).to_s,
+      available_locales: community_locales.map { |locale|
+        {
+          locale_name: locale[0],
+          locale_ident: locale[1],
+          change_locale_uri: paths.change_locale_path({locale: locale[1], redirect_uri: path_after_locale_change})
+        }
+      },
+    }
+  end
+
+  def missing_profile_image_path
+    ActionController::Base.helpers.image_path("profile_image/thumb/missing.png")
+  end
+
+  def paths
+    Rails.application.routes.url_helpers
+  end
+end

--- a/app/view_utils/topbar_helper.rb
+++ b/app/view_utils/topbar_helper.rb
@@ -2,11 +2,11 @@ module TopbarHelper
 
   module_function
 
-  def topbar_props(community:, user: nil, community_locales:, path_after_locale_change:)
+  def topbar_props(community:, user: nil, community_locales:, path_after_locale_change:, locale_param: nil)
 
     links = [
       {
-        link: "/", # FIXME
+        link: PathHelpers.landing_page_path(community, user, locale_param),
         title: I18n.t("header.home")
       },
       {
@@ -38,7 +38,7 @@ module TopbarHelper
 
     {
       logo: {
-        href: '/',
+        href: PathHelpers.landing_page_path(community, user, locale_param),
         text: community.name(I18n.locale),
         image: community.wide_logo.present? ? community.wide_logo.url(:header) : nil,
         image_highres: community.wide_logo.present? ? community.wide_logo.url(:header_highres) : nil

--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -2,9 +2,10 @@ module RailsContextExtension
   # Return a Hash that contains custom values from the view context that will get passed to
   # all calls to react_component and redux_store for rendering
   def self.custom_context(view_context)
+    community = view_context.request.env[:current_marketplace]
     {
-      marketplaceId: view_context.controller.current_community_id,
-    }.merge(view_context.controller.current_community_custom_colors)
+      marketplaceId: community&.id,
+    }.merge(CommonStylesHelper.marketplace_colors(community))
   end
 end
 


### PR DESCRIPTION
* Independently callable topbar props method
* Fix bug in current_locale handling
* Remove unnecessary helpers from app ctrl that were used in building RailsContext. There's a better way.