### PR TITLE
Remove unnecessary Google Maps script inclusions

### DIFF
--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -8,14 +8,11 @@
   - # maps.google can't be loaded twice
   - maps_key = @current_community.google_maps_key
   - key_param = maps_key ? "&key=#{maps_key}" : ""
-  - if(location_search_in_use && @view_type.eql?("map"))
+  - if(@view_type.eql?("map"))
     = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
     = javascript_include_tag "markerclusterer.js"
   - elsif(location_search_in_use)
     = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
-  - elsif(@view_type.eql?("map"))
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}"
-    = javascript_include_tag "markerclusterer.js"
 
 - content_for :title_header do
   - if @big_cover_photo

--- a/app/views/listings/edit.haml
+++ b/app/views/listings/edit.haml
@@ -10,7 +10,7 @@
 - content_for :extra_javascript do
   - maps_key = @current_community.google_maps_key
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
 
 #new_listing_form.new-listing-form.centered-section
 

--- a/app/views/listings/new.haml
+++ b/app/views/listings/new.haml
@@ -7,7 +7,7 @@
 - content_for :extra_javascript do
   - maps_key = @current_community.google_maps_key
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
 
 - content_for :title_header do
   %h1= t("listings.new.post_a_new_listing")

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -6,7 +6,7 @@
     window.ST.listing();
   - maps_key = @current_community.google_maps_key
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
 
 - content_for :title, raw(@listing.title)
 - content_for :meta_author, @listing.author.name(@current_community)

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -4,7 +4,7 @@
 - content_for :extra_javascript do
   - maps_key = @current_community.google_maps_key
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}"
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
 
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")


### PR DESCRIPTION
The new topbar contains the maps script so adding it is not necessary when the topbar is in use.