### PR TITLE
User-specific feature flags

### DIFF
--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -4,6 +4,7 @@
 #
 #  id           :integer          not null, primary key
 #  community_id :integer          not null
+#  person_id    :string(255)
 #  feature      :string(255)      not null
 #  enabled      :boolean          default(TRUE), not null
 #  created_at   :datetime         not null
@@ -11,7 +12,7 @@
 #
 # Indexes
 #
-#  index_feature_flags_on_community_id  (community_id)
+#  index_feature_flags_on_community_id_and_person_id  (community_id,person_id)
 #
 
 class FeatureFlag < ActiveRecord::Base

--- a/app/services/feature_flag_service/api/features.rb
+++ b/app/services/feature_flag_service/api/features.rb
@@ -6,32 +6,40 @@ module FeatureFlagService::API
       @feature_flag_store = feature_flag_store
     end
 
-    def enable(community_id:, features:)
+    # Enable features for a community or a person if person_id is provided.
+    def enable(community_id:, person_id: nil, features:)
       if features.blank?
         return Result::Error.new("You must specify one or more flags in #{@feature_flag_store.known_flags} to enable.")
       end
 
-      Result::Success.new(@feature_flag_store.enable(community_id, features))
+      Result::Success.new(@feature_flag_store.enable(community_id, person_id, features))
     end
 
-    def disable(community_id:, features:)
+    # Disable features for a community or a person if person_id is provided.
+    def disable(community_id:, person_id: nil, features:)
       if features.blank?
         return Result::Error.new("You must specify one or more flags in #{@feature_flag_store.known_flags} to disable.")
       end
 
-      Result::Success.new(@feature_flag_store.disable(community_id, features))
+      Result::Success.new(@feature_flag_store.disable(community_id, person_id, features))
     end
 
-    def get(community_id:)
-      Result::Success.new(@feature_flag_store.get(community_id))
+    # Fetch community-specific features or person-specific features if person_id is provided.
+    def get(community_id:, person_id: nil)
+      Result::Success.new(@feature_flag_store.get(community_id, person_id))
     end
 
-    def enabled?(community_id:, feature:)
-      if community_id
-        Result::Success.new(@feature_flag_store.get(community_id)[:features].include?(feature))
-      else
-        Result::Success.new(false)
-      end
+    # Check if a feature is enabled for a community or a person.
+    # Both checks are made by providing both id parameters.
+    def enabled?(community_id:, person_id: nil, feature:)
+      features =
+        if person_id
+          @feature_flag_store.get(community_id, person_id)[:features] + @feature_flag_store.get(community_id, nil)[:features]
+        else
+          @feature_flag_store.get(community_id, nil)[:features]
+        end
+
+      Result::Success.new(features.include?(feature))
     end
   end
 end

--- a/app/services/feature_flag_service/feature_flags_api.md
+++ b/app/services/feature_flag_service/feature_flags_api.md
@@ -1,22 +1,42 @@
+# feature_flags/v1/
 
-# feature_flags/v1/community
+## GET /?community_id=123&person_id=456
 
-## GET /:community_id
+Query params:
+
+ - `community_id`: mandatory
+ - `person_id`: optional (if `person_id` is provided, operation tagets user-specific feature flags)
 
 Request body: empty
 
-Response body:
+Response body (person_id not provided):
 
 ```ruby
 { community_id: 123
-, features: 
+, features:
   [ :topbar_v1
   , :new_login
   ]
 }
 ```
 
-## POST /:community_id
+Response body (person_id provided):
+
+```ruby
+{ person_id: 456
+, features:
+  [ :topbar_v1
+  , :new_login
+  ]
+}
+```
+
+## POST /?community_id=123&person_id=456
+
+Query params:
+
+ - `community_id`: mandatory
+ - `person_id`: optional (if `person_id` is provided, operation tagets user-specific feature flags)
 
 Request body:
 
@@ -26,11 +46,11 @@ Request body:
 ]
 ```
 
-Response body:
+Response body (person_id not provided):
 
 ```ruby
 { community_id: 123
-, features: 
+, features:
   [ :topbar_v1
   , :new_login
   , :some_feature
@@ -39,7 +59,25 @@ Response body:
 }
 ```
 
-## DELETE /:community_id
+Response body (person_id provided):
+
+```ruby
+{ person_id: 456
+, features:
+  [ :topbar_v1
+  , :new_login
+  , :some_feature
+  , :some_other_feature
+  ]
+}
+```
+
+## DELETE /?community_id=123&person_id=456
+
+Query params:
+
+ - `community_id`: mandatory
+ - `person_id`: optional (if `person_id` is provided, operation tagets user-specific feature flags)
 
 Request body:
 
@@ -49,175 +87,39 @@ Request body:
 ]
 ```
 
-Response body:
+Response body (person_id not provided):
 
 ```ruby
 { community_id: 123
-, features: 
+, features:
   [ :new_login
   , :some_other_feature
   ]
 }
 ```
 
-## GET /enabled/:community_id/:feature
-
-Request body: empty
-
-Response body:
+Response body (person_id not provided):
 
 ```ruby
-{ enabled: true
-}
-```
-
-# feature_flags/v1/user
-
-## GET /:user_id
-
-Request body: empty
-
-Response body:
-
-```ruby
-{ user_id: 123
-, features: 
-  [ :topbar_v1
-  , :new_login
-  ]
-}
-```
-
-## POST /:user_id
-
-Request body:
-
-```ruby
-[ :some_feature
-, :some_other_feature
-]
-```
-
-Response body:
-
-```ruby
-{ community_id: 123
-, features: 
-  [ :topbar_v1
-  , :new_login
-  , :some_feature
-  , :some_other_feature
-  ]
-}
-```
-
-## POST /
-
-Request body:
-
-```ruby
-{ users: 
-  [ "user_id_1"
-  , "user_id_2"
-  , "user_id_3"
-  ]
+{ person_id: 456
 , features:
-  [ :some_feature
-  , :some_other_feature
-  ]
-}
-```
-
-Response body:
-
-```ruby
-[ { user_id: "user_id_1"  
-  , features: 
-    [ :new_login
-    , :some_feature
-    , :some_other_feature
-    ]
-  }
-, { user_id: "user_id_2"  
-  , features: 
-    [ :topbar_v1
-    , :some_feature
-    , :some_other_feature
-    ]
-  }
-, { user_id: "user_id_3"  
-  , features: 
-    [ :some_feature
-    , :some_other_feature
-    ]
-  }
-]
-```
-
-## DELETE /:user_id
-
-Request body:
-
-```ruby
-[ :topbar_v1
-, :some_feature
-]
-```
-
-Response body:
-
-```ruby
-{ community_id: 123
-, features: 
   [ :new_login
   , :some_other_feature
   ]
 }
 ```
 
-## DELETE /
+## GET /enabled/?community_id=123&person_id=456
 
-Request body:
+Query params:
 
-```ruby
-{ user_ids: 
-  [ "user_id_1"
-  , "user_id_2"
-  , "user_id_3"
-  ]
-, features:
-  [ :some_feature
-  , :some_other_feature
-  ]
-}
-```
-
-Response body:
-
-```ruby
-[ { user_id: "user_id_1"  
-  , features: 
-    [ :new_login
-    ]
-  }
-, { user_id: "user_id_2"  
-  , features: 
-    [ :topbar_v1
-    ]
-  }
-, { user_id: "user_id_3"  
-  , features: [ ]
-  }
-]
-```
-
-## GET /enabled/:user_id/:feature
+ - `community_id`: mandatory
+ - `person_id`: optional (if `person_id` is provided, operation tagets community and user-specific feature flags, otherwise just community-specific flags are taken into account)
 
 Request body: empty
 
 Response body:
 
 ```ruby
-{ enabled: true
-}
+{ data: true }
 ```

--- a/app/services/feature_flag_service/feature_flags_api.md
+++ b/app/services/feature_flag_service/feature_flags_api.md
@@ -1,5 +1,5 @@
 
-# feature_flags/v1/
+# feature_flags/v1/community
 
 ## GET /:community_id
 
@@ -15,6 +15,7 @@ Response body:
   ]
 }
 ```
+
 ## POST /:community_id
 
 Request body:
@@ -60,6 +61,157 @@ Response body:
 ```
 
 ## GET /enabled/:community_id/:feature
+
+Request body: empty
+
+Response body:
+
+```ruby
+{ enabled: true
+}
+```
+
+# feature_flags/v1/user
+
+## GET /:user_id
+
+Request body: empty
+
+Response body:
+
+```ruby
+{ user_id: 123
+, features: 
+  [ :topbar_v1
+  , :new_login
+  ]
+}
+```
+
+## POST /:user_id
+
+Request body:
+
+```ruby
+[ :some_feature
+, :some_other_feature
+]
+```
+
+Response body:
+
+```ruby
+{ community_id: 123
+, features: 
+  [ :topbar_v1
+  , :new_login
+  , :some_feature
+  , :some_other_feature
+  ]
+}
+```
+
+## POST /
+
+Request body:
+
+```ruby
+{ users: 
+  [ "user_id_1"
+  , "user_id_2"
+  , "user_id_3"
+  ]
+, features:
+  [ :some_feature
+  , :some_other_feature
+  ]
+}
+```
+
+Response body:
+
+```ruby
+[ { user_id: "user_id_1"  
+  , features: 
+    [ :new_login
+    , :some_feature
+    , :some_other_feature
+    ]
+  }
+, { user_id: "user_id_2"  
+  , features: 
+    [ :topbar_v1
+    , :some_feature
+    , :some_other_feature
+    ]
+  }
+, { user_id: "user_id_3"  
+  , features: 
+    [ :some_feature
+    , :some_other_feature
+    ]
+  }
+]
+```
+
+## DELETE /:user_id
+
+Request body:
+
+```ruby
+[ :topbar_v1
+, :some_feature
+]
+```
+
+Response body:
+
+```ruby
+{ community_id: 123
+, features: 
+  [ :new_login
+  , :some_other_feature
+  ]
+}
+```
+
+## DELETE /
+
+Request body:
+
+```ruby
+{ user_ids: 
+  [ "user_id_1"
+  , "user_id_2"
+  , "user_id_3"
+  ]
+, features:
+  [ :some_feature
+  , :some_other_feature
+  ]
+}
+```
+
+Response body:
+
+```ruby
+[ { user_id: "user_id_1"  
+  , features: 
+    [ :new_login
+    ]
+  }
+, { user_id: "user_id_2"  
+  , features: 
+    [ :topbar_v1
+    ]
+  }
+, { user_id: "user_id_3"  
+  , features: [ ]
+  }
+]
+```
+
+## GET /enabled/:user_id/:feature
 
 Request body: empty
 

--- a/app/services/feature_flag_service/feature_flags_api.md
+++ b/app/services/feature_flag_service/feature_flags_api.md
@@ -1,0 +1,71 @@
+
+# feature_flags/v1/
+
+## GET /:community_id
+
+Request body: empty
+
+Response body:
+
+```ruby
+{ community_id: 123
+, features: 
+  [ :topbar_v1
+  , :new_login
+  ]
+}
+```
+## POST /:community_id
+
+Request body:
+
+```ruby
+[ :some_feature
+, :some_other_feature
+]
+```
+
+Response body:
+
+```ruby
+{ community_id: 123
+, features: 
+  [ :topbar_v1
+  , :new_login
+  , :some_feature
+  , :some_other_feature
+  ]
+}
+```
+
+## DELETE /:community_id
+
+Request body:
+
+```ruby
+[ :topbar_v1
+, :some_feature
+]
+```
+
+Response body:
+
+```ruby
+{ community_id: 123
+, features: 
+  [ :new_login
+  , :some_other_feature
+  ]
+}
+```
+
+## GET /enabled/:community_id/:feature
+
+Request body: empty
+
+Response body:
+
+```ruby
+{ enabled: true
+}
+```

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -27,8 +27,8 @@ module FeatureFlagService::Store
     def get(community_id, person_id)
       Maybe(FeatureFlagModel.where(community_id: community_id, person_id: person_id))
         .map { |features|
-          person_id ? from_person_models(person_id, features) : from_community_models(community_id, features) }
-        .or_else(no_flags(community_id, person_id))
+          person_id ? from_person_models(person_id, features) : from_community_models(community_id, features)
+        }.or_else(no_flags(community_id, person_id))
     end
 
     def enable(community_id, person_id, features)

--- a/db/migrate/20160728130503_add_person_id_to_feature_flags.rb
+++ b/db/migrate/20160728130503_add_person_id_to_feature_flags.rb
@@ -1,0 +1,8 @@
+class AddPersonIdToFeatureFlags < ActiveRecord::Migration
+  def change
+    add_column :feature_flags, :person_id, :string, default: nil, null: true, after: :community_id
+
+    remove_index :feature_flags, :community_id
+    add_index :feature_flags, [:community_id, :person_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160728102918) do
+ActiveRecord::Schema.define(version: 20160728130503) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -407,13 +407,14 @@ ActiveRecord::Schema.define(version: 20160728102918) do
 
   create_table "feature_flags", force: :cascade do |t|
     t.integer  "community_id", limit: 4,                  null: false
+    t.string   "person_id",    limit: 255
     t.string   "feature",      limit: 255,                null: false
     t.boolean  "enabled",                  default: true, null: false
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false
   end
 
-  add_index "feature_flags", ["community_id"], name: "index_feature_flags_on_community_id", using: :btree
+  add_index "feature_flags", ["community_id", "person_id"], name: "index_feature_flags_on_community_id_and_person_id", using: :btree
 
   create_table "feedbacks", force: :cascade do |t|
     t.text     "content",      limit: 65535

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -32,5 +32,6 @@ Feature flags can be toggled in two ways:
 1. Query params
 If you're logged in as superadmin, you can append `?enable_feature=<your_flag>` to enable the feature for current session
 
-1. Console
-Run this in Rails console: `FeatureFlagService::API::Api.features.enable(community_id: <community_id>, features: [:<your_flag>])`
+2. Run a command in console
+   - Community-specific flag: `FeatureFlagService::API::Api.features.enable(community_id: <community_id>, features: [:<your_flag>])`
+   - User-specific flag: `FeatureFlagService::API::Api.features.enable(community_id: <community_id>, person_id: <person_id>, features: [:<your_flag>])`

--- a/spec/services/feature_flag_service/api/features_spec.rb
+++ b/spec/services/feature_flag_service/api/features_spec.rb
@@ -5,10 +5,11 @@ describe FeatureFlagService::API::Features do
 
   let(:test_flag) { :bar_feature }
   let(:features) { FeatureFlagService::API::Features.new(
-    FeatureFlagService::Store::CachingFeatureFlag.new(
+    FeatureFlagService::Store::FeatureFlag.new(
     additional_flags: [test_flag]
   )) }
   let(:community_id) { 321 }
+  let(:person_id) { "abc123" }
 
   context "#enable" do
     it "returns error if called with empty or nil features list" do
@@ -19,7 +20,14 @@ describe FeatureFlagService::API::Features do
         .to eq(false)
     end
 
-    it "enables the given supported feature" do
+    it "enables the given supported feature for a person" do
+      res = features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
+
+      expect(res.success).to eq(true)
+      expect(res.data[:features]).to eq([test_flag].to_set)
+    end
+
+    it "enables the given supported feature for a community" do
       res = features.enable(community_id: community_id, features: [test_flag])
 
       expect(res.success).to eq(true)
@@ -43,9 +51,17 @@ describe FeatureFlagService::API::Features do
         .to eq(false)
     end
 
-    it "disables the given supported feature" do
+    it "disables the given supported community feature" do
       features.enable(community_id: community_id, features: [test_flag])
       res = features.disable(community_id: community_id, features: [test_flag])
+
+      expect(res.success).to eq(true)
+      expect(res.data[:features]).to eq(Set.new)
+    end
+
+    it "disables the given supported person feature" do
+      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
+      res = features.disable(community_id: community_id, person_id: person_id, features: [test_flag])
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq(Set.new)
@@ -68,12 +84,52 @@ describe FeatureFlagService::API::Features do
       expect(res.data[:features]).to eq(Set.new)
     end
 
-    it "returns enabled features as a set" do
+    it "returns result with no features enabled when nothing recorded for a person" do
+      res = features.get(community_id: community_id, person_id: person_id)
+
+      expect(res.success).to eq(true)
+      expect(res.data[:features]).to eq(Set.new)
+    end
+
+    it "returns enabled features as a set for a community" do
       features.enable(community_id: community_id, features: [test_flag])
       res = features.get(community_id: community_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq([test_flag].to_set)
+    end
+
+    it "returns enabled features as a set for a person" do
+      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
+      res = features.get(community_id: community_id, person_id: person_id)
+
+      expect(res.success).to eq(true)
+      expect(res.data[:features]).to eq([test_flag].to_set)
+    end
+  end
+
+  context "#enabled?" do
+    it "returns false when nothing is recorded for a community or a person" do
+      res = features.enabled?(community_id: community_id, person_id: person_id, feature: test_flag)
+
+      expect(res.success).to eq(true)
+      expect(res.data).to eq(false)
+    end
+
+    it "returns true if a features is enabled for a community" do
+      features.enable(community_id: community_id, features: [test_flag])
+      res = features.enabled?(community_id: community_id, feature: test_flag)
+
+      expect(res.success).to eq(true)
+      expect(res.data).to eq(true)
+    end
+
+    it "returns true if a features is enabled for a person" do
+      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
+      res = features.enabled?(community_id: community_id, person_id: person_id, feature: test_flag)
+
+      expect(res.success).to eq(true)
+      expect(res.data).to eq(true)
     end
   end
 end

--- a/spec/services/feature_flag_service/api/features_spec.rb
+++ b/spec/services/feature_flag_service/api/features_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 
 describe FeatureFlagService::API::Features do
 
-  let(:test_flag) { :bar_feature }
+  let(:test_flag) { :foo_feature }
+  let(:unknown_flag) { :bar_feature }
   let(:features) { FeatureFlagService::API::Features.new(
     FeatureFlagService::Store::FeatureFlag.new(
     additional_flags: [test_flag]
   )) }
   let(:community_id) { 321 }
-  let(:person_id) { "abc123" }
+  let(:person_id) { "123" }
 
   context "#enable" do
     it "returns error if called with empty or nil features list" do
@@ -17,6 +18,12 @@ describe FeatureFlagService::API::Features do
         .to eq(false)
 
       expect(features.enable(community_id: community_id, features: nil).success)
+        .to eq(false)
+
+      expect(features.enable(community_id: community_id, person_id: person_id, features: []).success)
+        .to eq(false)
+
+      expect(features.enable(community_id: community_id, person_id: person_id, features: nil).success)
         .to eq(false)
     end
 
@@ -35,10 +42,15 @@ describe FeatureFlagService::API::Features do
     end
 
     it "does nothing if called with unknown feature" do
-      res = features.enable(community_id: community_id, features: [:foo_feature])
+      res_community = features.enable(community_id: community_id, features: [unknown_flag])
 
-      expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq(Set.new)
+      expect(res_community.success).to eq(true)
+      expect(res_community.data[:features]).to eq(Set.new)
+
+      res_person = features.enable(community_id: community_id, person_id: person_id, features: [unknown_flag])
+
+      expect(res_person.success).to eq(true)
+      expect(res_person.data[:features]).to eq(Set.new)
     end
   end
 
@@ -48,6 +60,12 @@ describe FeatureFlagService::API::Features do
         .to eq(false)
 
       expect(features.disable(community_id: community_id, features: nil).success)
+        .to eq(false)
+
+      expect(features.disable(community_id: community_id, person_id: person_id, features: []).success)
+        .to eq(false)
+
+      expect(features.disable(community_id: community_id, person_id: person_id, features: nil).success)
         .to eq(false)
     end
 
@@ -69,10 +87,16 @@ describe FeatureFlagService::API::Features do
 
     it "does nothing if called with unknown feature" do
       features.enable(community_id: community_id, features: [test_flag])
-      res = features.disable(community_id: community_id, features: [:foo_feature])
+      res_community = features.disable(community_id: community_id, features: [unknown_flag])
 
-      expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq([test_flag].to_set)
+      expect(res_community.success).to eq(true)
+      expect(res_community.data[:features]).to eq([test_flag].to_set)
+
+      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
+      res_person = features.disable(community_id: community_id, person_id: person_id, features: [unknown_flag])
+
+      expect(res_person.success).to eq(true)
+      expect(res_person.data[:features]).to eq([test_flag].to_set)
     end
   end
 
@@ -116,7 +140,7 @@ describe FeatureFlagService::API::Features do
       expect(res.data).to eq(false)
     end
 
-    it "returns true if a features is enabled for a community" do
+    it "returns true if a feature is enabled for a community" do
       features.enable(community_id: community_id, features: [test_flag])
       res = features.enabled?(community_id: community_id, feature: test_flag)
 
@@ -127,6 +151,15 @@ describe FeatureFlagService::API::Features do
     it "returns true if a features is enabled for a person" do
       features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
       res = features.enabled?(community_id: community_id, person_id: person_id, feature: test_flag)
+
+      expect(res.success).to eq(true)
+      expect(res.data).to eq(true)
+    end
+
+    it "returns true if a feature is enabled for a community and a person" do
+      features.enable(community_id: community_id, features: [test_flag])
+      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
+      res = features.enabled?(community_id: community_id, feature: test_flag)
 
       expect(res.success).to eq(true)
       expect(res.data).to eq(true)


### PR DESCRIPTION
Currently our feature flags can only be set for a marketplace. The plan is to extend this feature by adding user-specific feature flags that allow enabling a feature for a single user.

The greater plan here is to allow marketplace admins to enable features in their marketplace. Currently this could be achieved with the marketplace-specific feature flags but with the user-specific feature flags an admin could enable the feature only for themselves and try it out before enabling it for the whole marketplace.