### PR TITLE
Scrollpane was missing from mobile menu

### DIFF
--- a/client/app/components/composites/MenuMobile/MenuMobile.css
+++ b/client/app/components/composites/MenuMobile/MenuMobile.css
@@ -81,6 +81,12 @@
   transition-property: transform;
 }
 
+.scrollPane {
+  height: auto;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+}
+
 .canvasOpen .offScreenMenu {
   display: flex;
   transform: translateX(0);
@@ -174,12 +180,12 @@
 .languages {
   font-size: var(--LanguagesMobile_fontSize);
   margin-top: var(--LanguagesMobile_marginTop);
-  margin-bottom: var(--LanguagesMobile_marginBottom);
+  padding-bottom: var(--LanguagesMobile_marginBottom);
 
   @media (--medium-viewport) {
     font-size: var(--LanguagesMobile_fontSizeTablet);
     margin-top: var(--LanguagesMobile_marginTopTablet);
-    margin-bottom: var(--LanguagesMobile_marginBottomTablet);
+    padding-bottom: var(--LanguagesMobile_marginBottomTablet);
   }
 }
 

--- a/client/app/components/composites/MenuMobile/OffScreenMenu.js
+++ b/client/app/components/composites/MenuMobile/OffScreenMenu.js
@@ -1,5 +1,6 @@
 import { Component, PropTypes } from 'react';
 import r, { div } from 'r-dom';
+import classNames from 'classnames';
 
 import * as variables from '../../../assets/styles/variables';
 import css from './MenuMobile.css';
@@ -12,7 +13,6 @@ import LoginLinks from '../../composites/LoginLinks/LoginLinks';
 class OffScreenMenu extends Component {
 
   render() {
-    const isOpenClass = this.props.isOpen ? css.offScreenMenuOpen : '';
     const headerItemHeight = variables['--MobileMenu_offscreenHeaderItemHeight'];
 
     const avatarExtras = { imageHeight: headerItemHeight };
@@ -27,13 +27,15 @@ class OffScreenMenu extends Component {
       r(LanguagesMobile, this.props.languages) : null;
 
     return div({
-      className: `OffScreenMenu ${css.offScreenMenu} ${isOpenClass}`,
+      className: classNames('OffScreenMenu', css.offScreenMenu),
+    }, div({
+      className: classNames('OffScreenMenu_scrollpane', css.scrollPane),
     }, [
       div({
-        className: `OffScreenMenu_header ${css.offScreenHeader}`,
+        className: classNames('OffScreenMenu_header', css.offScreenHeader),
       }, header),
       div({
-        className: `OffScreenMenu_main ${css.offScreenMain}`,
+        className: classNames('OffScreenMenu_main', css.offScreenMain),
       }, [
         r(MenuSection, {
           name: this.props.menuLinksTitle,
@@ -47,9 +49,9 @@ class OffScreenMenu extends Component {
         }),
       ]),
       div({
-        className: `OffScreenMenu_footer ${css.offScreenFooter}`,
+        className: classNames('OffScreenMenu_footer', css.offScreenFooter),
       }, languagesMobile),
-    ]);
+    ]));
   }
 }
 


### PR DESCRIPTION
Scrollpane was missing from mobile menu
And language menu's background-color should reach the page bottom.