### PR TITLE
Remove old_process column from transaction_processes

### DIFF
--- a/app/models/transaction_process.rb
+++ b/app/models/transaction_process.rb
@@ -8,7 +8,6 @@
 #  author_is_seller :boolean
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  old_process      :string(32)
 #
 # Indexes
 #

--- a/db/migrate/20160902103712_remove_old_process_column_from_transaction_processes.rb
+++ b/db/migrate/20160902103712_remove_old_process_column_from_transaction_processes.rb
@@ -1,0 +1,5 @@
+class RemoveOldProcessColumnFromTransactionProcesses < ActiveRecord::Migration
+  def change
+    remove_column :transaction_processes, :old_process, :string, limit: 32, after: :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160831054910) do
+ActiveRecord::Schema.define(version: 20160902103712) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -927,7 +927,6 @@ ActiveRecord::Schema.define(version: 20160831054910) do
     t.boolean  "author_is_seller"
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
-    t.string   "old_process",      limit: 32
   end
 
   add_index "transaction_processes", ["community_id"], name: "index_transaction_process_on_community_id", using: :btree


### PR DESCRIPTION
The column was added to enable rolling back from an earlier migration,
but since that is not needed, we can remove the column.