### PR TITLE
Disable Braintree payments

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -181,7 +181,8 @@ class ListingsController < ApplicationController
       [nil, nil]
     end
 
-    payment_gateway = MarketplaceService::Community::Query.payment_type(@current_community.id)
+    gateway = MarketplaceService::Community::Query.payment_type(@current_community.id)
+    payment_gateway = gateway == :braintree ? nil : gateway
     process = get_transaction_process(community_id: @current_community.id, transaction_process_id: @listing.transaction_process_id)
     form_path = new_transaction_path(listing_id: @listing.id)
     community_country_code = LocalizationUtils.valid_country_code(@current_community.country)

--- a/app/models/transaction_process.rb
+++ b/app/models/transaction_process.rb
@@ -8,6 +8,7 @@
 #  author_is_seller :boolean
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  old_process      :string(32)
 #
 # Indexes
 #

--- a/db/migrate/20160818110351_save_old_transaction_process.rb
+++ b/db/migrate/20160818110351_save_old_transaction_process.rb
@@ -1,0 +1,10 @@
+class SaveOldTransactionProcess < ActiveRecord::Migration
+  def up
+    add_column :transaction_processes, :old_process, :string, limit: 32
+    execute "UPDATE transaction_processes SET old_process = process"
+  end
+
+  def down
+    remove_column :transaction_processes, :old_process
+  end
+end

--- a/db/migrate/20160818111044_change_postpay_transaction_process_to_free.rb
+++ b/db/migrate/20160818111044_change_postpay_transaction_process_to_free.rb
@@ -1,0 +1,9 @@
+class ChangePostpayTransactionProcessToFree < ActiveRecord::Migration
+  def up
+    execute "UPDATE transaction_processes SET process = 'none' WHERE process = 'postpay'"
+  end
+
+  def down
+    execute "UPDATE transaction_processes SET process = old_process WHERE old_process = 'postpay'"
+  end
+end

--- a/db/migrate/20160818111724_change_braintree_preauthorization_processes_to_free.rb
+++ b/db/migrate/20160818111724_change_braintree_preauthorization_processes_to_free.rb
@@ -1,0 +1,18 @@
+class ChangeBraintreePreauthorizationProcessesToFree < ActiveRecord::Migration
+  def up
+    # Change all preauthorize processes to none unless they are in use with Paypal gateway
+    execute "UPDATE transaction_processes tp
+             SET process = 'none'
+             WHERE tp.process = 'preauthorize' AND (
+               SELECT COUNT(*) = 0
+               FROM payment_settings ps
+               WHERE ps.community_id = tp.community_id AND
+                     ps.active = 1 AND
+                     ps.payment_process = 'preauthorize'
+             )"
+  end
+
+  def down
+    execute "UPDATE transaction_processes SET process = old_process WHERE old_process = 'preauthorize'"
+  end
+end

--- a/db/migrate/20160818111724_change_braintree_preauthorization_processes_to_free.rb
+++ b/db/migrate/20160818111724_change_braintree_preauthorization_processes_to_free.rb
@@ -2,7 +2,7 @@ class ChangeBraintreePreauthorizationProcessesToFree < ActiveRecord::Migration
   def up
     # Change all preauthorize processes to none unless they are in use with Paypal gateway
     execute "UPDATE transaction_processes tp
-             SET process = 'none'
+             SET tp.process = 'none'
              WHERE tp.process = 'preauthorize' AND (
                SELECT COUNT(*) = 0
                FROM payment_settings ps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818110351) do
+ActiveRecord::Schema.define(version: 20160818111724) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818090814) do
+ActiveRecord::Schema.define(version: 20160818110351) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -995,6 +995,7 @@ ActiveRecord::Schema.define(version: 20160818090814) do
     t.boolean  "author_is_seller"
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
+    t.string   "old_process",      limit: 32
   end
 
   add_index "transaction_processes", ["community_id"], name: "index_transaction_process_on_community_id", using: :btree


### PR DESCRIPTION
This PR disables Braintree by changing the preauthorize and postpay payment flows into free payment flows.

The PR doesn't disable Braintree entirely: If there's an existing non-finished transaction with Braintree, it can be finished with Braintree. The main purpose of the PR is to ensure that there will be **no new Braintree transactions**. This is to first step for disabling Braintree entirely.

In order to rollback the changes, this PR adds a new column `old_process` to the `transaction_processes` table. That column will be removed in the future releases.