### PR TITLE
For unpaid listing, the total price is unit price * quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Updated React on Rails to 6.0.5 [#2428](https://github.com/sharetribe/sharetribe/pull/2428)
 
+### Fixed
+
+- Transactions in `initiated` state showed wrong total price in the transaction page if the item quantity was more than one [#2452](https://github.com/sharetribe/sharetribe/pull/2452)
+
 ## [5.11.0] - 2016-08-24
 
 ### Changed

--- a/app/services/transaction_service/gateway/paypal_adapter.rb
+++ b/app/services/transaction_service/gateway/paypal_adapter.rb
@@ -8,12 +8,6 @@ module TransactionService::Gateway
     end
 
     def create_payment(tx:, gateway_fields:, prefer_async:)
-      # Note: Quantity may be confusing in Paypal Checkout page, thus,
-      # we don't use separated unit price and quantity, only the total
-      # price for now.
-      shipping_total = Maybe(tx[:shipping_price]).or_else(0)
-      order_total = tx[:unit_price] * tx[:listing_quantity] + shipping_total
-
       create_payment_info = DataTypes.create_create_payment_request(
         {
          transaction_id: tx[:id],
@@ -24,7 +18,7 @@ module TransactionService::Gateway
          merchant_id: tx[:listing_author_id],
          require_shipping_address: tx[:delivery_method] == :shipping,
          shipping_total: tx[:shipping_price],
-         order_total: order_total,
+         order_total: order_total(tx),
          success: gateway_fields[:success_url],
          cancel: gateway_fields[:cancel_url],
          merchant_brand_logo_url: gateway_fields[:merchant_brand_logo_url]})
@@ -65,7 +59,7 @@ module TransactionService::Gateway
 
       payment_total = payment[:payment_total].or_else(nil)
       total_price = Maybe(payment[:payment_total].or_else(payment[:authorization_total].or_else(nil)))
-                    .or_else(tx[:unit_price] * tx[:listing_quantity])
+                    .or_else(order_total(tx))
 
       { payment_total: payment_total,
         total_price: total_price,
@@ -78,6 +72,15 @@ module TransactionService::Gateway
 
     def paypal_api
       PaypalService::API::Api
+    end
+
+    def order_total(tx)
+      # Note: Quantity may be confusing in Paypal Checkout page, thus,
+      # we don't use separated unit price and quantity, only the total
+      # price for now.
+
+      shipping_total = Maybe(tx[:shipping_price]).or_else(0)
+      tx[:unit_price] * tx[:listing_quantity] + shipping_total
     end
   end
 

--- a/app/services/transaction_service/gateway/paypal_adapter.rb
+++ b/app/services/transaction_service/gateway/paypal_adapter.rb
@@ -65,7 +65,7 @@ module TransactionService::Gateway
 
       payment_total = payment[:payment_total].or_else(nil)
       total_price = Maybe(payment[:payment_total].or_else(payment[:authorization_total].or_else(nil)))
-                    .or_else(tx[:unit_price])
+                    .or_else(tx[:unit_price] * tx[:listing_quantity])
 
       { payment_total: payment_total,
         total_price: total_price,


### PR DESCRIPTION
Steps to reproduce:

Prerequisite: PayPal setup ready for the marketplace

1. Add an Order Type with units enabled
2. Add a new listing "Bike" with price $10 per item
3. Log in as a seller
4. Go to the listing page of the "Bike", select that you want to buy 9 bikes and click the Buy button.
5. You are now being redirected to PayPal. Leave the PayPal page open but don't finish the payment. This leaves the transaction to `initiated` state.
6. Log in as an admin
7. Go to Admin > View Transactions and open the latest transaction

Expected:

You should see the details of the transaction: Price per item $10, quantity 9, subtotal 90, total 90.

<img width="514" alt="screen shot 2016-08-25 at 14 32 14" src="https://cloud.githubusercontent.com/assets/429876/17967696/81b56166-6ad1-11e6-80d4-54515341a338.png">


Actual:

Total is 10.

<img width="501" alt="screen shot 2016-08-25 at 14 31 37" src="https://cloud.githubusercontent.com/assets/429876/17967685/74cb5492-6ad1-11e6-9472-b3429aaa8a10.png">