### PR TITLE
This change allows to add Google Search Console verification tag in CLP.

### DIFF
--- a/app/services/custom_landing_page/example_data.rb
+++ b/app/services/custom_landing_page/example_data.rb
@@ -309,7 +309,8 @@ JSON
       "description": {"type": "marketplace_data", "id": "description"},
       "publisher": {"type": "marketplace_data", "id": "name"},
       "copyright": {"type": "marketplace_data", "id": "name"},
-      "facebook_site_name": {"type": "marketplace_data", "id": "name"}
+      "facebook_site_name": {"type": "marketplace_data", "id": "name"},
+      "google_site_verification": {"value": "CHANGEME"}
     },
     "sections": [
         {

--- a/app/services/custom_landing_page/example_data.rb
+++ b/app/services/custom_landing_page/example_data.rb
@@ -19,7 +19,8 @@ module CustomLandingPage
     "description": {"type": "marketplace_data", "id": "description"},
     "publisher": {"type": "marketplace_data", "id": "name"},
     "copyright": {"type": "marketplace_data", "id": "name"},
-    "facebook_site_name": {"type": "marketplace_data", "id": "name"}
+    "facebook_site_name": {"type": "marketplace_data", "id": "name"},
+    "google_site_verification": {"value": "CHANGEME"}
   },
 
   "sections": [

--- a/app/views/landing_page/_meta.erb
+++ b/app/views/landing_page/_meta.erb
@@ -62,5 +62,5 @@
 <% end %>
 
 <% if p["google_site_verification"] %>
-  <meta name="google_site_verification" content="<%= p["google_site_verification"]["value"] %>" />
+  <meta name="google-site-verification" content="<%= p["google_site_verification"]["value"] %>" />
 <% end %>

--- a/app/views/landing_page/_meta.erb
+++ b/app/views/landing_page/_meta.erb
@@ -61,3 +61,6 @@
   <meta name="twitter:description" content="<%= p["description"]["value"] %>" />
 <% end %>
 
+<% if p["google_site_verification"] %>
+  <meta name="google_site_verification" content="<%= p["google_site_verification"]["value"] %>" />
+<% end %>

--- a/docs/landing-page-structure.md
+++ b/docs/landing-page-structure.md
@@ -51,7 +51,7 @@ The following values are set in `page`:
 * `twitter_image` is used to render `twitter:image` `meta` tag. Make sure it links to the correct hero image asset id or if you want to use a different asset, you can link to it.
 * `facebook_image` is used to render `og:image` `meta` tag. Make sure it links to the correct hero image asset id.
 * `title` is the page title. Defaults to marketplace name and slogan.
-* `google_site_verification`is the meta tag for Google search console verification code. You need to edit the default value to the correct verification code code. If you don't have a google verification code you can remove this line from the structure. 
+* `google_site_verification`is the value for meta tag for Google search console verification code. You need to edit the default value to the correct verification code code. If you don't have a google verification code you can remove this line from the structure. 
 
 `page` includes a number of other SEO-related keys. They default to appropriate values for the marketplace, but can be overriden, if desired.
 

--- a/docs/landing-page-structure.md
+++ b/docs/landing-page-structure.md
@@ -51,6 +51,7 @@ The following values are set in `page`:
 * `twitter_image` is used to render `twitter:image` `meta` tag. Make sure it links to the correct hero image asset id or if you want to use a different asset, you can link to it.
 * `facebook_image` is used to render `og:image` `meta` tag. Make sure it links to the correct hero image asset id.
 * `title` is the page title. Defaults to marketplace name and slogan.
+* `google_site_verification`is the meta tag for Google search console verification code. You need to edit the default value to the correct verification code code. If you don't have a google verification code you can remove this line from the structure. 
 
 `page` includes a number of other SEO-related keys. They default to appropriate values for the marketplace, but can be overriden, if desired.
 


### PR DESCRIPTION
Right now it is not possible to verify Google Search console for our CLP customers, adding this change in the meta file and updating the structure file for the CLP that require it, will allow us to add this tag. Very simple change that does not affect the customers that don't have it. 