### PR TITLE
Safari 1px video gap

### DIFF
--- a/app/assets/stylesheets/landing_page/sections/video.scss
+++ b/app/assets/stylesheets/landing_page/sections/video.scss
@@ -65,11 +65,22 @@
 }
 
 .video__youtube-overlay {
+
+  // There seems to be a bit annoying issue in Safari: When the window
+  // size is changed, every now and then a 1px gap appears in the top or bottom
+  // of the video.
+  //
+  // I'm not sure what's the reason for this is. It might be a subpixel rendering
+  // bug or something like that. It seems to only appear in Safari.
+  //
+  // The hacky solution for this is to make the overlay bigger, so that it covers
+  // the missing gap. That's why -10px is added to the position.
+
   position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
+  top: -10px;
+  left: -10px;
+  bottom: -10px;
+  right: -10px;
 
   @include prefix-prop(user-select, none);
 


### PR DESCRIPTION
There seems to be a bit annoying issue in Safari: When the window size is changed, every now and then a 1px gap appears in the top or bottom of the video.

I'm not sure what's the reason for this is. It might be a subpixel rendering bug or something like that. It seems to only appear in Safari.

The hacky solution for this is to make the overlay bigger, so that it covers the missing gap. That's why -10px is added to the position.

Before:

<img width="1242" alt="screen shot 2016-07-08 at 10 15 52" src="https://cloud.githubusercontent.com/assets/429876/16680175/7efb14f4-44f5-11e6-8586-cbd55b3b38ca.png">

After:

<img width="1242" alt="screen shot 2016-07-08 at 10 16 25" src="https://cloud.githubusercontent.com/assets/429876/16680185/862d909e-44f5-11e6-842a-ee7e523b9d32.png">
