### PR TITLE
Revert "Revert "Merged ff get""

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -170,7 +170,8 @@ class ApplicationController < ActionController::Base
     # This allows to avoid skipping this filter in many places.
     return unless request.env[:current_marketplace]
 
-    FeatureFlagHelper.init(request, Maybe(@current_user).is_admin?.or_else(false))
+    FeatureFlagHelper.init(request, Maybe(@current_user).is_admin?.or_else(false),
+                           Maybe(@current_user).is_marketplace_admin?.or_else(false))
   end
 
   # Ensure that user accepts terms of community and has a valid email

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -221,7 +221,7 @@ class LandingPageController < ActionController::Metal
                          true)
     marketplace_context = marketplace_context(c, topbar_locale, request)
 
-    FeatureFlagHelper.init(request, false)
+    FeatureFlagHelper.init(request, false, false)
 
     denormalizer = build_denormalizer(
       cid: c&.id,

--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -31,17 +31,14 @@ module FeatureFlagHelper
   end
 
   def fetch_feature_flags(request, is_admin)
-    community_flags_from_service = FeatureFlagService::API::Api.features.get(community_id: community_id(request)).maybe[:features].or_else(Set.new)
-
-    person_flags_from_service = FeatureFlagService::API::Api.features
-      .get(community_id: community_id(request), person_id: person_id(request))
+    flags_from_service = FeatureFlagService::API::Api.features.get(community_id: community_id(request), person_id: person_id(request))
       .maybe[:features].or_else(Set.new)
 
     temp_flags = fetch_temp_flags(is_admin, request.params, request.session)
 
     request.session[:feature_flags] = temp_flags
 
-    community_flags_from_service.union(person_flags_from_service).union(temp_flags)
+    flags_from_service.union(temp_flags)
   end
 
   # Fetch temporary flags from params and session

--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -7,8 +7,8 @@ module FeatureFlagHelper
 
   module_function
 
-  def init(request, is_admin)
-    RequestStore.store[:feature_flags] ||= fetch_feature_flags(request, is_admin)
+  def init(request, is_admin, is_marketplace_admin)
+    RequestStore.store[:feature_flags] ||= fetch_feature_flags(request, is_admin, is_marketplace_admin)
   end
 
   def feature_enabled?(feature_name)
@@ -30,15 +30,21 @@ module FeatureFlagHelper
     RequestStore.store[:feature_flags]
   end
 
-  def fetch_feature_flags(request, is_admin)
-    flags_from_service = FeatureFlagService::API::Api.features.get(community_id: community_id(request), person_id: person_id(request))
-      .maybe[:features].or_else(Set.new)
+  def fetch_feature_flags(request, is_admin, is_marketplace_admin)
+    flags_from_service = fetch_flags_from_service(community_id(request), person_id(request), is_admin, is_marketplace_admin)
 
     temp_flags = fetch_temp_flags(is_admin, request.params, request.session)
 
     request.session[:feature_flags] = temp_flags
 
     flags_from_service.union(temp_flags)
+  end
+
+  def fetch_flags_from_service(community_id, person_id, is_admin, is_marketplace_admin)
+    # for non-admin users, only fetch the community specific feature flags
+    parameters = is_admin || is_marketplace_admin ? {community_id: community_id, person_id: person_id} : {community_id: community_id}
+
+    FeatureFlagService::API::Api.features.get(parameters).maybe[:features].or_else(Set.new)
   end
 
   # Fetch temporary flags from params and session

--- a/app/services/feature_flag_service/api/features.rb
+++ b/app/services/feature_flag_service/api/features.rb
@@ -24,22 +24,19 @@ module FeatureFlagService::API
       Result::Success.new(@feature_flag_store.disable(community_id, person_id, features))
     end
 
-    # Fetch community-specific features or person-specific features if person_id is provided.
-    def get(community_id:, person_id: nil)
-      Result::Success.new(@feature_flag_store.get(community_id, person_id))
-    end
+    # Fetch enabled features for a community, a person or both if both params are provided
+    def get(community_id: nil, person_id: nil)
+      unless community_id || person_id
+        return Result::Error.new("You must specify a community_id or a person_id for feature flag query.")
+      end
 
-    # Check if a feature is enabled for a community or a person.
-    # Both checks are made by providing both id parameters.
-    def enabled?(community_id:, person_id: nil, feature:)
-      features =
-        if person_id
-          @feature_flag_store.get(community_id, person_id)[:features] + @feature_flag_store.get(community_id, nil)[:features]
-        else
-          @feature_flag_store.get(community_id, nil)[:features]
-        end
-
-      Result::Success.new(features.include?(feature))
+      if community_id && person_id
+        Result::Success.new(@feature_flag_store.get(community_id, person_id))
+      elsif community_id
+        Result::Success.new(@feature_flag_store.get_by_community_id(community_id))
+      elsif person_id
+        Result::Success.new(@feature_flag_store.get_by_person_id(person_id))
+      end
     end
   end
 end

--- a/app/services/feature_flag_service/feature_flags_api.md
+++ b/app/services/feature_flag_service/feature_flags_api.md
@@ -4,8 +4,10 @@
 
 Query params:
 
- - `community_id`: mandatory
- - `person_id`: optional (if `person_id` is provided, operation tagets user-specific feature flags)
+ - `community_id`: optional, for searching community-specific features
+ - `person_id`: optional, for searching person-specific features
+
+If both parameters are provided, result includes features for the community and the person combined
 
 Request body: empty
 
@@ -24,6 +26,18 @@ Response body (person_id provided):
 
 ```ruby
 { person_id: 456
+, features:
+  [ :topbar_v1
+  , :new_login
+  ]
+}
+```
+
+Response body (both params):
+
+```ruby
+{ community_id: 123
+, person_id: 456
 , features:
   [ :topbar_v1
   , :new_login
@@ -107,19 +121,4 @@ Response body (person_id not provided):
   , :some_other_feature
   ]
 }
-```
-
-## GET /enabled/?community_id=123&person_id=456
-
-Query params:
-
- - `community_id`: mandatory
- - `person_id`: optional (if `person_id` is provided, operation tagets community and user-specific feature flags, otherwise just community-specific flags are taken into account)
-
-Request body: empty
-
-Response body:
-
-```ruby
-{ data: true }
 ```

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -30,7 +30,7 @@ module FeatureFlagService::Store
     end
 
     def get(community_id, person_id)
-      Maybe(FeatureFlagModel.where("(community_id = ? AND person_id IS NULL) OR person_id = ?", community_id, person_id))
+      Maybe(FeatureFlagModel.where("community_id = ? AND (person_id IS NULL OR person_id = ?)", community_id, person_id))
         .map { |features|
           from_combined_models(community_id, person_id, features)
         }.or_else(no_combined_flags(community_id, person_id))

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -122,7 +122,6 @@ module FeatureFlagService::Store
     end
   end
 
-
   class CachingFeatureFlag
 
     def initialize(additional_flags:)
@@ -133,8 +132,17 @@ module FeatureFlagService::Store
       @feature_flag_store.known_flags
     end
 
+    # The result of this query is not cached, as there is no trivial
+    # way to invalidate cache for combined queries that fetch
+    # person and community specific feature falgs.
+    #
+    # This method is only invoked for users with admin rights and
+    # feature flags for non-admin users are fetched with
+    # get_by_community_id(community_id).
+    #
+    # This method is still preserved in this class to
+    # achieve uniform API among feature flag store classes.
     def get(community_id, person_id)
-      # the combined query is not cached
       @feature_flag_store.get(community_id, person_id)
     end
 

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -11,6 +11,11 @@ module FeatureFlagService::Store
       [:person_id, :string, :mandatory],
       [:features, :mandatory, :set])
 
+    CombinedFlag = EntityUtils.define_builder(
+      [:community_id, :fixnum, :mandatory],
+      [:person_id, :string, :mandatory],
+      [:features, :mandatory, :set])
+
     FLAGS = [
       :export_transactions_as_csv,
       :topbar_v1,
@@ -25,28 +30,59 @@ module FeatureFlagService::Store
     end
 
     def get(community_id, person_id)
-      Maybe(FeatureFlagModel.where(community_id: community_id, person_id: person_id))
+      Maybe(FeatureFlagModel.where("(community_id = ? AND person_id IS NULL) OR person_id = ?", community_id, person_id))
         .map { |features|
-          person_id ? from_person_models(person_id, features) : from_community_models(community_id, features)
-        }.or_else(no_flags(community_id, person_id))
+          from_combined_models(community_id, person_id, features)
+        }.or_else(no_combined_flags(community_id, person_id))
+    end
+
+    def get_by_community_id(community_id)
+      Maybe(FeatureFlagModel.where(community_id: community_id, person_id: nil))
+        .map { |features|
+          from_community_models(community_id, features)
+        }.or_else(no_community_flags(community_id))
+    end
+
+    def get_by_person_id(person_id)
+      Maybe(FeatureFlagModel.where(person_id: person_id))
+        .map { |features|
+          from_person_models(person_id, features)
+        }.or_else(no_person_flags(person_id))
     end
 
     def enable(community_id, person_id, features)
       flags_to_enable = known_flags.intersection(features).map { |flag| [flag, true] }.to_h
       update_flags!(community_id, person_id, flags_to_enable)
 
-      get(community_id, person_id)
+      if person_id
+        get_by_person_id(person_id)
+      else
+        get_by_community_id(community_id)
+      end
     end
 
     def disable(community_id, person_id, features)
       flags_to_disable = known_flags.intersection(features).map { |flag| [flag, false] }.to_h
       update_flags!(community_id, person_id, flags_to_disable)
 
-      get(community_id, person_id)
+      if person_id
+        get_by_person_id(person_id)
+      else
+        get_by_community_id(community_id)
+      end
     end
 
 
     private
+
+    def from_combined_models(community_id, person_id, feature_models)
+      CombinedFlag.call(
+        community_id: community_id,
+        person_id: person_id,
+        features: feature_models.select { |m| known_flags.include?(m.feature.to_sym) && m.enabled }
+          .map { |m| m.feature.to_sym }
+          .to_set)
+    end
 
     def from_community_models(community_id, feature_models)
       CommunityFlag.call(
@@ -64,12 +100,16 @@ module FeatureFlagService::Store
           .to_set)
     end
 
-    def no_flags(community_id, person_id)
-      if person_id
-        PersonFlag.call(person_id: person_id, features: Set.new)
-      else
-        CommunityFlag.call(community_id: community_id, features: Set.new)
-      end
+    def no_combined_flags(community_id, person_id)
+      CombinedFlag.call(community_id: community_id, person_id: person_id, features: Set.new)
+    end
+
+    def no_community_flags(community_id)
+      CommunityFlag.call(community_id: community_id, features: Set.new)
+    end
+
+    def no_person_flags(person_id)
+      PersonFlag.call(person_id: person_id, features: Set.new)
     end
 
     def update_flags!(community_id, person_id, flags)
@@ -94,31 +134,48 @@ module FeatureFlagService::Store
     end
 
     def get(community_id, person_id)
-      Rails.cache.fetch(cache_key(community_id, person_id)) do
+      Rails.cache.fetch(cache_key(community_id: community_id, person_id: person_id)) do
         @feature_flag_store.get(community_id, person_id)
       end
     end
 
+    def get_by_community_id(community_id)
+      Rails.cache.fetch(cache_key(community_id: community_id)) do
+        @feature_flag_store.get_by_community_id(community_id)
+      end
+    end
+
+    def get_by_person_id(person_id)
+      Rails.cache.fetch(cache_key(person_id: person_id)) do
+        @feature_flag_store.get_by_person_id(person_id)
+      end
+    end
+
     def enable(community_id, person_id, features)
-      Rails.cache.delete(cache_key(community_id, person_id))
+      Rails.cache.delete(cache_key(community_id: community_id, person_id: person_id))
       @feature_flag_store.enable(community_id, person_id, features)
     end
 
     def disable(community_id, person_id, features)
-      Rails.cache.delete(cache_key(community_id, person_id))
+      Rails.cache.delete(cache_key(community_id: community_id, person_id: person_id))
       @feature_flag_store.disable(community_id, person_id, features)
     end
 
 
     private
 
-    def cache_key(community_id, person_id)
-      if person_id
-        "/feature_flag_service/person/#{person_id}"
-      else
-        raise ArgumentError.new("You must specify a valid community_id.") if community_id.blank?
-        "/feature_flag_service/community/#{community_id}"
-      end
+    def cache_key(community_id: nil, person_id: nil)
+      raise ArgumentError.new("You must specify a valid community_id or person_id.") unless community_id || person_id
+
+      id =
+        if person_id && community_id
+          "#{community_id}-#{person_id}"
+        elsif person_id
+          person_id
+        else
+          community_id
+        end
+      "/feature_flag_service/#{id}"
     end
   end
 end

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -134,9 +134,8 @@ module FeatureFlagService::Store
     end
 
     def get(community_id, person_id)
-      Rails.cache.fetch(cache_key(community_id: community_id, person_id: person_id)) do
-        @feature_flag_store.get(community_id, person_id)
-      end
+      # the combined query is not cached
+      @feature_flag_store.get(community_id, person_id)
     end
 
     def get_by_community_id(community_id)
@@ -167,15 +166,11 @@ module FeatureFlagService::Store
     def cache_key(community_id: nil, person_id: nil)
       raise ArgumentError.new("You must specify a valid community_id or person_id.") unless community_id || person_id
 
-      id =
-        if person_id && community_id
-          "#{community_id}-#{person_id}"
-        elsif person_id
-          person_id
-        else
-          community_id
-        end
-      "/feature_flag_service/#{id}"
+      if person_id
+        "/feature_flag_service/person/#{person_id}"
+      else
+        "/feature_flag_service/community/#{community_id}"
+      end
     end
   end
 end


### PR DESCRIPTION
Reverts sharetribe/sharetribe#2384

Contains merged feature flag query that was reverted from `master` due to feature flag caching problems. Original PR is [2380](https://github.com/sharetribe/sharetribe/pull/2380). In this version  the merged feature flag query is enabled only for marketplace admins and super-admins.