### PR TITLE
Remove :person_id from session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,7 +221,6 @@ class ApplicationController < ActionController::Base
       )
 
       sign_out
-      session[:person_id] = nil
       flash[:notice] = t("layouts.notifications.automatically_logged_out_please_sign_in")
 
       redirect_to search_path
@@ -447,7 +446,7 @@ class ApplicationController < ActionController::Base
   end
 
   def clear_user_session
-    @current_user = session[:person_id] = nil
+    @current_user = nil
   end
 
   # this generates the event_id that will be used in

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -138,8 +138,6 @@ class PeopleController < Devise::RegistrationsController
       session[:invitation_code] = nil
     end
 
-    session[:person_id] = @person.id
-
     # If invite was used, reduce usages left
     invitation.use_once! if invitation.present?
 
@@ -192,7 +190,6 @@ class PeopleController < Devise::RegistrationsController
 
     @person.store_picture_from_facebook
 
-    session[:person_id] = @person.id
     sign_in(resource_name, @person)
     flash[:notice] = t("layouts.notifications.login_successful", :person_name => view_context.link_to(@person.given_name_or_username, person_path(@person))).html_safe
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -64,8 +64,6 @@ class SessionsController < ApplicationController
       redirect_to terms_path and return
     end
 
-    session[:person_id] = current_person.id
-
     flash[:notice] = t("layouts.notifications.login_successful", person_name: view_context.link_to(@current_user.given_name_or_username, person_path(@current_user))).html_safe
     if session[:return_to]
       redirect_to session[:return_to]
@@ -80,7 +78,6 @@ class SessionsController < ApplicationController
 
   def destroy
     sign_out
-    session[:person_id] = nil
     flash[:notice] = t("layouts.notifications.logout_successful")
     redirect_to landing_page_path
   end

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -30,7 +30,6 @@ class TermsController < ApplicationController
     end
 
     sign_in @current_user
-    session[:person_id] = session[:temp_person_id]
     session[:temp_cookie] = session[:temp_person_id] = nil
     session[:temp_community_id] = nil
     session[:consent_changed] = nil

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -19,7 +19,6 @@ describe ApplicationController, type: :controller do
 
     it "logs the user out from Sharetribe" do
       get :index
-      expect(session[:person_id]).to be_nil
       expect(assigns("current_user")).to be_nil
     end
 


### PR DESCRIPTION
`:person_id` is stored in session in a few places but as it is never read it is removed from session altogether.