### PR TITLE
Quick fix to add missing limit_priority_links param to a call (to fix broken settings page)

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -332,7 +332,8 @@ class Admin::CommunitiesController < ApplicationController
         community_id: @current_community.id,
         main_search: params[:main_search],
         distance_unit: params[:distance_unit],
-        limit_search_distance: params[:limit_distance].present?
+        limit_search_distance: params[:limit_distance].present?,
+        limit_priority_links: nil
       })
     end
 


### PR DESCRIPTION
This should be checked later, as it might not make sense to have it
hard coded as nil here. But if it's completely missing, things break
in production currently, so this should allow smooth updating
of settings page again.