### PR TITLE
Confirm email address copy tweaks

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.haml
+++ b/app/views/devise/mailer/confirmation_instructions.haml
@@ -5,10 +5,6 @@
     %font{body_font}
       = t("emails.common.hey", :name => @resource.given_name_or_username)
 
--# This part can be enabled if need to send mails in some communities where staring to use mail confirmation now
--# %p
--#   = t("emails.confirmation_instructions.turning_on_confirmations_in_this_community")
-
 %tr
   %td{:align => "left"}
     %font{body_font}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -840,9 +840,9 @@ en:
       please_contant_admin_link: "please contact the administrator"
     confirmation_instructions:
       confirmation_instructions_signature: "Best regards,<br/>The %{service_name} Team"
-      need_to_confirm: "You need to confirm your email address."
-      confirmation_link_text: "Confirm my email"
-      or_paste_link: "Alternatively you can copy the following link to your browser's address bar:"
+      need_to_confirm: "Confirm your email address by clicking the button below."
+      confirmation_link_text: "Confirm my address"
+      or_paste_link: "Alternatively, you can copy the following link to your browser's address bar:"
     common:
       hey: "Hello %{name},"
       kassi_team: "The %{service_name} Team"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -840,11 +840,9 @@ en:
       please_contant_admin_link: "please contact the administrator"
     confirmation_instructions:
       confirmation_instructions_signature: "Best regards,<br/>The %{service_name} Team"
-      welcome_to_kassi: "Welcome to %{service_name}!"
       need_to_confirm: "You need to confirm your email address."
       confirmation_link_text: "Confirm my email"
       or_paste_link: "Alternatively you can copy the following link to your browser's address bar:"
-      turning_on_confirmations_in_this_community: "We are starting to use email confirmations in this %{service_name} marketplace."
     common:
       hey: "Hello %{name},"
       kassi_team: "The %{service_name} Team"


### PR DESCRIPTION
Slightly improve the copy in outgoing email messages about confirming your email address. Also remove two unused pieces of text.