### PR TITLE
Add rel=next and rel=prev links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Added date picker for "per night" listing unit type [#2481](https://github.com/sharetribe/sharetribe/pull/2481)
 - Added support for setting memory limits for image processing [#2521](https://github.com/sharetribe/sharetribe/pull/2521)
+- SEO: Added rel=next and rel=prev links to give a hint to crawlers about the paginated content [#2505](https://github.com/sharetribe/sharetribe/pull/2505)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Added date picker for "per night" listing unit type [#2481](https://github.com/sharetribe/sharetribe/pull/2481)
 - Added support for setting memory limits for image processing [#2521](https://github.com/sharetribe/sharetribe/pull/2521)
 - SEO: Added rel=next and rel=prev links to give a hint to crawlers about the paginated content [#2505](https://github.com/sharetribe/sharetribe/pull/2505)
+- Added _New layout_ admin page where marketplace admins can enable new layout designs for the whole marketplace or just for themselves to try out [#2338](https://github.com/sharetribe/sharetribe/pull/2338) and [#2469](https://github.com/sharetribe/sharetribe/pull/2469)
+- Added functionality to edit Post a new listing button text [#2448](https://github.com/sharetribe/sharetribe/pull/2448)
+
+### Removed
+
+- Removed configuration for TravisCI (CircleCI now fully in use) [#2489](https://github.com/sharetribe/sharetribe/pull/2489)
 
 ### Changed
 
-- Added _New layout_ admin page where marketplace admins can enable new layout designs for the whole marketplace or just for themselves to try out [#2338](https://github.com/sharetribe/sharetribe/pull/2338) and [#2469](https://github.com/sharetribe/sharetribe/pull/2469)
-- Added functionality to edit Post a new listing button text [#2448](https://github.com/sharetribe/sharetribe/pull/2448)
 - Updated React on Rails to 6.0.5 [#2428](https://github.com/sharetribe/sharetribe/pull/2428) and [#2472](https://github.com/sharetribe/sharetribe/pull/2472)
-- Removed configuration for TravisCI (CircleCI now fully in use) [#2489](https://github.com/sharetribe/sharetribe/pull/2489)
 
 ### Fixed
 

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -102,6 +102,7 @@ class HomepageController < ApplicationController
                  listing_shape_menu_enabled: listing_shape_menu_enabled,
                  main_search: main_search,
                  location_search_in_use: location_in_use,
+                 seo_pagination_links: seo_pagination_links(params, listings.current_page, listings.total_pages),
                  viewport: viewport }
       }.on_error { |e|
         flash[:error] = t("homepage.errors.search_engine_not_responding")
@@ -115,6 +116,7 @@ class HomepageController < ApplicationController
                  listing_shape_menu_enabled: listing_shape_menu_enabled,
                  main_search: main_search,
                  location_search_in_use: location_in_use,
+                 seo_pagination_links: seo_pagination_links(params, listings.current_page, listings.total_pages),
                  viewport: viewport }
       }
     end
@@ -348,6 +350,23 @@ class HomepageController < ApplicationController
         .map { |l| { center: [l.latitude, l.longitude] }}
         .or_else(nil)
     end
+  end
+
+  def seo_pagination_links(params, current_page, total_pages)
+    prev_page =
+      if current_page > 1
+        search_path(params.merge(page: current_page - 1))
+      end
+
+    next_page =
+      if current_page < total_pages
+        search_path(params.merge(page: current_page + 1))
+      end
+
+    {
+      prev: prev_page,
+      next: next_page
+    }
   end
 
 end

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -38,6 +38,12 @@
       - else
         = render partial: "search_bar"
 
+- content_for(:head) do
+  - if seo_pagination_links[:prev].present?
+    %link{rel: "prev", href: seo_pagination_links[:prev]}
+  - if seo_pagination_links[:next].present?
+    %link{rel: "next", href: seo_pagination_links[:next]}
+
 - if @current_community.private? && @big_cover_photo
   - if @community_customization && @community_customization.private_community_homepage_content
     .community-customization-wrapper


### PR DESCRIPTION
For better crawlability, Google recommends adding `rel=next` and `rel=prev` links to paginated content. This is especially important for infinite scroll, because the crawlers may not trigger the proper scroll events to see the content from the next pages.

This Pull Request adds those links to the "homepage" a.k.a "search page".

Read more:

* https://webmasters.googleblog.com/2014/02/infinite-scroll-search-friendly.html
* https://support.google.com/webmasters/answer/1663744