### PR TITLE
Remove old_unit_type column from transactions

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -22,7 +22,6 @@
 #  listing_author_id                 :string(255)
 #  listing_title                     :string(255)
 #  unit_type                         :string(32)
-#  old_unit_type                     :string(32)
 #  unit_price_cents                  :integer
 #  unit_price_currency               :string(8)
 #  unit_tr_key                       :string(64)

--- a/app/models/transaction_process.rb
+++ b/app/models/transaction_process.rb
@@ -8,7 +8,6 @@
 #  author_is_seller :boolean
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  old_process      :string(32)
 #
 # Indexes
 #

--- a/db/migrate/20160902103712_remove_old_process_column_from_transaction_processes.rb
+++ b/db/migrate/20160902103712_remove_old_process_column_from_transaction_processes.rb
@@ -1,0 +1,5 @@
+class RemoveOldProcessColumnFromTransactionProcesses < ActiveRecord::Migration
+  def change
+    remove_column :transaction_processes, :old_process, :string, limit: 32, after: :updated_at
+  end
+end

--- a/db/migrate/20160902104733_remove_old_unit_type_column_from_transactions.rb
+++ b/db/migrate/20160902104733_remove_old_unit_type_column_from_transactions.rb
@@ -1,0 +1,5 @@
+class RemoveOldUnitTypeColumnFromTransactions < ActiveRecord::Migration
+  def change
+    remove_column :transactions, :old_unit_type, :string, limit: 32, after: :unit_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160902103712) do
+ActiveRecord::Schema.define(version: 20160902104733) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -963,7 +963,6 @@ ActiveRecord::Schema.define(version: 20160902103712) do
     t.string   "listing_author_id",                 limit: 255
     t.string   "listing_title",                     limit: 255
     t.string   "unit_type",                         limit: 32
-    t.string   "old_unit_type",                     limit: 32
     t.integer  "unit_price_cents",                  limit: 4
     t.string   "unit_price_currency",               limit: 8
     t.string   "unit_tr_key",                       limit: 64

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160831054910) do
+ActiveRecord::Schema.define(version: 20160902103712) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -927,7 +927,6 @@ ActiveRecord::Schema.define(version: 20160831054910) do
     t.boolean  "author_is_seller"
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
-    t.string   "old_process",      limit: 32
   end
 
   add_index "transaction_processes", ["community_id"], name: "index_transaction_process_on_community_id", using: :btree


### PR DESCRIPTION
The column was added to enable rolling back an earlier migration but is
not needed anymore.

Built on top of #2499 so only the last commit is relevant to this PR.