### PR TITLE
Instruct search engines not to follow followers ajax link

### DIFF
--- a/app/views/people/_followed_people.haml
+++ b/app/views/people/_followed_people.haml
@@ -22,4 +22,4 @@
 - if followed_people.count > limit
   .people-load-more-listings-container
     #load-more-followed-people
-      = link_to t(".show_all_followed_people"), [ person, :followed_people ], :remote => true
+      = link_to t(".show_all_followed_people"), [ person, :followed_people ], :remote => true, :rel => "nofollow"


### PR DESCRIPTION
Bots don't seem to be sending the x-csrf-token header and expect text/html output.