### PR TITLE
Menuitem blur stopped

### DIFF
--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.css
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.css
@@ -20,6 +20,10 @@
   & :global(.notification-background) { /* stylelint-disable-line selector-class-pattern */
     display: none;
   }
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .avatarWithNotifications {

--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
@@ -32,8 +32,12 @@ class AvatarDropdown extends Component {
     }
   }
 
-  handleBlur() {
-    this.setState({ isOpen: false });// eslint-disable-line react/no-set-state
+  handleBlur(event) {
+    // FocusEvent is fired faster than the link elements native click handler
+    // gets its own event. Therefore, we need to check the origin of this FocusEvent.
+    if (!this.profileDropdown.contains(event.relatedTarget)) {
+      this.setState({ isOpen: false });// eslint-disable-line react/no-set-state
+    }
   }
 
   render() {
@@ -59,15 +63,19 @@ class AvatarDropdown extends Component {
         isAdmin: this.props.isAdmin,
         notificationCount: this.props.notificationCount,
         translations: this.props.translations,
+        profileDropdownRef: (c) => {
+          this.profileDropdown = c;
+        },
       }),
     ]);
   }
 }
 
+const { profileDropdownRef, ...passedThroughProps } = ProfileDropdown.propTypes; // eslint-disable-line no-unused-vars
 AvatarDropdown.propTypes = {
   avatar: PropTypes.shape(Avatar.propTypes).isRequired,
   notificationCount: PropTypes.number,
-  ...ProfileDropdown.propTypes,
+  ...passedThroughProps,
   className,
 };
 

--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
@@ -3,16 +3,12 @@ import r, { div } from 'r-dom';
 import classNames from 'classnames';
 
 import { className } from '../../../utils/PropTypes';
+import { hasTouchEvents } from '../../../utils/featureDetection';
 import ProfileDropdown from './ProfileDropdown';
 import Avatar from '../../elements/Avatar/Avatar';
 import NotificationBadge from '../../elements/NotificationBadge/NotificationBadge';
 
 import css from './AvatarDropdown.css';
-
-const isTouch =
-  !!(typeof window !== 'undefined' &&
-    (('ontouchstart' in window) ||
-      window.navigator.msMaxTouchPoints > 0));
 
 class AvatarDropdown extends Component {
   constructor(props, context) {
@@ -27,7 +23,7 @@ class AvatarDropdown extends Component {
   }
 
   handleClick() {
-    if (isTouch) {
+    if (hasTouchEvents) {
       this.setState({ isOpen: !this.state.isOpen });// eslint-disable-line react/no-set-state
     }
   }
@@ -41,7 +37,7 @@ class AvatarDropdown extends Component {
   }
 
   render() {
-    const touchClass = isTouch ? '' : css.touchless;
+    const touchClass = hasTouchEvents ? '' : css.touchless;
     const openClass = this.state.isOpen ? css.openDropdown : '';
     const notificationsClass = this.props.notificationCount > 0 ? css.hasNotifications : null;
     const notificationBadgeInArray = this.props.notificationCount > 0 ?

--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
@@ -46,6 +46,7 @@ class AvatarDropdown extends Component {
     return div({
       onClick: this.handleClick,
       onBlur: this.handleBlur,
+      tabIndex: 0,
       className: classNames(this.props.className, touchClass, openClass, css.avatarDropdown, notificationsClass),
     }, [
       div({ className: css.avatarWithNotifications }, [

--- a/client/app/components/composites/AvatarDropdown/ProfileDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/ProfileDropdown.js
@@ -39,6 +39,7 @@ class ProfileDropdown extends Component {
   render() {
     return div({
       className: this.props.className,
+      ref: this.props.profileDropdownRef,
     }, [
       div({ className: css.rootArrowTop }),
       div({ className: css.rootArrowBelow }),
@@ -83,6 +84,7 @@ ProfileDropdown.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   className,
   notificationCount: PropTypes.number,
+  profileDropdownRef: PropTypes.func.isRequired,
 };
 
 export default ProfileDropdown;

--- a/client/app/components/composites/AvatarDropdown/ProfileDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/ProfileDropdown.js
@@ -1,6 +1,5 @@
 import { Component, PropTypes } from 'react';
 import r, { a, div, span } from 'r-dom';
-import classNames from 'classnames';
 
 import css from './ProfileDropdown.css';
 import inboxEmptyIcon from './images/inboxEmptyIcon.svg';
@@ -39,7 +38,7 @@ ProfileActionCard.propTypes = {
 class ProfileDropdown extends Component {
   render() {
     return div({
-      className: classNames(css.profileDropdown, this.props.className),
+      className: this.props.className,
     }, [
       div({ className: css.rootArrowTop }),
       div({ className: css.rootArrowBelow }),

--- a/client/app/components/composites/Menu/Menu.js
+++ b/client/app/components/composites/Menu/Menu.js
@@ -3,6 +3,7 @@ import r, { div } from 'r-dom';
 import classNames from 'classnames';
 
 import { className } from '../../../utils/PropTypes';
+import { hasTouchEvents } from '../../../utils/featureDetection';
 
 import MenuLabel from './MenuLabel';
 import MenuLabelDropdown from './MenuLabelDropdown';
@@ -14,8 +15,6 @@ const MENULABEL_MAP = {
   menu: MenuLabel,
   dropdown: MenuLabelDropdown,
 };
-
-const isTouch = !!(typeof window !== 'undefined' && (('ontouchstart' in window) || window.navigator.msMaxTouchPoints > 0));
 
 class Menu extends Component {
 
@@ -42,7 +41,7 @@ class Menu extends Component {
   }
 
   handleClick() {
-    if (isTouch) {
+    if (hasTouchEvents) {
       this.setState({ isOpen: !this.state.isOpen });// eslint-disable-line react/no-set-state
     }
   }
@@ -58,7 +57,7 @@ class Menu extends Component {
   render() {
     const requestedLabel = MENULABEL_MAP[this.props.menuLabelType];
     const LabelComponent = requestedLabel != null ? requestedLabel : null;
-    const touchClass = isTouch ? '' : css.touchless;
+    const touchClass = hasTouchEvents ? '' : css.touchless;
     const openClass = this.state.isOpen ? css.openMenu : '';
 
     return div({

--- a/client/app/components/composites/Menu/Menu.js
+++ b/client/app/components/composites/Menu/Menu.js
@@ -47,8 +47,12 @@ class Menu extends Component {
     }
   }
 
-  handleBlur() {
-    this.setState({ isOpen: false });// eslint-disable-line react/no-set-state
+  handleBlur(event) {
+    // FocusEvent is fired faster than the link elements native click handler
+    // gets its own event. Therefore, we need to check the origin of this FocusEvent.
+    if (!this.menu.contains(event.relatedTarget)) {
+      this.setState({ isOpen: false });// eslint-disable-line react/no-set-state
+    }
   }
 
   render() {
@@ -62,6 +66,9 @@ class Menu extends Component {
       onClick: this.handleClick,
       onBlur: this.handleBlur,
       tabIndex: 0,
+      ref: (c) => {
+        this.menu = c;
+      },
     }, [
       r(LabelComponent,
         {

--- a/client/app/components/composites/Menu/Menu.js
+++ b/client/app/components/composites/Menu/Menu.js
@@ -81,9 +81,6 @@ class Menu extends Component {
           key: `${this.props.identifier}_menucontent`,
           content: this.props.content,
           arrowPosition: this.state.arrowPosition,
-          ref: (c) => {
-            this.menuContent = c;
-          },
         }
       ),
     ]);

--- a/client/app/components/composites/Menu/Menu.js
+++ b/client/app/components/composites/Menu/Menu.js
@@ -1,5 +1,4 @@
 import { Component, PropTypes } from 'react';
-import ReactDOM from 'react-dom';
 import r, { div } from 'r-dom';
 import classNames from 'classnames';
 
@@ -37,10 +36,8 @@ class Menu extends Component {
   }
 
   calculateDropdownPosition() {
-    const menuLabel = ReactDOM.findDOMNode(this.menuLabel);
-
     this.setState({ // eslint-disable-line react/no-did-mount-set-state, react/no-set-state
-      arrowPosition: menuLabel.offsetWidth > (INITIAL_ARROW_POSITION * 2) ? Math.floor(menuLabel.offsetWidth / 2) : INITIAL_ARROW_POSITION, // eslint-disable-line no-magic-numbers
+      arrowPosition: this.menuLabel.offsetWidth > (INITIAL_ARROW_POSITION * 2) ? Math.floor(this.menuLabel.offsetWidth / 2) : INITIAL_ARROW_POSITION, // eslint-disable-line no-magic-numbers
     });
   }
 
@@ -71,7 +68,7 @@ class Menu extends Component {
           key: `${this.props.identifier}_menulabel`,
           name: this.props.name,
           extraClasses: this.props.extraClassesLabel,
-          ref: (c) => {
+          menuLabelRef: (c) => {
             this.menuLabel = c;
           },
         }

--- a/client/app/components/composites/Menu/MenuContent.js
+++ b/client/app/components/composites/Menu/MenuContent.js
@@ -25,9 +25,6 @@ class MenuContent extends Component {
       div(
         {
           className: `MenuContent ${css.menuContent}`,
-          ref: (c) => {
-            this.menuContent = c;
-          },
         }, [
           div({
             className: css.menuContentArrowBelow,

--- a/client/app/components/composites/Menu/MenuLabel.js
+++ b/client/app/components/composites/Menu/MenuLabel.js
@@ -10,6 +10,7 @@ class MenuLabel extends Component {
     return (
       div({
         className: `MenuLabel ${css.menuLabel} ${extraClasses}`,
+        ref: this.props.menuLabelRef,
       }, [
         span({
           className: css.menuLabelIcon,
@@ -24,8 +25,9 @@ class MenuLabel extends Component {
 }
 
 MenuLabel.propTypes = {
-  name: PropTypes.string.isRequired,
   extraClasses: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  menuLabelRef: PropTypes.func.isRequired,
 };
 
 export default MenuLabel;

--- a/client/app/components/composites/Menu/MenuLabelDropdown.js
+++ b/client/app/components/composites/Menu/MenuLabelDropdown.js
@@ -11,6 +11,7 @@ class MenuLabelDropdown extends Component {
     return (
       div({
         className: `menu__label ${css.menuLabel} ${extraClasses}`,
+        ref: this.props.menuLabelRef,
       }, [
         this.props.name,
         span({
@@ -27,8 +28,9 @@ class MenuLabelDropdown extends Component {
 }
 
 MenuLabelDropdown.propTypes = {
-  name: PropTypes.string.isRequired,
   extraClasses: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  menuLabelRef: PropTypes.func.isRequired,
 };
 
 export default MenuLabelDropdown;

--- a/client/app/utils/featureDetection.js
+++ b/client/app/utils/featureDetection.js
@@ -16,8 +16,13 @@ const canUseDOM = !!(typeof window !== 'undefined' &&
 const canUsePushState = !!(typeof history !== 'undefined' &&
                             history.pushState);
 
+const hasTouchEvents = !!(typeof window !== 'undefined' &&
+                          (('ontouchstart' in window) ||
+                            window.navigator.msMaxTouchPoints > 0));
+
 export {
   canUseDOM,
   canUsePushState,
   hasCSSFilters,
+  hasTouchEvents,
 };


### PR DESCRIPTION
ToDo
- [ ] more testing: with win10 and android

Fix for Windows10 Chrome links not working inside topbar dropdowns.
(There Chrome thinks it's on a touch device even though it ain't - I'm not sure if there's good fix for that) 

Since Win10 Chrome thinks it's on touch device it uses 'click' pattern on opening drop downs. However, it sends _blur_ event before normal ```<a>``` tag navigation event kicks in. Therefore, we need to figure out if that event comes from child element of current dropdown element (in which case, we don't close the menu). RelatedTarget tells FocusEvents original source element. 

(FocusEvents behave differently than normal events - i.e. they don't bubble from child node to parent and their target is ```document``` instead of event source. Since focusable elements listen global document events, they can steal focus from each others despite their location on DOM hierarchy.) 

Cleaning related:
ref pattern: https://github.com/yannickcr/eslint-plugin-react/issues/678#issue-165177220

Check also commit comments.