### PR TITLE
Remove community ID from topbar menu url

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -190,7 +190,7 @@ class Admin::CommunitiesController < ApplicationController
 
     if translations.any?{ |t| t[:translation].blank? }
       flash[:error] = t("admin.communities.topbar.invalid_post_listing_button_label")
-      redirect_to topbar_admin_community_path(@community) and return
+      redirect_to admin_topbar_edit_path and return
     end
 
     translations_group = [{
@@ -201,7 +201,7 @@ class Admin::CommunitiesController < ApplicationController
 
     update(@community,
             menu_links_params,
-            topbar_admin_community_path(@community),
+            admin_topbar_edit_path,
             :menu_links)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -410,7 +410,7 @@ module ApplicationHelper
         :topic => :configure,
         :text => t("admin.communities.topbar.topbar"),
         :icon_class => icon_class("topbar_menu"),
-        :path => topbar_admin_community_path(@current_community),
+        :path => admin_topbar_edit_path,
         :name => "topbar"
       },
       {

--- a/app/views/admin/communities/topbar.haml
+++ b/app/views/admin/communities/topbar.haml
@@ -10,7 +10,7 @@
 
 .left-navi-section
   %h2= t("admin.communities.topbar.topbar")
-  = form_for community, :url => topbar_admin_community_path(community), :method => :put, html: {id: "topbar-menu-form"} do |form|
+  = form_for community, :url => admin_topbar_path, :method => :patch, html: {id: "topbar-menu-form"} do |form|
 
     = render partial: "new_listing_button", locals: { show_locales: show_locales }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,10 @@ Kassi::Application.routes.draw do
       get   "/new_layout"         => "communities#new_layout",                  as: :new_layout
       patch "/new_layout"         => "communities#update_new_layout",           as: :update_new_layout
 
+      # Topbar menu
+      get   "/topbar/edit"        => "communities#topbar",                      as: :topbar_edit
+      patch "/topbar"             => "communities#update_topbar",               as: :topbar
+
       resources :communities do
         member do
           get :edit_welcome_email
@@ -180,9 +184,13 @@ Kassi::Application.routes.draw do
           get :analytics
           put :social_media, to: 'communities#update_social_media'
           put :analytics, to: 'communities#update_analytics'
-          get :topbar
-          put :topbar, to: 'communities#update_topbar'
           delete :delete_marketplace
+
+          # DEPRECATED (2016-08-26)
+          # These routes are not in use anymore, don't use them
+          # See new "Topbar menu" routes above, outside of communities resource
+          get :topbar, to: redirect("/admin/topbar/edit")
+          put :topbar, to: "communities#update_topbar" # PUT request, no redirect
 
           # DEPRECATED (2016-07-07)
           # These routes are not in use anymore, don't use them

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,9 @@ Kassi::Application.routes.draw do
           # See new "Topbar menu" routes above, outside of communities resource
           get :topbar, to: redirect("/admin/topbar/edit")
           put :topbar, to: "communities#update_topbar" # PUT request, no redirect
+          # also redirect old menu link requests to topbar
+          get :menu_links, to: redirect("/admin/topbar/edit")
+          put :menu_links, to: "communities#update_topbar" # PUT request, no redirect
 
           # DEPRECATED (2016-07-07)
           # These routes are not in use anymore, don't use them

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -81,7 +81,7 @@ module NavigationHelpers
     when /the analytics admin page/
       analytics_admin_community_path(:id => @current_community.id)
     when /the top bar admin page/
-      topbar_admin_community_path(:id => @current_community.id)
+      admin_topbar_edit_path
     when /the transactions admin page/
       admin_community_transactions_path(:community_id => @current_community.id)
     when /the getting started guide for admins/

--- a/spec/controllers/admin/communities_controller_spec.rb
+++ b/spec/controllers/admin/communities_controller_spec.rb
@@ -73,7 +73,7 @@ describe Admin::CommunitiesController, type: :controller do
       text_en = "Modified en"
 
       expect(TranslationService::API::Api.translations).to_not receive(:create).with(anything())
-      put :update_topbar, id: @community.id, post_new_listing_button: {fi: text_fi, en: text_en}
+      patch :update_topbar, post_new_listing_button: {fi: text_fi, en: text_en}
     end
   end
 


### PR DESCRIPTION
 - Remove id form top bar menu url
 - Redirect old menu links paths to new top bar paths