### PR TITLE
Fix feature flag id handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -167,10 +167,13 @@ class ApplicationController < ActionController::Base
   def initialize_feature_flags
     # Skip this if there is no current marketplace.
     # This allows to avoid skipping this filter in many places.
-    return unless request.env[:current_marketplace]
+    return unless @current_community
 
-    FeatureFlagHelper.init(request, Maybe(@current_user).is_admin?.or_else(false),
-                           Maybe(@current_user).is_marketplace_admin?.or_else(false))
+    FeatureFlagHelper.init(community_id: @current_community.id,
+                           user_id: @current_user&.id,
+                           request: request,
+                           is_admin: Maybe(@current_user).is_admin?.or_else(false),
+                           is_marketplace_admin: Maybe(@current_user).is_marketplace_admin?.or_else(false))
   end
 
   # Ensure that user accepts terms of community and has a valid email

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -221,7 +221,12 @@ class LandingPageController < ActionController::Metal
                          true)
     marketplace_context = marketplace_context(c, topbar_locale, request)
 
-    FeatureFlagHelper.init(request, false, false)
+    # Init feature flags with marketplace specific flags, skip personal
+    FeatureFlagHelper.init(community_id: c.id,
+                           user_id: nil,
+                           request: request,
+                           is_admin: false,
+                           is_marketplace_admin: false)
 
     denormalizer = build_denormalizer(
       cid: c&.id,

--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -59,14 +59,6 @@ module FeatureFlagHelper
     from_session.union(from_params)
   end
 
-  def person_id(request)
-    request.session[:person_id]
-  end
-
-  def community_id(request)
-    request.env[:current_marketplace].id
-  end
-
   def search_engine
     use_external_search = Maybe(APP_CONFIG).external_search_in_use.map { |v| v == true || v.to_s.casecmp("true") == 0 }.or_else(false)
     use_external_search ? :zappy : :sphinx

--- a/app/helpers/feature_flag_helper.rb
+++ b/app/helpers/feature_flag_helper.rb
@@ -7,8 +7,8 @@ module FeatureFlagHelper
 
   module_function
 
-  def init(request, is_admin, is_marketplace_admin)
-    RequestStore.store[:feature_flags] ||= fetch_feature_flags(request, is_admin, is_marketplace_admin)
+  def init(community_id:, user_id:, request:, is_admin:, is_marketplace_admin:)
+    RequestStore.store[:feature_flags] ||= fetch_feature_flags(community_id, user_id, request, is_admin, is_marketplace_admin)
   end
 
   def feature_enabled?(feature_name)
@@ -30,9 +30,8 @@ module FeatureFlagHelper
     RequestStore.store[:feature_flags]
   end
 
-  def fetch_feature_flags(request, is_admin, is_marketplace_admin)
-    flags_from_service = fetch_flags_from_service(community_id(request), person_id(request), is_admin, is_marketplace_admin)
-
+  def fetch_feature_flags(community_id, person_id, request, is_admin, is_marketplace_admin)
+    flags_from_service = fetch_flags_from_service(community_id, person_id, is_admin, is_marketplace_admin)
     temp_flags = fetch_temp_flags(is_admin, request.params, request.session)
 
     request.session[:feature_flags] = temp_flags
@@ -43,7 +42,7 @@ module FeatureFlagHelper
   def fetch_flags_from_service(community_id, person_id, is_admin, is_marketplace_admin)
     # for admin users fetch combined feature flags,
     # for non-admin users only fetch the community specific feature flags
-    if is_admin || is_marketplace_admin
+    if person_id && (is_admin || is_marketplace_admin)
       FeatureFlagService::API::Api.features.get(community_id: community_id, person_id: person_id).maybe[:features].or_else(Set.new)
     else
       FeatureFlagService::API::Api.features.get_for_community(community_id: community_id).maybe[:features].or_else(Set.new)


### PR DESCRIPTION
Changes FeatureFlagsHelper to use explicitly defined person_id and community_id instead of relying to session.

This pull request will fix the odd case where in some cases admins are not presented with correct feature flags.

### Steps to reproduce

  1. In master, create a new marketplace through int_api
  2. Enable feature flag: `topbar_v1` through console to the newly created user
  3. Confirm email and log in with the auth token from int_api response

*Expected*: New top bar is visible
*Actual*: Old top bar is still visible
*Reason*: Auth token login doesn't put session[:person_id] into place

### Next steps

Removal of session[:person_id] is investigated later as it seems that it's not read anywhere except the removed code in FeatureFlagsHelper, but this needs to be tested thoroughly.