### PR TITLE
Remove columns related to organizations

### DIFF
--- a/app/models/braintree_payment.rb
+++ b/app/models/braintree_payment.rb
@@ -5,7 +5,6 @@
 #  id                       :integer          not null, primary key
 #  payer_id                 :string(255)
 #  recipient_id             :string(255)
-#  organization_id          :string(255)
 #  transaction_id           :integer
 #  status                   :string(255)
 #  created_at               :datetime         not null

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -68,7 +68,6 @@
 #  wide_logo_content_type                     :string(255)
 #  wide_logo_file_size                        :integer
 #  wide_logo_updated_at                       :datetime
-#  only_organizations                         :boolean
 #  listing_comments_in_use                    :boolean          default(FALSE)
 #  show_listing_publishing_date               :boolean          default(FALSE)
 #  require_verification_to_post_listings      :boolean          default(FALSE)

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -33,7 +33,6 @@
 #  transaction_process_id          :integer
 #  shape_name_tr_key               :string(255)
 #  action_button_tr_key            :string(255)
-#  organization_id                 :integer
 #  price_cents                     :integer
 #  currency                        :string(255)
 #  quantity                        :string(255)

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,7 +5,6 @@
 #  id                       :integer          not null, primary key
 #  payer_id                 :string(255)
 #  recipient_id             :string(255)
-#  organization_id          :string(255)
 #  transaction_id           :integer
 #  status                   :string(255)
 #  created_at               :datetime         not null

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,8 +38,6 @@
 #  authentication_token               :string(255)
 #  community_updates_last_sent_at     :datetime
 #  min_days_between_community_updates :integer          default(1)
-#  is_organization                    :boolean
-#  organization_name                  :string(255)
 #  deleted                            :boolean          default(FALSE)
 #  cloned_from                        :string(22)
 #

--- a/db/migrate/20160818090814_remove_organization_columns.rb
+++ b/db/migrate/20160818090814_remove_organization_columns.rb
@@ -1,0 +1,9 @@
+class RemoveOrganizationColumns < ActiveRecord::Migration
+  def change
+    remove_column :communities, :only_organizations, :boolean, after: :wide_logo_updated_at
+    remove_column :people, :organization_name, :string, limit: 255, after: :is_organization
+    remove_column :people, :is_organization, :boolean, after: :min_days_between_community_updates
+    remove_column :payments, :organization_id, :string, limit: 255, after: :recipient_id
+    remove_column :listings, :organization_id, :integer, after: :action_button_tr_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160817140558) do
+ActiveRecord::Schema.define(version: 20160818090814) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -193,7 +193,6 @@ ActiveRecord::Schema.define(version: 20160817140558) do
     t.string   "wide_logo_content_type",                     limit: 255
     t.integer  "wide_logo_file_size",                        limit: 4
     t.datetime "wide_logo_updated_at"
-    t.boolean  "only_organizations"
     t.boolean  "listing_comments_in_use",                                     default: false
     t.boolean  "show_listing_publishing_date",                                default: false
     t.boolean  "require_verification_to_post_listings",                       default: false
@@ -560,7 +559,6 @@ ActiveRecord::Schema.define(version: 20160817140558) do
     t.integer  "transaction_process_id",          limit: 4
     t.string   "shape_name_tr_key",               limit: 255
     t.string   "action_button_tr_key",            limit: 255
-    t.integer  "organization_id",                 limit: 4
     t.integer  "price_cents",                     limit: 4
     t.string   "currency",                        limit: 255
     t.string   "quantity",                        limit: 255
@@ -775,7 +773,6 @@ ActiveRecord::Schema.define(version: 20160817140558) do
   create_table "payments", force: :cascade do |t|
     t.string   "payer_id",                 limit: 255
     t.string   "recipient_id",             limit: 255
-    t.string   "organization_id",          limit: 255
     t.integer  "transaction_id",           limit: 4
     t.string   "status",                   limit: 255
     t.datetime "created_at",                                                        null: false
@@ -931,8 +928,6 @@ ActiveRecord::Schema.define(version: 20160817140558) do
     t.string   "authentication_token",               limit: 255
     t.datetime "community_updates_last_sent_at"
     t.integer  "min_days_between_community_updates", limit: 4,     default: 1
-    t.boolean  "is_organization"
-    t.string   "organization_name",                  limit: 255
     t.boolean  "deleted",                                          default: false
     t.string   "cloned_from",                        limit: 22
   end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -69,7 +69,6 @@
 #  wide_logo_content_type                     :string(255)
 #  wide_logo_file_size                        :integer
 #  wide_logo_updated_at                       :datetime
-#  only_organizations                         :boolean
 #  listing_comments_in_use                    :boolean          default(FALSE)
 #  show_listing_publishing_date               :boolean          default(FALSE)
 #  require_verification_to_post_listings      :boolean          default(FALSE)

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -32,7 +32,6 @@
 #  transaction_process_id          :integer
 #  shape_name_tr_key               :string(255)
 #  action_button_tr_key            :string(255)
-#  organization_id                 :integer
 #  price_cents                     :integer
 #  currency                        :string(255)
 #  quantity                        :string(255)

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -5,7 +5,6 @@
 #  id                       :integer          not null, primary key
 #  payer_id                 :string(255)
 #  recipient_id             :string(255)
-#  organization_id          :string(255)
 #  transaction_id           :integer
 #  status                   :string(255)
 #  created_at               :datetime         not null

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -38,8 +38,6 @@
 #  authentication_token               :string(255)
 #  community_updates_last_sent_at     :datetime
 #  min_days_between_community_updates :integer          default(1)
-#  is_organization                    :boolean
-#  organization_name                  :string(255)
 #  deleted                            :boolean          default(FALSE)
 #  cloned_from                        :string(22)
 #


### PR DESCRIPTION
Support for organizations was removed in another PR. This PR includes a migration that removes columns related to organizations.