### PR TITLE
Valid OAuth - problems

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -124,6 +124,10 @@ class SessionsController < ApplicationController
         redirect_to sign_up_path and return
       end
 
+      if data.username.blank? && data.family_name.blank? && data.given_name.blank?
+        FacebookSignupFails.create(auth_data: data, community_id: @current_community.id)
+      end
+
       facebook_data = {"email" => data.email,
                        "given_name" => data.first_name,
                        "family_name" => data.last_name,

--- a/app/models/facebook_signup_fails.rb
+++ b/app/models/facebook_signup_fails.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: facebook_signup_fails
+#
+#  id           :integer          not null, primary key
+#  community_id :integer
+#  auth_data    :text
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+class FacebookSignupFails < ActiveRecord::Base
+  attr_accessible :auth_data, :community_id
+end

--- a/db/migrate/20151105120334_create_facebook_signup_fails.rb
+++ b/db/migrate/20151105120334_create_facebook_signup_fails.rb
@@ -1,0 +1,10 @@
+class CreateFacebookSignupFails < ActiveRecord::Migration
+  def change
+    create_table :facebook_signup_fails do |t|
+      t.integer :community_id
+      t.text :auth_data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151102084029) do
+ActiveRecord::Schema.define(:version => 20151105120334) do
 
   create_table "auth_tokens", :force => true do |t|
     t.string   "token"
@@ -205,6 +205,7 @@ ActiveRecord::Schema.define(:version => 20151102084029) do
     t.datetime "favicon_updated_at"
     t.integer  "default_min_days_between_community_updates",               :default => 7
     t.boolean  "listing_location_required",                                :default => false
+    t.text     "custom_head_script"
     t.boolean  "follow_in_use",                                            :default => true,                      :null => false
     t.boolean  "logo_processing"
     t.boolean  "wide_logo_processing"
@@ -214,7 +215,6 @@ ActiveRecord::Schema.define(:version => 20151102084029) do
     t.string   "dv_test_file_name",                          :limit => 64
     t.string   "dv_test_file",                               :limit => 64
     t.boolean  "deleted"
-    t.text     "custom_head_script"
   end
 
   add_index "communities", ["domain"], :name => "index_communities_on_domain"
@@ -404,6 +404,13 @@ ActiveRecord::Schema.define(:version => 20151102084029) do
 
   add_index "emails", ["address"], :name => "index_emails_on_address", :unique => true
   add_index "emails", ["person_id"], :name => "index_emails_on_person_id"
+
+  create_table "facebook_signup_fails", :force => true do |t|
+    t.integer  "community_id"
+    t.text     "auth_data"
+    t.datetime "created_at",   :null => false
+    t.datetime "updated_at",   :null => false
+  end
 
   create_table "feature_flags", :force => true do |t|
     t.integer  "community_id",                   :null => false


### PR DESCRIPTION
I had an Instant Article, everything was ok... and suddenly I have a problem, when I tried to add another page on the my site. After I deleted all details from that page, I still have a problem.

I'm using Facebook Instant Articles Plugin.

I got this msg:

URL Blocked: This redirect failed because the redirect URI is not whitelisted in the app’s Client OAuth Settings. Make sure Client and Web OAuth Login are on and add all your app domains as Valid OAuth Redirect URIs. (when I put https://___________.com/login/callback)

When I put just (https://_________.com), I can't list pages through the Instant Article Plugin.

How to resolve the problem? What to do?

When I tried a new app, I got same problem.

Kind Regards,
Alonzo

https://wordpress.org/plugins/fb-instant-articles/