### PR TITLE
Add option for lighter dimming of background images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ## [Unreleased]
 
+### Added
+
+- Add possibility to choose between light and dark background image filter for hero and info sections in custom landing pages [#2310](https://github.com/sharetribe/sharetribe/pull/2310)
+
 ## [5.8.0] - 2016-07-15
 
 ### Added

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -11,9 +11,16 @@
   background-position: center;
   @include prefix-val(display, flex);
   @include prefix-prop(align-items, center);
-  box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.5); /* is there any cleaner way? */
-
   @include dimensions__section--paddings;
+}
+
+.hero__section--light {
+  @extend .hero__section;
+  box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.3); /* is there any cleaner way? */
+}
+.hero__section--dark {
+  @extend .hero__section;
+  box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.5); /* is there any cleaner way? */
 }
 
 .hero__content {

--- a/app/assets/stylesheets/landing_page/sections/info.scss
+++ b/app/assets/stylesheets/landing_page/sections/info.scss
@@ -18,9 +18,14 @@
   @include viewport-unit(min-height, 80vh);
 }
 
-.info__section--background-image {
+.info__section--background-image--light {
   @extend .info__section--background;
-  box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.65); /* is there any cleaner way? */
+  box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.3); /* is there any cleaner way? */
+}
+
+.info__section--background-image--dark {
+  @extend .info__section--background;
+  box-shadow: inset 0 0 0 999999px rgba(0, 0, 0, 0.5); /* is there any cleaner way? */
 }
 
 .info__section--background-color {

--- a/app/services/custom_landing_page/example_data.rb
+++ b/app/services/custom_landing_page/example_data.rb
@@ -30,6 +30,7 @@ module CustomLandingPage
       "title": {"type": "marketplace_data", "id": "slogan"},
       "subtitle": {"type": "marketplace_data", "id": "description"},
       "background_image": {"type": "assets", "id": "default_hero_background"},
+      "background_image_variation": "dark",
       "search_button": {"type": "translation", "id": "search_button"},
       "search_path": {"type": "path", "id": "search"},
       "search_placeholder": {"type": "marketplace_data", "id": "search_placeholder"},
@@ -74,7 +75,8 @@ module CustomLandingPage
       "button_color_hover": {"type": "marketplace_data", "id": "primary_color_darken"},
       "button_title": "Go to sharetribe.com",
       "button_path": {"value": "https://www.sharetribe.com"},
-      "background_image": {"type": "assets", "id": "default_hero_background"}
+      "background_image": {"type": "assets", "id": "default_hero_background"},
+      "background_image_variation": "dark"
     },
     {
       "id": "single_info_with_cta",
@@ -314,6 +316,7 @@ JSON
             "title": {"type": "marketplace_data", "id": "slogan"},
             "subtitle": {"type": "marketplace_data", "id": "description"},
             "background_image": {"type": "assets", "id": "hero_background_image"},
+            "background_image_variation": "dark",
             "search_button": {"type": "translation", "id": "search_button"},
             "search_path": {"type": "path", "id": "search"},
             "search_placeholder": {"type": "marketplace_data", "id": "search_placeholder"},

--- a/app/views/landing_page/_hero.erb
+++ b/app/views/landing_page/_hero.erb
@@ -1,5 +1,6 @@
+<% section_style_class = s["background_image_variation"] == "light" ? "hero__section--light" : "hero__section--dark" %>
 <% content_for :hero_css do %>
-  .hero__section {
+  .<%= section_style_class %> {
     background-image: url('<%= s["background_image"]["src"] %>');
   }
 
@@ -19,7 +20,7 @@
   }
 <% end %>
 
-<section id="<%= section_id %>" class="hero__section">
+<section id="<%= section_id %>" class="<%= section_style_class %>">
   <div class="hero__content">
     <div class="hero__content-container">
       <h1 class="hero__title"><%= s["title"]["value"] %></h1>

--- a/app/views/landing_page/_info.erb
+++ b/app/views/landing_page/_info.erb
@@ -10,9 +10,11 @@
   variation_modifier        = variation_modifiers[s["variation"]]
   background_color_style    = background_color_enabled ? "background-color: rgb(#{s["background_color"].join(",")});" : "";
 
+  background_image_modifier = background_image_enabled && s["background_image_variation"] == "light" ? "light"  : "dark"
+
   section_style_modifier =
     if background_image_enabled
-      "background-image"
+      "background-image--#{background_image_modifier}"
     elsif background_color_enabled
       "background-color"
     elsif second_wo_background

--- a/docs/landing-page-structure.md
+++ b/docs/landing-page-structure.md
@@ -65,8 +65,9 @@ Section `kind` is `hero`.
 Values to set:
 
 * `background_image`
+* `background_image_variation` sets the amount of dimming applied to the image. Possible values are `dark` (default) and `light`.
 
-Normally, the only key that you need to modify in a `hero` section is the `background_image`, which links to an asset. For example:
+Normally, the only keys that you need to modify in a `hero` section are the `background_image`, which links to an asset, and the `background_image_variation`, which sets the amount of darkening applied. For example:
 
 ```json
 ...
@@ -75,6 +76,7 @@ Normally, the only key that you need to modify in a `hero` section is the `backg
         "id": "hero",
         "kind": "hero",
         "background_image": {"type": "assets", "id": "hero_bg"},
+        "background_image_variation": "dark",
         ...
     }
 ]
@@ -102,6 +104,7 @@ Values to set:
 
 * `title`
 * `background_image`
+* `background_image_variation` - possible values: `light` and `dark` (default)
 * `paragraph`
 * `button_title`
 * `button_path`


### PR DESCRIPTION


The change is backward compatible, with default being the current, darker dimming.
Also make the darker dimming for info section same amount as hero section.