### PR TITLE
Listing shape availability

### DIFF
--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -153,7 +153,11 @@ window.ST.initializeListingShapeForm = function(formId) {
   var toggleRadio = function(el, state) {
     if(state) {
       el.prop('disabled', false);
-      el.first().prop('checked', true);
+
+      // Check the first one if none of the radiobuttons is checked
+      if (!el.is(":checked")) {
+        el.first().prop('checked', true);
+      }
     } else {
       el.prop('disabled', true);
       el.prop('checked', false);

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -86,11 +86,9 @@ window.ST.initializeListingShapeForm = function(formId) {
     if(enabled) {
       toggleAvailabilityUnitsEnabled(true);
       toggleUnitsEnabled(false);
-      $('.js-pricing-units-disabled-info').show();
     } else {
       toggleAvailabilityUnitsEnabled(false)
       toggleUnitsEnabled(true);
-      $('.js-pricing-units-disabled-info').hide();
     }
   }
 
@@ -107,6 +105,7 @@ window.ST.initializeListingShapeForm = function(formId) {
   var toggleUnitsEnabled = function(enabled) {
     toggleCheckbox($(".js-unit-checkbox"), enabled);
     toggleLabel($(".js-unit-label"), enabled);
+    toggleInfo($('.js-pricing-units-info'), enabled);
   };
 
   var toggleAvailabilityEnabled = function(enabled) {
@@ -117,6 +116,7 @@ window.ST.initializeListingShapeForm = function(formId) {
   var toggleAvailabilityUnitsEnabled = function(enabled) {
     toggleRadio($(".js-availability-unit"), enabled);
     toggleLabel($(".js-availability-unit-label"), enabled);
+    toggleInfo($('.js-pricing-units-disabled-info'), enabled)
   };
 
   var removeCustomUnit = function() {
@@ -161,6 +161,14 @@ window.ST.initializeListingShapeForm = function(formId) {
     } else {
       el.prop('disabled', true);
       el.prop('checked', false);
+    }
+  };
+
+  var toggleInfo = function(el, state) {
+    if (state) {
+      el.show();
+    } else {
+      el.hide();
     }
   };
 

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -93,30 +93,30 @@ window.ST.initializeListingShapeForm = function(formId) {
   }
 
   var toggleOnlinePaymentEnabled = function(enabled) {
-    toggleCheckbox($(".js-online-payments"), enabled);
-    toggleLabel($(".js-online-payments-label"), enabled);
+    toggleCheckboxEnabled($(".js-online-payments"), enabled);
+    toggleLabelEnabled($(".js-online-payments-label"), enabled);
   };
 
   var toggleShippingEnabled = function(enabled) {
-    toggleCheckbox($(".js-shipping-enabled"), enabled);
-    toggleLabel($(".js-shipping-enabled-label"), enabled);
+    toggleCheckboxEnabled($(".js-shipping-enabled"), enabled);
+    toggleLabelEnabled($(".js-shipping-enabled-label"), enabled);
   };
 
   var toggleUnitsEnabled = function(enabled) {
-    toggleCheckbox($(".js-unit-checkbox"), enabled);
-    toggleLabel($(".js-unit-label"), enabled);
-    toggleInfo($('.js-pricing-units-info'), enabled);
+    toggleCheckboxEnabled($(".js-unit-checkbox"), enabled);
+    toggleLabelEnabled($(".js-unit-label"), enabled);
+    toggleInfoEnabled($('.js-pricing-units-info'), enabled);
   };
 
   var toggleAvailabilityEnabled = function(enabled) {
-    toggleCheckbox($(".js-availability"), enabled);
-    toggleLabel($(".js-availability-label"), enabled);
+    toggleCheckboxEnabled($(".js-availability"), enabled);
+    toggleLabelEnabled($(".js-availability-label"), enabled);
   };
 
   var toggleAvailabilityUnitsEnabled = function(enabled) {
-    toggleRadio($(".js-availability-unit"), enabled);
-    toggleLabel($(".js-availability-unit-label"), enabled);
-    toggleInfo($('.js-pricing-units-disabled-info'), enabled)
+    toggleRadioEnabled($(".js-availability-unit"), enabled);
+    toggleLabelEnabled($(".js-availability-unit-label"), enabled);
+    toggleInfoEnabled($('.js-pricing-units-disabled-info'), enabled)
   };
 
   var removeCustomUnit = function() {
@@ -141,7 +141,7 @@ window.ST.initializeListingShapeForm = function(formId) {
     this.parentElement.remove();
   };
 
-  var toggleCheckbox = function(el, state) {
+  var toggleCheckboxEnabled = function(el, state) {
     if(state) {
       el.prop('disabled', false);
     } else {
@@ -150,7 +150,7 @@ window.ST.initializeListingShapeForm = function(formId) {
     }
   };
 
-  var toggleRadio = function(el, state) {
+  var toggleRadioEnabled = function(el, state) {
     if(state) {
       el.prop('disabled', false);
 
@@ -164,7 +164,7 @@ window.ST.initializeListingShapeForm = function(formId) {
     }
   };
 
-  var toggleInfo = function(el, state) {
+  var toggleInfoEnabled = function(el, state) {
     if (state) {
       el.show();
     } else {
@@ -172,7 +172,7 @@ window.ST.initializeListingShapeForm = function(formId) {
     }
   };
 
-  var toggleLabel = function(el, state) {
+  var toggleLabelEnabled = function(el, state) {
     el.toggleClass("listing-shape-label-disabled", !state);
   };
 

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -86,9 +86,11 @@ window.ST.initializeListingShapeForm = function(formId) {
     if(enabled) {
       toggleAvailabilityUnitsEnabled(true);
       toggleUnitsEnabled(false);
+      $('.js-pricing-units-disabled-info').show();
     } else {
       toggleAvailabilityUnitsEnabled(false)
       toggleUnitsEnabled(true);
+      $('.js-pricing-units-disabled-info').hide();
     }
   }
 

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -73,11 +73,24 @@ window.ST.initializeListingShapeForm = function(formId) {
   var onlinePaymentsChanged = function(currentEl) {
     var enabled = currentEl.is(':checked');
     if(enabled) {
+      toggleAvailabilityEnabled(true);
       toggleShippingEnabled(true);
     } else {
+      toggleAvailabilityEnabled(false);
       toggleShippingEnabled(false);
     }
   };
+
+  var availabilityChanged = function(currentEl) {
+    var enabled = currentEl.is(':checked');
+    if(enabled) {
+      toggleAvailabilityUnitsEnabled(true);
+      toggleUnitsEnabled(false);
+    } else {
+      toggleAvailabilityUnitsEnabled(false)
+      toggleUnitsEnabled(true);
+    }
+  }
 
   var toggleOnlinePaymentEnabled = function(enabled) {
     toggle($(".js-online-payments"), enabled);
@@ -92,6 +105,16 @@ window.ST.initializeListingShapeForm = function(formId) {
   var toggleUnitsEnabled = function(enabled) {
     toggle($(".js-unit-checkbox"), enabled);
     toggleLabel($(".js-unit-label"), enabled);
+  };
+
+  var toggleAvailabilityEnabled = function(enabled) {
+    toggle($(".js-availability"), enabled);
+    toggleLabel($(".js-availability-label"), enabled);
+  };
+
+  var toggleAvailabilityUnitsEnabled = function(enabled) {
+    toggle($(".js-availability-unit"), enabled);
+    toggleLabel($(".js-availability-unit-label"), enabled);
   };
 
   var removeCustomUnit = function() {
@@ -138,11 +161,14 @@ window.ST.initializeListingShapeForm = function(formId) {
   $('.js-listing-shape-add-custom-unit-link').click(function() {
     addCustomUnitForm();
   });
+  $('.js-availability').click(function() {
+    availabilityChanged($(this));
+  });
+
   $('.js-listing-shape-close-custom-unit-form').click(closeCustomUnitForm);
   $('.js-remove-custom-unit').click(removeCustomUnit);
 
   // Run once on init
   priceChanged($('.js-price-enabled'));
   onlinePaymentsChanged($('.js-online-payments'));
-
 };

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -67,6 +67,8 @@ window.ST.initializeListingShapeForm = function(formId) {
       toggleOnlinePaymentEnabled(false);
       toggleShippingEnabled(false);
       toggleUnitsEnabled(false);
+      toggleAvailabilityEnabled(false);
+      toggleAvailabilityUnitsEnabled(false);
     }
   };
 
@@ -75,9 +77,12 @@ window.ST.initializeListingShapeForm = function(formId) {
     if(enabled) {
       toggleAvailabilityEnabled(true);
       toggleShippingEnabled(true);
+      toggleUnitsEnabled(true);
     } else {
       toggleAvailabilityEnabled(false);
+      toggleAvailabilityUnitsEnabled(false);
       toggleShippingEnabled(false);
+      toggleUnitsEnabled(true);
     }
   };
 

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -93,27 +93,27 @@ window.ST.initializeListingShapeForm = function(formId) {
   }
 
   var toggleOnlinePaymentEnabled = function(enabled) {
-    toggle($(".js-online-payments"), enabled);
+    toggleCheckbox($(".js-online-payments"), enabled);
     toggleLabel($(".js-online-payments-label"), enabled);
   };
 
   var toggleShippingEnabled = function(enabled) {
-    toggle($(".js-shipping-enabled"), enabled);
+    toggleCheckbox($(".js-shipping-enabled"), enabled);
     toggleLabel($(".js-shipping-enabled-label"), enabled);
   };
 
   var toggleUnitsEnabled = function(enabled) {
-    toggle($(".js-unit-checkbox"), enabled);
+    toggleCheckbox($(".js-unit-checkbox"), enabled);
     toggleLabel($(".js-unit-label"), enabled);
   };
 
   var toggleAvailabilityEnabled = function(enabled) {
-    toggle($(".js-availability"), enabled);
+    toggleCheckbox($(".js-availability"), enabled);
     toggleLabel($(".js-availability-label"), enabled);
   };
 
   var toggleAvailabilityUnitsEnabled = function(enabled) {
-    toggle($(".js-availability-unit"), enabled);
+    toggleRadio($(".js-availability-unit"), enabled);
     toggleLabel($(".js-availability-unit-label"), enabled);
   };
 
@@ -139,9 +139,19 @@ window.ST.initializeListingShapeForm = function(formId) {
     this.parentElement.remove();
   };
 
-  var toggle = function(el, state) {
+  var toggleCheckbox = function(el, state) {
     if(state) {
       el.prop('disabled', false);
+    } else {
+      el.prop('disabled', true);
+      el.prop('checked', false);
+    }
+  };
+
+  var toggleRadio = function(el, state) {
+    if(state) {
+      el.prop('disabled', false);
+      el.first().prop('checked', true);
     } else {
       el.prop('disabled', true);
       el.prop('checked', false);
@@ -171,4 +181,5 @@ window.ST.initializeListingShapeForm = function(formId) {
   // Run once on init
   priceChanged($('.js-price-enabled'));
   onlinePaymentsChanged($('.js-online-payments'));
+  availabilityChanged($('.js-availability'));
 };

--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -23,18 +23,6 @@
 #
 
 class ListingShape < ActiveRecord::Base
-  attr_accessible(
-    :community_id,
-    :transaction_process_id,
-    :price_enabled,
-    :shipping_enabled,
-    :name,
-    :sort_priority,
-    :name_tr_key,
-    :action_button_tr_key,
-    :price_quantity_placeholder,
-    :deleted
-  )
 
   has_and_belongs_to_many :categories, -> { order("sort_priority") }, join_table: "category_listing_shapes"
   has_many :listing_units

--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -14,6 +14,7 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  deleted                :boolean          default(FALSE)
+#  availability           :string(32)       default("none")
 #
 # Indexes
 #

--- a/app/models/listing_unit.rb
+++ b/app/models/listing_unit.rb
@@ -18,14 +18,6 @@
 #
 
 class ListingUnit < ActiveRecord::Base
-  attr_accessible(
-    :listing_shape_id,
-    :unit_type,
-    :name_tr_key,
-    :selector_tr_key,
-    :quantity_selector,
-    :kind
-  )
 
   def self.columns
     super.reject { |c| c.name == "translation_key"}

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -19,7 +19,8 @@ module FeatureFlagService::Store
     FLAGS = [
       :export_transactions_as_csv,
       :topbar_v1,
-      :searchpage_v1
+      :searchpage_v1,
+      :availability
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/services/listing_service/api/shapes.rb
+++ b/app/services/listing_service/api/shapes.rb
@@ -25,10 +25,12 @@ module ListingService::API
     end
 
     def create(community_id:, opts:)
-      Result::Success.new(ShapeStore.create(
-        community_id: community_id,
-        opts: opts
-      ))
+      validate_upsert_opts(opts).and_then { |opts|
+        Result::Success.new(ShapeStore.create(
+                              community_id: community_id,
+                              opts: opts
+                            ))
+      }
     end
 
     def update(community_id:, listing_shape_id: nil, name: nil, opts:)
@@ -39,10 +41,12 @@ module ListingService::API
       }
 
       validate_find_opts(find_opts, unique_result_required: true).and_then { |f_opts|
-        Maybe(ShapeStore.update(f_opts.merge(opts: opts))).map { |shape|
+        validate_upsert_opts(f_opts.merge(opts: opts))
+      }.and_then { |update_opts|
+        Maybe(ShapeStore.update(update_opts)).map { |shape|
           Result::Success.new(shape)
         }.or_else {
-          Result::Error.new("Cannot find listing shape for #{f_opts}")
+          Result::Error.new("Cannot find listing shape for #{find_opts}")
         }
       }
     end
@@ -64,6 +68,19 @@ module ListingService::API
     end
 
     private
+
+    def validate_upsert_opts(opts)
+      error =
+        if opts[:availability] == :booking
+          if opts[:units].length != 1
+            Result::Error.new("Only one unit is allowed if booking availability is in use. Was: #{opts[:units].inspect}")
+          elsif ![:day, :night].include?(opts[:units].first[:type])
+            Result::Error.new("Only day or night unit is allowed if booking availability is in use. Was: #{opts[:units].inspect}")
+          end
+        end
+
+      error || Result::Success.new(opts)
+    end
 
     def validate_find_opts(opts, unique_result_required:)
       if opts[:listing_shape_id].present? && opts[:name].present?

--- a/app/services/listing_service/api/shapes.rb
+++ b/app/services/listing_service/api/shapes.rb
@@ -25,10 +25,10 @@ module ListingService::API
     end
 
     def create(community_id:, opts:)
-      validate_upsert_opts(opts).and_then { |opts|
+      validate_upsert_opts(opts).and_then { |valid_opts|
         Result::Success.new(ShapeStore.create(
                               community_id: community_id,
-                              opts: opts
+                              opts: valid_opts
                             ))
       }
     end

--- a/app/services/listing_service/store/shape.rb
+++ b/app/services/listing_service/store/shape.rb
@@ -13,7 +13,8 @@ module ListingService::Store::Shape
     [:shipping_enabled, :bool, :mandatory],
     [:units, :array, default: []], # Mandatory only if price_enabled
     [:sort_priority, :fixnum],
-    [:basename, :string, :mandatory]
+    [:basename, :string, :mandatory],
+    [:availability, :symbol, one_of: [:none, :booking], default: :none] # Possibly :stock in the future
   )
 
   Shape = EntityUtils.define_builder(
@@ -27,7 +28,8 @@ module ListingService::Store::Shape
     [:shipping_enabled, :bool, :mandatory],
     [:name, :string, :mandatory],
     [:sort_priority, :fixnum, default: 0],
-    [:category_ids, :array]
+    [:category_ids, :array],
+    [:availability, :to_symbol, one_of: [:none, :booking]]
   )
 
   UpdateShape = EntityUtils.define_builder(
@@ -37,7 +39,8 @@ module ListingService::Store::Shape
     [:transaction_process_id, :fixnum],
     [:units, :array],
     [:shipping_enabled, :bool],
-    [:sort_priority, :fixnum]
+    [:sort_priority, :fixnum],
+    [:availability, :symbol, one_of: [:none, :booking], default: :none] # Possibly :stock in the future
   )
 
   BuiltInUnit = EntityUtils.define_builder(

--- a/app/view_utils/listing_shape_data_types.rb
+++ b/app/view_utils/listing_shape_data_types.rb
@@ -37,7 +37,8 @@ module ListingShapeDataTypes
     [:price_enabled, transform_with: CHECKBOX],
     [:online_payments, transform_with: CHECKBOX],
     [:units, default: [], collection: Unit],
-    [:author_is_seller, :bool]
+    [:author_is_seller, :bool],
+    [:availability, :to_symbol, one_of: [:none, :booking], default: :none] # also stock, in the future
   )
 
   KEY_MAP = {

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -81,7 +81,9 @@
 .row
   .col-12
     = label_tag("units_title", t("admin.listing_shapes.units_title"), class: "input")
-    = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.units_desc")}
+
+    .js-pricing-units-info.hidden
+      = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.units_desc")}
 
     - if feature_enabled?(:availability)
       .js-pricing-units-disabled-info.hidden

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -56,30 +56,37 @@
       = check_box_tag(:shipping_enabled, "true", shape[:shipping_enabled], class: "checkbox-row-checkbox js-shipping-enabled")
       = label_tag(:shipping_enabled, t("admin.listing_shapes.shipping_label"), class: "checkbox-row-label js-shipping-enabled-label")
 
-- unless uneditable_fields[:availability]
+- if feature_enabled?(:availability)
+  - unless uneditable_fields[:availability]
 
-  .row
-    .col-12
-      = label_tag("", t("admin.listing_shapes.availability_title"), class: "input")
+    .row
+      .col-12
+        = label_tag("", t("admin.listing_shapes.availability_title"), class: "input")
 
-  .row
-    .col-12
-      = check_box_tag(:availability, "booking", shape[:availability] == :booking, class: "checkbox-row-checkbox js-availability")
-      = label_tag(:availability, t("admin.listing_shapes.allow_availability_management"), class: "checkbox-row-label js-availability-label")
+    .row
+      .col-12
+        = check_box_tag(:availability, "booking", shape[:availability] == :booking, class: "checkbox-row-checkbox js-availability")
+        = label_tag(:availability, t("admin.listing_shapes.allow_availability_management"), class: "checkbox-row-label js-availability-label")
 
-  .row
-    .col-12
-      = radio_button_tag(:availability_unit, "day", shape[:availability] == :booking && shape[:availability_unit] == :day, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
-      = label_tag(:availability, t("admin.listing_shapes.per_day_availability"), class: "checkbox-row-label js-availability-unit-label")
+    .row
+      .col-12
+        = radio_button_tag(:availability_unit, "day", shape[:availability] == :booking && shape[:availability_unit] == :day, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
+        = label_tag(:availability, t("admin.listing_shapes.per_day_availability"), class: "checkbox-row-label js-availability-unit-label")
 
-  .row
-    .col-12
-      = radio_button_tag(:availability_unit, "night", shape[:availability] == :booking && shape[:availability_unit] == :night, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
-      = label_tag(:availability, t("admin.listing_shapes.per_night_availability"), class: "checkbox-row-label js-availability-unit-label")
+    .row
+      .col-12
+        = radio_button_tag(:availability_unit, "night", shape[:availability] == :booking && shape[:availability_unit] == :night, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
+        = label_tag(:availability, t("admin.listing_shapes.per_night_availability"), class: "checkbox-row-label js-availability-unit-label")
+
 .row
   .col-12
     = label_tag("units_title", t("admin.listing_shapes.units_title"), class: "input")
     = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.units_desc")}
+
+    - if feature_enabled?(:availability)
+      .js-pricing-units-disabled-info.hidden
+        = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.pricing_units_disabled_info")}
+
 - shape[:predefined_units].map do |unit|
   .row
     .col-12

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -69,12 +69,12 @@
 
   .row
     .col-12
-      = radio_button_tag(:availability_unit, "day", shape[:availability_unit] == :day, disabled: true, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
+      = radio_button_tag(:availability_unit, "day", shape[:availability] == :booking && shape[:availability_unit] == :day, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
       = label_tag(:availability, t("admin.listing_shapes.per_day_availability"), class: "checkbox-row-label js-availability-unit-label")
 
   .row
     .col-12
-      = radio_button_tag(:availability_unit, "night", shape[:availability_unit] == :night, disabled: true, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
+      = radio_button_tag(:availability_unit, "night", shape[:availability] == :booking && shape[:availability_unit] == :night, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
       = label_tag(:availability, t("admin.listing_shapes.per_night_availability"), class: "checkbox-row-label js-availability-unit-label")
 .row
   .col-12

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -56,6 +56,26 @@
       = check_box_tag(:shipping_enabled, "true", shape[:shipping_enabled], class: "checkbox-row-checkbox js-shipping-enabled")
       = label_tag(:shipping_enabled, t("admin.listing_shapes.shipping_label"), class: "checkbox-row-label js-shipping-enabled-label")
 
+- unless uneditable_fields[:availability]
+
+  .row
+    .col-12
+      = label_tag("", t("admin.listing_shapes.availability_title"), class: "input")
+
+  .row
+    .col-12
+      = check_box_tag(:availability, "booking", shape[:availability] == :booking, class: "checkbox-row-checkbox js-availability")
+      = label_tag(:availability, t("admin.listing_shapes.allow_availability_management"), class: "checkbox-row-label js-availability-label")
+
+  .row
+    .col-12
+      = radio_button_tag(:availability_unit, "day", shape[:availability_unit] == :day, disabled: true, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
+      = label_tag(:availability, t("admin.listing_shapes.per_day_availability"), class: "checkbox-row-label js-availability-unit-label")
+
+  .row
+    .col-12
+      = radio_button_tag(:availability_unit, "night", shape[:availability_unit] == :night, disabled: true, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
+      = label_tag(:availability, t("admin.listing_shapes.per_night_availability"), class: "checkbox-row-label js-availability-unit-label")
 .row
   .col-12
     = label_tag("units_title", t("admin.listing_shapes.units_title"), class: "input")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,10 @@ en:
       online_payments_label: "Allow sellers to accept payments online"
       shipping_label: "Allow sellers to define a shipping fee"
       price_label: "Allow sellers to add a price to their listings"
+      availability_title: "Availability"
+      allow_availability_management: "Allow providers to manage their availability from a calendar"
+      per_day_availability: "\"Per day\" availability"
+      per_night_availability: "\"Per night\" availability"
       units_title: "Pricing units"
       units_desc: "If you have enabled pricing units, the listing price is displayed as \"price per pricing unit\". An example: \"$39 per hour\"."
       units:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,10 +444,6 @@ en:
       online_payments_label: "Allow sellers to accept payments online"
       shipping_label: "Allow sellers to define a shipping fee"
       price_label: "Allow sellers to add a price to their listings"
-      availability_title: "Availability"
-      allow_availability_management: "Allow providers to manage their availability from a calendar"
-      per_day_availability: "\"Per day\" availability"
-      per_night_availability: "\"Per night\" availability"
       units_title: "Pricing units"
       units_desc: "If you have enabled pricing units, the listing price is displayed as \"price per pricing unit\". An example: \"$39 per hour\"."
       units:

--- a/config/locales/unreleased_features/en.yml
+++ b/config/locales/unreleased_features/en.yml
@@ -1,1 +1,8 @@
 en:
+  admin:
+    listing_shapes:
+      availability_title: "Availability"
+      allow_availability_management: "Allow providers to manage their availability from a calendar"
+      per_day_availability: "\"Per day\" availability"
+      per_night_availability: "\"Per night\" availability"
+      pricing_units_disabled_info: Pricing units cannot be used when availability calendar is enabled.

--- a/db/migrate/20160907095103_add_availability_to_listing_shape.rb
+++ b/db/migrate/20160907095103_add_availability_to_listing_shape.rb
@@ -1,5 +1,5 @@
 class AddAvailabilityToListingShape < ActiveRecord::Migration
   def change
-    add_column :listing_shapes, :availability, :string, limit: 32, default: "none"
+    add_column :listing_shapes, :availability, :string, limit: 32, default: "none", after: :shipping_enabled
   end
 end

--- a/db/migrate/20160907095103_add_availability_to_listing_shape.rb
+++ b/db/migrate/20160907095103_add_availability_to_listing_shape.rb
@@ -1,0 +1,5 @@
+class AddAvailabilityToListingShape < ActiveRecord::Migration
+  def change
+    add_column :listing_shapes, :availability, :string, limit: 32, default: "none"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -481,6 +481,7 @@ ActiveRecord::Schema.define(version: 20160907095103) do
     t.integer  "transaction_process_id", limit: 4,                    null: false
     t.boolean  "price_enabled",                                       null: false
     t.boolean  "shipping_enabled",                                    null: false
+    t.string   "availability",           limit: 32,  default: "none"
     t.string   "name",                   limit: 255,                  null: false
     t.string   "name_tr_key",            limit: 255,                  null: false
     t.string   "action_button_tr_key",   limit: 255,                  null: false
@@ -488,7 +489,6 @@ ActiveRecord::Schema.define(version: 20160907095103) do
     t.datetime "created_at",                                          null: false
     t.datetime "updated_at",                                          null: false
     t.boolean  "deleted",                            default: false
-    t.string   "availability",           limit: 32,  default: "none"
   end
 
   add_index "listing_shapes", ["community_id", "deleted", "sort_priority"], name: "multicol_index", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160902104733) do
+ActiveRecord::Schema.define(version: 20160907095103) do
 
   create_table "auth_tokens", force: :cascade do |t|
     t.string   "token",            limit: 255
@@ -477,17 +477,18 @@ ActiveRecord::Schema.define(version: 20160902104733) do
   add_index "listing_images", ["listing_id"], name: "index_listing_images_on_listing_id", using: :btree
 
   create_table "listing_shapes", force: :cascade do |t|
-    t.integer  "community_id",           limit: 4,                   null: false
-    t.integer  "transaction_process_id", limit: 4,                   null: false
-    t.boolean  "price_enabled",                                      null: false
-    t.boolean  "shipping_enabled",                                   null: false
-    t.string   "name",                   limit: 255,                 null: false
-    t.string   "name_tr_key",            limit: 255,                 null: false
-    t.string   "action_button_tr_key",   limit: 255,                 null: false
-    t.integer  "sort_priority",          limit: 4,   default: 0,     null: false
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
+    t.integer  "community_id",           limit: 4,                    null: false
+    t.integer  "transaction_process_id", limit: 4,                    null: false
+    t.boolean  "price_enabled",                                       null: false
+    t.boolean  "shipping_enabled",                                    null: false
+    t.string   "name",                   limit: 255,                  null: false
+    t.string   "name_tr_key",            limit: 255,                  null: false
+    t.string   "action_button_tr_key",   limit: 255,                  null: false
+    t.integer  "sort_priority",          limit: 4,   default: 0,      null: false
+    t.datetime "created_at",                                          null: false
+    t.datetime "updated_at",                                          null: false
     t.boolean  "deleted",                            default: false
+    t.string   "availability",           limit: 32,  default: "none"
   end
 
   add_index "listing_shapes", ["community_id", "deleted", "sort_priority"], name: "multicol_index", using: :btree

--- a/spec/services/admin_category_service_spec.rb
+++ b/spec/services/admin_category_service_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe Admin::CategoryService do
 
   before(:each) do

--- a/spec/services/listing_service/api/shapes_spec.rb
+++ b/spec/services/listing_service/api/shapes_spec.rb
@@ -29,6 +29,7 @@ describe ListingService::API::Shapes do
       name_tr_key: name_tr_key,
       action_button_tr_key: action_button_tr_key,
       basename: "Selling",
+      availability: :none,
 
       units: [
         {
@@ -75,6 +76,7 @@ describe ListingService::API::Shapes do
         expect(shape[:action_button_tr_key]).to eql(action_button_tr_key)
         expect(shape[:category_ids].sort).to eq category_ids.sort
         expect(shape[:name]).to eql("selling")
+        expect(shape[:availability]).to eql(:none)
 
         units = shape[:units]
 
@@ -85,6 +87,41 @@ describe ListingService::API::Shapes do
         expect(units[1][:quantity_selector]).to eql(:number)
         expect(units[1][:name_tr_key]).to eql('my.custom.units.translation')
         expect(units[1][:selector_tr_key]).to eql('my.custom.selector.translation')
+      end
+
+      it "creates a new listing shape with availability" do
+        create_shape_res = create_shape(
+          availability: :booking,
+          units: [
+            {
+              type: :day,
+              quantity_selector: :day
+            }
+          ]
+        )
+
+        expect(create_shape_res.success).to eql(true)
+        listing_shape_id = create_shape_res.data[:id]
+        res = listings_api.shapes.get(community_id: community_id, listing_shape_id: listing_shape_id, include_categories: true)
+        expect(res.success).to eql(true)
+
+        shape = res.data
+
+        expect(shape[:id]).to be_a(Fixnum)
+        expect(shape[:community_id]).to eql(community_id)
+        expect(shape[:price_enabled]).to eql(true)
+        expect(shape[:shipping_enabled]).to eql(true)
+        expect(shape[:transaction_process_id]).to eql(transaction_process_id)
+        expect(shape[:name_tr_key]).to eql(name_tr_key)
+        expect(shape[:action_button_tr_key]).to eql(action_button_tr_key)
+        expect(shape[:category_ids].sort).to eq category_ids.sort
+        expect(shape[:name]).to eql("selling")
+        expect(shape[:availability]).to eq(:booking)
+
+        units = shape[:units]
+
+        expect(units[0][:type]).to eql(:day)
+        expect(units[0][:quantity_selector]).to eql(:day)
       end
     end
 


### PR DESCRIPTION
This PR adds availability calendar options to Order Types admin UI.

**Changes to datamodel**

A new column `availability` is added to `listing_shapes` table. Possible values for `availability` are `none` (default) and `booking`.

**UI changes**

A new section "Availability" is now added to Order Types admin UI. The availability can be enabled/disabled and doing so will enable/disable pricing units. In addition to choosing to use availability, the admin can choose whether "per day" or "per night" availability is used.

In the UI, we have two different "units". We have the "availability unit" (per day, per night, only one can be chosen) and "pricing units" (day, night, hour, week, etc. many can be chosen). However, in the data model, we have only the "pricing units". If availability is enabled (value is `booking`), we know that the unit `night` means the "per night availability unit". Because of this, we do some mapping on the controller, where we map UI value to data model values and vice versa.

**Screenshot**

![screen shot 2016-09-08 at 10 24 18](https://cloud.githubusercontent.com/assets/429876/18341872/bd11aee8-75b4-11e6-9a2f-4cf99d1d7243.png)


