### PR TITLE
Fix: selected MenuItem has indicator that pushes through rounded borders

### DIFF
--- a/client/app/components/composites/Menu/Menu.css
+++ b/client/app/components/composites/Menu/Menu.css
@@ -78,6 +78,14 @@
   border-radius: 3px;
   position: absolute;
   box-shadow: var(--Menu_boxShadow);
+
+  /* 3rd child is the first child after arrow - i.e. first menu item */
+  & :nth-child(3) {
+    border-top-left-radius: 3px;
+  }
+  & :last-child {
+    border-bottom-left-radius: 3px;
+  }
 }
 
 .menuContentArrowTop,

--- a/client/app/components/elements/MenuItem/MenuItem.css
+++ b/client/app/components/elements/MenuItem/MenuItem.css
@@ -33,4 +33,5 @@
   left: -1px;
   width: 0.5em; /* topbar can't trust root font-size due to old design */
   height: 100%;
+  border-radius: inherit;
 }


### PR DESCRIPTION
If the first or last menu item has been selected (i.e. it has active indicator on left side), the indicator element doesn't follow border-radius rule.