### PR TITLE
When priority link limit was set to 0, menu didn't show up

### DIFF
--- a/client/app/components/composites/MenuPriority/MenuPriority.css
+++ b/client/app/components/composites/MenuPriority/MenuPriority.css
@@ -5,6 +5,7 @@
   @nest :global(.js-enabled) & {
     visibility: hidden;
 
+    &.noPriorityLinks,
     &.isMeasured {
       visibility: visible;
     }

--- a/client/app/components/composites/MenuPriority/MenuPriority.js
+++ b/client/app/components/composites/MenuPriority/MenuPriority.js
@@ -124,7 +124,8 @@ class MenuPriority extends Component {
       width: '100%',
     };
 
-    const fallbackLabel = !isMeasured || this.state.priorityLinks.length === 0 ? { name: this.props.nameFallback, menuLabelType: this.props.menuLabelTypeFallback } : {};
+    const useFallback = !isMeasured || this.state.priorityLinks.length === 0;
+    const fallbackLabel = useFallback ? { name: this.props.nameFallback, menuLabelType: this.props.menuLabelTypeFallback } : {};
     const extraMenuProps = Object.assign({
       className: css.hiddenLinks,
       content: this.state.hiddenLinks,
@@ -135,7 +136,7 @@ class MenuPriority extends Component {
     const menuProps = Object.assign(Object.assign({}, this.props, extraMenuProps));
 
     return div({
-      className: classNames('MenuPriority', css.menuPriority, { [css.isMeasured]: isMeasured }),
+      className: classNames('MenuPriority', css.menuPriority, { [css.isMeasured]: isMeasured, [css.noPriorityLinks]: useFallback }),
       ref: (c) => {
         this.menuPriorityMounted = c;
       },


### PR DESCRIPTION
Previous blinking menu fix, broke show-no-priority-links option. 
(i.e. when admin sets maximum number of links displayed in the top bar to 0)