### PR TITLE
Add whitespace between mobile menu sections

### DIFF
--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -211,6 +211,8 @@ module.exports = {
   '--MenuSection_paddingOffScreenVertical': pxToEms(10, 12), // eslint-disable-line no-magic-numbers
   '--MenuSection_paddingOffScreenHorizontal': pxToEms(24, 12), // eslint-disable-line no-magic-numbers
   '--MenuSection_paddingOffScreenHorizontalTablet': pxToEms(36, 12), // eslint-disable-line no-magic-numbers
+  '--MenuSection_marginOffScreenBottom': pxToEms(16, 17), // eslint-disable-line no-magic-numbers
+  '--MenuSection_marginOffScreenBottomTablet': pxToEms(28, 17), // eslint-disable-line no-magic-numbers
   '--MenuSection_iconMargin': pxToEms(9, 12), // eslint-disable-line no-magic-numbers
 
   '--MobileMenu_labelPaddingVertical': '18px',
@@ -218,6 +220,7 @@ module.exports = {
   '--MobileMenu_offscreenMenuWidth': '288px',
   '--MobileMenu_offscreenHeaderItemHeight': '44px',
   '--MobileMenu_offscreenFooterBackgroundColor': backgroundColorGrey,
+  '--MobileMenu_offscreenFooterMarginTop': pxToEms(14, 17), // eslint-disable-line no-magic-numbers
 
   '--LanguagesMobile_fontSize': fontSizeMobileSmall,
   '--LanguagesMobile_fontSizeTablet': fontSizeMobileSmaller,

--- a/client/app/components/composites/MenuMobile/MenuMobile.css
+++ b/client/app/components/composites/MenuMobile/MenuMobile.css
@@ -113,9 +113,15 @@
 
 .offScreenFooter {
   background-color: var(--MobileMenu_offscreenFooterBackgroundColor);
+  margin-top: var(--MobileMenu_offscreenFooterMarginTop);
 }
 
 .menuSection {
+  margin-bottom: var(--MenuSection_marginOffScreenBottom);
+
+  @media (--medium-viewport) {
+    margin-bottom: var(--MenuSection_marginOffScreenBottomTablet);
+  }
 
   & .menuSectionMenuItem {
     border-bottom: 0;


### PR DESCRIPTION
Add proper whitespace between mobile menu sections and also between the last section and the footer.