### PR TITLE
Fix adding the Google Maps script on the page

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -54,10 +54,10 @@ class HomepageController < ApplicationController
         raise ArgumentError.new("Unknown view_type #{@view_type}")
       end
 
-    main_search = FeatureFlagHelper.location_search_available ? MarketplaceService::API::Api.configurations.get(community_id: @current_community.id).data[:main_search] : :keyword
-    search_modes = search_modes_in_use(params[:q], params[:lc], main_search)
-    keyword_in_use = search_modes[:keyword]
-    location_in_use = search_modes[:location]
+    main_search = search_mode
+    enabled_search_modes = search_modes_in_use(params[:q], params[:lc], main_search)
+    keyword_in_use = enabled_search_modes[:keyword]
+    location_in_use = enabled_search_modes[:location]
 
     search_result = find_listings(params, per_page, compact_filter_params, includes.to_set, location_in_use, keyword_in_use)
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -661,6 +661,10 @@ module ApplicationHelper
       opts: opts)
   end
 
+  def search_mode
+    FeatureFlagHelper.location_search_available ? MarketplaceService::API::Api.configurations.get(community_id: @current_community.id).data[:main_search] : :keyword
+  end
+
   def landing_page_path
     PathHelpers.landing_page_path(
       community_id: @current_community.id,

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -8,11 +8,12 @@
   - # maps.google can't be loaded twice
   - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
   - key_param = maps_key ? "&key=#{maps_key}" : ""
+  - # Topbar adds its own maps script, otherwise add it if location search enabled or map is visible
+  - needs_maps = !FeatureFlagHelper.feature_enabled?(:topbar_v1) && (main_search != :keyword || @view_type.eql?("map"))
+  - if(needs_maps)
+    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}"
   - if(@view_type.eql?("map"))
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
     = javascript_include_tag "markerclusterer.js"
-  - elsif(location_search_in_use)
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
 
 - content_for :title_header do
   - is_homepage = params[:controller] == "homepage" && params[:action] == "index"
@@ -26,13 +27,13 @@
             .content
               = t("layouts.application.connect")
         - else
-          - if(location_search_in_use)
+          - if(main_search == :location)
             = render partial: "location_bar"
           - else
             = render partial: "search_bar"
   - elsif !(is_homepage && FeatureFlagHelper.feature_enabled?(:topbar_v1))
     .browse-view-search-form
-      - if(location_search_in_use)
+      - if(main_search == :location)
         = render partial: "location_bar"
       - else
         = render partial: "search_bar"

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -17,10 +17,13 @@
         = react_component("OnboardingTopBar", props: props, prerender: true)
 
   - if FeatureFlagHelper.feature_enabled?(:topbar_v1)
+    - if(search_mode != :keyword || @view_type.eql?("map"))
+      - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
+      - key_param = maps_key ? "&key=#{maps_key}" : ""
+      = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}"
+    - if(@view_type.eql?("map"))
+      = javascript_include_tag "markerclusterer.js"
     - props = topbar_props
-    - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
-    - key_param = maps_key ? "&key=#{maps_key}" : ""
-    = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}"
     = react_component("TopbarApp", props: props, prerender: true)
   - else
     = render partial: 'layouts/global_header', locals: header_props()


### PR DESCRIPTION
The script was added based on the location_search_in_use flag, but that
is not a feature flag, it signals if a location search was
performed. Therefore the script tag was missing when the topbar_v1
feature flag was not enabled and a location search wasn't performed.