### PR TITLE
Refactor FeatureFlagHelper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 require 'will_paginate/array'
 
 class ApplicationController < ActionController::Base
-  class FeatureFlagNotEnabledError < StandardError; end
 
   module DefaultURLOptions
     # Adds locale to all links
@@ -646,23 +645,6 @@ class ApplicationController < ActionController::Base
     from_params = Maybe(params)[:enable_feature].map { |feature| [feature.to_sym] }.to_set.or_else(Set.new)
 
     from_session.union(from_params)
-  end
-
-  def ensure_feature_enabled(feature_name)
-    raise FeatureFlagNotEnabledError unless feature_flags.include?(feature_name)
-  end
-
-  # Handy before_filter shorthand.
-  #
-  # Usage:
-  #
-  # class YourController < ApplicationController
-  #   ensure_feature_enabled :shipping, only: [:new_shipping, :edit_shipping]
-  #   ...
-  #  end
-  #
-  def self.ensure_feature_enabled(feature_name, options = {})
-    before_filter(options) { ensure_feature_enabled(feature_name) }
   end
 
   def render_not_found!(msg = "Not found")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -636,17 +636,6 @@ class ApplicationController < ActionController::Base
     Maybe(Sharetribe::AVAILABLE_LOCALES.find { |l| l[:ident] == locale.to_s })[:name].or_else(locale).to_s
   end
 
-
-  # Fetch temporary flags from params and session
-  def self.fetch_temp_flags(is_admin, params, session)
-    return Set.new unless is_admin
-
-    from_session = Maybe(session)[:feature_flags].or_else(Set.new)
-    from_params = Maybe(params)[:enable_feature].map { |feature| [feature.to_sym] }.to_set.or_else(Set.new)
-
-    from_session.union(from_params)
-  end
-
   def render_not_found!(msg = "Not found")
     raise ActionController::RoutingError.new(msg)
   end

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -21,6 +21,7 @@ class LandingPageController < ActionController::Metal
   # Adds helper_method
   include ActionController::Helpers
 
+  # Access feature flags set for the community
   include FeatureFlagHelper
 
   CACHE_TIME = APP_CONFIG[:clp_cache_time].to_i.seconds
@@ -319,4 +320,3 @@ class LandingPageController < ActionController::Metal
     raise ArgumentError.new("You called `locale` method. This was probably a mistake. Most likely you'd want to use `landing_page_locale`, `default_locale`, or `locale_param`")
   end
 end
-

--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -1,35 +1,79 @@
+# A module intended to be used as a mixin with controllers whose
+# actions / views want to access information about feature flags.
 module FeatureFlagHelper
 
-  def feature_enabled?(feature_name)
-    feature_flags.include? feature_name
+  class FeatureFlagNotEnabledError < StandardError; end
+
+  def self.included(target)
+    target.include InstanceMethods
+    target.extend ClassMethods
   end
 
-  def with_feature(feature_name, &block)
-    block.call if feature_enabled?(feature_name)
+  module InstanceMethods
+    def feature_enabled?(feature_name)
+      feature_flags.include? feature_name
+    end
+
+    def assert_feature_enabled(feature_name)
+      raise FeatureFlagNotEnabledError.new("Missing required feature: #{feature_name}") unless feature_enabled?(feature_name)
+    end
+
+    def with_feature(feature_name, &block)
+      block.call if feature_enabled?(feature_name)
+    end
+
+    def feature_flags
+      RequestStore.store[:feature_flags] ||= fetch_feature_flags
+    end
+
+    def fetch_feature_flags
+      flags_from_service = FeatureFlagService::API::Api.features.get(community_id: community_id(request)).maybe[:features].or_else(Set.new)
+
+      is_admin = called_with_admin_user?
+      temp_flags = ApplicationController.fetch_temp_flags(is_admin, params, session)
+
+      session[:feature_flags] = temp_flags
+
+      flags_from_service.union(temp_flags)
+    end
+
+    def community_id(request)
+      request.env[:current_marketplace].id
+    end
+
+    # If the including controller defines @current_user we use it to
+    # determine if the method is being called with an admin
+    # user. Otherwise we assume that's not the case. The @current_user
+    # should be made available in request.env similarly to marketplace
+    # to make this functionality portable outside
+    # ApplicationController inheritance hierarchy.
+    def called_with_admin_user?
+      Maybe(@current_user).is_admin?.or_else(false)
+    end
+
+    def search_engine
+      use_external_search = Maybe(APP_CONFIG).external_search_in_use.map { |v| v == true || v.to_s.casecmp("true") == 0 }.or_else(false)
+      use_external_search ? :zappy : :sphinx
+    end
+
+    def location_search_available
+      search_engine == :zappy
+    end
   end
 
-  def feature_flags
-    @feature_flags ||= fetch_feature_flags # fetch_feature_flags is defined in ApplicationController
-  end
-
-  def fetch_feature_flags
-    flags_from_service = FeatureFlagService::API::Api.features.get(community_id: @current_community.id).maybe[:features].or_else(Set.new)
-
-    is_admin = Maybe(@current_user).is_admin?.or_else(false)
-    temp_flags = ApplicationController.fetch_temp_flags(is_admin, params, session)
-
-    session[:feature_flags] = temp_flags
-
-    flags_from_service.union(temp_flags)
-  end
-
-  def search_engine
-    use_external_search = Maybe(APP_CONFIG).external_search_in_use.map { |v| v == true || v.to_s.casecmp("true") == 0 }.or_else(false)
-    use_external_search ? :zappy : :sphinx
-  end
-
-  def location_search_available
-    search_engine == :zappy
+  module ClassMethods
+    # Add a before filter that asserts given feature flag is set.
+    #
+    # Usage:
+    #
+    # class YourController < ApplicationController
+    #   ensure_feature_enabled :shipping, only: [:new_shipping, :edit_shipping]
+    #   ...
+    #  end
+    #
+    def ensure_feature_enabled(feature_name, options = {})
+      before_filter(options) { assert_feature_enabled(feature_name) }
+    end
   end
 
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -96,17 +96,4 @@ describe ApplicationController, type: :controller do
       end
     end
   end
-
-  describe "ApplicationController.fetch_temp_flags" do
-    let(:session) { {feature_flags: [:shipping].to_set} }
-    let(:params) { {enable_feature: "booking"} }
-
-    it "fetches temporary flags from session and params" do
-      expect(ApplicationController.fetch_temp_flags(true, params, session)).to eq [:shipping, :booking].to_set
-    end
-
-    it "returns empty set if not admin" do
-      expect(ApplicationController.fetch_temp_flags(false, params, session)).to eq [].to_set
-    end
-  end
 end

--- a/spec/helpers/feature_flag_helper_spec.rb
+++ b/spec/helpers/feature_flag_helper_spec.rb
@@ -3,8 +3,13 @@ require "spec_helper"
 RSpec.describe FeatureFlagHelper, type: :helper do
 
   before(:each) do
-    # Assign instance variable
-    assign(:feature_flags, [:stable_feature].to_set)
+    RequestStore.begin!
+    RequestStore.store[:feature_flags] = [:stable_feature].to_set
+  end
+
+  after(:each) do
+    RequestStore.end!
+    RequestStore.clear!
   end
 
 
@@ -29,6 +34,19 @@ RSpec.describe FeatureFlagHelper, type: :helper do
       block_called = false
       helper.with_feature(:stable_feature) { block_called = true }
       expect(block_called).to eq(true)
+    end
+  end
+
+  describe "fetch_temp_flags" do
+    let(:session) { {feature_flags: [:shipping].to_set} }
+    let(:params) { {enable_feature: "booking"} }
+
+    it "fetches temporary flags from session and params" do
+      expect(fetch_temp_flags(true, params, session)).to eq [:shipping, :booking].to_set
+    end
+
+    it "returns empty set if not admin" do
+      expect(fetch_temp_flags(false, params, session)).to eq [].to_set
     end
   end
 end


### PR DESCRIPTION
* Move everything out of ApplicationController
* Don't require global @current_community, use the request.env set by middleware instead
* Comment the bad practice of relying on @current_user