### PR TITLE
Handle HTML GET requests for followed_people

### DIFF
--- a/app/controllers/followed_people_controller.rb
+++ b/app/controllers/followed_people_controller.rb
@@ -4,6 +4,7 @@ class FollowedPeopleController < ApplicationController
     target_user = Person.find_by!(username: params[:person_id], community_id: @current_community.id)
 
     respond_to do |format|
+      format.html { render nothing: true,  status: :not_acceptable }
       format.js { render partial: "people/followed_person", collection: target_user.followed_people, as: :person }
     end
   end


### PR DESCRIPTION
Avoids a frequent error when browsers seem like mistakenly prefetching
/:username/followed_people, which is intended only to be called by XHR.