### PR TITLE
Add iterator id to the section_id to make it unique

### DIFF
--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -7,10 +7,10 @@
   # styles would be empty
 %>
 <% content_for :sections do %>
-  <% sections.each do |section| %>
+  <% sections.each_with_index do |section, index| %>
 
     <% s = section["section"] %>
-    <% section_id = "#{s['kind']}__#{s['id']}" %>
+    <% section_id = "#{s['kind']}__#{s['id']}__#{index}" %>
 
     <% case s["kind"] %>
     <% when "hero" %>
@@ -20,18 +20,18 @@
     <% when "info" %>
       <%
       second_wo_background =
-        sections.reduce([Set.new, false]) { |(consecutive_infos, second_in_row), section|
+        sections.each_with_index.reduce([Set.new, false]) { |(consecutive_infos, second_in_row), (section, idx)|
           sect = section["section"]
           if sect["kind"] == "info" && sect["background_image"].nil? && sect["background_color"].nil?
             if second_in_row
-              [consecutive_infos.add(sect["id"]), false]
+              [consecutive_infos.add([sect["id"], idx]), false]
             else
               [consecutive_infos, true]
             end
           else
             [consecutive_infos, false]
           end
-        }.first.include?(s["id"])
+        }.first.include?([s["id"], index])
       %>
 
       <%= render partial: "info", locals: {section_id: section_id, s: s, second_wo_background: second_wo_background } %>


### PR DESCRIPTION
If user decides (for some weird reason) add the same section twice in the landing page, the `section_id`, that is used e.g. in click handlers to identify the section, because not unique. This PR adds iterator ID to the `section_id` to make it unique. In addition, it takes this into account in the logic that defines whether two consecutive white info sections should have zebra colors.