### PR TITLE
Fix Google Maps API inclusion in keyword search mode

### DIFF
--- a/app/views/listings/edit.haml
+++ b/app/views/listings/edit.haml
@@ -10,7 +10,8 @@
 - content_for :extra_javascript do
   - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
+  - needs_maps = !FeatureFlagHelper.feature_enabled?(:topbar_v1) || search_mode == :keyword
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" if needs_maps
 
 #new_listing_form.new-listing-form.centered-section
 

--- a/app/views/listings/new.haml
+++ b/app/views/listings/new.haml
@@ -7,7 +7,8 @@
 - content_for :extra_javascript do
   - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
+  - needs_maps = !FeatureFlagHelper.feature_enabled?(:topbar_v1) || search_mode == :keyword
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" if needs_maps
 
 - content_for :title_header do
   %h1= t("listings.new.post_a_new_listing")

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -6,7 +6,8 @@
     window.ST.listing();
   - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
+  - needs_maps = !FeatureFlagHelper.feature_enabled?(:topbar_v1) || search_mode == :keyword
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" if needs_maps
 
 - content_for :title, raw(@listing.title)
 - content_for :meta_author, @listing.author.name(@current_community)

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -4,7 +4,8 @@
 - content_for :extra_javascript do
   - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
   - key_param = maps_key ? "?key=#{maps_key}" : ""
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
+  - needs_maps = !FeatureFlagHelper.feature_enabled?(:topbar_v1) || search_mode == :keyword
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" if needs_maps
 
 - content_for :title_header do
   %h1= t("layouts.no_tribe.settings")


### PR DESCRIPTION
Currently Google Maps API is included only if topbar is included. This introduces a caveat when topbar is enabled but search is in `:keyowrd` mode. To fix this, a check for search type is added.

Pages influenced:
 - listing edit
 - listing new
 - listing show
 - person edit