### PR TITLE
Add flex-shrink workaround to fix bug in Safari's flexbox implementation

### DIFF
--- a/app/assets/stylesheets/landing_page/sections/video.scss
+++ b/app/assets/stylesheets/landing_page/sections/video.scss
@@ -21,11 +21,16 @@
   // https://bugzilla.mozilla.org/show_bug.cgi?id=958714
 
   width: 100%;
-  position: relative;
+
+  // Workaround for Safari bug:
+  // https://github.com/philipwalton/flexbugs/tree/bba00a51c0ecc0e8afcd718f8757a3cbcb41cf56#1-minimum-content-sizing-of-flex-items-not-honored
+  @include prefix-prop(flex-shrink, 0);
 }
 
 .video__youtube-player-container--aspect-ratio {
   // Dimensions are added in the ERB file
+
+  position: relative;
 }
 
 .video__youtube-player {


### PR DESCRIPTION
There's a bug in Safari's flexbox implementation: [Minimum content sizing of flex items not honored](https://github.com/philipwalton/flexbugs/tree/bba00a51c0ecc0e8afcd718f8757a3cbcb41cf56#1-minimum-content-sizing-of-flex-items-not-honored)

This PR adds `flex-shrink: 0` which is a workaround that solves the issue

Old:

<img width="1552" alt="screen shot 2016-07-08 at 09 06 18" src="https://cloud.githubusercontent.com/assets/429876/16678852/bfb23c7a-44eb-11e6-9918-c7d28442cd77.png">

New:

<img width="1552" alt="screen shot 2016-07-08 at 09 03 55" src="https://cloud.githubusercontent.com/assets/429876/16678853/c5f45da2-44eb-11e6-81e5-fd0fd5baf805.png">
