### PR TITLE
Changed header title for invite new users page

### DIFF
--- a/app/views/invitations/new.haml
+++ b/app/views/invitations/new.haml
@@ -4,8 +4,6 @@
 
 - content_for :title_header do
   %h1
-    = t("layouts.admin.admin")
-    = "-"
     = t("admin.communities.edit_details.invite_people")
 
 - if local_assigns[:show_onboarding_popup]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
         private_community_homepage_content: "Private marketplace homepage content"
         edit_private_community_homepage_content_description: "This content is shown on the homepage of private marketplaces to users who are not logged in. Here you can describe your marketplace and the process to join it. You can also add images, videos and HTML content here. %{see_how_it_looks_like}."
         update_information: "Save settings"
-        invite_people: "Invite new users"
+        invite_people: "Invite new users to %{service_name}"
         edit_signup_info: "Signup info"
         edit_signup_info_description: "This is an info text that can be shown to users in the signup page. There you can give the users instructions for signing up, information like where to get an invite, etc. By default there are no instructions."
         edit_info: "Edit information"


### PR DESCRIPTION
Right now, the title of the `` page is `Community Name admin panel - Invite new users`.
This doesn't make sense for non-admin users.

Because this pages isn't really part of the admin panel anyway (it doesn't use the navigation, etc), it felt easier to simply:
- remove the `Community Name admin panel - ` part
- add the service_name in the remaining text

So this page header will now be `Invite new users to Community Name`, which work for all users, admins or not.