### PR TITLE
Use default community description and slogan

### DIFF
--- a/app/services/custom_landing_page/marketplace_data_store.rb
+++ b/app/services/custom_landing_page/marketplace_data_store.rb
@@ -21,6 +21,8 @@ module CustomLandingPage
                            .pluck(:name, :slogan, :description, :search_placeholder)
                            .first
 
+      slogan             ||= I18n.t("common.default_community_slogan", locale: locale)
+      description        ||= I18n.t("common.default_community_description", locale: locale)
       search_placeholder ||= I18n.t("landing_page.hero.search_placeholder", locale: locale)
 
       main_search = MarketplaceConfigurations


### PR DESCRIPTION
This fixes a bug if marketplace doesn't have slogan and description.

Steps to reproduce:

1. Create a new community (or set the `community_customizations.slogan` in database to NULL)
1. Enable landing page
1. Go to the landing page

Expected result: Default slogan and description

Actual result: Null pointer