### PR TITLE
Clp fixes 7

### DIFF
--- a/app/assets/stylesheets/landing_page/mixins/_buttons.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_buttons.scss
@@ -10,10 +10,10 @@ You may want to override following properties:
 - height
 
 */
-.landing-page__button {
+@mixin landing-page__button {
   $button-border-size: 2px;
 
-  @include typography__bold;
+  @include typography__semibold;
   font-size: 16px;
   letter-spacing: 0px;
   padding: (16px - $button-border-size) (32px - $button-border-size);

--- a/app/assets/stylesheets/landing_page/mixins/_dimensions.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_dimensions.scss
@@ -40,6 +40,10 @@ $dimension-card-border-radius: 4px;
   }
 }
 
+@mixin dimensions__section--paddings {
+  padding: 96px 0px;
+}
+
 @mixin dimensions__section-paragraph {
 
   margin-bottom: 8px;

--- a/app/assets/stylesheets/landing_page/mixins/_dimensions.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_dimensions.scss
@@ -27,16 +27,16 @@ $dimension-golden-ratio: 1.61803398875;
 $dimension-card-border-radius: 4px;
 
 @mixin dimensions__section-title--limited-width {
-  margin: 18px $dimension-mobile-margin 36px $dimension-mobile-margin;
+  margin: 0px $dimension-mobile-margin 36px $dimension-mobile-margin;
 
   @media #{$tablet} {
     max-width: 75%;
-    margin: 24px auto 48px auto;
+    margin: 0px auto 48px auto;
   }
 
   @media #{$desktop} {
     max-width: 75%;
-    margin: 24px auto 48px auto;
+    margin: 0px auto 48px auto;
   }
 }
 

--- a/app/assets/stylesheets/landing_page/mixins/_dimensions.scss
+++ b/app/assets/stylesheets/landing_page/mixins/_dimensions.scss
@@ -41,7 +41,15 @@ $dimension-card-border-radius: 4px;
 }
 
 @mixin dimensions__section--paddings {
-  padding: 96px 0px;
+  padding: 36px 0px 48px 0px;
+
+  @media #{$desktop} {
+    padding: 60px 0px 72px 0px;
+  }
+
+  @media #{$desktop} {
+    padding: 96px 0px;
+  }
 }
 
 @mixin dimensions__section-paragraph {

--- a/app/assets/stylesheets/landing_page/sections/categories.scss
+++ b/app/assets/stylesheets/landing_page/sections/categories.scss
@@ -27,7 +27,7 @@ $categories__mobile-gutter: 12px;
   @include prefix-val(display, flex);
   @include prefix-prop(align-items, center);
 
-  padding: $dimension-section-margin 0px;
+  @include dimensions__section--paddings;
 }
 
 .categories__content {

--- a/app/assets/stylesheets/landing_page/sections/categories.scss
+++ b/app/assets/stylesheets/landing_page/sections/categories.scss
@@ -53,7 +53,7 @@ $categories__mobile-gutter: 12px;
 }
 
 .categories__button--ghost {
-  @extend .landing-page__button;
+  @include landing-page__button;
 }
 
 .categories__categories {

--- a/app/assets/stylesheets/landing_page/sections/categories.scss
+++ b/app/assets/stylesheets/landing_page/sections/categories.scss
@@ -310,6 +310,9 @@ $categories__mobile-gutter: 12px;
 
   font-size: 16px;
 
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
   @media #{$desktop} {
     font-size: 18px;
   }

--- a/app/assets/stylesheets/landing_page/sections/footer.scss
+++ b/app/assets/stylesheets/landing_page/sections/footer.scss
@@ -9,21 +9,20 @@
 }
 
 .footer__content {
-  min-height: 279px;
   margin: 0 auto;
 
   @include prefix-val(display, flex);
   @include prefix-prop(justify-content, center);
   @include prefix-prop(flex-direction, column);
 
-  padding: 36px;
+  padding: 48px 36px;
 
   @media #{$tablet}  {
-    padding: 36px 96px;
+    padding: 48px 96px;
   }
 
   @media #{$desktop} {
-    padding: 36px;
+    padding: 48px 36px;
     max-width: 1140px + (2 * 36px);
   }
 }
@@ -156,20 +155,20 @@ $footer__link-margin-tablet: 16px;
   margin-top: 30px;
   font-size: 12px;
   letter-spacing: 0px;
-  line-height: 14px;
+  line-height: 18px;
 
   @media #{$tablet} {
     margin-top: 30px;
     font-size: 12px;
     letter-spacing: 0px;
-    line-height: 14px;
+    line-height: 18px;
   }
 
   @media #{$desktop} {
     margin-top: 48px;
     font-size: 14px;
     letter-spacing: 0px;
-    line-height: 14px;
+    line-height: 18px;
   }
 
 }

--- a/app/assets/stylesheets/landing_page/sections/footer.scss
+++ b/app/assets/stylesheets/landing_page/sections/footer.scss
@@ -187,6 +187,7 @@ $footer__social-media-margin: 18px;
 
 .footer__social-media-link {
   padding: $footer__clickarea-y-padding-desktop $footer__social-media-margin;
+  display: inline-block;
 }
 
 

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -12,6 +12,8 @@
   @include prefix-val(display, flex);
   @include prefix-prop(align-items, center);
   box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.5); /* is there any cleaner way? */
+
+  @include dimensions__section--paddings;
 }
 
 .hero__content {

--- a/app/assets/stylesheets/landing_page/sections/info.scss
+++ b/app/assets/stylesheets/landing_page/sections/info.scss
@@ -180,7 +180,13 @@ $content-padding: 36px;
   @include prefix-prop(justify-content, space-between);
 
   width: 100%;
-  margin: 0px 0px 76px 0px;
+
+  // Mobile
+  margin: 0px 0px 72px 0px;
+
+  &:last-child {
+    margin: 0px;
+  }
 
   @media #{$tablet} {
     margin: 0px;

--- a/app/assets/stylesheets/landing_page/sections/info.scss
+++ b/app/assets/stylesheets/landing_page/sections/info.scss
@@ -128,12 +128,12 @@ $content-padding: 36px;
 
 .info__button {
   color: inherit;
-  @extend .landing-page__button;
+  @include landing-page__button;
 }
 
 .info__column-button--ghost {
   color: inherit;
-  @extend .landing-page__button;
+  @include landing-page__button;
   margin-top: 36px;
 }
 

--- a/app/assets/stylesheets/landing_page/sections/info.scss
+++ b/app/assets/stylesheets/landing_page/sections/info.scss
@@ -29,7 +29,8 @@
 .info__section--blank {
   @extend .info__section;
   color: $typography__main-color;
-  padding: $dimension-section-margin 0;
+
+  @include dimensions__section--paddings;
 }
 
 .info__section--zebra {

--- a/app/assets/stylesheets/landing_page/sections/listings.scss
+++ b/app/assets/stylesheets/landing_page/sections/listings.scss
@@ -147,7 +147,7 @@ $listings__tablet-gutter: 16px;
 }
 
 .listings__button--ghost {
-  @extend .landing-page__button;
+  @include landing-page__button;
 }
 
 .listings__listing-title {

--- a/app/assets/stylesheets/landing_page/sections/listings.scss
+++ b/app/assets/stylesheets/landing_page/sections/listings.scss
@@ -10,7 +10,8 @@ $listings__tablet-gutter: 16px;
   @include prefix-val(display, flex);
   @include prefix-prop(align-items, center);
 
-  padding: $dimension-section-margin 0px;
+  @include dimensions__section--paddings;
+
   background-color: #F9F9F9;
 }
 


### PR DESCRIPTION
This PR fixes @jannekoivistoinen 's comments:

- [X] All the titles have margin-top, which creates too much padding in total. In example, categories__categories has padding of 96px for desktop, which is correct, but then the title has additional margin of 24px. So the total is 110px instead of 96px. Please remove the title's margins.
- [X] On tablet (~1025-601, don't remember the exact breakpoints now) the padding for the sections should be 60px, without any title margins - now it's 96px from the desktop
- [X] On mobile, the padding for sections should be 36px, without any title margins - now it's 96px from the desktop
- [X] Same thing happens with multi-columns, categories etc. In general, the first content (title's) or last content (categories, buttons, texts) inside the section shouldn't effect the vertical padding, it should always come from the section's settings. In example about the last one, info__column--two-columns on mobile has a margin-bottom 76px; (This should be 72px, because 324 = 72)* then the section has padding of 96px; so it totals 172px instead of 48px in the design.
- [X] Footer fixes (no min-height)
- [X] Category fixes (font-smoothing)
- [X] Button text from bold to semibold