### PR TITLE
Except boolean and string values from SSL config

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -458,7 +458,7 @@ class Community < ActiveRecord::Base
     end
 
     if options[:with_protocol]
-      dom = "#{(APP_CONFIG.always_use_ssl ? "https://" : "http://")}#{dom}"
+      dom = "#{(APP_CONFIG.always_use_ssl.to_s == "true" ? "https://" : "http://")}#{dom}"
     end
 
     return dom


### PR DESCRIPTION
When creating an url for community, expect boolean and string values for `APP_CONFIG.always_use_ssl` as it might come from environment variables or be set in runtime.