### PR TITLE
Reset cleanup strategy after executing a :no-transaction test

### DIFF
--- a/spec/support/database_cleanup.rb
+++ b/spec/support/database_cleanup.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
 
   config.after(:each, :'no-transaction' => true) do
     clean_db.call
+    DatabaseCleaner.strategy = :transaction
   end
 
   config.before(:each) do


### PR DESCRIPTION
This resolves a rare bug where DatabaseCleaner is initialized with :truncation strategy
in a before(:all) block, if previous suite had :no-transaction set to true.