### PR TITLE
Use flexbox in booking-button to fix centering in IE

### DIFF
--- a/app/assets/stylesheets/views/_listings.css.scss
+++ b/app/assets/stylesheets/views/_listings.css.scss
@@ -207,6 +207,10 @@ $listing-author-avatar-height: 108;
   margin-top: 0;
   width: 100%;
   text-align: center;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-align-items: center;
+  align-items: center;
 }
 
 // Transaction action button


### PR DESCRIPTION
.booking-button has child element .content, which has display: block;
For some reason IE doesn't like that and don't center the block vertically within button. 
Since we nowadays support flexbox, I decided to apply that as a fix.