### PR TITLE
Change page content top padding

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -66,7 +66,7 @@ body {
     padding-top: lines(1);
 
     &.no-cover-photo {
-      padding-top: lines(1.75);
+      padding-top: 33px;
     }
   }
 


### PR DESCRIPTION
Change the padding so that page content and top bar links are equally far
from the bottom of the top bar.

In the old version page content is too far from from top bar:
![image](https://cloud.githubusercontent.com/assets/57473/17772662/b345c740-6552-11e6-9fd4-15e3275b09e6.png)

Now the _Grid_, _List_ and _Map_ buttons are as far from top bar bottomline as are the top bar links:
![image](https://cloud.githubusercontent.com/assets/57473/17772710/090a52a4-6553-11e6-8905-8ec977b36514.png)

The padding is calculated as follows: _(Top bar height (80px) - Top bar link font size (14px) / 2)_.