### PR TITLE
Add third search option: keyword_and_location

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -187,7 +187,8 @@ class Admin::CommunitiesController < ApplicationController
     if(FeatureFlagHelper.location_search_available)
       marketplace_configurations = MarketplaceService::API::Api.configurations.get(community_id: @current_community.id).data
 
-      main_search_select_options = [:keyword, :location]
+      keyword_and_location = FeatureFlagHelper.feature_enabled?(:topbar_v1) ? [:keyword_and_location] : []
+      main_search_select_options = [:keyword, :location].concat(keyword_and_location)
         .map { |type|
           [SettingsViewUtils.search_type_translation(type), type]
         }

--- a/app/services/marketplace_service/store/marketplace_configurations.rb
+++ b/app/services/marketplace_service/store/marketplace_configurations.rb
@@ -4,7 +4,7 @@ module MarketplaceService::Store::MarketplaceConfigurations
 
   MarketplaceConfigurations = EntityUtils.define_builder(
     [:community_id, :mandatory, :fixnum],
-    [:main_search, :to_symbol, one_of: [:keyword, :location]],
+    [:main_search, :to_symbol, one_of: [:keyword, :location, :keyword_and_location]],
     [:distance_unit, :to_symbol, one_of: [:metric, :imperial]],
     [:limit_search_distance, :to_bool, default: true]
   )

--- a/app/view_utils/settings_view_utils.rb
+++ b/app/view_utils/settings_view_utils.rb
@@ -9,6 +9,8 @@ module SettingsViewUtils
       t("admin.communities.settings.keyword_search")
     when :location
       t("admin.communities.settings.location_search")
+    when :keyword_and_location
+      t("admin.communities.settings.keyword_and_location_search")
     else
       raise("Unknown search type: #{search_type}")
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,6 +191,7 @@ en:
         search_preferences: "Search preferences"
         default_search_type: "Search type: %{select_search_type}"
         keyword_search: "Keyword search"
+        keyword_and_location_search: "Keyword and location search"
         location_search: "Location search"
         select_distance_unit: "Show distance in %{distance_units_selector}"
         km: km


### PR DESCRIPTION
N.B. Things to do:
- When we have "Use new topbar" feature available in admin panel, we need to change marketplace_configurations related to search options. If marketplace removes feature flag :topbar_v1 then main search can't be :keyword_and_location.
- Admin can't choose :keyword_and_location to be previewed, unless we have some kind of fallback memory for this option (marketplace users should see previous option - let's say :location - even if marketplace admin chooses to test this :keyword_and_location mode