### PR TITLE
Hide search from homepage main when using new topbar

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -45,7 +45,7 @@ body {
   padding-bottom: lines(3);
   padding-top: lines(0.5);
 
-  &.homepage {
+  &.no-cover-photo {
     padding-top: lines(0.5);
   }
 
@@ -65,7 +65,7 @@ body {
   @include media(tablet) {
     padding-top: lines(1);
 
-    &.homepage {
+    &.no-cover-photo {
       padding-top: lines(1.75);
     }
   }

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -45,6 +45,10 @@ body {
   padding-bottom: lines(3);
   padding-top: lines(0.5);
 
+  &.homepage {
+    padding-top: lines(0.5);
+  }
+
   p {
     margin-bottom: lines(0.5);
     -webkit-hyphens: auto;
@@ -60,6 +64,10 @@ body {
 
   @include media(tablet) {
     padding-top: lines(1);
+
+    &.homepage {
+      padding-top: lines(1.75);
+    }
   }
 
 }

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -23,12 +23,12 @@
         %a.inline-big-button{href: sign_up_path}
           .content
             = t("layouts.application.connect")
-      - else
+      - elsif !FeatureFlagHelper.feature_enabled?(:topbar_v1)
         - if(location_search_in_use)
           = render partial: "location_bar"
         - else
           = render partial: "search_bar"
-  - else
+  - elsif !(params[:controller] == "homepage" && params[:action] == "index" && FeatureFlagHelper.feature_enabled?(:topbar_v1))
     .browse-view-search-form
       - if(location_search_in_use)
         = render partial: "location_bar"

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -15,20 +15,22 @@
     = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
 
 - content_for :title_header do
+  - is_homepage = params[:controller] == "homepage" && params[:action] == "index"
   - if @big_cover_photo
     %h1.marketplace-lander-content-title= community_slogan.html_safe
     %p= community_description.html_safe
-    .search-form
-      - if @current_community.private?
-        %a.inline-big-button{href: sign_up_path}
-          .content
-            = t("layouts.application.connect")
-      - elsif !FeatureFlagHelper.feature_enabled?(:topbar_v1)
-        - if(location_search_in_use)
-          = render partial: "location_bar"
+    - unless (is_homepage && !@current_community.private? && FeatureFlagHelper.feature_enabled?(:topbar_v1))
+      .search-form
+        - if @current_community.private?
+          %a.inline-big-button{href: sign_up_path}
+            .content
+              = t("layouts.application.connect")
         - else
-          = render partial: "search_bar"
-  - elsif !(params[:controller] == "homepage" && params[:action] == "index" && FeatureFlagHelper.feature_enabled?(:topbar_v1))
+          - if(location_search_in_use)
+            = render partial: "location_bar"
+          - else
+            = render partial: "search_bar"
+  - elsif !(is_homepage && FeatureFlagHelper.feature_enabled?(:topbar_v1))
     .browse-view-search-form
       - if(location_search_in_use)
         = render partial: "location_bar"

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -46,7 +46,7 @@
             .marketplace-title-header
               = yield :title_header
 
-    %article.page-content{class: is_homepage ? 'homepage' : ''}
+    %article.page-content{class: is_homepage && !@big_cover_photo ? 'no-cover-photo' : ''}
       .wrapper
         = render :partial => "layouts/notifications"
         = yield

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -5,6 +5,7 @@
   -# Render railsContext here before any react component gets rendered
   = prepend_render_rails_context("")
 
+  - is_homepage = params[:controller] == "homepage" && params[:action] == "index"
   %noscript
     .noscript-padding
       -# Noscript content will be positioned here
@@ -35,7 +36,7 @@
           %figure.marketplace-cover.fluidratio
             .lander-content.marketplace-lander-content
               = yield :title_header
-      - else
+      - elsif !(is_homepage && FeatureFlagHelper.feature_enabled?(:topbar_v1))
         .coverimage
           %figure.marketplace-cover-small.fluidratio
           .coverimage-fade{:class => yield(:coverfade_class)}
@@ -45,7 +46,7 @@
             .marketplace-title-header
               = yield :title_header
 
-    %article.page-content
+    %article.page-content{class: is_homepage ? 'homepage' : ''}
       .wrapper
         = render :partial => "layouts/notifications"
         = yield
@@ -56,7 +57,7 @@
     On homepage, we want to wrap the whole page content (search bar and the "real" content) to a form, so that
     pressing send from either search bar of filter list will send all the form fields
 
-  - if params[:controller] == "homepage" && params[:action] == "index"
+  - if is_homepage
     %form{method: "get", id: "homepage-filters"}
       - params.except("action", "controller", "q", "lc", "ls", "view", "utf8", "boundingbox", "distance_max").each do |param, value|
         - unless param.match(/^filter_option/) || param.match(/^checkbox_filter_option/) || param.match(/^nf_/) || param.match(/^price_/)


### PR DESCRIPTION
Short paddings:
<img width="1276" alt="screen shot 2016-08-04 at 01 33 16" src="https://cloud.githubusercontent.com/assets/717315/17385608/856167a6-59ec-11e6-900a-a230fd8391fc.png">
vs
expanded padding-top:
<img width="1274" alt="screen shot 2016-08-04 at 01 31 36" src="https://cloud.githubusercontent.com/assets/717315/17385619/93591b1a-59ec-11e6-8c69-5554db20599c.png">

The latter takes same height as narrow cover image in other pages:
<img width="1277" alt="screen shot 2016-08-04 at 01 32 34" src="https://cloud.githubusercontent.com/assets/717315/17385664/d9b0a13c-59ec-11e6-8df7-415f508d6295.png">

