### PR TITLE
Fix avatar dropdown in IE

### DIFF
--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.css
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.css
@@ -6,14 +6,14 @@
   height: 100%;
 
   & .avatarProfileDropdown {
-    display: none;
+    visibility: hidden;
+    margin-bottom: -32px;
   }
 
   &.openDropdown,
   &.touchless:hover {
     & .avatarProfileDropdown {
-      display: block;
-      margin-bottom: -32px;
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
`display: none/block` causes element size to change, and IE doesn't handle this nicely. Hiding the elements instead of removing them from layout seems to work better.