### PR TITLE
Improve contact us feedback page texts

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -47,7 +47,9 @@ class FeedbacksController < ApplicationController
   private
 
   def render_form(form = nil)
-    render action: :new, locals: feedback_locals(form)
+    render action: :new, locals: feedback_locals(form).merge({
+      has_admin_rights: @current_user && @current_user.has_admin_rights?
+    })
   end
 
   def feedback_locals(feedback_form)

--- a/app/views/feedbacks/new.haml
+++ b/app/views/feedbacks/new.haml
@@ -4,6 +4,9 @@
 - content_for :title_header do
   %h1= t("layouts.no_tribe.feedback")
 
+- if has_admin_rights	
+  %p= render :partial => "layouts/info_text", :locals => { :text => t("layouts.application.dont_use_to_contact_support") }
+
 .new-feedback-form.centered-section
   = form_for feedback_form, :url => user_feedbacks_path do |form|
     - unless email_present

--- a/app/views/feedbacks/new.haml
+++ b/app/views/feedbacks/new.haml
@@ -4,7 +4,7 @@
 - content_for :title_header do
   %h1= t("layouts.no_tribe.feedback")
 
-- if has_admin_rights	
+- if has_admin_rights
   %p= render :partial => "layouts/info_text", :locals => { :text => t("layouts.application.dont_use_to_contact_support") }
 
 .new-feedback-form.centered-section

--- a/app/views/feedbacks/new.haml
+++ b/app/views/feedbacks/new.haml
@@ -12,6 +12,6 @@
     = form.label :title, "You should not see this field, if CSS is working.", :class => "unwanted_text_field"
     = form.text_field :title, :class => "unwanted_text_field", :id => "error_feedback_unwanted_title"
     = form.label :content, t("layouts.application.feedback")
-    = form.text_area :content, :placeholder => t("layouts.application.default_feedback")
+    = form.text_area :content
     = form.hidden_field :url, :value => request.headers["HTTP_REFERER"] || request.original_url
     = form.button t("layouts.application.send_feedback_to_admin")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1027,8 +1027,8 @@ en:
       javascript_is_disabled_in_your_browser: "Javascript is disabled in your browser"
       kassi_does_not_currently_work_without_javascript: "%{service_name} does not work properly without javascript. Try to enable javascript from your browser's preferences and then reload this page again."
       contact_us: "contact us"
-      send_feedback: "Send feedback"
-      your_feedback_to_admins: "Your feedback to admins"
+      send_feedback: "Send message"
+      your_feedback_to_admins: "Your message to %{service_name} team"
     send: Send
     your_email_address: "Your email address"
   errors:
@@ -1220,13 +1220,13 @@ en:
     application:
       join_this_community: "Join marketplace"
       read_more: "Read more"
-      feedback: "What would you like to tell us?"
-      default_feedback: "Did you encounter a problem with %{service_name}? Have a suggestion for improving the service? Noticed some suspicious content? Or just have something you want to discuss with us? Let us know!"
+      feedback: "Your message to %{service_name} team"
+      dont_use_to_contact_support: "We noticed you're an admin of %{service_name}. This form is what your users use to contact you. You cannot use this form to contact Sharetribe support. You can do that via the Support link in your admin panel instead."
       feedback_forum: "feedback forum"
       feedback_handle: Feedback
       give_feedback: "Contact us"
       or_check_our: "...or check our"
-      send_feedback_to_admin: "Send feedback"
+      send_feedback_to_admin: "Send message"
       to_see_what_others_have_suggested: "to see what other users have suggested, and vote for the ideas there."
       your_email_address: "Your email address (to contact you)"
       connect: "Sign up"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1296,7 +1296,7 @@ en:
       error_with_session: "Error with session."
       feedback_considered_spam: "Feedback not saved, due to its formatting. Try again or use the feedback forum."
       feedback_not_saved: "Feedback could not be sent."
-      feedback_saved: "Thanks a lot for your feedback! We'll get back to you as soon as possible."
+      feedback_saved: "Thanks a lot for your message! We'll get back to you as soon as possible."
       feedback_sent_to: "Feedback sent to %{target_person}."
       feedback_skipped: "Feedback skipped"
       invitation_cannot_be_sent: "Invitation could not be sent"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1216,7 +1216,7 @@ en:
     no_tribe:
       inbox: Inbox
       settings: Settings
-      feedback: "Contact us"
+      feedback: "Contact %{service_name} team"
     application:
       join_this_community: "Join marketplace"
       read_more: "Read more"

--- a/features/feedback/user_sends_feedback_to_admins.feature
+++ b/features/feedback/user_sends_feedback_to_admins.feature
@@ -9,9 +9,9 @@ Feature: User sends feedback to admins
     When I open the menu
     And I follow "Contact us" within the menu
     And I fill in "Your email address" with "test@example.com"
-    And I fill in "What would you like to tell us?" with "Feedback"
-    And I press "Send feedback"
-    Then I should see "Thanks a lot for your feedback!" within ".flash-notifications"
+    And I fill in "feedback_content" with "Feedback"
+    And I press "Send message"
+    Then I should see "Thanks a lot for your message!" within ".flash-notifications"
 
   @javascript
   Scenario: Giving feedback successfully when logged in
@@ -19,9 +19,9 @@ Feature: User sends feedback to admins
     When I open the menu
     And I follow "Contact us" within the menu
     Then I should not see "Your email"
-    When I fill in "What would you like to tell us?" with "Feedback"
-    And I press "Send feedback"
-    Then I should see "Thanks a lot for your feedback!"
+    When I fill in "feedback_content" with "Feedback"
+    And I press "Send message"
+    Then I should see "Thanks a lot for your message!"
 
   @javascript
   Scenario: Trying to give invalid feedback
@@ -29,7 +29,7 @@ Feature: User sends feedback to admins
     When I open the menu
     And I follow "Contact us" within the menu
     And I fill in "Your email address" with "test"
-    And I press "Send feedback"
+    And I press "Send message"
     Then I should see "This field is required"
     And I should see "Please enter a valid email address"
 
@@ -38,11 +38,11 @@ Feature: User sends feedback to admins
     Given I am logged in
     When I open the menu
     And I follow "Contact us" within the menu
-    And I fill in "What would you like to tell us?" with "[url=testi"
-    And I press "Send feedback"
+    And I fill in "feedback_content" with "[url=testi"
+    And I press "Send message"
     Then I should see "Feedback not saved, due to its formatting. Try again or use the feedback forum." within ".flash-notifications"
-    When I fill in "What would you like to tell us?" with "<a href="
-    And I press "Send feedback"
+    When I fill in "feedback_content" with "<a href="
+    And I press "Send message"
     Then I should see "Feedback not saved, due to its formatting. Try again or use the feedback forum."
 
 

--- a/features/step_definitions/admin_manage_members_steps.rb
+++ b/features/step_definitions/admin_manage_members_steps.rb
@@ -106,9 +106,9 @@ end
 
 Then(/^I should be able to send a message to admin$/) do
   steps %Q{
-    When I fill in "What would you like to tell us?" with "I sad that I have been banned."
-    And I press "Send feedback"
-    Then I should see "Thanks a lot for your feedback!" within ".flash-notifications"
+    When I fill in "feedback_content" with "I sad that I have been banned."
+    And I press "Send message"
+    Then I should see "Thanks a lot for your message!" within ".flash-notifications"
   }
 end
 


### PR DESCRIPTION
Some admin use the "Contact us" page hoping to reach Sharetribe support. 

This changes a bit some copy texts and add some info texts to make it more obvious that this is a form used by their users to contact them, and that they should not use it to contact Sharetribe support.

![screenshot-aalto sharetribe us 2016-08-14 11-53-30](https://cloud.githubusercontent.com/assets/2463785/17648214/d7d09a30-6215-11e6-8a82-135c51e0c800.jpg)
