### PR TITLE
Merged ff get

### DIFF
--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -31,17 +31,14 @@ module FeatureFlagHelper
   end
 
   def fetch_feature_flags(request, is_admin)
-    community_flags_from_service = FeatureFlagService::API::Api.features.get(community_id: community_id(request)).maybe[:features].or_else(Set.new)
-
-    person_flags_from_service = FeatureFlagService::API::Api.features
-      .get(community_id: community_id(request), person_id: person_id(request))
+    flags_from_service = FeatureFlagService::API::Api.features.get(community_id: community_id(request), person_id: person_id(request))
       .maybe[:features].or_else(Set.new)
 
     temp_flags = fetch_temp_flags(is_admin, request.params, request.session)
 
     request.session[:feature_flags] = temp_flags
 
-    community_flags_from_service.union(person_flags_from_service).union(temp_flags)
+    flags_from_service.union(temp_flags)
   end
 
   # Fetch temporary flags from params and session

--- a/app/services/feature_flag_service/api/features.rb
+++ b/app/services/feature_flag_service/api/features.rb
@@ -28,18 +28,5 @@ module FeatureFlagService::API
     def get(community_id:, person_id: nil)
       Result::Success.new(@feature_flag_store.get(community_id, person_id))
     end
-
-    # Check if a feature is enabled for a community or a person.
-    # Both checks are made by providing both id parameters.
-    def enabled?(community_id:, person_id: nil, feature:)
-      features =
-        if person_id
-          @feature_flag_store.get(community_id, person_id)[:features] + @feature_flag_store.get(community_id, nil)[:features]
-        else
-          @feature_flag_store.get(community_id, nil)[:features]
-        end
-
-      Result::Success.new(features.include?(feature))
-    end
   end
 end

--- a/app/services/feature_flag_service/api/features.rb
+++ b/app/services/feature_flag_service/api/features.rb
@@ -24,19 +24,19 @@ module FeatureFlagService::API
       Result::Success.new(@feature_flag_store.disable(community_id, person_id, features))
     end
 
-    # Fetch community and person-specific features combined
-    def get(community_id:, person_id:)
-      Result::Success.new(@feature_flag_store.get(community_id, person_id))
-    end
+    # Fetch enabled features for a community, a person or both if both params are provided
+    def get(community_id: nil, person_id: nil)
+      unless community_id || person_id
+        return Result::Error.new("You must specify a community_id or a person_id for feature flag query.")
+      end
 
-    # Featch feature flags for a community
-    def get_by_community_id(community_id:)
-      Result::Success.new(@feature_flag_store.get_by_community_id(community_id))
-    end
-
-    # Featch feature flags for a person
-    def get_by_person_id(person_id:)
-      Result::Success.new(@feature_flag_store.get_by_person_id(person_id))
+      if community_id && person_id
+        Result::Success.new(@feature_flag_store.get(community_id, person_id))
+      elsif community_id
+        Result::Success.new(@feature_flag_store.get_by_community_id(community_id))
+      elsif person_id
+        Result::Success.new(@feature_flag_store.get_by_person_id(person_id))
+      end
     end
   end
 end

--- a/app/services/feature_flag_service/api/features.rb
+++ b/app/services/feature_flag_service/api/features.rb
@@ -24,9 +24,19 @@ module FeatureFlagService::API
       Result::Success.new(@feature_flag_store.disable(community_id, person_id, features))
     end
 
-    # Fetch community-specific features or person-specific features if person_id is provided.
-    def get(community_id:, person_id: nil)
+    # Fetch community and person-specific features combined
+    def get(community_id:, person_id:)
       Result::Success.new(@feature_flag_store.get(community_id, person_id))
+    end
+
+    # Featch feature flags for a community
+    def get_by_community_id(community_id:)
+      Result::Success.new(@feature_flag_store.get_by_community_id(community_id))
+    end
+
+    # Featch feature flags for a person
+    def get_by_person_id(person_id:)
+      Result::Success.new(@feature_flag_store.get_by_person_id(person_id))
     end
   end
 end

--- a/app/services/feature_flag_service/feature_flags_api.md
+++ b/app/services/feature_flag_service/feature_flags_api.md
@@ -4,8 +4,10 @@
 
 Query params:
 
- - `community_id`: mandatory
- - `person_id`: optional (if `person_id` is provided, operation tagets user-specific feature flags)
+ - `community_id`: optional, for searching community-specific features
+ - `person_id`: optional, for searching person-specific features
+
+If both parameters are provided, result includes features for the community and the person combined
 
 Request body: empty
 
@@ -24,6 +26,18 @@ Response body (person_id provided):
 
 ```ruby
 { person_id: 456
+, features:
+  [ :topbar_v1
+  , :new_login
+  ]
+}
+```
+
+Response body (both params):
+
+```ruby
+{ community_id: 123
+, person_id: 456
 , features:
   [ :topbar_v1
   , :new_login
@@ -107,19 +121,4 @@ Response body (person_id not provided):
   , :some_other_feature
   ]
 }
-```
-
-## GET /enabled/?community_id=123&person_id=456
-
-Query params:
-
- - `community_id`: mandatory
- - `person_id`: optional (if `person_id` is provided, operation tagets community and user-specific feature flags, otherwise just community-specific flags are taken into account)
-
-Request body: empty
-
-Response body:
-
-```ruby
-{ data: true }
 ```

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -11,6 +11,11 @@ module FeatureFlagService::Store
       [:person_id, :string, :mandatory],
       [:features, :mandatory, :set])
 
+    CombinedFlag = EntityUtils.define_builder(
+      [:community_id, :fixnum, :optional],
+      [:person_id, :string, :optional],
+      [:features, :mandatory, :set])
+
     FLAGS = [
       :export_transactions_as_csv,
       :topbar_v1,
@@ -25,28 +30,59 @@ module FeatureFlagService::Store
     end
 
     def get(community_id, person_id)
-      Maybe(FeatureFlagModel.where(community_id: community_id, person_id: person_id))
+      Maybe(FeatureFlagModel.where("community_id = ? or person_id = ?", community_id, person_id))
         .map { |features|
-          person_id ? from_person_models(person_id, features) : from_community_models(community_id, features)
-        }.or_else(no_flags(community_id, person_id))
+          from_combined_models(community_id, person_id, features)
+        }.or_else(no_combined_flags(community_id, person_id))
+    end
+
+    def get_by_community_id(community_id)
+      Maybe(FeatureFlagModel.where(community_id: community_id))
+        .map { |features|
+          from_community_models(community_id, features)
+        }.or_else(no_community_flags(community_id))
+    end
+
+    def get_by_person_id(person_id)
+      Maybe(FeatureFlagModel.where(person_id: person_id))
+        .map { |features|
+          from_person_models(person_id, features)
+        }.or_else(no_person_flags(person_id))
     end
 
     def enable(community_id, person_id, features)
       flags_to_enable = known_flags.intersection(features).map { |flag| [flag, true] }.to_h
       update_flags!(community_id, person_id, flags_to_enable)
 
-      get(community_id, person_id)
+      if person_id
+        get_by_person_id(person_id)
+      else
+        get_by_community_id(community_id)
+      end
     end
 
     def disable(community_id, person_id, features)
       flags_to_disable = known_flags.intersection(features).map { |flag| [flag, false] }.to_h
       update_flags!(community_id, person_id, flags_to_disable)
 
-      get(community_id, person_id)
+      if person_id
+        get_by_person_id(person_id)
+      else
+        get_by_community_id(community_id)
+      end
     end
 
 
     private
+
+    def from_combined_models(community_id, person_id, feature_models)
+      CombinedFlag.call(
+        community_id: community_id,
+        person_id: person_id,
+        features: feature_models.select { |m| known_flags.include?(m.feature.to_sym) && m.enabled }
+          .map { |m| m.feature.to_sym }
+          .to_set)
+    end
 
     def from_community_models(community_id, feature_models)
       CommunityFlag.call(
@@ -64,12 +100,16 @@ module FeatureFlagService::Store
           .to_set)
     end
 
-    def no_flags(community_id, person_id)
-      if person_id
-        PersonFlag.call(person_id: person_id, features: Set.new)
-      else
-        CommunityFlag.call(community_id: community_id, features: Set.new)
-      end
+    def no_combined_flags(community_id, person_id)
+      CombinedFlag.call(community_id: community_id, person_id: person_id, features: Set.new)
+    end
+
+    def no_community_flags(community_id)
+      CommunityFlag.call(community_id: community_id, features: Set.new)
+    end
+
+    def no_person_flags(person_id)
+      PersonFlag.call(person_id: person_id, features: Set.new)
     end
 
     def update_flags!(community_id, person_id, flags)
@@ -94,31 +134,48 @@ module FeatureFlagService::Store
     end
 
     def get(community_id, person_id)
-      Rails.cache.fetch(cache_key(community_id, person_id)) do
+      Rails.cache.fetch(cache_key(community_id: community_id, person_id: person_id)) do
         @feature_flag_store.get(community_id, person_id)
       end
     end
 
+    def get_by_community_id(community_id)
+      Rails.cache.fetch(cache_key(community_id: community_id)) do
+        @feature_flag_store.get_by_community_id(community_id)
+      end
+    end
+
+    def get_by_person_id(person_id)
+      Rails.cache.fetch(cache_key(person_id: community_id)) do
+        @feature_flag_store.get_by_person_id(person_id)
+      end
+    end
+
     def enable(community_id, person_id, features)
-      Rails.cache.delete(cache_key(community_id, person_id))
+      Rails.cache.delete(cache_key(community_id: community_id, person_id: person_id))
       @feature_flag_store.enable(community_id, person_id, features)
     end
 
     def disable(community_id, person_id, features)
-      Rails.cache.delete(cache_key(community_id, person_id))
+      Rails.cache.delete(cache_key(community_id: community_id, person_id: person_id))
       @feature_flag_store.disable(community_id, person_id, features)
     end
 
 
     private
 
-    def cache_key(community_id, person_id)
-      if person_id
-        "/feature_flag_service/person/#{person_id}"
-      else
-        raise ArgumentError.new("You must specify a valid community_id.") if community_id.blank?
-        "/feature_flag_service/community/#{community_id}"
-      end
+    def cache_key(community_id:, person_id:)
+      raise ArgumentError.new("You must specify a valid community_id or person_id.") if community_id.blank? && person_id.blank?
+
+      id =
+        if person_id && community_id
+          "#{community_id}-#{person_id}"
+        elsif person_id
+          person_id
+        else
+          community_id
+        end
+      "/feature_flag_service/#{id}"
     end
   end
 end

--- a/spec/services/feature_flag_service/api/features_spec.rb
+++ b/spec/services/feature_flag_service/api/features_spec.rb
@@ -131,38 +131,4 @@ describe FeatureFlagService::API::Features do
       expect(res.data[:features]).to eq([test_flag].to_set)
     end
   end
-
-  context "#enabled?" do
-    it "returns false when nothing is recorded for a community or a person" do
-      res = features.enabled?(community_id: community_id, person_id: person_id, feature: test_flag)
-
-      expect(res.success).to eq(true)
-      expect(res.data).to eq(false)
-    end
-
-    it "returns true if a feature is enabled for a community" do
-      features.enable(community_id: community_id, features: [test_flag])
-      res = features.enabled?(community_id: community_id, feature: test_flag)
-
-      expect(res.success).to eq(true)
-      expect(res.data).to eq(true)
-    end
-
-    it "returns true if a features is enabled for a person" do
-      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
-      res = features.enabled?(community_id: community_id, person_id: person_id, feature: test_flag)
-
-      expect(res.success).to eq(true)
-      expect(res.data).to eq(true)
-    end
-
-    it "returns true if a feature is enabled for a community and a person" do
-      features.enable(community_id: community_id, features: [test_flag])
-      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
-      res = features.enabled?(community_id: community_id, feature: test_flag)
-
-      expect(res.success).to eq(true)
-      expect(res.data).to eq(true)
-    end
-  end
 end

--- a/spec/services/feature_flag_service/api/features_spec.rb
+++ b/spec/services/feature_flag_service/api/features_spec.rb
@@ -102,8 +102,22 @@ describe FeatureFlagService::API::Features do
   end
 
   context "#get" do
-    it "returns result with no features enabled when nothing recorded for a community or a person" do
+    it "returns a result with no features enabled when nothing recorded for a community or a person" do
       res = features.get(community_id: community_id, person_id: person_id)
+
+      expect(res.success).to eq(true)
+      expect(res.data[:features]).to eq(Set.new)
+    end
+
+    it "returns a result with no features enabled when nothing recorded for a community" do
+      res = features.get(community_id: community_id)
+
+      expect(res.success).to eq(true)
+      expect(res.data[:features]).to eq(Set.new)
+    end
+
+    it "returns a result with no features enabled when nothing recorded for a person" do
+      res = features.get(person_id: person_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq(Set.new)
@@ -111,7 +125,7 @@ describe FeatureFlagService::API::Features do
 
     it "returns enabled features as a set for a community" do
       features.enable(community_id: community_id, features: [test_flag])
-      res = features.get(community_id: community_id, person_id: person_id)
+      res = features.get(community_id: community_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq([test_flag].to_set)
@@ -119,7 +133,7 @@ describe FeatureFlagService::API::Features do
 
     it "returns enabled features as a set for a person" do
       features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
-      res = features.get(community_id: community_id, person_id: person_id)
+      res = features.get(person_id: person_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq([test_flag].to_set)
@@ -132,40 +146,6 @@ describe FeatureFlagService::API::Features do
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq([test_flag, test_flag2].to_set)
-    end
-  end
-
-  context "#get_by_community_id" do
-    it "returns result with no features enabled when nothing recorded for a community" do
-      res = features.get_by_community_id(community_id: community_id)
-
-      expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq(Set.new)
-    end
-
-    it "returns enabled features as a set for a community" do
-      features.enable(community_id: community_id, features: [test_flag])
-      res = features.get_by_community_id(community_id: community_id)
-
-      expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq([test_flag].to_set)
-    end
-  end
-
-  context "#get_by_person_id" do
-    it "returns result with no features enabled when nothing recorded for a person" do
-      res = features.get_by_person_id(person_id: person_id)
-
-      expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq(Set.new)
-    end
-
-    it "returns enabled features as a set for a person" do
-      features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
-      res = features.get_by_person_id(person_id: person_id)
-
-      expect(res.success).to eq(true)
-      expect(res.data[:features]).to eq([test_flag].to_set)
     end
   end
 end


### PR DESCRIPTION
Change feature flag service API so that `get` returns an combined set of person and community-specific features. For fetching person or community-specific feature flags specifically, there are `get_by_person_id` and `get_by_community_id` respectively.

Also `FeatureFlagService::API::Api.features.enabled?` is removed as it is never invoked.