### PR TITLE
Disable Checkout Payment gateway

### DIFF
--- a/db/migrate/20160816083020_migrate_checkout_postpay_listings_to_free.rb
+++ b/db/migrate/20160816083020_migrate_checkout_postpay_listings_to_free.rb
@@ -1,0 +1,18 @@
+class MigrateCheckoutPostpayListingsToFree < ActiveRecord::Migration
+  def up
+    # 1) Find all listings where transaction process is "postpay" and payment gateway is "Checkout"
+    # 2) Change the listings' transaction process to "none"
+
+    execute("
+      UPDATE listings l
+      LEFT JOIN transaction_processes txp_current ON (txp_current.id = l.transaction_process_id)
+      LEFT JOIN payment_gateways pg ON (pg.community_id = l.community_id)
+      SET l.transaction_process_id = (SELECT id FROM transaction_processes WHERE community_id = l.community_id AND process = 'none' AND author_is_seller = 1)
+      WHERE txp_current.process = 'postpay' AND pg.type = 'Checkout';
+    ")
+  end
+
+  def down
+    # Nothing here
+  end
+end

--- a/db/migrate/20160816083028_migrate_checkout_postpay_order_types_to_free.rb
+++ b/db/migrate/20160816083028_migrate_checkout_postpay_order_types_to_free.rb
@@ -1,0 +1,18 @@
+class MigrateCheckoutPostpayOrderTypesToFree < ActiveRecord::Migration
+  def up
+    # 1) Find all listing shapes (i.e. Order Types) where transaction process is "postpay" and payment gateway is "Checkout"
+    # 2) Change the listing shapes' transaction process to "none"
+
+    execute("
+      UPDATE listing_shapes ls
+      LEFT JOIN transaction_processes txp_current ON (txp_current.id = ls.transaction_process_id)
+      LEFT JOIN payment_gateways pg ON (pg.community_id = ls.community_id)
+      SET ls.transaction_process_id = (SELECT id FROM transaction_processes WHERE community_id = ls.community_id AND process = 'none' AND author_is_seller = 1)
+      WHERE txp_current.process = 'postpay' AND pg.type = 'Checkout';
+    ")
+  end
+
+  def down
+    # Nothing here
+  end
+end

--- a/db/migrate/20160816083349_remove_checkout_postpay_transaction_processes.rb
+++ b/db/migrate/20160816083349_remove_checkout_postpay_transaction_processes.rb
@@ -1,0 +1,9 @@
+class RemoveCheckoutPostpayTransactionProcesses < ActiveRecord::Migration
+  def up
+    execute("
+      DELETE transaction_processes FROM transaction_processes
+      LEFT JOIN payment_gateways pg ON (pg.community_id = transaction_processes.community_id)
+      WHERE pg.type = 'Checkout' AND transaction_processes.process = 'postpay'
+    ")
+  end
+end

--- a/db/migrate/20160816083607_remove_checkout_payment_gateway.rb
+++ b/db/migrate/20160816083607_remove_checkout_payment_gateway.rb
@@ -1,0 +1,11 @@
+class RemoveCheckoutPaymentGateway < ActiveRecord::Migration
+  def up
+    execute("
+      DELETE FROM payment_gateways WHERE type = 'Checkout'
+    ")
+  end
+
+  def down
+    # Nothing here
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160728130503) do
+ActiveRecord::Schema.define(version: 20160816083607) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255


### PR DESCRIPTION
This commit changes the communities that are using Checkout payment gateway in following ways:

1. The "transaction process" (i.e. free/postpay/preauthorize) is changed from `postpay` to `free` for all listings that are currently using `postpay` process
2. The transaction process is changed from `postpay` to `free` for all listing shapes (i.e. order types) that are currently using `postpay` process
3. The transaction process `postpay` is removed
4. The Checkout payment gateway is removed from the community.

So in practice these four changes will change the marketplace from Checkout marketplace to "free" marketplace, where all the transactions will go the "free" flow.

This commit doesn't try to migrate transaction that are ongoing (i.e. in pending/paid state). Accessing and changing the state of such transaction will probably cause an error.