### PR TITLE
Add translation fallback mechanism

### DIFF
--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -1,0 +1,55 @@
+module TranslationHelper
+  class NewTranslationOrFallback
+
+    def initialize(new_translation = nil)
+      @new_translation = new_translation
+    end
+
+    def or_fallback_to(tr_key, opts = {})
+      @new_translation || I18n.translate(tr_key, opts)
+    end
+  end
+
+  # Uses translations key or a fallback, if the first given key is translated in the current language
+  #
+  # Usage:
+  #
+  # # yml:
+  # build_a_vehicle_with_four_wheels: Build a vehicle with four wheels.
+  # build_a_car: Build a car.
+  # build_a_vehicle_that_flies: Build a vehicle that flies.
+  # build_an_airplane: ~
+  # count_apples: "There are #{count} appels"
+  # apples:
+  #   one: "#{count} apple"
+  #   other:
+  #
+  # # haml:
+  #
+  # use_new_translation("build_a_car").or_fallback_to("build_a_vehicle_with_four_wheels")
+  # => "Build a car."
+  #
+  # use_new_translation("build_an_airplane").or_fallback_to("build_a_vehicle_that_flies")
+  # => "Build a vehicle that flies."
+  #
+  # use_new_translation("apples", count: "1").or_fallback_to("count_apples")
+  # => "1 apple"
+  #
+  # use_new_translation("apples", count: "5").or_fallback_to("count_apples")
+  # => "There are 5 apples"
+  #
+  def use_new_translation(tr_key, opts = {})
+    begin
+      translation =
+        I18n.translate(tr_key, opts.merge(
+                         throw: true,        # Throw error, if not found
+                         fallback: true,     # Disable fallbacks (no idea why the value needs to be `true`
+                                             # instead of `false`. Feels counter intuitive)
+                       ))
+
+      NewTranslationOrFallback.new(translation)
+    rescue StandardError
+      NewTranslationOrFallback.new
+    end
+  end
+end

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -39,19 +39,17 @@ module TranslationHelper
   # => "There are 5 apples"
   #
   def use_new_translation(tr_key, opts = {})
-    begin
-      translation =
-        I18n.translate(tr_key, opts.merge(
-                         # Throw error, if not found
-                         # Disable fallbacks (no idea why the value needs to be `true`
-                         # instead of `false`. Feels counter intuitive)
-                         throw: true,
-                         fallback: true,
-                       ))
+    translation =
+      I18n.translate(tr_key, opts.merge(
+                       # Throw error, if not found
+                       # Disable fallbacks (no idea why the value needs to be `true`
+                       # instead of `false`. Feels counter intuitive)
+                       throw: true,
+                       fallback: true
+                     ))
 
-      NewTranslationOrFallback.new(translation)
-    rescue StandardError
-      NewTranslationOrFallback.new
-    end
+    NewTranslationOrFallback.new(translation)
+  rescue StandardError
+    NewTranslationOrFallback.new
   end
 end

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -42,9 +42,11 @@ module TranslationHelper
     begin
       translation =
         I18n.translate(tr_key, opts.merge(
-                         throw: true,        # Throw error, if not found
-                         fallback: true,     # Disable fallbacks (no idea why the value needs to be `true`
-                                             # instead of `false`. Feels counter intuitive)
+                         # Throw error, if not found
+                         # Disable fallbacks (no idea why the value needs to be `true`
+                         # instead of `false`. Feels counter intuitive)
+                         throw: true,
+                         fallback: true,
                        ))
 
       NewTranslationOrFallback.new(translation)

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -32,10 +32,10 @@ module TranslationHelper
   # use_new_translation("build_an_airplane").or_fallback_to("build_a_vehicle_that_flies")
   # => "Build a vehicle that flies."
   #
-  # use_new_translation("apples", count: "1").or_fallback_to("count_apples")
+  # use_new_translation("apples", count: "1").or_fallback_to("count_apples", count: 1)
   # => "1 apple"
   #
-  # use_new_translation("apples", count: "5").or_fallback_to("count_apples")
+  # use_new_translation("apples", count: "5").or_fallback_to("count_apples", count: 5)
   # => "There are 5 apples"
   #
   def use_new_translation(tr_key, opts = {})

--- a/app/views/transactions/_price_break_down.haml
+++ b/app/views/transactions/_price_break_down.haml
@@ -12,9 +12,9 @@
     .initiate-transaction-booking-wrapper
       %span.initiate-transaction-booking-label
         - if unit_type == :day
-          = t("transactions.initiate.booked_days")
+          = use_new_translation("transactions.initiate.booked_days_label", count: duration).or_fallback_to("transactions.initiate.booked_days")
         - else
-          = t("transactions.initiate.booked_nights")
+          = use_new_translation("transactions.initiate.booked_nights_label", count: duration).or_fallback_to("transactions.initiate.booked_nights")
       %span.initiate-transaction-booking-value
         = l start_on, format: :long_with_abbr_day_name
         = "-"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2036,6 +2036,12 @@ en:
     initiate:
       booked_days: "Booked days:"
       booked_nights: "Booked nights:"
+      booked_days_label:
+        one: "Booked day:"
+        other: "Booked days:"
+      booked_nights_label:
+        one: "Booked night:"
+        other: "Booked nights:"
       price_per_day: "Price per day:"
       price_per_night: "Price per night:"
       quantity: "Quantity:"


### PR DESCRIPTION
This PR adds a fallback mechanism for untranslated translation keys.

The default fallback mechanism in Rails provides a way to first look key A in language 1, then look key A in language 2.

This fallback mechanism lets us look key A in language 1 and if that is not found, then key B in language 1. Only after that, the default fallback mechanism tries to look for key B in language 2.

This way we can start using new translations and "deprecate" the old translations. Without this mechanism, users would see wrong language (most likely English) in the UI when we change translations before translators have had change to translate them.