### PR TITLE
IE fix: jquery.validate has a patch that adds focus events everywhere

### DIFF
--- a/vendor/assets/javascripts/jquery.validate.js
+++ b/vendor/assets/javascripts/jquery.validate.js
@@ -1225,10 +1225,14 @@ $.format = $.validator.format;
 		}, function( original, fix ){
 			$.event.special[fix] = {
 				setup:function() {
-					this.addEventListener( original, handler, true );
+					if ($(this).parents('.Topbar')[0] != null) {
+						this.addEventListener( original, handler, true );
+					}
 				},
 				teardown:function() {
-					this.removeEventListener( original, handler, true );
+					if ($(this).parents('.Topbar')[0] != null) {
+						this.removeEventListener( original, handler, true );
+					}
 				},
 				handler: function(e) {
 					var args = arguments;


### PR DESCRIPTION
This excludes Topbar since it's React component and it's life cycle
is different from what jQuery assumes and therefore causes problems
in IE