### PR TITLE
Add hover color to ProfileDropdown (overwrite old styles)

### DIFF
--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -162,6 +162,7 @@ module.exports = {
   '--ProfileDropdown_zIndex': 1,
   '--ProfileDropdown_rightOffset': bodyPadding,
   '--ProfileDropdown_textColor': textColor,
+  '--ProfileDropdown_textColorFocus': textColorFocus,
   '--ProfileDropdown_logoutLinkColor': textColorGrey,
   '--ProfileDropdown_textLinkSize': pxToEms(13, 14), // eslint-disable-line no-magic-numbers
 

--- a/client/app/components/composites/AvatarDropdown/ProfileDropdown.css
+++ b/client/app/components/composites/AvatarDropdown/ProfileDropdown.css
@@ -37,6 +37,7 @@
 
   &:hover {
     background-color: rgb(249, 249, 249);
+    color: var(--ProfileDropdown_textColorFocus);
   }
 }
 
@@ -59,4 +60,8 @@
   float: right;
   cursor: pointer;
   color: var(--ProfileDropdown_logoutLinkColor);
+
+  &:hover {
+    color: var(--ProfileDropdown_textColorFocus);
+  }
 }


### PR DESCRIPTION
Marketplace ```<a>``` styles were leaking since there was no specific profile hover styles.