### PR TITLE
Unify hover colors

### DIFF
--- a/app/services/custom_landing_page/marketplace_data_store.rb
+++ b/app/services/custom_landing_page/marketplace_data_store.rb
@@ -38,7 +38,7 @@ module CustomLandingPage
         end
 
       color = primary_color.present? ? primary_color : DEFAULT_COLOR
-      color_darken = ColorUtils.darken(color, 15)
+      color_darken = ColorUtils.brightness(color, 85)
 
       { "primary_color" => ColorUtils.css_to_rgb_array(color),
         "primary_color_darken" => ColorUtils.css_to_rgb_array(color_darken),

--- a/app/utils/color_utils.rb
+++ b/app/utils/color_utils.rb
@@ -2,6 +2,23 @@ module ColorUtils
 
   module_function
 
+  # Same as in filter: brightness(80%) in CSS
+  #
+  # Usage:
+  #
+  # brightness("80E619", 80) == "66B814"
+  #
+  def brightness(name_or_hex, percentage)
+    # CSS brightness(80%) is the same as adjust_brightness(-20)
+    p = percentage - 100
+
+    Color::RGB
+      .by_css(name_or_hex)
+      .adjust_brightness(p)
+      .hex
+      .upcase
+  end
+
   # Same as darken(color, percentage) is SASS
   #
   # Usage:

--- a/app/utils/color_utils.rb
+++ b/app/utils/color_utils.rb
@@ -4,23 +4,31 @@ module ColorUtils
 
   # Same as in filter: brightness(80%) in CSS
   #
+  # The implementation operates on RBG space according
+  # to CSS filter effects spec.
+  #
   # Usage:
   #
   # brightness("80E619", 80) == "66B814"
   #
   def brightness(name_or_hex, percentage)
-    # CSS brightness(80%) is the same as adjust_brightness(-20)
-    p = percentage - 100
+    p = normalize_percentage(percentage)
+    rgb = Color::RGB.by_css(name_or_hex)
 
-    Color::RGB
-      .by_css(name_or_hex)
-      .adjust_brightness(p)
-      .hex
-      .upcase
+    rgb.r *= p
+    rgb.g *= p
+    rgb.b *= p
+
+    rgb.hex.upcase
   end
 
   def css_to_rgb_array(css)
     color = Color::RGB.by_css(css)
     [color.red.to_i, color.green.to_i, color.blue.to_i]
   end
+
+  def normalize_percentage(percentage)
+    percentage.to_f / 100.to_f
+  end
+
 end

--- a/app/utils/color_utils.rb
+++ b/app/utils/color_utils.rb
@@ -19,25 +19,8 @@ module ColorUtils
       .upcase
   end
 
-  # Same as darken(color, percentage) is SASS
-  #
-  # Usage:
-  #
-  # darken("80E619", 20) == "4D8A0F"
-  #
-  def darken(name_or_hex, percentage)
-    hsl = Color::RGB.by_css(name_or_hex).to_hsl
-    hsl.l -= normalize_percentage(percentage)
-    hsl.to_rgb.hex.upcase
-  end
-
   def css_to_rgb_array(css)
     color = Color::RGB.by_css(css)
     [color.red.to_i, color.green.to_i, color.blue.to_i]
   end
-
-  def normalize_percentage(percentage)
-    percentage.to_f / 100.to_f
-  end
-
 end

--- a/spec/utils/color_utils_spec.rb
+++ b/spec/utils/color_utils_spec.rb
@@ -5,6 +5,9 @@ describe ColorUtils do
   describe "#brightness" do
     it "takes hex color and percentage and returns a new color with altered brightness" do
       expect(ColorUtils.brightness("80E619", 80)).to eq("66B814")
+      expect(ColorUtils.brightness("80E619", 90)).to eq("73CF17")
+      expect(ColorUtils.brightness("80E619", 110)).to eq("8DFD1C")
+      expect(ColorUtils.brightness("80E619", 300)).to eq("FFFF4B")
     end
   end
 end

--- a/spec/utils/color_utils_spec.rb
+++ b/spec/utils/color_utils_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 describe ColorUtils do
 
+  describe "#brightness" do
+    it "takes hex color and percentage and returns a new color with altered brightness" do
+      expect(ColorUtils.brightness("80E619", 80)).to eq("66B814")
+    end
+  end
+
   describe "#darken" do
     it "takes hex color and percentage and returns darkened color" do
       expect(ColorUtils.darken("80E619", 20)).to eq("4D8A0F")

--- a/spec/utils/color_utils_spec.rb
+++ b/spec/utils/color_utils_spec.rb
@@ -7,11 +7,4 @@ describe ColorUtils do
       expect(ColorUtils.brightness("80E619", 80)).to eq("66B814")
     end
   end
-
-  describe "#darken" do
-    it "takes hex color and percentage and returns darkened color" do
-      expect(ColorUtils.darken("80E619", 20)).to eq("4D8A0F")
-    end
-  end
-
 end


### PR DESCRIPTION
We are using three different methods to calculate the hover color based on marketplace color:

* `filter: brightness(80%)` is used in browsers that support it
* `ColorLuminance` JavaScript code is used in browsers that don't support filter
* `ColorUtils.darken` is used in landing page

**The problem** is that brightness filter and ColorLuminance script were resulting the same color, where as `ColorUtils.darken` was returning a different color.

The first two make the brightening operation each component in RBG. The ColorUtils.darken made the operation by following how SCSS does the brightening, that is, covert RBG to HSL and substracting from L component.

**The solution** is that new method `ColorUtils.brightness` is added in this PR. This method uses follows the CSS filter spec and ColorLuminance implementation, which multiplies each RGB component, resulting the same result as brightness filter.

[This JS Fiddle](https://jsfiddle.net/9102079c/4/) can be used to test the result of brightness filter and ColorLuminance