### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ Before starting these steps, perform [steps 1-5 from above](#setting-up-the-deve
   RAILS_ENV=production bundle exec rake ts:start
   ```
 
+1. Following cmd is not required if the next command has never been executed earlier (else):
+
+  ```bash
+  rm -rf /public/assets
+  ```
+
 1. Precompile the assets:
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Before starting these steps, perform [steps 1-5 from above](#setting-up-the-deve
 1. Following cmd is not required if the next command has never been executed earlier (else):
 
   ```bash
-  rm -rf /public/assets
+  rm -rf public/assets
   ```
 
 1. Precompile the assets:


### PR DESCRIPTION
this cmd would remove the precompiled assets from public/assets dir ... and leave a clean place for the subsequent command 

not using this command leaves stylesheets incorrectly linked and leads to problems in Modernizer, Squares instead of Icons etc etc 

PS : we would like to add a procfile cmd for the production envt too