### PR TITLE
Improve SyncDelayedJobObserver to clean any remaining jobs from database

### DIFF
--- a/spec/support/sync_delayed_job_observer.rb
+++ b/spec/support/sync_delayed_job_observer.rb
@@ -30,6 +30,7 @@ class SyncDelayedJobObserver
       @total_processed = 0
       @enabled = false
 
+      Delayed::Job.delete_all
       Delayed::Worker.delay_jobs = true
     end
 


### PR DESCRIPTION
This should improve the stability of tests if other test cases leave jobs behing.