### PR TITLE
Client's search placeholder is used in Topbar too

### DIFF
--- a/app/view_utils/topbar_helper.rb
+++ b/app/view_utils/topbar_helper.rb
@@ -78,6 +78,7 @@ module TopbarHelper
         image_highres: community.wide_logo.present? ? community.stable_image_url(:wide_logo, :header_highres) : nil
       },
       search: landing_page ? nil : {
+        search_placeholder: search_placeholder,
         mode: main_search.to_s,
       },
       search_path: search_path_string,

--- a/client/app/components/sections/Topbar/Topbar.js
+++ b/client/app/components/sections/Topbar/Topbar.js
@@ -267,6 +267,7 @@ class Topbar extends Component {
       {};
 
     const oldSearchParams = parseSearchParams(location);
+    const searchPlaceholder = this.props.search ? this.props.search.search_placeholder : null;
 
     return div({ className: classNames('Topbar', css.topbar) }, [
       this.props.menu ? r(MenuMobile, { ...mobileMenuProps, className: css.topbarMobileMenu }) : null,
@@ -275,8 +276,8 @@ class Topbar extends Component {
       this.props.search ?
         r(SearchBar, {
           mode: this.props.search.mode,
-          keywordPlaceholder: t('web.topbar.search_placeholder'),
-          locationPlaceholder: t('web.topbar.search_location_placeholder'),
+          keywordPlaceholder: searchPlaceholder || t('web.topbar.search_placeholder'),
+          locationPlaceholder: searchPlaceholder == null || this.props.search.mode === 'keyword_and_location' ? t('web.topbar.search_location_placeholder') : searchPlaceholder,
           keywordQuery: oldSearchParams.q,
           locationQuery: oldSearchParams.lq,
           customColor: marketplace_color1,


### PR DESCRIPTION
It seems this was taken away at some point, but business & support wanted it back.
In combined mode, the space makes some restrictions, so admins need to consider short texts like "Search..." instead of using sentences.