### PR TITLE
Category resolver

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -118,7 +118,7 @@ class LandingPageController < ActionController::Metal
     Rails.cache.write("clp/#{community_id}/#{version}/#{digest}", content, expires_in: cache_time)
   end
 
-  def path_to_search(lp_enabled:, params: {})
+  def path_to_search(lp_enabled:, locale:, params: {})
     if lp_enabled
       search_with_locale_path({locale: locale}.merge(params))
     else
@@ -129,7 +129,7 @@ class LandingPageController < ActionController::Metal
   def build_denormalizer(cid:, locale:, sitename:, lp_enabled:)
 
     # Application paths
-    paths = { "search" => path_to_search(lp_enabled: true),
+    paths = { "search" => path_to_search(lp_enabled: true, locale: locale),
               "signup" => sign_up_path,
               "about" => about_infos_path,
               "contact_us" => new_user_feedback_path,
@@ -139,7 +139,7 @@ class LandingPageController < ActionController::Metal
     marketplace_data = CLP::MarketplaceDataStore.marketplace_data(cid, locale)
 
     build_category_path = ->(category_name_param) {
-      path_to_search(lp_enabled: lp_enabled, params: {category: category_name_param})
+      path_to_search(lp_enabled: lp_enabled, locale: locale, params: {category: category_name_param})
     }
 
     CLP::Denormalizer.new(

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -118,16 +118,18 @@ class LandingPageController < ActionController::Metal
     Rails.cache.write("clp/#{community_id}/#{version}/#{digest}", content, expires_in: cache_time)
   end
 
+  def path_to_search(lp_enabled:, params: {})
+    if lp_enabled
+      search_with_locale_path({locale: locale}.merge(params))
+    else
+      homepage_without_locale_path({locale: nil}.merge(params))
+    end
+  end
 
   def build_denormalizer(cid:, locale:, sitename:, lp_enabled:)
-    path_to_search =
-      if lp_enabled
-        search_with_locale_path(locale: locale)
-      else
-        homepage_without_locale_path(locale: nil)
-      end
+
     # Application paths
-    paths = { "search" => path_to_search,
+    paths = { "search" => path_to_search(lp_enabled: true),
               "signup" => sign_up_path,
               "about" => about_infos_path,
               "contact_us" => new_user_feedback_path,
@@ -136,12 +138,17 @@ class LandingPageController < ActionController::Metal
 
     marketplace_data = CLP::MarketplaceDataStore.marketplace_data(cid, locale)
 
+    build_category_path = ->(category_name_param) {
+      path_to_search(lp_enabled: lp_enabled, params: {category: category_name_param})
+    }
+
     CLP::Denormalizer.new(
       link_resolvers: {
         "path" => CLP::LinkResolver::PathResolver.new(paths),
         "marketplace_data" => CLP::LinkResolver::MarketplaceDataResolver.new(marketplace_data),
         "assets" => CLP::LinkResolver::AssetResolver.new(APP_CONFIG[:clp_asset_host], sitename),
-        "translation" => CLP::LinkResolver::TranslationResolver.new(locale)
+        "translation" => CLP::LinkResolver::TranslationResolver.new(locale),
+        "category" => CLP::LinkResolver::CategoryResolver.new(cid, locale, build_category_path)
       }
     )
   end

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -91,5 +91,31 @@ module CustomLandingPage
         end
       end
     end
+
+    class CategoryResolver
+      def initialize(cid, locale, build_category_path)
+        @_cid = cid
+        @_locale = locale
+        @_build_category_path = build_category_path
+      end
+
+      def call(type, id, _)
+        Maybe(categories.find { |c| c.id == id }).map { |c|
+          {
+            "title" => c.display_name(@_locale),
+            "path" => @_build_category_path.call(c.url)
+          }
+        }.or_else {
+          {
+            "title" => "N/A",
+            "path" => nil
+          }
+        }
+      end
+
+      def categories
+        @_categories ||= Category.where(community_id: @_cid).to_a
+      end
+    end
   end
 end

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -105,12 +105,7 @@ module CustomLandingPage
             "title" => c.display_name(@_locale),
             "path" => @_build_category_path.call(c.url)
           }
-        }.or_else {
-          {
-            "title" => "N/A",
-            "path" => nil
-          }
-        }
+        }.or_else(nil)
       end
 
       def categories

--- a/app/views/landing_page/_categories.erb
+++ b/app/views/landing_page/_categories.erb
@@ -29,11 +29,12 @@
 
     <div class="categories__categories">
       <% num_of_categories = s["categories"].length %>
-      <% s["categories"].each do |c| %>
+      <% s["categories"].each do |category| %>
+        <% c = category["category"] || {} # Make template tolerant to nil values %>
         <div class="categories__category--<%= num_of_categories %>">
-          <a href="<%= c["category"]["path"] %>">
-            <div class="<%= section_id %>__categories__category-content categories__category-content" style="background-image: url(<%= c["background_image"]["src"] %>)">
-              <h3 class="categories__category-title"><%= c["category"]["title"] %></h3>
+          <a href="<%= c["path"] %>">
+            <div class="<%= section_id %>__categories__category-content categories__category-content" style="background-image: url(<%= category["background_image"]["src"] %>)">
+              <h3 class="categories__category-title"><%= c["title"] %></h3>
             </div>
           </a>
         </div>


### PR DESCRIPTION
This PR adds a new resolver `CategoryResolver`

The resolver resolves links of type:

```
{ 
  "type": "category", 
  "id": 123
}
```

to:

```
{ 
  "type": "category", 
  "id": 123, 
  "title": "Category title", 
  "path": "<search_path>/?category=category_name"
}
```

The rendering is implemented so that it tolerates `nil` values (the CategoryResolver might return `nil` for example if given category ID doesn't exist for the community). We don't want the whole landing page to break if the category ID was mistyped.