### PR TITLE
Fix locale routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,11 +54,13 @@ Kassi::Application.routes.draw do
   # and regexp anchors are not allowed in routing requirements.
   get '/_lp_preview' => 'landing_page#preview'
 
-  locale_matcher = Regexp.new(Sharetribe::AVAILABLE_LOCALES.map { |l| l[:ident] }.concat(Sharetribe::REMOVED_LOCALES.to_a).join("|"))
+  locale_regex_string = Sharetribe::AVAILABLE_LOCALES.map { |l| l[:ident] }.concat(Sharetribe::REMOVED_LOCALES.to_a).join("|")
+  locale_matcher = Regexp.new(locale_regex_string)
+  locale_matcher_anchored = Regexp.new("^(#{locale_regex_string})$")
 
   # Conditional routes for custom landing pages
   get '/:locale/' => 'landing_page#index', as: :landing_page_with_locale, constraints: ->(request) {
-    locale_matcher.match(request.params["locale"]) &&
+    locale_matcher_anchored.match(request.params["locale"]) &&
       CustomLandingPage::LandingPageStore.enabled?(request.env[:current_marketplace]&.id)
   }
   get '/' => 'landing_page#index', as: :landing_page_without_locale, constraints: ->(request) {
@@ -67,7 +69,7 @@ Kassi::Application.routes.draw do
 
   # Conditional routes for search view if landing page is enabled
   get '/:locale/s' => 'homepage#index', as: :search_with_locale, constraints: ->(request) {
-    locale_matcher.match(request.params["locale"]) &&
+    locale_matcher_anchored.match(request.params["locale"]) &&
       CustomLandingPage::LandingPageStore.enabled?(request.env[:current_marketplace]&.id)
   }
   get '/s' => 'homepage#index', as: :search_without_locale, constraints: ->(request) {

--- a/spec/requests/landing_pages_spec.rb
+++ b/spec/requests/landing_pages_spec.rb
@@ -60,6 +60,12 @@ describe "Landing page", type: :request do
     @community = FactoryGirl.create(:community, :domain => @domain, use_domain: true)
     @community.reload
 
+    # Person with username with no substrings that match a valid locale
+    @person = FactoryGirl.create(:person, username: "u1234")
+
+    # Person with username with a locale present as substring
+    @person_with_locale_substring = FactoryGirl.create(:person, username: "fooen")
+
     10.times do
       FactoryGirl.create(:category, community_id: @community.id)
     end
@@ -117,6 +123,22 @@ describe "Landing page", type: :request do
 
     it "search path routes to search" do
       expect_controller("http://#{@domain}/s", "homepage", "index")
+    end
+
+    it "/:locale routes to landing page" do
+      expect_controller("http://#{@domain}/en", "landing_page", "index")
+    end
+
+    it "/:person routes to person" do
+      expect_controller("http://#{@domain}/#{@person.username}", "people", "show")
+    end
+
+    it "/:person routes to person when username has locale as substring" do
+      expect_controller("http://#{@domain}/#{@person_with_locale_substring.username}", "people", "show")
+    end
+
+    it "/:locale/s routes to search" do
+      expect_controller("http://#{@domain}/en/s", "homepage", "index")
     end
 
     it "shows correct landing page version" do

--- a/spec/routing/people_routing_spec.rb
+++ b/spec/routing/people_routing_spec.rb
@@ -5,7 +5,12 @@ describe "routing for people", type: :routing do
   before(:each) do
     @community = FactoryGirl.create(:community)
     @protocol_and_host = "http://#{@community.ident}.test.host"
-    @person = FactoryGirl.create(:person)
+
+    # Person with username with no substrings that match a valid locale
+    @person = FactoryGirl.create(:person, username: "u1234")
+
+    # Person with username with a locale present as substring
+    @person_with_locale_substring = FactoryGirl.create(:person, username: "fooen")
   end
 
   it "routes /:username to people controller" do
@@ -15,6 +20,18 @@ describe "routing for people", type: :routing do
           :controller => "people",
           :action => "show",
           :username => @person.username
+        }
+      )
+    )
+  end
+
+  it "routes /:username to people controller when username has locale as substring" do
+    expect(get "/#{@person_with_locale_substring.username}").to(
+      route_to(
+        {
+          :controller => "people",
+          :action => "show",
+          :username => @person_with_locale_substring.username
         }
       )
     )


### PR DESCRIPTION
Rails automatically anchors regex constraints when directly specified as:

```
... constraints: { locale: /regex/ }
```

but does NOT do that when the constraint is a proc:

```
... constraints: ->(request) {...}
```

So we need to use anchored regex there to make sure that a username
with a locale as substring doesn't get mistaken for locale (e.g. "foo**en**").