### PR TITLE
Removes a double space in an admin panel section

### DIFF
--- a/app/views/admin/communities/edit_look_and_feel.haml
+++ b/app/views/admin/communities/edit_look_and_feel.haml
@@ -56,7 +56,7 @@
 
     .row
       .col-12
-        - post_new_listing = "<i>#{t("homepage.index.post_new_listing")}&nbsp;</i>"
+        - post_new_listing = "<i>#{t("homepage.index.post_new_listing")}</i>"
         = form.label :custom_color2, t(".community_custom_color2", post_new_listing: post_new_listing).html_safe, :class => "input"
         = render :partial => "layouts/info_text", :locals => { :text =>  t(".custom_color2_instructions_text", post_new_listing: post_new_listing).html_safe }
         = form.text_field :custom_color2, :maxlength => "6", :class => "text_field"


### PR DESCRIPTION
Because the key `community_custom_color2` is `%{post_new_listing} button color` it already contains the space character after `post_new_listing` so it isn't needed to have another one.