### PR TITLE
Fix an error where an email is sent to nil address

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,6 @@ Lint/AmbiguousRegexpLiteral:
 Lint/AssignmentInCondition:
   Exclude:
     - 'app/controllers/community_memberships_controller.rb'
-    - 'app/controllers/confirmations_controller.rb'
     - 'app/controllers/sessions_controller.rb'
     - 'app/models/category.rb'
     - 'app/models/community.rb'
@@ -772,7 +771,6 @@ Style/HashSyntax:
 Style/IdenticalConditionalBranches:
   Exclude:
     - 'app/controllers/admin/communities_controller.rb'
-    - 'app/controllers/confirmations_controller.rb'
 
 # Offense count: 7
 Style/IfInsideElse:


### PR DESCRIPTION
 - Refactor `confirmations_controller#create`
 - At the same time fix an issue where user has already confirmed an email address but is still on the confirm page and clicks confirm again

## How to reproduce

1. Sign up as a new user
2. Leave the confirmation page open
3. Confirm email
4. In the still open confirmation page click `Resend confirmation instructions`

*Expected:* User is redirected to search page
*Actual*: An exception is thrown