### PR TITLE
PayPal Capybara tests

### DIFF
--- a/features/paypal/paypal.feature
+++ b/features/paypal/paypal.feature
@@ -1,0 +1,5 @@
+Feature: Transaction with PayPal
+
+  @javascript
+  Scenario: Test transaction with PayPal
+    Then I expect transaction with PayPal test to pass

--- a/features/step_definitions/paypal_steps.rb
+++ b/features/step_definitions/paypal_steps.rb
@@ -21,12 +21,12 @@ Then("I expect transaction with PayPal test to pass") do
   paypal_actions.connect_seller_paypal
 
   # Add new listing
-  listing_actions.add_new_listing("Lörem ipsum")
+  listing_actions.add_new_listing("Snowman for sale: ☃")
   onboarding_wizard.dismiss_dialog
 
   # Member buys the listing
   login.logout_and_login_as(member[:username], member[:password])
-  paypal_actions.request_listing("Lörem ipsum")
+  paypal_actions.request_listing("Snowman for sale: ☃")
 
   # Adming accepts request
   login.logout_and_login_as(admin[:username], admin[:password])

--- a/features/step_definitions/paypal_steps.rb
+++ b/features/step_definitions/paypal_steps.rb
@@ -1,0 +1,48 @@
+# coding: utf-8
+
+def dismiss_onboarding_wizard_dialog
+  expect(page).to have_content("Woohoo, task completed!")
+  page.click_on("I'll do it later, thanks")
+end
+
+Then("I expect transaction with PayPal test to pass") do
+  navigation = FeatureTests::Navigation
+  data = FeatureTests::Data
+  login = FeatureTests::Action::Login
+  listing_actions = FeatureTests::Action::Listing
+  paypal_actions = FeatureTests::Action::Paypal
+
+  marketplace = data.create_marketplace(payment_gateway: :paypal)
+  admin = data.create_member(username: "paypal_admin", marketplace_id: marketplace[:id], admin: true)
+  member = data.create_member(username: "paypal_buyer", marketplace_id: marketplace[:id], admin: false)
+
+  navigation.navigate_in_marketplace!(ident: marketplace[:ident])
+
+  # Connect Paypal for marketplace and seller
+  login.login_as(admin[:username], admin[:password])
+  paypal_actions.connect_marketplace_paypal
+  dismiss_onboarding_wizard_dialog
+  paypal_actions.connect_seller_paypal
+
+  # Add new listing
+  listing_actions.add_new_listing("Lörem ipsum")
+  dismiss_onboarding_wizard_dialog
+
+  # Member buys the listing
+  login.logout_and_login_as(member[:username], member[:password])
+  paypal_actions.request_listing("Lörem ipsum")
+
+  # Adming accepts request
+  login.logout_and_login_as(admin[:username], admin[:password])
+  paypal_actions.accept_listing_request
+
+  # Member marks the payment completed
+  login.logout_and_login_as(member[:username], member[:password])
+  paypal_actions.buyer_mark_completed
+
+  # Admin skips feedback
+  login.logout_and_login_as(admin[:username], admin[:password])
+  paypal_actions.seller_mark_completed
+
+  expect(page).to have_content("Completed")
+end

--- a/features/step_definitions/paypal_steps.rb
+++ b/features/step_definitions/paypal_steps.rb
@@ -1,16 +1,12 @@
 # coding: utf-8
 
-def dismiss_onboarding_wizard_dialog
-  expect(page).to have_content("Woohoo, task completed!")
-  page.click_on("I'll do it later, thanks")
-end
-
 Then("I expect transaction with PayPal test to pass") do
   navigation = FeatureTests::Navigation
   data = FeatureTests::Data
   login = FeatureTests::Action::Login
   listing_actions = FeatureTests::Action::Listing
   paypal_actions = FeatureTests::Action::Paypal
+  onboarding_wizard = FeatureTests::Section::OnboardingWizard
 
   marketplace = data.create_marketplace(payment_gateway: :paypal)
   admin = data.create_member(username: "paypal_admin", marketplace_id: marketplace[:id], admin: true)
@@ -21,12 +17,12 @@ Then("I expect transaction with PayPal test to pass") do
   # Connect Paypal for marketplace and seller
   login.login_as(admin[:username], admin[:password])
   paypal_actions.connect_marketplace_paypal
-  dismiss_onboarding_wizard_dialog
+  onboarding_wizard.dismiss_dialog
   paypal_actions.connect_seller_paypal
 
   # Add new listing
   listing_actions.add_new_listing("Lörem ipsum")
-  dismiss_onboarding_wizard_dialog
+  onboarding_wizard.dismiss_dialog
 
   # Member buys the listing
   login.logout_and_login_as(member[:username], member[:password])

--- a/features/support/feature_tests/action/listing.rb
+++ b/features/support/feature_tests/action/listing.rb
@@ -1,0 +1,22 @@
+module FeatureTests
+  module Action
+    module Listing
+      extend Capybara::DSL
+      extend RSpec::Matchers
+
+      module_function
+
+      def add_new_listing(title, price: "2.0")
+        topbar = FeatureTests::Section::Topbar
+        new_listing = FeatureTests::Page::NewListing
+
+        topbar.click_post_a_new_listing
+        new_listing.fill(title, price: price)
+        new_listing.save_listing
+
+        expect(page).to have_content("Listing created successfully.")
+        expect(page).to have_content(title)
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/action/login.rb
+++ b/features/support/feature_tests/action/login.rb
@@ -1,0 +1,33 @@
+module FeatureTests
+  module Action
+    module Login
+      extend Capybara::DSL
+      extend RSpec::Matchers
+
+      module_function
+
+      def login_as(username, password)
+        topbar = FeatureTests::Section::Topbar
+        login_page = FeatureTests::Page::Login
+
+        visit("/")
+        topbar.click_login_link
+        login_page.fill_and_submit(username: username, password: password)
+        expect(page).to have_content("Welcome")
+      end
+
+      def logout
+        topbar = FeatureTests::Section::Topbar
+
+        topbar.open_user_menu
+        topbar.click_logout
+        expect(page).to have_content("You have now been logged out")
+      end
+
+      def logout_and_login_as(username, password)
+        logout
+        login_as(username, password)
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/action/paypal.rb
+++ b/features/support/feature_tests/action/paypal.rb
@@ -48,7 +48,9 @@ module FeatureTests
         home = FeatureTests::Page::Home
         listing = FeatureTests::Page::Listing
         listing_book = FeatureTests::Page::ListingBook
+        topbar = FeatureTests::Section::Topbar
 
+        topbar.click_logo
         home.click_listing(listing_title)
         listing.fill_in_booking_dates
         listing.click_request

--- a/features/support/feature_tests/action/paypal.rb
+++ b/features/support/feature_tests/action/paypal.rb
@@ -20,7 +20,7 @@ module FeatureTests
         expect(page).to have_content("PayPal account connected")
 
         # Save payment preferences
-        paypal_preferences.set_payment_preferences("2.0", "5", "1.0")
+        paypal_preferences.set_payment_preferences(min_price: "2.0", commission: "5", min_commission: "1.0")
         paypal_preferences.save_settings
         expect(page).to have_content("Payment preferences updated")
       end

--- a/features/support/feature_tests/action/paypal.rb
+++ b/features/support/feature_tests/action/paypal.rb
@@ -56,11 +56,11 @@ module FeatureTests
         listing.click_request
 
         expect(page).to have_content("Request #{listing_title}")
-        listing_book.fill_in_message("Trölölö #{listing_title}")
+        listing_book.fill_in_message("Snowman ☃ sells: #{listing_title}")
         listing_book.proceed_to_payment
 
         expect(page).to have_content("Payment authorized")
-        expect(page).to have_content("Trölölö #{listing_title}")
+        expect(page).to have_content("Snowman ☃ sells: #{listing_title}")
       end
 
       def accept_listing_request

--- a/features/support/feature_tests/action/paypal.rb
+++ b/features/support/feature_tests/action/paypal.rb
@@ -1,0 +1,112 @@
+# coding: utf-8
+module FeatureTests
+  module Action
+    module Paypal
+      extend Capybara::DSL
+      extend RSpec::Matchers
+
+      module_function
+
+      def connect_marketplace_paypal
+        topbar = FeatureTests::Section::Topbar
+        paypal_preferences = FeatureTests::Page::AdminPaypalPreferences
+        admin_sidebar = FeatureTests::Section::AdminSidebar
+
+        # Connect Paypal for admin
+        topbar.navigate_to_admin
+        admin_sidebar.click_payments_link
+        paypal_preferences.connect_paypal_account
+
+        expect(page).to have_content("PayPal account connected")
+
+        # Save payment preferences
+        paypal_preferences.set_payment_preferences("2.0", "5", "1.0")
+        paypal_preferences.save_settings
+        expect(page).to have_content("Payment preferences updated")
+      end
+
+      def connect_seller_paypal
+        topbar = FeatureTests::Section::Topbar
+        settings_sidebar = FeatureTests::Section::UserSettingsSidebar
+        paypal_preferences = FeatureTests::Section::UserPaypalPreferences
+
+        # Connect Paypal for seller
+        topbar.open_user_menu
+        topbar.click_settings
+        settings_sidebar.click_payments_link
+        paypal_preferences.connect_paypal_account
+
+        expect(page).to have_content("PayPal account connected")
+
+        # Grant commission fee
+        paypal_preferences.grant_permission
+
+        expect(page).to have_content("Hooray, everything is set up!")
+      end
+
+      def request_listing(listing_title)
+        home = FeatureTests::Page::Home
+        listing = FeatureTests::Page::Listing
+        listing_book = FeatureTests::Page::ListingBook
+
+        home.click_listing(listing_title)
+        listing.fill_in_booking_dates
+        listing.click_request
+
+        expect(page).to have_content("Request #{listing_title}")
+        listing_book.fill_in_message("Trölölö #{listing_title}")
+        listing_book.proceed_to_payment
+
+        expect(page).to have_content("Payment authorized")
+        expect(page).to have_content("Trölölö #{listing_title}")
+      end
+
+      def accept_listing_request
+        topbar = FeatureTests::Section::Topbar
+
+        topbar.click_inbox
+
+        # Inbox
+        expect(page).to have_content("Waiting for you to accept the request")
+        page.click_link("Payment authorized")
+
+        # Transaction conversation page
+        page.click_link("Accept request")
+
+        # Order details page
+        page.click_button("Accept")
+        expect(page).to have_content("Request accepted")
+        expect(page).to have_content("Payment successful")
+      end
+
+      def buyer_mark_completed
+        topbar = FeatureTests::Section::Topbar
+
+        topbar.click_inbox
+
+        # Transaction conversation page
+        expect(page).to have_content("Waiting for you to mark the order completed")
+        page.click_link("accepted the request, received payment for")
+        page.click_link("Mark completed")
+
+        choose("Skip feedback")
+        page.click_button("Continue")
+
+        expect(page).to have_content("Offer confirmed")
+        expect(page).to have_content("Feedback skipped")
+      end
+
+      def seller_mark_completed
+        topbar = FeatureTests::Section::Topbar
+
+        topbar.click_inbox
+
+        # Transaction conversation page
+        expect(page).to have_content("Waiting for you to give feedback")
+        page.click_link("marked the order as completed")
+        page.click_link("Skip feedback")
+        expect(page).to have_content("Feedback skipped")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/action/paypal.rb
+++ b/features/support/feature_tests/action/paypal.rb
@@ -28,7 +28,7 @@ module FeatureTests
       def connect_seller_paypal
         topbar = FeatureTests::Section::Topbar
         settings_sidebar = FeatureTests::Section::UserSettingsSidebar
-        paypal_preferences = FeatureTests::Section::UserPaypalPreferences
+        paypal_preferences = FeatureTests::Page::UserSettingsPayments
 
         # Connect Paypal for seller
         topbar.open_user_menu

--- a/features/support/feature_tests/data.rb
+++ b/features/support/feature_tests/data.rb
@@ -1,0 +1,62 @@
+module FeatureTests
+  module Data
+    module_function
+
+    def create_marketplace(payment_gateway:)
+
+      marketplace = MarketplaceService::API::Marketplaces.create(
+        marketplace_name: "Test marketplace",
+        marketplace_type: "service",
+        marketplace_country: "us",
+        marketplace_language: "en",
+        payment_process: :preauthorize
+      )
+
+      if payment_gateway
+        TransactionService::API::Api.settings.provision(
+          community_id: marketplace[:id],
+          payment_gateway: payment_gateway,
+          payment_process: :preauthorize,
+          active: true)
+      end
+
+      {
+        id: marketplace[:id],
+        ident: marketplace[:ident]
+      }
+    end
+
+    def create_member(username:, marketplace_id:, admin:)
+      u = create_user(username: username, marketplace_id: marketplace_id)
+      m = create_membership(user_id: u[:id], marketplace_id: marketplace_id, admin: admin)
+      u
+    end
+
+    def create_user(username:, marketplace_id:)
+      password = "test"
+
+      u = FactoryGirl.create(:person,
+        username: username,
+        community_id: marketplace_id,
+        password: password,
+        emails: [
+          FactoryGirl.build(:email, address: "#{username}@example.com")
+        ]
+      )
+
+      {
+        id: u.id,
+        username: u.username,
+        password: password
+      }
+    end
+
+    def create_membership(user_id:, marketplace_id:, admin: false)
+      FactoryGirl.create(:community_membership,
+                         person_id: user_id,
+                         community_id: marketplace_id,
+                         consent: "SHARETRIBE1.0",
+                         admin: admin)
+    end
+  end
+end

--- a/features/support/feature_tests/navigation.rb
+++ b/features/support/feature_tests/navigation.rb
@@ -1,0 +1,11 @@
+module FeatureTests
+  module Navigation
+
+    module_function
+
+    def navigate_in_marketplace!(ident:)
+      Capybara.default_host = "#{ident}.lvh.me"
+      Capybara.app_host = "http://#{ident}.lvh.me:9887"
+    end
+  end
+end

--- a/features/support/feature_tests/page/admin_paypal_preferences.rb
+++ b/features/support/feature_tests/page/admin_paypal_preferences.rb
@@ -1,0 +1,27 @@
+module FeatureTests
+  module Page
+    module AdminPaypalPreferences
+      extend Capybara::DSL
+
+      module_function
+
+      def payment_settings
+        find(".payment-settings")
+      end
+
+      def connect_paypal_account
+        payment_settings.click_button("Connect your PayPal account")
+      end
+
+      def set_payment_preferences(min_tx_size, tx_fee, min_tx_fee)
+        payment_settings.fill_in("paypal_preferences_form[minimum_listing_price]", with: min_tx_size)
+        payment_settings.fill_in("paypal_preferences_form[commission_from_seller]", with: tx_fee)
+        payment_settings.fill_in("paypal_preferences_form[minimum_transaction_fee]", with: min_tx_fee)
+      end
+
+      def save_settings
+        payment_settings.click_button("Save settings")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/page/admin_paypal_preferences.rb
+++ b/features/support/feature_tests/page/admin_paypal_preferences.rb
@@ -13,10 +13,10 @@ module FeatureTests
         payment_settings.click_button("Connect your PayPal account")
       end
 
-      def set_payment_preferences(min_tx_size, tx_fee, min_tx_fee)
-        payment_settings.fill_in("paypal_preferences_form[minimum_listing_price]", with: min_tx_size)
-        payment_settings.fill_in("paypal_preferences_form[commission_from_seller]", with: tx_fee)
-        payment_settings.fill_in("paypal_preferences_form[minimum_transaction_fee]", with: min_tx_fee)
+      def set_payment_preferences(min_price:, commission:, min_commission:)
+        payment_settings.fill_in("paypal_preferences_form[minimum_listing_price]", with: min_price)
+        payment_settings.fill_in("paypal_preferences_form[commission_from_seller]", with: commission)
+        payment_settings.fill_in("paypal_preferences_form[minimum_transaction_fee]", with: min_commission)
       end
 
       def save_settings

--- a/features/support/feature_tests/page/home.rb
+++ b/features/support/feature_tests/page/home.rb
@@ -1,0 +1,17 @@
+module FeatureTests
+  module Page
+    module Home
+      extend Capybara::DSL
+
+      module_function
+
+      def click_listing(title)
+        page_content.find(".fluid-thumbnail-grid-image-title", text: title).click
+      end
+
+      def page_content
+        find(".page-content")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/page/listing.rb
+++ b/features/support/feature_tests/page/listing.rb
@@ -1,0 +1,35 @@
+module FeatureTests
+  module Page
+    module Listing
+      extend Capybara::DSL
+
+      module_function
+
+      def fill_in_booking_dates
+
+        # Select the first available day in the current month
+        page_content.find("input[name=start_on]").click
+        datepicker.first(".day:not(.disabled):not(.new)").click
+
+        # Select the first available day in the following month
+        page_content.find("input[name=end_on]").click
+        datepicker.find(".next").click
+        datepicker.first(".day:not(.disabled):not(.old)").click
+
+        find(".listing-title").click
+      end
+
+      def click_request
+        page_content.click_button("Request")
+      end
+
+      def datepicker
+        find(".datepicker")
+      end
+
+      def page_content
+        find(".page-content")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/page/listing_book.rb
+++ b/features/support/feature_tests/page/listing_book.rb
@@ -1,0 +1,21 @@
+module FeatureTests
+  module Page
+    module ListingBook
+      extend Capybara::DSL
+
+      module_function
+
+      def fill_in_message(message)
+        page_content.fill_in("listing_conversation[content]", with: message)
+      end
+
+      def proceed_to_payment
+        page_content.click_button("Proceed to payment")
+      end
+
+      def page_content
+        find(".page-content")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/page/login.rb
+++ b/features/support/feature_tests/page/login.rb
@@ -1,0 +1,27 @@
+module FeatureTests
+  module Page
+    module Login
+      extend Capybara::DSL
+
+      module_function
+
+      def fill_and_submit(username:, password:)
+        fill(username: username, password: password)
+        submit
+      end
+
+      def fill(username:, password:)
+        page_content.fill_in("main_person_login", with: username)
+        page_content.fill_in("main_person_password", with: password)
+      end
+
+      def submit
+        page_content.find("#main_log_in_button").click
+      end
+
+      def page_content
+        find(".page-content")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/page/new_listing.rb
+++ b/features/support/feature_tests/page/new_listing.rb
@@ -1,0 +1,23 @@
+module FeatureTests
+  module Page
+    module NewListing
+      extend Capybara::DSL
+
+      module_function
+
+      def fill(title, price: "", description: "")
+        new_listing_form.fill_in("listing[title]", with: title)
+        new_listing_form.fill_in("listing[price]", with: price)
+        new_listing_form.fill_in("listing[description]", with: description)
+      end
+
+      def save_listing
+        new_listing_form.click_button("Save listing")
+      end
+
+      def new_listing_form
+        find("form.new_listing")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/page/user_settings_payments.rb
+++ b/features/support/feature_tests/page/user_settings_payments.rb
@@ -1,6 +1,6 @@
 module FeatureTests
-  module Section
-    module UserPaypalPreferences
+  module Page
+    module UserSettingsPayments
       extend Capybara::DSL
 
       module_function

--- a/features/support/feature_tests/section/admin_sidebar.rb
+++ b/features/support/feature_tests/section/admin_sidebar.rb
@@ -1,0 +1,17 @@
+module FeatureTests
+  module Section
+    module AdminSidebar
+      extend Capybara::DSL
+
+      module_function
+
+      def click_payments_link
+        sidebar.click_on("Payments")
+      end
+
+      def sidebar
+        find(".left-navi")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/section/onboarding_wizard.rb
+++ b/features/support/feature_tests/section/onboarding_wizard.rb
@@ -1,0 +1,16 @@
+module FeatureTests
+  module Section
+    module OnboardingWizard
+      extend Capybara::DSL
+      extend RSpec::Matchers
+
+      module_function
+
+      def dismiss_dialog
+        expect(page).to have_content("Woohoo, task completed!")
+        page.click_on("I'll do it later, thanks")
+      end
+
+    end
+  end
+end

--- a/features/support/feature_tests/section/topbar.rb
+++ b/features/support/feature_tests/section/topbar.rb
@@ -1,0 +1,54 @@
+module FeatureTests
+  module Section
+    module Topbar
+      extend Capybara::DSL
+
+      module_function
+
+      def click_login_link
+        header.click_link("Log in")
+      end
+
+      def navigate_to_admin
+        open_menu
+        click_admin_link
+      end
+
+      def open_menu
+        header.find("span", text: "Menu").click
+      end
+
+      def open_user_menu
+        header.find(".header-user-toggle").click
+      end
+
+      def user_menu
+        header.find(".header-toggle-menu-user")
+      end
+
+      def click_settings
+        user_menu.click_link("Settings")
+      end
+
+      def click_logout
+        user_menu.click_link("Log out")
+      end
+
+      def click_admin_link
+        header.click_link("Admin")
+      end
+
+      def click_post_a_new_listing
+        header.click_link("Post a new listing")
+      end
+
+      def click_inbox
+        header.find("#inbox-link").click
+      end
+
+      def header
+        find(".header")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/section/topbar.rb
+++ b/features/support/feature_tests/section/topbar.rb
@@ -46,6 +46,10 @@ module FeatureTests
         header.find("#inbox-link").click
       end
 
+      def click_logo
+        header.find(".header-logo").click
+      end
+
       def header
         find(".header")
       end

--- a/features/support/feature_tests/section/user_paypal_preferences.rb
+++ b/features/support/feature_tests/section/user_paypal_preferences.rb
@@ -1,0 +1,25 @@
+module FeatureTests
+  module Section
+    module UserPaypalPreferences
+      extend Capybara::DSL
+
+      module_function
+
+      def payment_settings
+        find(".payment-settings")
+      end
+
+      def connect_paypal_account
+        payment_settings.click_button("Connect your PayPal account")
+      end
+
+      def save_settings
+        payment_settings.click_button("Save settings")
+      end
+
+      def grant_permission
+        payment_settings.click_button("Grant permission")
+      end
+    end
+  end
+end

--- a/features/support/feature_tests/section/user_settings_sidebar.rb
+++ b/features/support/feature_tests/section/user_settings_sidebar.rb
@@ -1,0 +1,17 @@
+module FeatureTests
+  module Section
+    module UserSettingsSidebar
+      extend Capybara::DSL
+
+      module_function
+
+      def click_payments_link
+        sidebar.click_link("Payments")
+      end
+
+      def sidebar
+        find(".left-navi")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an integration test for the full Paypal payment flow using the Fakepal payments implementation. Instead of writing the test as steps in a feature file, the whole test is written in the `paypal_steps.rb` file.

Test helpers are organised in a few directories under `features/support/feature_tests/`:

 - `action/`: UI flows than might span several pages
 - `page/`: abstracted selectors and actions for separate pages
 - `section/`: abstacted selectors and actions for UI components
