### PR TITLE
Fix allowed features filtering

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -131,6 +131,8 @@ class Admin::CommunitiesController < ApplicationController
   end
 
   def update_new_layout
+    redirect_to admin_getting_started_guide_path and return unless(FeatureFlagHelper.feature_enabled?(:feature_flags_page))
+
     @community = @current_community
 
     enabled_for_user = Maybe(params[:enabled_for_user]).map { |f| NewLayoutViewUtils.enabled_features(f) }.or_else([])

--- a/app/view_utils/new_layout_view_utils.rb
+++ b/app/view_utils/new_layout_view_utils.rb
@@ -38,11 +38,11 @@ module NewLayoutViewUtils
   # and returns the keys as symbols from the entries
   # that hold value "true".
   def enabled_features(feature_params)
-    allowed_features = FEATURES.map { |f| f[:name]}
-    feature_params.select { |key, value| value == "true"}
+    allowed_features = FEATURES.map { |f| f[:name] }
+    feature_params.select { |key, value| value == "true" }
       .keys
-      .select { |k| allowed_features.include?(k)}
       .map(&:to_sym)
+      .select { |k| allowed_features.include?(k) }
   end
 
   # From the list of features, selects the ones

--- a/spec/controllers/admin/communities_controller_spec.rb
+++ b/spec/controllers/admin/communities_controller_spec.rb
@@ -7,6 +7,7 @@ describe Admin::CommunitiesController, type: :controller do
     @request.host = "#{@community.ident}.lvh.me"
     @request.env[:current_marketplace] = @community
     @user = create_admin_for(@community)
+    FeatureFlagService::API::Api.features.enable(community_id: @community.id, features: [:feature_flags_page])
     sign_in_for_spec(@user)
   end
 

--- a/spec/view_utils/new_layout_view_utils_spec.rb
+++ b/spec/view_utils/new_layout_view_utils_spec.rb
@@ -130,9 +130,9 @@ describe NewLayoutViewUtils do
     context "when invalid features are passed as params" do
       it "thise should not be returned" do
         feature_params = {
-          foo: "true",
-          bar: "true",
-          invalid: "true"
+          "foo" => "true",
+          "bar" => "true",
+          "invalid" => "true"
         }
         expect(NewLayoutViewUtils.enabled_features(feature_params))
           .to eql([:foo, :bar])


### PR DESCRIPTION
Fixes filtering of allowed features when an admin enables a feature flag in the new layout view in admin panel.