### PR TITLE
Landing page configuration changes

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -167,7 +167,7 @@ class LandingPageController < ActionController::Metal
       link_resolvers: {
         "path" => CLP::LinkResolver::PathResolver.new(paths),
         "marketplace_data" => CLP::LinkResolver::MarketplaceDataResolver.new(marketplace_data),
-        "assets" => CLP::LinkResolver::AssetResolver.new(APP_CONFIG[:clp_asset_host], sitename),
+        "assets" => CLP::LinkResolver::AssetResolver.new(APP_CONFIG[:clp_asset_url], sitename),
         "translation" => CLP::LinkResolver::TranslationResolver.new(landing_page_locale),
         "category" => CLP::LinkResolver::CategoryResolver.new(category_data),
         "listing" => CLP::LinkResolver::ListingResolver.new(cid, landing_page_locale, locale_param, name_display_type)

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -24,7 +24,7 @@ class LandingPageController < ActionController::Metal
   CACHE_TIME = APP_CONFIG[:clp_cache_time].to_i.seconds
   CACHE_HEADER = "X-CLP-Cache"
 
-  FONT_PATH = APP_CONFIG[:font_proximanovasoft_url].present? ? APP_CONFIG[:font_proximanovasoft_url] : "/landing_page/fonts"
+  FONT_PATH = APP_CONFIG[:font_proximanovasoft_url]
 
   def index
     cid = community(request).id

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -59,7 +59,7 @@ module CustomLandingPage
 
       def append_asset_path(asset)
         host = @_asset_url || ""
-        src = URLUtils.join(@_asset_url, asset["src"]).sub("${sitename}", @_sitename)
+        src = URLUtils.join(@_asset_url, asset["src"]).sub("%{sitename}", @_sitename)
 
         asset.merge("src" => src)
       end

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -58,12 +58,10 @@ module CustomLandingPage
       private
 
       def append_asset_path(asset)
-        if @_asset_host.present?
-          asset.merge("src" => [@_asset_host, @_sitename, asset["src"]].join("/"))
-        else
-          # If asset_host is not configured serve assets locally
-          asset.merge("src" => ["landing_page", asset["src"]].join("/"))
-        end
+        host = @_asset_host || ""
+        src = URLUtils.join(@_asset_host, asset["src"]).sub("${sitename}", @_sitename)
+
+        asset.merge("src" => src)
       end
     end
 

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -35,12 +35,12 @@ module CustomLandingPage
     end
 
     class AssetResolver
-      def initialize(asset_host, sitename)
+      def initialize(asset_url, sitename)
         unless sitename.present?
           raise CustomLandingPage::LandingPageConfigurationError.new("Missing sitename.")
         end
 
-        @_asset_host = asset_host
+        @_asset_url = asset_url
         @_sitename = sitename
       end
 
@@ -58,8 +58,8 @@ module CustomLandingPage
       private
 
       def append_asset_path(asset)
-        host = @_asset_host || ""
-        src = URLUtils.join(@_asset_host, asset["src"]).sub("${sitename}", @_sitename)
+        host = @_asset_url || ""
+        src = URLUtils.join(@_asset_url, asset["src"]).sub("${sitename}", @_sitename)
 
         asset.merge("src" => src)
       end

--- a/app/utils/url_utils.rb
+++ b/app/utils/url_utils.rb
@@ -48,8 +48,6 @@ module URLUtils
   #
   # Usage: URLUtils.join("foo", "bar/", "baz") => "foo/bar/baz"
   def join(*parts)
-    parts.select(&:present?).reduce { |a, b|
-      "#{a.sub(/\/+\z/, "")}/#{b}"
-    }
+    File.join(*parts.select(&:present?))
   end
 end

--- a/app/utils/url_utils.rb
+++ b/app/utils/url_utils.rb
@@ -43,4 +43,13 @@ module URLUtils
   def strip_port_from_host(host)
     host.split(":").first
   end
+
+  # Naive join method, which can be used to normalize multiple slashes
+  #
+  # Usage: URLUtils.join("foo", "bar/", "baz") => "foo/bar/baz"
+  def join(*parts)
+    parts.select(&:present?).reduce { |a, b|
+      "#{a.sub(/\/+\z/, "")}/#{b}"
+    }
+  end
 end

--- a/app/views/landing_page/_fonts.erb
+++ b/app/views/landing_page/_fonts.erb
@@ -10,7 +10,7 @@
 
  <%
    # Copied from URLUtils
-   join = ->(*parts) { parts.select(&:present?).reduce { |a, b| "#{a.sub(/\/+\z/, "")}/#{b}" } }
+   join = ->(*parts) { File.join(parts.select(&:present?)) }
  %>
 
  @font-face {

--- a/app/views/landing_page/_fonts.erb
+++ b/app/views/landing_page/_fonts.erb
@@ -8,15 +8,20 @@
   *
   */
 
+ <%
+   # Copied from URLUtils
+   join = ->(*parts) { parts.select(&:present?).reduce { |a, b| "#{a.sub(/\/+\z/, "")}/#{b}" } }
+ %>
+
  @font-face {
    /* 'ProximaNovaSoft-Regular' */
    font-family: 'Proxima Nova Soft';
-   src: url('<%= font_path %>/proximanovasoft-regular-webfont.eot');
-   src: url('<%= font_path %>/proximanovasoft-regular-webfont.eot?#iefix') format('embedded-opentype'),
-   url('<%= font_path %>/proximanovasoft-regular-webfont.woff2') format('woff2'),
-   url('<%= font_path %>/proximanovasoft-regular-webfont.woff') format('woff'),
-   url('<%= font_path %>/proximanovasoft-regular-webfont.ttf') format('truetype'),
-   url('<%= font_path %>/proximanovasoft-regular-webfont.svg#proxima_nova_softregular') format('svg');
+   src: url('<%= join.call(font_path, "proximanovasoft-regular-webfont.eot") %>');
+   src: url('<%= join.call(font_path, "proximanovasoft-regular-webfont.eot?#iefix") %>') format('embedded-opentype'),
+   url('<%= join.call(font_path, "proximanovasoft-regular-webfont.woff2") %>') format('woff2'),
+   url('<%= join.call(font_path, "proximanovasoft-regular-webfont.woff") %>') format('woff'),
+   url('<%= join.call(font_path, "proximanovasoft-regular-webfont.ttf") %>') format('truetype'),
+   url('<%= join.call(font_path, "proximanovasoft-regular-webfont.svg#proxima_nova_softregular") %>') format('svg');
    font-weight: 400;
    font-style: normal;
  }
@@ -24,12 +29,12 @@
  @font-face {
    /* 'ProximaNovaSoft-Medium' */
    font-family: 'Proxima Nova Soft';
-   src: url('<%= font_path %>/proximanovasoft-medium-webfont.eot');
-   src: url('<%= font_path %>/proximanovasoft-medium-webfont.eot?#iefix') format('embedded-opentype'),
-   url('<%= font_path %>/proximanovasoft-medium-webfont.woff2') format('woff2'),
-   url('<%= font_path %>/proximanovasoft-medium-webfont.woff') format('woff'),
-   url('<%= font_path %>/proximanovasoft-medium-webfont.ttf') format('truetype'),
-   url('<%= font_path %>/proximanovasoft-medium-webfont.svg#proxima_nova_softmedium') format('svg');
+   src: url('<%= join.call(font_path, "proximanovasoft-medium-webfont.eot") %>');
+   src: url('<%= join.call(font_path, "proximanovasoft-medium-webfont.eot?#iefix") %>') format('embedded-opentype'),
+   url('<%= join.call(font_path, "proximanovasoft-medium-webfont.woff2") %>') format('woff2'),
+   url('<%= join.call(font_path, "proximanovasoft-medium-webfont.woff") %>') format('woff'),
+   url('<%= join.call(font_path, "proximanovasoft-medium-webfont.ttf") %>') format('truetype'),
+   url('<%= join.call(font_path, "proximanovasoft-medium-webfont.svg#proxima_nova_softmedium") %>') format('svg');
    font-weight: 500;
    font-style: normal;
  }
@@ -37,12 +42,12 @@
  @font-face {
    /* 'ProximaNovaSoft-Semibold' */
    font-family: 'Proxima Nova Soft';
-   src: url('<%= font_path %>/proximanovasoft-semibold-webfont.eot');
-   src: url('<%= font_path %>/proximanovasoft-semibold-webfont.eot?#iefix') format('embedded-opentype'),
-   url('<%= font_path %>/proximanovasoft-semibold-webfont.woff2') format('woff2'),
-   url('<%= font_path %>/proximanovasoft-semibold-webfont.woff') format('woff'),
-   url('<%= font_path %>/proximanovasoft-semibold-webfont.ttf') format('truetype'),
-   url('<%= font_path %>/proximanovasoft-semibold-webfont.svg#proxima_nova_softsemibold') format('svg');
+   src: url('<%= join.call(font_path, "proximanovasoft-semibold-webfont.eot") %>');
+   src: url('<%= join.call(font_path, "proximanovasoft-semibold-webfont.eot?#iefix") %>') format('embedded-opentype'),
+   url('<%= join.call(font_path, "proximanovasoft-semibold-webfont.woff2") %>') format('woff2'),
+   url('<%= join.call(font_path, "proximanovasoft-semibold-webfont.woff") %>') format('woff'),
+   url('<%= join.call(font_path, "proximanovasoft-semibold-webfont.ttf") %>') format('truetype'),
+   url('<%= join.call(font_path, "proximanovasoft-semibold-webfont.svg#proxima_nova_softsemibold") %>') format('svg');
    font-weight: 600;
    font-style: normal;
  }
@@ -50,12 +55,12 @@
  @font-face {
    /* 'ProximaNovaSoft-Bold' */
    font-family: 'Proxima Nova Soft';
-   src: url('<%= font_path %>/proximanovasoft-bold-webfont.eot');
-   src: url('<%= font_path %>/proximanovasoft-bold-webfont.eot?#iefix') format('embedded-opentype'),
-   url('<%= font_path %>/proximanovasoft-bold-webfont.woff2') format('woff2'),
-   url('<%= font_path %>/proximanovasoft-bold-webfont.woff') format('woff'),
-   url('<%= font_path %>/proximanovasoft-bold-webfont.ttf') format('truetype'),
-   url('<%= font_path %>/proximanovasoft-bold-webfont.svg#proxima_nova_softbold') format('svg');
+   src: url('<%= join.call(font_path, "proximanovasoft-bold-webfont.eot") %>');
+   src: url('<%= join.call(font_path, "proximanovasoft-bold-webfont.eot?#iefix") %>') format('embedded-opentype'),
+   url('<%= join.call(font_path, "proximanovasoft-bold-webfont.woff2") %>') format('woff2'),
+   url('<%= join.call(font_path, "proximanovasoft-bold-webfont.woff") %>') format('woff'),
+   url('<%= join.call(font_path, "proximanovasoft-bold-webfont.ttf") %>') format('truetype'),
+   url('<%= join.call(font_path, "proximanovasoft-bold-webfont.svg#proxima_nova_softbold") %>') format('svg');
    font-weight: 700;
    font-style: normal;
  }

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -65,7 +65,9 @@
   <%= favicon_link_tag community_context[:favicon] %>
   <%= favicon_link_tag community_context[:apple_touch_icon], rel: 'apple-touch-icon-precomposed', type: 'image/png' %>
 
-  <%= render partial: "fonts", locals: { font_path: font_path } %>
+  <% if font_path.present? %>
+    <%= render partial: "fonts", locals: { font_path: font_path } %>
+  <% end %>
 
   <style type="text/css">
     <% # Basic styling %>

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -301,8 +301,19 @@ default: &default_settings
   # development and false for other environments.
   use_js_routes_middleware: false
 
-  # Custom landing page asset host, e.g. https://s3.amazonaws.com/my-bucket/sites
-  clp_asset_host:
+  # Path or URL for landing page assets.
+  #
+  # Because a directory is expected, it's recommended to include trailing slash.
+  #
+  # You can add %{sitename} in the URL and it will be replaced with the sitename,
+  # that is saved in the landing page structure JSON.
+  #
+  # Example values:
+  #
+  # - landing_page/
+  # - https://s3.amazonaws.com/my-bucket/sites/${sitename}/
+  #
+  clp_asset_url: "landing_page/"
 
   # Default caching time for custom landing pages in seconds
   clp_cache_time: 900

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -311,7 +311,7 @@ default: &default_settings
   # Example values:
   #
   # - landing_page/
-  # - https://s3.amazonaws.com/my-bucket/sites/${sitename}/
+  # - https://s3.amazonaws.com/my-bucket/sites/%{sitename}/
   #
   clp_asset_url: "landing_page/"
 

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -307,7 +307,20 @@ default: &default_settings
   # Default caching time for custom landing pages in seconds
   clp_cache_time: 900
 
-  # Root url for hosted proximanovasoft font files
+  #######
+  # Fonts
+  #######
+
+  # Path or URL for Proxima Nova Soft font files
+  #
+  # Because a directory is expected, it's recommended to include trailing slash.
+  #
+  # Example values:
+  #
+  # - empty: don't use Proximan Nova Soft font
+  # - landing_page/
+  # - https://s3.amazonaws.com/my-bucket/fonts/
+  #
   font_proximanovasoft_url:
 
 production: &production_settings

--- a/spec/utils/url_utils_spec.rb
+++ b/spec/utils/url_utils_spec.rb
@@ -36,4 +36,38 @@ describe URLUtils do
     expect(URLUtils.build_url("www.example.com", { intParam: 1, nilParam: nil, strParam: "foo"}))
       .to eql "www.example.com?intParam=1&strParam=foo"
   end
+
+  describe "#join" do
+
+    def expect_url_join(*parts)
+      expect(URLUtils.join(*parts))
+    end
+
+    it "joins absolute paths" do
+      expect_url_join("//example.com").to eq("//example.com")
+      expect_url_join("//example.com", "foo").to eq("//example.com/foo")
+      expect_url_join("//example.com", "foo", "bar").to eq("//example.com/foo/bar")
+
+      expect_url_join("https://example.com").to eq("https://example.com")
+      expect_url_join("https://example.com", "foo").to eq("https://example.com/foo")
+      expect_url_join("https://example.com", "foo", "bar").to eq("https://example.com/foo/bar")
+
+      expect_url_join("https://example.com/", "foo/").to eq("https://example.com/foo/")
+      expect_url_join("https://example.com/", "foo/", "bar/").to eq("https://example.com/foo/bar/")
+    end
+
+    it "joins relative paths" do
+      expect_url_join(nil, "foo").to eq("foo")
+      expect_url_join("", "foo").to eq("foo")
+      expect_url_join("", "", "foo", "", "bar", "", "").to eq("foo/bar")
+      expect_url_join("foo").to eq("foo")
+      expect_url_join("foo/").to eq("foo/")
+      expect_url_join("/", "foo").to eq("/foo")
+      expect_url_join("/foo/", "bar/", "baz").to eq("/foo/bar/baz")
+      expect_url_join("foo/", "bar/", "baz").to eq("foo/bar/baz")
+
+      expect_url_join("/foo/").to eq("/foo/")
+      expect_url_join("/", "foo/", "bar/").to eq("/foo/bar/")
+    end
+  end
 end

--- a/spec/utils/url_utils_spec.rb
+++ b/spec/utils/url_utils_spec.rb
@@ -54,6 +54,8 @@ describe URLUtils do
 
       expect_url_join("https://example.com/", "foo/").to eq("https://example.com/foo/")
       expect_url_join("https://example.com/", "foo/", "bar/").to eq("https://example.com/foo/bar/")
+
+      expect_url_join("https://example.com/", "foo/", "/bar/").to eq("https://example.com/foo/bar/")
     end
 
     it "joins relative paths" do
@@ -68,6 +70,8 @@ describe URLUtils do
 
       expect_url_join("/foo/").to eq("/foo/")
       expect_url_join("/", "foo/", "bar/").to eq("/foo/bar/")
+
+      expect_url_join("/", "/foo/", "/bar/").to eq("/foo/bar/")
     end
   end
 end


### PR DESCRIPTION
This PR contains some landing page configuration changes:

Fonts:

- [X] Font partial is not rendered, if font path is not present
- [X] In the configuration comments, trailing slash is recommended for `font_path`
- [X] `_fonts.erb` partial tolerates and normalized multiple slashes

Assets:

- [X] `clp_asset_host` renamed to `clp_asset_url`
- [X] In the configuration comments, trailing slash is recommended for `clp_asset_url`
- [X] `clp_asset_url` configuration can now contain optional `${sitename}` placeholder, which will be replaced with the landing page site name