### PR TITLE
Fix marketplaceContext missing in server rendering

### DIFF
--- a/client/app/reducers/reducersIndex.js
+++ b/client/app/reducers/reducersIndex.js
@@ -4,6 +4,7 @@ import routesReducer from './RoutesReducer';
 // This is how you do a directory of reducers.
 // The `import * as reducers` does not work for a directory, but only with a single file
 export default {
+  marketplaceContext: (state = {}) => state,
   onboarding_guide_page: onboardingGuideReducer,
   routes: routesReducer,
 };

--- a/client/app/startup/OnboardingGuideApp.js
+++ b/client/app/startup/OnboardingGuideApp.js
@@ -31,7 +31,7 @@ export default (props, marketplaceContext) => {
   ], { locale: marketplaceContext.i18nLocale });
 
   const combinedReducer = combineReducers(reducers);
-  const combinedProps = Object.assign({}, props, { routes });
+  const combinedProps = Object.assign({}, props, { routes, marketplaceContext });
 
   const store = applyMiddleware(middleware)(createStore)(combinedReducer, combinedProps);
 


### PR DESCRIPTION
OnboardingGuide requires the context to be in the store for server
rendering.