### PR TITLE
Add community_id to person feature flag query

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -243,7 +243,7 @@ class Admin::CommunitiesController < ApplicationController
       marketplace_configurations = MarketplaceService::API::Api.configurations.get(community_id: @current_community.id).data
 
       keyword_and_location =
-        if FeatureFlagService::API::Api.features.get(community_id: @current_community.id).data[:features].include?(:topbar_v1)
+        if FeatureFlagService::API::Api.features.get_for_community(community_id: @current_community.id).data[:features].include?(:topbar_v1)
           [:keyword_and_location]
         else
           []

--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -41,10 +41,13 @@ module FeatureFlagHelper
   end
 
   def fetch_flags_from_service(community_id, person_id, is_admin, is_marketplace_admin)
-    # for non-admin users, only fetch the community specific feature flags
-    parameters = is_admin || is_marketplace_admin ? {community_id: community_id, person_id: person_id} : {community_id: community_id}
-
-    FeatureFlagService::API::Api.features.get(parameters).maybe[:features].or_else(Set.new)
+    # for admin users fetch combined feature flags,
+    # for non-admin users only fetch the community specific feature flags
+    if is_admin || is_marketplace_admin
+      FeatureFlagService::API::Api.features.get(community_id: community_id, person_id: person_id).maybe[:features].or_else(Set.new)
+    else
+      FeatureFlagService::API::Api.features.get_for_community(community_id: community_id).maybe[:features].or_else(Set.new)
+    end
   end
 
   # Fetch temporary flags from params and session

--- a/app/services/feature_flag_service/api/features.rb
+++ b/app/services/feature_flag_service/api/features.rb
@@ -24,19 +24,29 @@ module FeatureFlagService::API
       Result::Success.new(@feature_flag_store.disable(community_id, person_id, features))
     end
 
-    # Fetch enabled features for a community, a person or both if both params are provided
+    # Fetch features enabled for a community or a person
     def get(community_id: nil, person_id: nil)
-      unless community_id || person_id
-        return Result::Error.new("You must specify a community_id or a person_id for feature flag query.")
+      unless community_id && person_id
+        return Result::Error.new("You must specify a community_id and a person_id for feature flag query.")
       end
 
-      if community_id && person_id
-        Result::Success.new(@feature_flag_store.get(community_id, person_id))
-      elsif community_id
-        Result::Success.new(@feature_flag_store.get_by_community_id(community_id))
-      elsif person_id
-        Result::Success.new(@feature_flag_store.get_by_person_id(person_id))
+      Result::Success.new(@feature_flag_store.get(community_id, person_id))
+    end
+
+    def get_for_person(community_id:, person_id:)
+      unless community_id && person_id
+        return Result::Error.new("You must specify a community_id and a person_id for feature flag query.")
       end
+
+      Result::Success.new(@feature_flag_store.get_for_person(community_id, person_id))
+    end
+
+    def get_for_community(community_id:)
+      unless community_id
+        return Result::Error.new("You must specify a community_id for feature flag query.")
+      end
+
+      Result::Success.new(@feature_flag_store.get_for_community(community_id))
     end
   end
 end

--- a/app/services/feature_flag_service/feature_flags_api.md
+++ b/app/services/feature_flag_service/feature_flags_api.md
@@ -4,36 +4,12 @@
 
 Query params:
 
- - `community_id`: optional, for searching community-specific features
- - `person_id`: optional, for searching person-specific features
-
-If both parameters are provided, result includes features for the community and the person combined
+ - `community_id`: mandatory, for searching community-specific features
+ - `person_id`: mandatory, for searching person-specific features
 
 Request body: empty
 
-Response body (person_id not provided):
-
-```ruby
-{ community_id: 123
-, features:
-  [ :topbar_v1
-  , :new_login
-  ]
-}
-```
-
-Response body (person_id provided):
-
-```ruby
-{ person_id: 456
-, features:
-  [ :topbar_v1
-  , :new_login
-  ]
-}
-```
-
-Response body (both params):
+Response body:
 
 ```ruby
 { community_id: 123
@@ -44,6 +20,43 @@ Response body (both params):
   ]
 }
 ```
+
+## GET /community/?community_id=123
+
+Query params:
+
+ - `community_id`: mandatory, for searching community-specific features
+
+Request body: empty
+
+Response body:
+
+```ruby
+{ community_id: 123
+, features:
+  [ :topbar_v1
+  ]
+}
+```
+
+## GET /person/?person_id=456
+
+Query params:
+
+ - `person_id`: mandatory, for searching person-specific features
+
+Request body: empty
+
+Response body:
+
+```ruby
+{ person_id: 456
+, features:
+  [ :new_login
+  ]
+}
+```
+
 
 ## POST /?community_id=123&person_id=456
 
@@ -66,7 +79,6 @@ Response body (person_id not provided):
 { community_id: 123
 , features:
   [ :topbar_v1
-  , :new_login
   , :some_feature
   , :some_other_feature
   ]
@@ -78,8 +90,7 @@ Response body (person_id provided):
 ```ruby
 { person_id: 456
 , features:
-  [ :topbar_v1
-  , :new_login
+  [ :new_login
   , :some_feature
   , :some_other_feature
   ]

--- a/app/view_utils/new_layout_view_utils.rb
+++ b/app/view_utils/new_layout_view_utils.rb
@@ -17,8 +17,8 @@ module NewLayoutViewUtils
   module_function
 
   def features(community_id, person_id)
-    person_flags = FeatureFlagService::API::Api.features.get(person_id: person_id).maybe[:features].or_else(Set.new)
-    community_flags = FeatureFlagService::API::Api.features.get(community_id: community_id).maybe[:features].or_else(Set.new)
+    person_flags = FeatureFlagService::API::Api.features.get_for_person(community_id: community_id, person_id: person_id).data[:features]
+    community_flags = FeatureFlagService::API::Api.features.get_for_community(community_id: community_id).data[:features]
 
     FEATURES.map { |f|
       Feature.build({

--- a/spec/controllers/admin/csv_export_spec.rb
+++ b/spec/controllers/admin/csv_export_spec.rb
@@ -51,7 +51,8 @@ describe Admin::CommunityTransactionsController, type: :controller do
     @request.env[:current_marketplace] = @community
     @transaction = FactoryGirl.create(:transaction, starter: @person, listing: @listing, community: @community)
 
-    FeatureFlagService::API::Api.features.enable(community_id: @community.id, features: [:export_transactions_as_csv])
+    allow(FeatureFlagHelper).to receive(:feature_enabled?)
+      .with(:export_transactions_as_csv).and_return(true)
   end
 
   describe "transactions CSV export" do

--- a/spec/services/feature_flag_service/api/features_spec.rb
+++ b/spec/services/feature_flag_service/api/features_spec.rb
@@ -110,14 +110,14 @@ describe FeatureFlagService::API::Features do
     end
 
     it "returns a result with no features enabled when nothing recorded for a community" do
-      res = features.get(community_id: community_id)
+      res = features.get_for_community(community_id: community_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq(Set.new)
     end
 
     it "returns a result with no features enabled when nothing recorded for a person" do
-      res = features.get(person_id: person_id)
+      res = features.get_for_person(community_id: community_id, person_id: person_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq(Set.new)
@@ -125,7 +125,7 @@ describe FeatureFlagService::API::Features do
 
     it "returns enabled features as a set for a community" do
       features.enable(community_id: community_id, features: [test_flag])
-      res = features.get(community_id: community_id)
+      res = features.get_for_community(community_id: community_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq([test_flag].to_set)
@@ -133,7 +133,7 @@ describe FeatureFlagService::API::Features do
 
     it "returns enabled features as a set for a person" do
       features.enable(community_id: community_id, person_id: person_id, features: [test_flag])
-      res = features.get(person_id: person_id)
+      res = features.get_for_person(community_id: community_id, person_id: person_id)
 
       expect(res.success).to eq(true)
       expect(res.data[:features]).to eq([test_flag].to_set)

--- a/spec/view_utils/new_layout_view_utils_spec.rb
+++ b/spec/view_utils/new_layout_view_utils_spec.rb
@@ -2,18 +2,18 @@ require 'spec_helper'
 
 describe NewLayoutViewUtils do
   before do
-    TEST_FEATURES = [
-      { title: "Foo",
-        name: :foo
-      },
-      { title: "Bar",
-        name: :bar
-      },
-      { title: "Wat",
-        name: :wat
-      }
-    ]
-    stub_const("NewLayoutViewUtils::FEATURES", TEST_FEATURES)
+    stub_const("NewLayoutViewUtils::FEATURES",
+      [
+        { title: "Foo",
+          name: :foo
+        },
+        { title: "Bar",
+          name: :bar
+        },
+        { title: "Wat",
+          name: :wat
+        }
+      ])
   end
 
   describe "#features" do
@@ -36,9 +36,9 @@ describe NewLayoutViewUtils do
           }
         )
 
-        allow(FeatureFlagService::API::Api.features).to receive(:get)
-          .with({person_id: person_id}).and_return(Result::Success.new(person_features))
-        allow(FeatureFlagService::API::Api.features).to receive(:get)
+        allow(FeatureFlagService::API::Api.features).to receive(:get_for_person)
+          .with({community_id: community_id, person_id: person_id}).and_return(Result::Success.new(person_features))
+        allow(FeatureFlagService::API::Api.features).to receive(:get_for_community)
           .with({community_id: community_id}).and_return(Result::Success.new(community_features))
       end
 
@@ -79,9 +79,9 @@ describe NewLayoutViewUtils do
           }
         )
 
-        allow(FeatureFlagService::API::Api.features).to receive(:get)
-          .with({person_id: person_id}).and_return(Result::Success.new(person_features))
-        allow(FeatureFlagService::API::Api.features).to receive(:get)
+        allow(FeatureFlagService::API::Api.features).to receive(:get_for_person)
+          .with({community_id: community_id, person_id: person_id}).and_return(Result::Success.new(person_features))
+        allow(FeatureFlagService::API::Api.features).to receive(:get_for_community)
           .with({community_id: community_id}).and_return(Result::Success.new(community_features))
       end
 


### PR DESCRIPTION
community_id is added as a parameter to query person-specific feature
flags in order to make the person flags community specific for super
admins.