### PR TITLE
Fix CLP top-bar assets not linked to asset_host when configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Add support for using CDN for dynamic assets (uploaded images, custom compiled stylesheets) when S3 is otherwise in use [#2314](https://github.com/sharetribe/sharetribe/pull/2314)
 - Add possibility to choose between light and dark background image filter for hero and info sections in custom landing pages [#2310](https://github.com/sharetribe/sharetribe/pull/2310)
 
+### Fixed
+
+- Fix some asset links not respecting `asset_host` setting on landing pages [#2320](https://github.com/sharetribe/sharetribe/pull/2320)
+
 ## [5.8.0] - 2016-07-15
 
 ### Added

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -250,6 +250,7 @@ class LandingPageController < ActionController::Metal
                      sections: denormalizer.to_tree(structure, root: "composition"),
                      community_context: community_context(request, landing_page_locale),
                      feature_flags: FeatureFlagHelper.feature_flags,
+                     asset_host: APP_CONFIG.asset_host,
                    }
   end
 

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -129,9 +129,10 @@
         <%= javascripts[:translations] %>
     </script>
 
-    <%= stylesheet_link_tag 'app-bundle' %>
-    <%= javascript_include_tag 'vendor-bundle' %>
-    <%= javascript_include_tag 'app-bundle' %>
+    <% asset_host = local_assigns.key?(:asset_host) ? asset_host : nil %>
+    <%= stylesheet_link_tag asset_path('app-bundle', type: :stylesheet, host: asset_host) %>
+    <%= javascript_include_tag asset_path('vendor-bundle', type: :javascript, host: asset_host) %>
+    <%= javascript_include_tag asset_path('app-bundle', type: :javascript, host: asset_host) %>
 
     <%= render partial: "topbar",
         locals: {props: topbar[:props],


### PR DESCRIPTION
This happens, because we use `ActionController::Metal` and the
setting of `config.action_controller.asset_host` doesn't take effect.

Alternatively, we could load a bunch of extra modules and hooks, but it
seems an overkill, because there are lots of hooked hooks, it seems:

``` ruby
include AbstractController::AssetPaths
include ActionController::ParamsWrapper
ActiveSupport.run_load_hooks(:action_controller, self)
```