### PR TITLE
Language bugs and app-bundle move from head to body

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -151,7 +151,7 @@ class LandingPageController < ActionController::Metal
     Rails.cache.write("clp/#{community_id}/#{version}/#{digest}", content, expires_in: cache_time)
   end
 
-  def build_denormalizer(cid:, default_locale:, locale_param:, sitename:)
+  def build_denormalizer(cid:, default_locale:, locale_param:, landing_page_locale:, sitename:)
     search_path = ->(opts = {}) {
       PathHelpers.search_path(
         community_id: cid,
@@ -175,19 +175,19 @@ class LandingPageController < ActionController::Metal
               "privacy" => privacy_infos_path(locale: locale_param)
             }
 
-    marketplace_data = CLP::MarketplaceDataStore.marketplace_data(cid, locale)
+    marketplace_data = CLP::MarketplaceDataStore.marketplace_data(cid, landing_page_locale)
     name_display_type = marketplace_data["name_display_type"]
 
-    category_data = CLP::CategoryStore.categories(cid, locale, search_path)
+    category_data = CLP::CategoryStore.categories(cid, landing_page_locale, search_path)
 
     CLP::Denormalizer.new(
       link_resolvers: {
         "path" => CLP::LinkResolver::PathResolver.new(paths),
         "marketplace_data" => CLP::LinkResolver::MarketplaceDataResolver.new(marketplace_data),
         "assets" => CLP::LinkResolver::AssetResolver.new(APP_CONFIG[:clp_asset_host], sitename),
-        "translation" => CLP::LinkResolver::TranslationResolver.new(locale),
+        "translation" => CLP::LinkResolver::TranslationResolver.new(landing_page_locale),
         "category" => CLP::LinkResolver::CategoryResolver.new(category_data),
-        "listing" => CLP::LinkResolver::ListingResolver.new(cid, locale, name_display_type)
+        "listing" => CLP::LinkResolver::ListingResolver.new(cid, landing_page_locale, locale_param, name_display_type)
       }
     )
   end
@@ -235,6 +235,7 @@ class LandingPageController < ActionController::Metal
       cid: c&.id,
       locale_param: locale_param,
       default_locale: default_locale,
+      landing_page_locale: landing_page_locale,
       sitename: sitename
     )
 

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -240,6 +240,7 @@ class LandingPageController < ActionController::Metal
 
     render_to_string :landing_page,
            locals: { font_path: FONT_PATH,
+                     landing_page_locale: landing_page_locale,
                      styles: landing_page_styles,
                      javascripts: {
                        location_search: location_search_js,

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -108,16 +108,18 @@ module CustomLandingPage
     end
 
     class ListingResolver
-      def initialize(cid, locale, name_display_type)
+      def initialize(cid, landing_page_locale, locale_param, name_display_type)
         @_cid = cid
-        @_locale = locale
+        @_landing_page_locale = landing_page_locale
+        @_locale_param = locale_param
         @_name_display_type = name_display_type
       end
 
       def call(type, id, _)
         ListingStore.listing(id: id,
                              community_id: @_cid,
-                             locale: @_locale,
+                             landing_page_locale: @_landing_page_locale,
+                             locale_param: @_locale_param,
                              name_display_type: @_name_display_type)
       end
 

--- a/app/services/custom_landing_page/listing_store.rb
+++ b/app/services/custom_landing_page/listing_store.rb
@@ -3,7 +3,7 @@ module CustomLandingPage
 
     module_function
 
-    def listing(community_id:, locale:, name_display_type:, id:)
+    def listing(community_id:, landing_page_locale:, locale_param:, name_display_type:, id:)
 
       listing = Listing.includes(:author).find_by(community_id: community_id, id: id)
 
@@ -25,8 +25,8 @@ module CustomLandingPage
         {
           "title" => listing.title,
           "price" => Maybe(listing.price).format(no_cents_if_whole: true).or_else(nil),
-          "price_unit" => Maybe(listing.unit_type).map { |unit_type| ListingViewUtils.translate_unit(unit_type, listing.unit_tr_key) }.or_else(nil),
-          "shape_name" => I18n.t(listing.shape_name_tr_key, locale: locale),
+          "price_unit" => Maybe(listing.unit_type).map { |unit_type| ListingViewUtils.translate_unit(unit_type, listing.unit_tr_key, locale: landing_page_locale) }.or_else(nil),
+          "shape_name" => I18n.t(listing.shape_name_tr_key, locale: landing_page_locale),
           "author_name" => PersonViewUtils.display_name(
             first_name: author.given_name,
             last_name: author.family_name,
@@ -39,20 +39,20 @@ module CustomLandingPage
           ),
           "author_avatar" => author_avatar,
           "listing_image" => listing_image,
-          "listing_path" => listing_path(listing.id, locale),
-          "author_path" => author_path(author.username, locale)
+          "listing_path" => listing_path(listing.id, locale_param),
+          "author_path" => author_path(author.username, locale_param)
         }
       end
     end
 
     # private
 
-    def author_path(username, locale)
-      paths.person_path(username: username, locale: locale)
+    def author_path(username, locale_param)
+      paths.person_path(username: username, locale: locale_param)
     end
 
-    def listing_path(id, locale)
-      paths.listing_path(id: id, locale: locale)
+    def listing_path(id, locale_param)
+      paths.listing_path(id: id, locale: locale_param)
     end
 
 

--- a/app/view_utils/listing_view_utils.rb
+++ b/app/view_utils/listing_view_utils.rb
@@ -30,20 +30,22 @@ module ListingViewUtils
       }
   end
 
-  def translate_unit(type, tr_key)
+  def translate_unit(type, tr_key, locale: nil)
+    l = (locale || I18n.locale).to_sym
+
     case type
     when :hour
-      I18n.translate("listings.unit_types.hour")
+      I18n.translate("listings.unit_types.hour", locale: l)
     when :day
-      I18n.translate("listings.unit_types.day")
+      I18n.translate("listings.unit_types.day", locale: l)
     when :night
-      I18n.translate("listings.unit_types.night")
+      I18n.translate("listings.unit_types.night", locale: l)
     when :week
-      I18n.translate("listings.unit_types.week")
+      I18n.translate("listings.unit_types.week", locale: l)
     when :month
-      I18n.translate("listings.unit_types.month")
+      I18n.translate("listings.unit_types.month", locale: l)
     when :custom
-      I18n.translate(tr_key)
+      I18n.translate(tr_key, locale: l)
     else
       raise ArgumentError.new("No translation for unit type: #{type}, translation_key: #{tr_key}")
     end

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -60,8 +60,6 @@
   <%= favicon_link_tag community_context[:favicon] %>
   <%= favicon_link_tag community_context[:apple_touch_icon], rel: 'apple-touch-icon-precomposed', type: 'image/png' %>
 
-  <%= stylesheet_link_tag 'app-bundle' %>
-
   <!-- SEO Meta -->
   <!--
   <meta name="description" content="The HTML5 Herald">
@@ -130,6 +128,7 @@
     <%= javascripts[:translations] %>
   </script>
 
+  <%= stylesheet_link_tag 'app-bundle' %>
   <%= javascript_include_tag 'vendor-bundle' %>
   <%= javascript_include_tag 'app-bundle' %>
 

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -46,7 +46,7 @@
   <% end # sections#each %>
 <% end # capture %>
 
-<html lang="en">
+<html lang="<%= landing_page_locale %>">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
- [X] Add correct language to HTML tag
- [X] All landing page content is in the language that is defined in the structure
- [X] All landing page links are rendered with the locale that is in the URL param, or without locale if logged in user
- [X] Move app-bundle CSS from head to html

  Originally, we decided to add app-bundle CSS to the head, because we though that loading it in the body would trigger additional browser redraw and we wanted to avoid that. However, as Google Page Speed points out, adding the app-bundle in the head prevents any rendering from happening, before the app-bundle CSS is loaded. My hunch is that blocking rendering is bigger bad than triggering page redraw.

Screenshots before app-bundle move and after:

![screen shot 2016-07-05 at 13 28 13](https://cloud.githubusercontent.com/assets/429876/16582262/7963d1fc-42b6-11e6-87ec-da37c8713099.png)

![screen shot 2016-07-05 at 13 42 56](https://cloud.githubusercontent.com/assets/429876/16582268/7ec522a4-42b6-11e6-84c7-8deec17338d0.png)
