### PR TITLE
Topbar login links

### DIFF
--- a/app/view_utils/common_styles_helper.rb
+++ b/app/view_utils/common_styles_helper.rb
@@ -4,8 +4,8 @@ module CommonStylesHelper
 
   def marketplace_colors(community)
     {
-      marketplace_color1: community ? "##{community.custom_color1}" : "#a64c5d",
-      marketplace_color2: community ? "##{community.custom_color2}" : "#00a26c"
+      marketplace_color1: community&.custom_color1 ? "##{community.custom_color1}" : "#a64c5d",
+      marketplace_color2: community&.custom_color2 ? "##{community.custom_color2}" : "#00a26c"
     }
   end
 end

--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -109,6 +109,7 @@ module.exports = {
   '--Topbar_logoHeight': '25px',
   '--Topbar_textLogoMaxWidth': '20em',
   '--Topbar_fontFamily': "'Proxima Nova Soft', Helvetica, sans",
+  '--Topbar_borderColor': 'rgba(0, 0, 50, 0.1)',
 
    // Must be at least 16px to avoid iOS from zooming in when focusing
    // on an input.

--- a/client/app/components/elements/Link/Link.css
+++ b/client/app/components/elements/Link/Link.css
@@ -1,0 +1,7 @@
+.link {
+  transition: all 100ms ease-in;
+
+  &:hover {
+    filter: brightness(80%);
+  }
+}

--- a/client/app/components/elements/Link/Link.js
+++ b/client/app/components/elements/Link/Link.js
@@ -1,0 +1,29 @@
+import { PropTypes } from 'react';
+import { a } from 'r-dom';
+
+import * as propTypeUtils from '../../../utils/PropTypes';
+import * as variables from '../../../assets/styles/variables';
+
+import css from './Link.css';
+
+export default function Link({ href, className, customColor, openInNewTab, children }) {
+  const color = customColor || variables['--customColorFallback'];
+
+  return a({
+    className: className || '',
+    classSet: { [css.link]: true },
+    href,
+    style: { color },
+    ...(openInNewTab ? { target: '_blank', rel: 'noreferrer' } : null),
+  }, children);
+}
+
+const { string, bool } = PropTypes;
+
+Link.propTypes = {
+  href: string.isRequired,
+  className: propTypeUtils.className,
+  customColor: string,
+  openInNewTab: bool,
+  children: string.isRequired,
+};

--- a/client/app/components/sections/Topbar/Topbar.css
+++ b/client/app/components/sections/Topbar/Topbar.css
@@ -6,7 +6,7 @@
   justify-content: space-between;
   align-items: center;
   background: var(--colorBackground);
-  border-bottom: 1px solid rgba(0, 0, 50, 0.1);
+  border-bottom: 1px solid var(--Topbar_borderColor);
 
   font-size: var(--Topbar_fontSize);
 
@@ -160,3 +160,24 @@
     margin: var(--Topbar_avatarPadding);
   }
 }
+
+.topbarLinks {
+  height: 100%;
+
+  & .topbarLink {
+    display: inline-block;
+    height: 100%;
+    line-height: var(--Topbar_mobileHeight);
+    padding: 0 0.5em;
+
+    &:hover {
+      background-color: var(--Topbar_borderColor);
+      filter: none;
+    }
+
+    @media (--large-viewport) {
+      line-height: var(--Topbar_height);
+    }
+  }
+}
+

--- a/client/app/components/sections/Topbar/Topbar.js
+++ b/client/app/components/sections/Topbar/Topbar.js
@@ -12,6 +12,7 @@ import Menu from '../../composites/Menu/Menu';
 import MenuMobile from '../../composites/MenuMobile/MenuMobile';
 import AvatarDropdown from '../../composites/AvatarDropdown/AvatarDropdown';
 import AddNewListingButton from '../../elements/AddNewListingButton/AddNewListingButton';
+import Link from '../../elements/Link/Link';
 
 const profileDropdownActions = function profileDropdownActions(routes, username) {
   return username ?
@@ -83,6 +84,30 @@ const profileLinks = function profileLinks(username, router, location, customCol
     ];
   }
   return [];
+};
+
+const LoginLinks = ({ loginUrl, signupUrl, customColor }) =>
+  div({
+    className: 'LoginLinks',
+    classSet: { [css.topbarLinks]: true },
+  }, [
+    r(Link, {
+      className: css.topbarLink,
+      href: signupUrl,
+      customColor,
+      openInNewTab: true,
+    }, t('web.topbar.signup')),
+    r(Link, {
+      className: css.topbarLink,
+      href: loginUrl,
+      customColor,
+    }, t('web.topbar.login')),
+  ]);
+
+LoginLinks.propTypes = {
+  loginUrl: PropTypes.string.isRequired,
+  signupUrl: PropTypes.string.isRequired,
+  customColor: PropTypes.string,
 };
 
 const DEFAULT_CONTEXT = {
@@ -157,9 +182,11 @@ class Topbar extends Component {
       }) :
       {};
 
-    const newListingRoute = this.props.routes && this.props.routes.new_listing_path ?
+    const newListingRoute = this.props.routes.new_listing_path ?
             this.props.routes.new_listing_path() :
             '#';
+    const loginRoute = this.props.routes.login_path ? this.props.routes.login_path() : '#';
+    const signupRoute = this.props.routes.sign_up_path ? this.props.routes.sign_up_path() : '#';
 
     return div({ className: css.topbar }, [
       this.props.menu ? r(MenuMobile, { ...mobileMenuProps, className: css.topbarMobileMenu }) : null,
@@ -178,12 +205,16 @@ class Topbar extends Component {
       this.props.menu ? r(Menu, { ...menuProps, className: css.topbarMenu }) : null,
       div({ className: css.topbarSpacer }),
       hasMultipleLanguages ? r(Menu, { ...languageMenuProps, className: css.topbarMenu }) : null,
-      this.props.avatarDropdown ?
+      this.props.avatarDropdown && loggedInUsername ?
         r(AvatarDropdown, {
           ...avatarDropdownProps(this.props.avatarDropdown, marketplace_color1, loggedInUsername, this.props.routes),
           classSet: css.topbarAvatarDropdown,
         }) :
-        div({ className: css.topbarAvatarDropdownPlaceholder }),
+        r(LoginLinks, {
+          loginUrl: loginRoute,
+          signupUrl: signupRoute,
+          customColor: marketplace_color1,
+        }),
       this.props.newListingButton ?
         r(AddNewListingButton, {
           ...this.props.newListingButton,

--- a/client/app/startup/TopbarApp.js
+++ b/client/app/startup/TopbarApp.js
@@ -16,6 +16,8 @@ export default (props, marketplaceContext) => {
     'person_settings',
     'logout',
     'admin',
+    'login',
+    'sign_up',
   ], { locale });
 
   const combinedProps = Object.assign({}, props, { marketplaceContext, routes });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2172,6 +2172,8 @@ en:
       manage_listings: "Manage listings"
       settings: Settings
       logout: "Log out"
+      login: "Log in"
+      signup: "Sign up"
   will_paginate:
     models:
       person:


### PR DESCRIPTION
This PR adds the "Sign up" and "Log in" links to the Topbar.

[Interactive example](https://sharetribe.github.io/sharetribe/topbar-login-links/?selectedKind=Top%20bar&selectedStory=Basic%20state) in the Styleguide.