### PR TITLE
Cache access to url_helpers module in view utils

### DIFF
--- a/app/services/custom_landing_page/category_store.rb
+++ b/app/services/custom_landing_page/category_store.rb
@@ -25,7 +25,7 @@ module CustomLandingPage
     # private
 
     def paths
-      Rails.application.routes.url_helpers
+      @_url_helpers ||= Rails.application.routes.url_helpers
     end
   end
 end

--- a/app/services/custom_landing_page/listing_store.rb
+++ b/app/services/custom_landing_page/listing_store.rb
@@ -57,7 +57,7 @@ module CustomLandingPage
 
 
     def paths
-      Rails.application.routes.url_helpers
+      @_url_helpers ||= Rails.application.routes.url_helpers
     end
   end
 end

--- a/app/view_utils/path_helpers.rb
+++ b/app/view_utils/path_helpers.rb
@@ -56,7 +56,7 @@ module PathHelpers
   end
 
   def paths
-    RequestStore.store[:url_helpers] ||= Rails.application.routes.url_helpers
+    @_url_helpers ||= Rails.application.routes.url_helpers
   end
 
 end

--- a/app/view_utils/topbar_helper.rb
+++ b/app/view_utils/topbar_helper.rb
@@ -102,6 +102,6 @@ module TopbarHelper
   end
 
   def paths
-    Rails.application.routes.url_helpers
+    @_url_herlpers ||= Rails.application.routes.url_helpers
   end
 end


### PR DESCRIPTION
Rails.application.routes.url_helpers is ~500 times slower than just
Rails.application.routes. This is because .url_helpers dynamically
builds an involved module on every invocation. This module is intended
to be mixed in to classes in which case it gets cached as part of the
Class definition. When accessed directly in other modules it must always
be cached to avoid the costly reconstruction on every call.

This will still work with Rails autoloading because upon detecting a change Rails will autoload all classes and not just Rails specific classes: http://guides.rubyonrails.org/autoloading_and_reloading_constants.html#constant-reloading.