### PR TITLE
Use custom Post a new listing button text in header and email

### DIFF
--- a/app/views/community_mailer/community_updates.html.haml
+++ b/app/views/community_mailer/community_updates.html.haml
@@ -31,7 +31,7 @@
 
                             %tr
 
-                              = render :partial => "person_mailer/action_button", :locals => { :text => t("emails.community_updates.post_a_new_listing"), :url => new_request_without_locale_url(@url_params.merge({:type => "offer"})), :align => "center"}
+                              = render :partial => "person_mailer/action_button", :locals => { :text => t("homepage.index.post_new_listing"), :url => new_request_without_locale_url(@url_params.merge({:type => "offer"})), :align => "center"}
                       %td{:width => "5%"}
             %tr
               %td{:style => "text-align: left;width:100%;max-width:602px;padding: 5px 30px;"}

--- a/app/views/listings/new.haml
+++ b/app/views/listings/new.haml
@@ -11,7 +11,7 @@
   = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" if needs_maps
 
 - content_for :title_header do
-  %h1= t("listings.new.post_a_new_listing")
+  %h1= t("homepage.index.post_new_listing")
 #new_listing_form.new-listing-form.centered-section
 
   #selected-groups

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -858,7 +858,6 @@ en:
       title_link_text: "%{community_name}"
       intro_paragraph: "Here are some of the things that happened on %{community_link} during the past %{time_since_last_update}."
       intro_paragraph_link_text: "%{community_name}"
-      post_a_new_listing: "Post a new listing!"
       reduce_email_footer_text: "Too much email? %{settings_link} or %{unsubscribe_link}."
       settings_link_text: "Edit your email settings here"
       unsubscribe_link_text: unsubscribe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1514,7 +1514,6 @@ en:
       how_paypal_works: "How PayPal Works"
       payment_help: "Payment help"
     new:
-      post_a_new_listing: "Post a new listing"
       listing: listing
       selected_category: "Category: %{category}"
       selected_subcategory: "Subcategory: %{subcategory}"


### PR DESCRIPTION
The _Post a new listing_ button text can now be edited from the admin panel. For consistency, this custom text should also be used in two places:

- Listing creation form (header)
- CTA button in update emails (button label)

This PR also removes the old translation keys, as they are no longer relevant.

**One question**
The new text is set as `homepage.index.post_new_listing`. Because it is actually also used in other places than homepage (other pages and now listing creation page and email), should the translation key be changed?