### PR TITLE
Use bounding box center as origin when limiting by distance

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -175,6 +175,12 @@ class HomepageController < ApplicationController
     distance_limit = [distance, APP_CONFIG[:external_search_distance_limit_min].to_f].max if limit_search_distance
 
     if @view_type != 'map' && location_search_in_use
+      center_point = if limit_search_distance && params[:boundingbox]
+        LocationUtils.center(*params[:boundingbox].split(',').map { |n| LocationUtils.to_radians(n) })
+      else
+        search_coordinates(params[:lc])
+      end
+
       scale_multiplier = APP_CONFIG[:external_search_scale_multiplier].to_f
       offset_multiplier = APP_CONFIG[:external_search_offset_multiplier].to_f
       combined_search_in_use = location_search_in_use && keyword_search_in_use && scale_multiplier && offset_multiplier
@@ -194,7 +200,7 @@ class HomepageController < ApplicationController
         distance_max: distance_limit,
         sort: sort
       })
-      .merge(search_coordinates(params[:lc]))
+      .merge(center_point)
       .merge(combined_search_params)
       .compact
     end

--- a/app/utils/location_utils.rb
+++ b/app/utils/location_utils.rb
@@ -1,0 +1,26 @@
+module LocationUtils
+  module_function
+
+  def center(lat1, lng1, lat2, lng2)
+    # Midway point along a great circle path between the two corners
+    unless (lat1.present? && lng1.present? && lat2.present? && lng2.present?)
+      ArgumentError.new("Two coordinate pairs required: \"#{lat1},#{lng1}; #{lat2},#{lng2}\"")
+    end
+    bx = Math.cos(lat2) * Math.cos(lng2 - lng1)
+    by = Math.cos(lat2) * Math.sin(lng2 - lng1)
+    lat_c = Math.atan2(Math.sin(lat1) + Math.sin(lat2),
+                       Math.sqrt((Math.cos(lat1) + bx) * (Math.cos(lat1) + bx) + by * by))
+    lng_c = lng1 + Math.atan2(by, Math.cos(lat1) + bx)
+    { latitude: to_degrees(lat_c), longitude: to_degrees(lng_c) }
+  end
+
+  def to_radians(deg)
+    deg_f = deg.is_a?(Numeric) ? deg : deg.to_f
+    deg_f * Math::PI / 180
+  end
+
+  def to_degrees(rad)
+    rad_f = rad.is_a?(Numeric) ? rad : rad.to_f
+    rad_f / Math::PI * 180
+  end
+end


### PR DESCRIPTION
The point returned by Google was not the center, which caused some weird behaviour when searching with distance limit.