### PR TITLE
Fix Context handling for landing page topbar

### DIFF
--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -171,25 +171,35 @@
   <%= javascript_include_tag 'app-bundle' %>
 
   <script>
-    var renderTopBar = function renderTopBar(props, marketplaceCtx) {
-      componentFn = function (props) {
-        return window.ReactOnRails.getComponent('TopbarApp').component(props, marketplaceCtx)
-      }
-      ReactDOM.render(React.createElement(componentFn, props), document.getElementById('topbar-placeholder'));
-    };
+    (function() {
+      var renderTopBar = function renderTopBar(props, marketplaceCtx) {
+        componentFn = function (props) {
+          return window.ReactOnRails.getComponent('TopbarApp').component(props, marketplaceCtx)
+        }
+        ReactDOM.render(React.createElement(componentFn, props), document.getElementById('topbar-placeholder'));
+      };
 
-    staticProps = <%= topbar_props.to_json.html_safe %>
-    staticMarketplaceContext = <%= marketplace_context.to_json.html_safe %>
+      var staticProps = <%= topbar_props.to_json.html_safe %>
+      var staticMarketplaceContext = <%= marketplace_context.to_json.html_safe %>
 
-    renderTopBar(staticProps, staticMarketplaceContext);
+      var p = Promise.race([
+        window.fetch("<%= topbar_props_path %>", { credentials: 'same-origin' }),
+        new Promise(function (resolve, reject) {
+          setTimeout(function() { reject(new Error('request timeout')) }, 3000);
+        })]);
 
-    window.fetch("<%= topbar_props_path %>", { credentials: 'same-origin' })
-      .then(function (res) { return res.json(); })
-      .then(function (resJson) {
-        props = Object.assign({}, staticProps, resJson.props);
-        mCtx = Object.assign({}, staticMarketplaceContext, resJson.marketplaceContext)
-        renderTopBar(props, mCtx);
+      p.then(function (res) { return res.json(); })
+       .then(function (resJson) {
+          props = Object.assign({}, staticProps, resJson.props);
+          mCtx = Object.assign({}, staticMarketplaceContext, resJson.marketplaceContext);
+          renderTopBar(props, mCtx);
+        });
+
+      p.catch(function(error) {
+        console.error(error);
+        renderTopBar(staticProps, staticMarketplaceContext);
       });
+    }());
   </script>
   <% end %>
 

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -178,14 +178,18 @@
       ReactDOM.render(React.createElement(componentFn, props), document.getElementById('topbar-placeholder'));
     };
 
-    static_props = <%= topbar_props.to_json.html_safe %>
-    marketplaceContext = <%= marketplace_context.to_json.html_safe %>
+    staticProps = <%= topbar_props.to_json.html_safe %>
+    staticMarketplaceContext = <%= marketplace_context.to_json.html_safe %>
 
-    renderTopBar(static_props, marketplaceContext);
+    renderTopBar(staticProps, staticMarketplaceContext);
 
     window.fetch("<%= topbar_props_path %>", { credentials: 'same-origin' })
       .then(function (res) { return res.json(); })
-      .then(function (props) { renderTopBar(Object.assign({}, static_props, props), marketplaceContext); });
+      .then(function (resJson) {
+        props = Object.assign({}, staticProps, resJson.props);
+        mCtx = Object.assign({}, staticMarketplaceContext, resJson.marketplaceContext)
+        renderTopBar(props, mCtx);
+      });
   </script>
   <% end %>
 


### PR DESCRIPTION
* Detect logged in user and pass it correctly to topbar
* Add timeout and fallback in case topbar api doesn't respond (fast enough)