### PR TITLE
Google Maps API key

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -58,6 +58,7 @@
 #  facebook_connect_id                        :string(255)
 #  facebook_connect_secret                    :string(255)
 #  google_analytics_key                       :string(255)
+#  google_maps_key                            :string(64)
 #  name_display_type                          :string(255)      default("first_name_with_initial")
 #  twitter_handle                             :string(255)
 #  use_community_location_as_default          :boolean          default(FALSE)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -29,7 +29,7 @@ class Location < ActiveRecord::Base
 
   def search_and_fill_latlng(address=nil, locale=APP_CONFIG.default_locale)
     okresponse = false
-    geocoder = "http://maps.googleapis.com/maps/api/geocode/json?sensor=false&address="
+    geocoder = "http://maps.googleapis.com/maps/api/geocode/json?address="
 
     if address == nil
       address = self.address

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -6,13 +6,15 @@
 
 - content_for :extra_javascript do
   - # maps.google can't be loaded twice
+  - maps_key = @current_community.google_maps_key
+  - key_param = maps_key ? "&key=#{maps_key}" : ""
   - if(location_search_in_use && @view_type.eql?("map"))
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places" unless feature_enabled?(:topbar_v1)
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}" unless feature_enabled?(:topbar_v1)
     = javascript_include_tag "markerclusterer.js"
   - elsif(location_search_in_use)
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places" unless feature_enabled?(:topbar_v1)
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}" unless feature_enabled?(:topbar_v1)
   - elsif(@view_type.eql?("map"))
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places"
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}"
     = javascript_include_tag "markerclusterer.js"
 
 - content_for :title_header do

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -7,12 +7,12 @@
 - content_for :extra_javascript do
   - # maps.google can't be loaded twice
   - if(location_search_in_use && @view_type.eql?("map"))
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places" unless feature_enabled?(:topbar_v1)
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places" unless feature_enabled?(:topbar_v1)
     = javascript_include_tag "markerclusterer.js"
   - elsif(location_search_in_use)
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places" unless feature_enabled?(:topbar_v1)
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places" unless feature_enabled?(:topbar_v1)
   - elsif(@view_type.eql?("map"))
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places"
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places"
     = javascript_include_tag "markerclusterer.js"
 
 - content_for :title_header do

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -18,7 +18,9 @@
 
   - if feature_enabled?(:topbar_v1)
     - props = topbar_props
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places"
+    - maps_key = @current_community.google_maps_key
+    - key_param = maps_key ? "&key=#{maps_key}" : ""
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}"
     = react_component("TopbarApp", props: props, prerender: true)
   - # this will be an alternative old header
   - # but for the sake of developing we include them both for a short while

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -18,7 +18,7 @@
 
   - if feature_enabled?(:topbar_v1)
     - props = topbar_props
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places"
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&libraries=places"
     = react_component("TopbarApp", props: props, prerender: true)
   - # this will be an alternative old header
   - # but for the sake of developing we include them both for a short while

--- a/app/views/listings/edit.haml
+++ b/app/views/listings/edit.haml
@@ -8,7 +8,7 @@
     });
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
 
 #new_listing_form.new-listing-form.centered-section
 

--- a/app/views/listings/edit.haml
+++ b/app/views/listings/edit.haml
@@ -8,7 +8,9 @@
     });
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
+  - maps_key = @current_community.google_maps_key
+  - key_param = maps_key ? "?key=#{maps_key}" : ""
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
 
 #new_listing_form.new-listing-form.centered-section
 

--- a/app/views/listings/edit.haml
+++ b/app/views/listings/edit.haml
@@ -8,7 +8,7 @@
     });
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.google.com/maps/api/js?sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
 
 #new_listing_form.new-listing-form.centered-section
 

--- a/app/views/listings/new.haml
+++ b/app/views/listings/new.haml
@@ -5,7 +5,9 @@
     });
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
+  - maps_key = @current_community.google_maps_key
+  - key_param = maps_key ? "?key=#{maps_key}" : ""
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
 
 - content_for :title_header do
   %h1= t("listings.new.post_a_new_listing")

--- a/app/views/listings/new.haml
+++ b/app/views/listings/new.haml
@@ -5,7 +5,7 @@
     });
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
 
 - content_for :title_header do
   %h1= t("listings.new.post_a_new_listing")

--- a/app/views/listings/new.haml
+++ b/app/views/listings/new.haml
@@ -5,7 +5,7 @@
     });
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.google.com/maps/api/js?sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
 
 - content_for :title_header do
   %h1= t("listings.new.post_a_new_listing")

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -4,7 +4,9 @@
 - content_for :extra_javascript do
   :javascript
     window.ST.listing();
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
+  - maps_key = @current_community.google_maps_key
+  - key_param = maps_key ? "?key=#{maps_key}" : ""
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
 
 - content_for :title, raw(@listing.title)
 - content_for :meta_author, @listing.author.name(@current_community)

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -4,7 +4,7 @@
 - content_for :extra_javascript do
   :javascript
     window.ST.listing();
-  = javascript_include_tag "https://maps.google.com/maps/api/js?sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
 
 - content_for :title, raw(@listing.title)
 - content_for :meta_author, @listing.author.name(@current_community)

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -4,7 +4,7 @@
 - content_for :extra_javascript do
   :javascript
     window.ST.listing();
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
 
 - content_for :title, raw(@listing.title)
 - content_for :meta_author, @listing.author.name(@current_community)

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -2,7 +2,9 @@
   initialize_update_profile_info_form("#{I18n.locale}","#{target_user.id.to_s}", #{@current_community.real_name_required?});
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
+  - maps_key = @current_community.google_maps_key
+  - key_param = maps_key ? "?key=#{maps_key}" : ""
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
 
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -2,7 +2,7 @@
   initialize_update_profile_info_form("#{I18n.locale}","#{target_user.id.to_s}", #{@current_community.real_name_required?});
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.google.com/maps/api/js?sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
 
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -2,7 +2,7 @@
   initialize_update_profile_info_form("#{I18n.locale}","#{target_user.id.to_s}", #{@current_community.real_name_required?});
 
 - content_for :extra_javascript do
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}&sensor=true"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{@current_community.google_maps_key}"
 
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")

--- a/db/migrate/20160627063918_add_google_maps_api_key_to_communities.rb
+++ b/db/migrate/20160627063918_add_google_maps_api_key_to_communities.rb
@@ -1,0 +1,5 @@
+class AddGoogleMapsApiKeyToCommunities < ActiveRecord::Migration
+  def change
+    add_column :communities, :google_maps_key, :string, limit: 64, after: :google_analytics_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160615145518) do
+ActiveRecord::Schema.define(version: 20160627063918) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -183,6 +183,7 @@ ActiveRecord::Schema.define(version: 20160615145518) do
     t.string   "facebook_connect_id",                        limit: 255
     t.string   "facebook_connect_secret",                    limit: 255
     t.string   "google_analytics_key",                       limit: 255
+    t.string   "google_maps_key",                            limit: 64
     t.string   "name_display_type",                          limit: 255,      default: "first_name_with_initial"
     t.string   "twitter_handle",                             limit: 255
     t.boolean  "use_community_location_as_default",                           default: false

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -59,6 +59,7 @@
 #  facebook_connect_id                        :string(255)
 #  facebook_connect_secret                    :string(255)
 #  google_analytics_key                       :string(255)
+#  google_maps_key                            :string(64)
 #  name_display_type                          :string(255)      default("first_name_with_initial")
 #  twitter_handle                             :string(255)
 #  use_community_location_as_default          :boolean          default(FALSE)


### PR DESCRIPTION
This PR adds a column to the communities table for a Google Maps API key. This key is then included in the script tab URLs that load the Maps API.