### PR TITLE
Fix GA event sending about created listings

### DIFF
--- a/app/assets/javascripts/listing_form.js
+++ b/app/assets/javascripts/listing_form.js
@@ -512,6 +512,7 @@ window.ST = window.ST || {};
 
     var isLoading = status.map(function(stats) { return stats.loading > 0; });
 
+    // This handler is used only when Image uploader is loading
     validFormSubmitted.filter(isLoading).onValue(function(e) {
       var confirmed = window.confirm(imageLoadingInProgressConfirm);
 
@@ -522,10 +523,13 @@ window.ST = window.ST || {};
         // executing. Please note that the order matters. This works
         // before it's called BEFORE the submitHandler
         e.stopImmediatePropagation();
-      } else {
-        report_analytics_event("listing", "created");
-        disable_submit_button(form_id, locale);
       }
+    });
+
+    // This handler is used when Image uploader is not loading
+    validFormSubmitted.filter(isLoading.not()).onValue(function(e) {
+      report_analytics_event("listing", "created");
+      disable_submit_button(form_id, locale);
     });
 
     set_textarea_maxlength();


### PR DESCRIPTION
We noted with Vesa that the handler where Google Analytics event sending was, was only used when image uploader was still uploading, so now made another handler to be used in positive case, and put the GA event there.