### PR TITLE
Fix autoprefixer in production

### DIFF
--- a/client/webpack.client.config.js
+++ b/client/webpack.client.config.js
@@ -28,7 +28,7 @@ config.module.loaders.push(
     loader: ExtractTextPlugin.extract(
       'style-loader',
       'css-loader?modules&localIdentName=[name]__[local]__[hash:base64:5]' + // eslint-disable-line prefer-template
-        (devBuild ? '' : '&minimize') +
+        (devBuild ? '' : '&minimize&-autoprefixer') +
         '!postcss-loader'
     ),
   },


### PR DESCRIPTION
CSS loader minimizer removed some prefixes set by Autoprefixer, added a config switch disables that functionality.

https://github.com/webpack/css-loader#minification