### PR TITLE
Refactor PreauthorizeTransactionController

### DIFF
--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -46,33 +46,46 @@ class PreauthorizeTransactionsController < ApplicationController
       return redirect_to error_not_found_path
     end
 
-    quantity = TransactionViewUtils.parse_quantity(params[:quantity])
+    quantity_data = parse_quantity_data(@listing, params)
+
+    quantity = quantity_data[:quantity]
 
     vprms = view_params(listing_id: params[:listing_id],
                         quantity: quantity,
                         shipping_enabled: delivery_method == :shipping)
 
+    Maybe(quantity_data)[:booking_parse_error].each { |booking_parse_error|
+      flash[:error] = booking_parse_error
+      return redirect_to listing_path(vprms[:listing][:id])
+    }
+
+    community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
+
     price_break_down_locals = TransactionViewUtils.price_break_down_locals({
-      booking:  false,
-      quantity: quantity,
+      booking:  quantity_data[:booking],
+      quantity: quantity_data[:quantity],
+      start_on: quantity_data[:start_on],
+      end_on:   quantity_data[:end_on],
+      duration: quantity_data[:duration],
       listing_price: vprms[:listing][:price],
       localized_unit_type: translate_unit_from_listing(vprms[:listing]),
       localized_selector_label: translate_selector_label_from_listing(vprms[:listing]),
-      subtotal: (quantity > 1 || vprms[:listing][:shipping_price].present?) ? vprms[:subtotal] : nil,
+      subtotal: subtotal_to_show(quantity: quantity, shipping_price: vprms[:listing][:shipping_price], subtotal: vprms[:subtotal]),
       shipping_price: delivery_method == :shipping ? vprms[:shipping_price] : nil,
       total: vprms[:total_price]
     })
 
-    community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
-
     render "listing_conversations/initiate", locals: {
-      preauthorize_form: PreauthorizeMessageForm.new,
+      preauthorize_form: PreauthorizeBookingForm.new({
+          start_on: quantity_data[:start_on],
+          end_on: quantity_data[:end_on]
+      }),
       listing: vprms[:listing],
       delivery_method: delivery_method,
       quantity: quantity,
       author: query_person_entity(vprms[:listing][:author_id]),
       action_button_label: vprms[:action_button_label],
-      expiration_period: MarketplaceService::Transaction::Entity.authorization_expiration_period(vprms[:payment_type]),
+      expiration_period: MarketplaceService::Transaction::Entity.authorization_expiration_period(:paypal),
       form_action: initiated_order_path(person_id: @current_user.id, listing_id: vprms[:listing][:id]),
       price_break_down_locals: price_break_down_locals,
       country_code: community_country_code
@@ -134,59 +147,14 @@ class PreauthorizeTransactionsController < ApplicationController
     end
   end
 
-  def book
-    delivery_method = valid_delivery_method(delivery_method_str: params[:delivery],
-                                            shipping: @listing.require_shipping_address,
-                                            pickup: @listing.pickup_enabled)
-    if(delivery_method == :errored)
-      return redirect_to error_not_found_path
-    end
-
-    booking_data = verified_booking_data(params[:start_on], params[:end_on])
-    vprms = view_params(listing_id: params[:listing_id],
-                        quantity: booking_data[:duration],
-                        shipping_enabled: delivery_method == :shipping)
-
-    if booking_data[:error].present?
-      flash[:error] = booking_data[:error]
-      return redirect_to listing_path(vprms[:listing][:id])
-    end
-
-    community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
-
-    price_break_down_locals = TransactionViewUtils.price_break_down_locals({
-      booking:  true,
-      start_on: booking_data[:start_on],
-      end_on:   booking_data[:end_on],
-      duration: booking_data[:duration],
-      listing_price: vprms[:listing][:price],
-      localized_unit_type: translate_unit_from_listing(vprms[:listing]),
-      localized_selector_label: translate_selector_label_from_listing(vprms[:listing]),
-      subtotal: vprms[:subtotal],
-      shipping_price: delivery_method == :shipping ? vprms[:shipping_price] : nil,
-      total: vprms[:total_price]
-    })
-
-    render "listing_conversations/initiate", locals: {
-      preauthorize_form: PreauthorizeBookingForm.new({
-          start_on: booking_data[:start_on],
-          end_on: booking_data[:end_on]
-      }),
-      country_code: community_country_code,
-      listing: vprms[:listing],
-      delivery_method: delivery_method,
-      subtotal: vprms[:subtotal],
-      author: query_person_entity(vprms[:listing][:author_id]),
-      action_button_label: vprms[:action_button_label],
-      expiration_period: MarketplaceService::Transaction::Entity.authorization_expiration_period(vprms[:payment_type]),
-      form_action: booked_path(person_id: @current_user.id, listing_id: vprms[:listing][:id]),
-      price_break_down_locals: price_break_down_locals
-    }
-  end
-
   def booked
-    payment_type = MarketplaceService::Community::Query.payment_type(@current_community.id)
     conversation_params = params[:listing_conversation]
+
+    if @current_community.transaction_agreement_in_use? && conversation_params[:contract_agreed] != "1"
+      return render_error_response(request.xhr?,
+        t("error_messages.transaction_agreement.required_error"),
+        { action: :book, start_on: TransactionViewUtils.stringify_booking_date(start_on), end_on: TransactionViewUtils.stringify_booking_date(end_on) })
+    end
 
     start_on = DateUtils.from_date_select(conversation_params, :start_on)
     end_on = DateUtils.from_date_select(conversation_params, :end_on)
@@ -196,10 +164,10 @@ class PreauthorizeTransactionsController < ApplicationController
       listing_id: @listing.id
     }))
 
-    if @current_community.transaction_agreement_in_use? && conversation_params[:contract_agreed] != "1"
+    unless preauthorize_form.valid?
       return render_error_response(request.xhr?,
-        t("error_messages.transaction_agreement.required_error"),
-        { action: :book, start_on: TransactionViewUtils.stringify_booking_date(start_on), end_on: TransactionViewUtils.stringify_booking_date(end_on) })
+        preauthorize_form.errors.full_messages.join(", "),
+       { action: :book, start_on: TransactionViewUtils.stringify_booking_date(start_on), end_on: TransactionViewUtils.stringify_booking_date(end_on) })
     end
 
     delivery_method = valid_delivery_method(delivery_method_str: preauthorize_form.delivery_method,
@@ -209,18 +177,15 @@ class PreauthorizeTransactionsController < ApplicationController
       return render_error_response(request.xhr?, "Delivery method is invalid.", action: :booked)
     end
 
-    unless preauthorize_form.valid?
-      return render_error_response(request.xhr?,
-        preauthorize_form.errors.full_messages.join(", "),
-       { action: :book, start_on: TransactionViewUtils.stringify_booking_date(start_on), end_on: TransactionViewUtils.stringify_booking_date(end_on) })
-    end
+    quantity = DateUtils.duration_days(preauthorize_form.start_on, preauthorize_form.end_on)
+    shipping_price = shipping_price_total(@listing.shipping_price, @listing.shipping_price_additional, quantity)
 
     transaction_response = create_preauth_transaction(
-      payment_type: payment_type,
+      payment_type: :paypal,
       community: @current_community,
       listing: @listing,
+      listing_quantity: quantity,
       user: @current_user,
-      listing_quantity: DateUtils.duration_days(preauthorize_form.start_on, preauthorize_form.end_on),
       content: preauthorize_form.content,
       use_async: request.xhr?,
       delivery_method: delivery_method,
@@ -231,14 +196,7 @@ class PreauthorizeTransactionsController < ApplicationController
       })
 
     unless transaction_response[:success]
-      error =
-        if (payment_type == :paypal)
-          t("error_messages.paypal.generic_error")
-        else
-          "An error occured while trying to create a new transaction: #{transaction_response[:error_msg]}"
-        end
-
-      return render_error_response(request.xhr?, error, { action: :book, start_on: TransactionViewUtils.stringify_booking_date(start_on), end_on: TransactionViewUtils.stringify_booking_date(end_on) })
+      return render_error_response(request.xhr?, t("error_messages.paypal.generic_error"), { action: :book, start_on: TransactionViewUtils.stringify_booking_date(start_on), end_on: TransactionViewUtils.stringify_booking_date(end_on) })
     end
 
     if (transaction_response[:data][:gateway_fields][:redirect_url])
@@ -277,20 +235,50 @@ class PreauthorizeTransactionsController < ApplicationController
 
   def view_params(listing_id:, quantity: 1, shipping_enabled: false)
     listing = ListingQuery.listing(listing_id)
-    payment_type = MarketplaceService::Community::Query.payment_type(@current_community.id)
 
     action_button_label = translate(listing[:action_button_tr_key])
 
     subtotal = listing[:price] * quantity
-    shipping_price = shipping_price_total(listing[:shipping_price], listing[:shipping_price_additional], quantity)
-    total_price = shipping_enabled ? subtotal + shipping_price : subtotal
+    shipping_price = shipping_price_total(listing[:shipping_price], listing[:shipping_price_additional], quantity) || 0
+    total_price = subtotal + shipping_price
 
     { listing: listing,
-      payment_type: payment_type,
       action_button_label: action_button_label,
       subtotal: subtotal,
       shipping_price: shipping_price,
       total_price: total_price }
+  end
+
+  def subtotal_to_show(quantity:, shipping_price:, subtotal:)
+    (quantity > 1 || shipping_price.present?) ? subtotal : nil
+  end
+
+  def booking?(listing)
+    [:day].include?(listing.unit_type&.to_sym)
+  end
+
+  def parse_quantity_data(listing, params)
+    if booking?(listing)
+      booking = verified_booking_data(params[:start_on], params[:end_on])
+
+      {
+        booking: true,
+        start_on: booking[:start_on],
+        end_on: booking[:end_on],
+        quantity: booking[:duration],
+        duration: booking[:duration],
+        booking_parse_error: booking[:error]
+      }
+    else
+      {
+        booking: false,
+        start_on: nil,
+        end_on: nil,
+        quantity: TransactionViewUtils.parse_quantity(params[:quantity]),
+        duration: nil,
+        booking_parse_error: nil,
+      }
+    end
   end
 
   def render_error_response(is_xhr, error_msg, redirect_params)
@@ -326,10 +314,6 @@ class PreauthorizeTransactionsController < ApplicationController
 
   def fetch_listing_from_params
     @listing = Listing.find(params[:listing_id] || params[:id])
-  end
-
-  def new_contact_form(conversation_params = {})
-    ContactForm.new(conversation_params.merge({sender_id: @current_user.id, listing_id: @listing.id, community_id: @current_community.id}))
   end
 
   def ensure_can_receive_payment

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -268,7 +268,7 @@ class PreauthorizeTransactionsController < ApplicationController
         when :delivery_method_missing
           [t("listing_conversations.preauthorize.delivery_method_missing"), listing_path(listing.id)]
         when :agreement_missing
-          [t("error_messages.transaction_agreement.required_error"), error_path(tx_params)]
+          [t("error_messages.transaction_agreement.required_error"), error_path(data[:tx_params])]
         else
           raise NotImplementedError.new("Unknown error #{data[:code]}")
         end
@@ -374,7 +374,7 @@ class PreauthorizeTransactionsController < ApplicationController
   end
 
   def error_path(tx_params)
-    booking_dates = HashUtils.map_values(tx_params.slice(:start_on, :end_on).select(&:present?)) { |date|
+    booking_dates = HashUtils.map_values(tx_params.slice(:start_on, :end_on).compact) { |date|
       TransactionViewUtils.stringify_booking_date(date)
     }
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -27,15 +27,11 @@ class TransactionsController < ApplicationController
         ensure_can_start_transactions(listing_model: listing_model, current_user: @current_user, current_community: @current_community)
       }
     ).on_success { |((listing_id, listing_model, author_model, process, gateway))|
-      booking = listing_model.unit_type == :day
-
       transaction_params = HashUtils.symbolize_keys({listing_id: listing_model.id}.merge(params.slice(:start_on, :end_on, :quantity, :delivery)))
 
-      case [process[:process], gateway, booking]
+      case [process[:process], gateway]
       when matches([:none])
         render_free(listing_model: listing_model, author_model: author_model, community: @current_community, params: transaction_params)
-      when matches([:preauthorize, __, true])
-        redirect_to book_path(transaction_params)
       when matches([:preauthorize, :paypal])
         redirect_to initiate_order_path(transaction_params)
       else

--- a/app/views/listing_conversations/_transaction_agreement_checkbox.haml
+++ b/app/views/listing_conversations/_transaction_agreement_checkbox.haml
@@ -1,7 +1,7 @@
 .row
   .col-12
     .checkbox-container
-      = form.check_box :contract_agreed, class: "required"
+      = check_box_tag :contract_agreed, "1", class: "required"
       %label
         = @community_customization.transaction_agreement_label
         = link_to(t(".read_more"), "#", id: "transaction-agreement-read-more").html_safe

--- a/app/views/listing_conversations/_transaction_agreement_checkbox.haml
+++ b/app/views/listing_conversations/_transaction_agreement_checkbox.haml
@@ -1,7 +1,7 @@
 .row
   .col-12
     .checkbox-container
-      = check_box_tag :contract_agreed, "1", class: "required"
+      = check_box_tag :contract_agreed, "1", false, class: "required"
       %label
         = @community_customization.transaction_agreement_label
         = link_to(t(".read_more"), "#", id: "transaction-agreement-read-more").html_safe

--- a/app/views/listing_conversations/initiate.haml
+++ b/app/views/listing_conversations/initiate.haml
@@ -27,15 +27,10 @@
       %li
         = render partial: "transactions/price_break_down", locals: price_break_down_locals
 
-  = form_for preauthorize_form,
-    :url => form_action,
-      :method => "post",
-      :html => { :id => "transaction-form" } do |form|
+  = form_tag form_action, method: :post, id: "transaction-form" do
 
-    -# TODO Fix this, no respond_to?
-    - if preauthorize_form.respond_to?(:start_on) && preauthorize_form.respond_to?(:end_on)
-      = form.date_select :start_on, { value: preauthorize_form.start_on }, { class: "hidden" }
-      = form.date_select :end_on, { value: preauthorize_form.end_on }, { class: "hidden" }
+    = hidden_field_tag(:start_on, start_on&.iso8601 )
+    = hidden_field_tag(:end_on, end_on&.iso8601 )
 
     .preauthorize-section
       %h2
@@ -43,21 +38,20 @@
 
       .row
         .col-12
-          = form.text_area :content, :class => "text_area"
-          = form.hidden_field :sender_id, :value => @current_user.id
+          = text_area_tag :message, nil, :class => "text_area"
 
       - if @current_community.transaction_agreement_in_use
-        = render :partial => "listing_conversations/transaction_agreement_checkbox", locals: { form: form }
+        = render :partial => "listing_conversations/transaction_agreement_checkbox"
 
-      - if local_assigns.has_key?(:quantity)
-        = form.hidden_field :quantity, value: quantity
+      - if quantity
+        = hidden_field_tag :quantity, quantity
 
       - if delivery_method
-        = form.hidden_field :delivery_method, value: delivery_method
+        = hidden_field_tag :delivery, delivery_method
 
       .row
         .col-12.paypal-button-wrapper
-          = form.button t("paypal.pay_with_paypal"), class: "checkout-with-paypal-button"
+          = button_tag t("paypal.pay_with_paypal"), class: "checkout-with-paypal-button"
 
       .row
         .col-12

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1593,6 +1593,7 @@ en:
       you_will_be_charged: "You will be charged only if %{author} accepts the transaction. %{author} needs to accept the transaction within %{expiration_period} days. If %{author} declines or does not respond, no charge is made."
       day: day
       days: days
+      invalid_parameters: "Invalid values for new transaction"
     transaction_agreement_checkbox:
       read_more: View.
   mapview:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,13 +104,15 @@ Kassi::Application.routes.draw do
     get "/transactions/new" => "transactions#new", as: :new_transaction
 
     # preauthorize flow
-    get "/listings/:listing_id/book", :to => redirect { |path_params, request|
-      # Deprecated route (26-08-2016)
-      query_params = request.params
-      "/listings/#{path_params[:listing_id]}/initiate?start_on=#{query_params[:start_on]}&end_on=#{query_params[:end_on]}"
+
+    # Deprecated route (26-08-2016)
+    get "/listings/:listing_id/book", :to => redirect { |params, request|
+      "/#{params[:locale]}/listings/#{params[:listing_id]}/initiate?#{request.query_string}"
     }
-    post "/listings/:listing_id/booked" => "preauthorize_transactions#booked", :as => :booked
-    get "/listings/:listing_id/initiate" => "preauthorize_transactions#initiate", :as => :initiate_order
+    # Deprecated route (26-08-2016)
+    post "/listings/:listing_id/booked"    => "preauthorize_transactions#initiated", as: :booked # POST request, no redirect
+
+    get "/listings/:listing_id/initiate"   => "preauthorize_transactions#initiate", :as => :initiate_order
     post "/listings/:listing_id/initiated" => "preauthorize_transactions#initiated", :as => :initiated_order
 
     # free flow

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,11 @@ Kassi::Application.routes.draw do
     get "/transactions/new" => "transactions#new", as: :new_transaction
 
     # preauthorize flow
-    get "/listings/:listing_id/book" => "preauthorize_transactions#book", :as => :book
+    get "/listings/:listing_id/book", :to => redirect { |path_params, request|
+      # Deprecated route (26-08-2016)
+      query_params = request.params
+      "/listings/#{path_params[:listing_id]}/initiate?start_on=#{query_params[:start_on]}&end_on=#{query_params[:end_on]}"
+    }
     post "/listings/:listing_id/booked" => "preauthorize_transactions#booked", :as => :booked
     get "/listings/:listing_id/initiate" => "preauthorize_transactions#initiate", :as => :initiate_order
     post "/listings/:listing_id/initiated" => "preauthorize_transactions#initiated", :as => :initiated_order

--- a/features/step_definitions/paypal_steps.rb
+++ b/features/step_definitions/paypal_steps.rb
@@ -20,12 +20,16 @@ Then("I expect transaction with PayPal test to pass") do
   paypal_actions.connect_seller_paypal
 
   # Add new listing
-  listing_actions.add_new_listing("Snowman for sale: ☃")
+  listing_price = 10
+  listing_actions.add_new_listing(title: "Snowman for sale: ☃", price: listing_price.to_s)
   onboarding_wizard.dismiss_dialog
+
+  # Page::Listing.fill_in_booking_dates always selects a two day period
+  expected_price = listing_price * 2
 
   # Member buys the listing
   login.logout_and_login_as(member[:username], member[:password])
-  paypal_actions.request_listing("Snowman for sale: ☃")
+  paypal_actions.request_listing(title: "Snowman for sale: ☃", expected_price: expected_price.to_s)
 
   # Adming accepts request
   login.logout_and_login_as(admin[:username], admin[:password])

--- a/features/support/feature_tests/action/listing.rb
+++ b/features/support/feature_tests/action/listing.rb
@@ -6,7 +6,7 @@ module FeatureTests
 
       module_function
 
-      def add_new_listing(title, price: "2.0")
+      def add_new_listing(title:, price: "2.0")
         topbar = FeatureTests::Section::Topbar
         new_listing = FeatureTests::Page::NewListing
 

--- a/features/support/feature_tests/page/listing.rb
+++ b/features/support/feature_tests/page/listing.rb
@@ -7,9 +7,9 @@ module FeatureTests
 
       def fill_in_booking_dates
 
-        # Select the first available day in the current month
+        # Select the last available day in the current month
         page_content.find("input[name=start_on]").click
-        datepicker.first(".day:not(.disabled):not(.new)").click
+        datepicker.all(".day:not(.disabled):not(.new)").last.click
 
         # Select the first available day in the following month
         page_content.find("input[name=end_on]").click

--- a/features/support/feature_tests/page/listing_book.rb
+++ b/features/support/feature_tests/page/listing_book.rb
@@ -6,7 +6,7 @@ module FeatureTests
       module_function
 
       def fill_in_message(message)
-        page_content.fill_in("listing_conversation[content]", with: message)
+        page_content.fill_in("message", with: message)
       end
 
       def proceed_to_payment

--- a/features/support/feature_tests/page/listing_book.rb
+++ b/features/support/feature_tests/page/listing_book.rb
@@ -13,6 +13,10 @@ module FeatureTests
         page_content.click_button("Proceed to payment")
       end
 
+      def total_value
+        page_content.find('.initiate-transaction-total-value')
+      end
+
       def page_content
         find(".page-content")
       end

--- a/spec/controllers/preauthorize_transactions_controller_spec.rb
+++ b/spec/controllers/preauthorize_transactions_controller_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe PreauthorizeTransactionsController, type: :controller do
+
+
+
+end

--- a/spec/controllers/preauthorize_transactions_controller_spec.rb
+++ b/spec/controllers/preauthorize_transactions_controller_spec.rb
@@ -8,48 +8,50 @@ end
 
 describe PreauthorizeTransactionsController::ItemTotal do
 
-  ItemTotal = PreauthorizeTransactionsController::ItemTotal
+  let(:item_total) { PreauthorizeTransactionsController::ItemTotal }
 
   it "calculates the item total" do
-    expect(ItemTotal.new(unit_price: Money.new(2500, "USD"), quantity: 10).total)
+    expect(item_total.new(unit_price: Money.new(2500, "USD"), quantity: 10).total)
       .to eq(Money.new(25_000, "USD"))
 
-    expect(ItemTotal.new(unit_price: Money.new(0, "EUR"), quantity: 10).total)
+    expect(item_total.new(unit_price: Money.new(0, "EUR"), quantity: 10).total)
       .to eq(Money.new(0, "EUR"))
 
-    expect(ItemTotal.new(unit_price: Money.new(2500, "USD"), quantity: 0).total)
+    expect(item_total.new(unit_price: Money.new(2500, "USD"), quantity: 0).total)
       .to eq(Money.new(0, "USD"))
   end
 end
 
 describe PreauthorizeTransactionsController::ShippingTotal do
 
-  ShippingTotal = PreauthorizeTransactionsController::ShippingTotal
+  let(:shipping_total) { PreauthorizeTransactionsController::ShippingTotal }
 
   it "calculates the shipping total" do
-    expect(ShippingTotal.new(initial: Money.new(5000, "EUR"), additional: 0, quantity: 1).total)
+    expect(shipping_total.new(initial: Money.new(5000, "EUR"), additional: 0, quantity: 1).total)
       .to eq(Money.new(5000, "EUR"))
 
-    expect(ShippingTotal.new(initial: Money.new(5000, "EUR"), additional: 0, quantity: 10).total)
+    expect(shipping_total.new(initial: Money.new(5000, "EUR"), additional: 0, quantity: 10).total)
       .to eq(Money.new(5000, "EUR"))
 
-    expect(ShippingTotal.new(initial: Money.new(5000, "USD"), additional: Money.new(1000, "USD"), quantity: 1).total)
+    expect(shipping_total.new(initial: Money.new(5000, "USD"), additional: Money.new(1000, "USD"), quantity: 1).total)
       .to eq(Money.new(5000, "USD"))
 
-    expect(ShippingTotal.new(initial: Money.new(5000, "USD"), additional: Money.new(1000, "USD"), quantity: 5).total)
+    expect(shipping_total.new(initial: Money.new(5000, "USD"), additional: Money.new(1000, "USD"), quantity: 5).total)
       .to eq(Money.new(9000, "USD"))
   end
 end
 
 describe PreauthorizeTransactionsController::OrderTotal do
 
-  OrderTotal = PreauthorizeTransactionsController::OrderTotal
+  let(:item_total) { PreauthorizeTransactionsController::ItemTotal }
+  let(:shipping_total) { PreauthorizeTransactionsController::ShippingTotal }
+  let(:order_total) { PreauthorizeTransactionsController::OrderTotal }
 
   it "calculates the order total (item total + shipping total)" do
-    items = ItemTotal.new(unit_price: Money.new(25_000, "EUR"), quantity: 5)
-    shipping = ShippingTotal.new(initial: Money.new(2_000, "EUR"), additional: Money.new(500, "EUR"), quantity: 5)
+    items = item_total.new(unit_price: Money.new(25_000, "EUR"), quantity: 5)
+    shipping = shipping_total.new(initial: Money.new(2_000, "EUR"), additional: Money.new(500, "EUR"), quantity: 5)
 
-    expect(OrderTotal.new(item_total: items, shipping_total: shipping).total)
+    expect(order_total.new(item_total: items, shipping_total: shipping).total)
       .to eq(Money.new(129_000, "EUR"))
   end
 end

--- a/spec/controllers/preauthorize_transactions_controller_spec.rb
+++ b/spec/controllers/preauthorize_transactions_controller_spec.rb
@@ -55,3 +55,141 @@ describe PreauthorizeTransactionsController::OrderTotal do
       .to eq(Money.new(129_000, "EUR"))
   end
 end
+
+describe PreauthorizeTransactionsController::Validator do
+
+  let(:validator) { PreauthorizeTransactionsController::Validator }
+
+  describe "#validate_delivery_method" do
+
+    context "valid" do
+      it "passes valid delivery method" do
+        params = {
+          tx_params: {
+            delivery: :shipping
+          },
+          shipping_enabled: true,
+          pickup_enabled: true
+        }
+
+        expect(validator.validate_delivery_method(params).success).to eq(true)
+      end
+    end
+
+    context "invalid" do
+
+      it "fails for invalid delivery method" do
+        params = {
+          tx_params: {
+            delivery: :shipping
+          },
+          shipping_enabled: false,
+          pickup_enabled: false
+        }
+
+        expect(validator.validate_delivery_method(params).data[:code]).to eq(:delivery_method_missing)
+      end
+
+      it "fails if delivery method is missing" do
+
+        params = {
+          tx_params: {
+            delivery: nil
+          },
+          shipping_enabled: true,
+          pickup_enabled: true
+        }
+
+        expect(validator.validate_delivery_method(params).data[:code]).to eq(:delivery_method_missing)
+      end
+    end
+  end
+
+  describe "#validate_booking" do
+    context "valid" do
+      it "passes for valid booking dates" do
+        params = {
+          tx_params: {
+            start_on: 1.day.from_now,
+            end_on: 2.days.from_now
+          },
+          is_booking: true
+        }
+
+        expect(validator.validate_booking(params).success).to eq(true)
+      end
+
+      it "passes if booking is not in use" do
+        params = {
+          tx_params: {},
+          is_booking: false
+        }
+
+        expect(validator.validate_booking(params).success).to eq(true)
+      end
+    end
+
+    context "invalid" do
+      it "fails if start date is after end date" do
+        params = {
+          tx_params: {
+            start_on: 1.day.from_now,
+            end_on: 2.days.ago
+          },
+          is_booking: true
+        }
+
+        expect(validator.validate_booking(params).data[:code]).to eq(:end_cant_be_before_start)
+
+      end
+
+      it "fails if start date or end date is missing" do
+        params = {
+          tx_params: {},
+          is_booking: true
+        }
+
+        expect(validator.validate_booking(params).data[:code]).to eq(:dates_missing)
+      end
+    end
+  end
+
+  describe "#validate_transaction_agreement" do
+    context "valid" do
+      it "passes if agreement is in use and agreed" do
+        params = {
+          tx_params: {
+            contract_agreed: true
+          },
+          transaction_agreement_in_use: true
+        }
+
+        expect(validator.validate_transaction_agreement(params).success).to eq(true)
+      end
+
+      it "passes if agreement is not in use" do
+        params = {
+          tx_params: {},
+          transaction_agreement_in_use: false
+        }
+
+        expect(validator.validate_transaction_agreement(params).success).to eq(true)
+      end
+
+    end
+
+    context "invalid" do
+      it "fails if agreement is in use but not agreed" do
+        params = {
+          tx_params: {
+            contract_agreed: false
+          },
+          transaction_agreement_in_use: true
+        }
+
+        expect(validator.validate_transaction_agreement(params).data[:code]).to eq(:agreement_missing)
+
+      end
+    end
+  end
+end

--- a/spec/controllers/preauthorize_transactions_controller_spec.rb
+++ b/spec/controllers/preauthorize_transactions_controller_spec.rb
@@ -5,3 +5,51 @@ describe PreauthorizeTransactionsController, type: :controller do
 
 
 end
+
+describe PreauthorizeTransactionsController::ItemTotal do
+
+  ItemTotal = PreauthorizeTransactionsController::ItemTotal
+
+  it "calculates the item total" do
+    expect(ItemTotal.new(unit_price: Money.new(2500, "USD"), quantity: 10).total)
+      .to eq(Money.new(25_000, "USD"))
+
+    expect(ItemTotal.new(unit_price: Money.new(0, "EUR"), quantity: 10).total)
+      .to eq(Money.new(0, "EUR"))
+
+    expect(ItemTotal.new(unit_price: Money.new(2500, "USD"), quantity: 0).total)
+      .to eq(Money.new(0, "USD"))
+  end
+end
+
+describe PreauthorizeTransactionsController::ShippingTotal do
+
+  ShippingTotal = PreauthorizeTransactionsController::ShippingTotal
+
+  it "calculates the shipping total" do
+    expect(ShippingTotal.new(initial: Money.new(5000, "EUR"), additional: 0, quantity: 1).total)
+      .to eq(Money.new(5000, "EUR"))
+
+    expect(ShippingTotal.new(initial: Money.new(5000, "EUR"), additional: 0, quantity: 10).total)
+      .to eq(Money.new(5000, "EUR"))
+
+    expect(ShippingTotal.new(initial: Money.new(5000, "USD"), additional: Money.new(1000, "USD"), quantity: 1).total)
+      .to eq(Money.new(5000, "USD"))
+
+    expect(ShippingTotal.new(initial: Money.new(5000, "USD"), additional: Money.new(1000, "USD"), quantity: 5).total)
+      .to eq(Money.new(9000, "USD"))
+  end
+end
+
+describe PreauthorizeTransactionsController::OrderTotal do
+
+  OrderTotal = PreauthorizeTransactionsController::OrderTotal
+
+  it "calculates the order total (item total + shipping total)" do
+    items = ItemTotal.new(unit_price: Money.new(25_000, "EUR"), quantity: 5)
+    shipping = ShippingTotal.new(initial: Money.new(2_000, "EUR"), additional: Money.new(500, "EUR"), quantity: 5)
+
+    expect(OrderTotal.new(item_total: items, shipping_total: shipping).total)
+      .to eq(Money.new(129_000, "EUR"))
+  end
+end


### PR DESCRIPTION
This PR aims to refactor PreauthorizeTransactionController so that it's easier to reason about. In addition to that, some duplication was removed by combining `book` method with `initiate` method and `booked` method with `initiated` method.

Goals for refactoring:

* Get rid of early exists (e.g. `redirect_to :error if something_failed`), unless they are in the very beginning of the method (i.e. they are "guards"). For this, we use Result object for nicer control flow.
* Improve parameter handling, validation and coercion. For this, we use EntityBuilder.
* Extract validation logic out of controller action method
* Extract business logic (shipping price calculations e.g.) out of controller action method