### PR TITLE
Translations to the new member notification email

### DIFF
--- a/app/views/person_mailer/new_member_notification.html.haml
+++ b/app/views/person_mailer/new_member_notification.html.haml
@@ -1,10 +1,11 @@
-A new member has joined #{@community.full_name(@person.locale)}. They may still have to confirm their email address.
+= t("emails.new_member_notification.new_member_has_joined", :community => @community.full_name(@person.locale))
+
 
 %div{:style => "margin: 15px 0; padding: 10px; background-color: #d1c9b4;"}
-  %b Name:
+  %b= t("emails.new_member_notification.person_name")
   = @person.name(@community)
   %br/
-  %b Email:
+  %b= t("emails.new_member_notification.person_email")
   = @email
 
-This is an automatic message sent to administrators of #{@community.full_name(@person.locale)}.
+= t("emails.new_member_notification.this_is_automatic_message", :community => @community.full_name(@person.locale))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -975,6 +975,11 @@ en:
       has_posted_a_new_listing: "%{author_name} has posted a new listing:"
       you_are_receiving_this_because: "You received this notification because you follow %{author_name}."
       view_listing: "View listing"
+    new_member_notification:
+      new_member_has_joined: "A new member has joined %{community}. They may still have to confirm their email address."
+      this_is_automatic_message: "This is an automatic message sent to administrators of %{community}."
+      person_name: "Name:"
+      person_email: "Email:"
   error_messages:
     onboarding:
       server_rendering: "Getting started guide failed to load. We have been informed about the situation and we are fixing it."


### PR DESCRIPTION
Add translations of the email notification about new members (that is sent to admins) to come through WTI.