### PR TITLE
Fixes bug in infinite scroll pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Correctly add https or http to links generated in `community.rb` [#2459](https://github.com/sharetribe/sharetribe/pull/2459)
 - Transactions in `initiated` state showed wrong total price in the transaction page if the item quantity was more than one [#2452](https://github.com/sharetribe/sharetribe/pull/2452)
+- Fix bug in infinite scroll: The current page was not taken into account [#2532](https://github.com/sharetribe/sharetribe/pull/2532)
 
 ## [5.11.0] - 2016-08-24
 

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -94,37 +94,29 @@ class HomepageController < ApplicationController
         render nothing: true, status: 500
       }
     else
+      locals = {
+        shapes: all_shapes,
+        filters: filters,
+        show_price_filter: show_price_filter,
+        selected_shape: selected_shape,
+        shape_name_map: shape_name_map,
+        listing_shape_menu_enabled: listing_shape_menu_enabled,
+        main_search: main_search,
+        location_search_in_use: location_in_use,
+        current_page: current_page,
+        current_search_path_without_page: search_path(params.except(:page)),
+        viewport: viewport }
+
       search_result.on_success { |listings|
         @listings = listings
-        render locals: {
-                 shapes: all_shapes,
-                 filters: filters,
-                 show_price_filter: show_price_filter,
-                 selected_shape: selected_shape,
-                 shape_name_map: shape_name_map,
-                 listing_shape_menu_enabled: listing_shape_menu_enabled,
-                 main_search: main_search,
-                 location_search_in_use: location_in_use,
-                 current_page: current_page,
-                 current_search_path_without_page: search_path(params.except(:page)),
-                 seo_pagination_links: seo_pagination_links(params, listings.current_page, listings.total_pages),
-                 viewport: viewport }
+        render locals: locals.merge(
+                 seo_pagination_links: seo_pagination_links(params, @listings.current_page, @listings.total_pages))
       }.on_error { |e|
         flash[:error] = t("homepage.errors.search_engine_not_responding")
         @listings = Listing.none.paginate(:per_page => 1, :page => 1)
-        render status: 500, locals: {
-                 shapes: all_shapes,
-                 filters: filters,
-                 show_price_filter: show_price_filter,
-                 selected_shape: selected_shape,
-                 shape_name_map: shape_name_map,
-                 listing_shape_menu_enabled: listing_shape_menu_enabled,
-                 main_search: main_search,
-                 location_search_in_use: location_in_use,
-                 current_page: current_page,
-                 current_search_path_without_page: search_path(params.except(:page)),
-                 seo_pagination_links: seo_pagination_links(params, listings.current_page, listings.total_pages),
-                 viewport: viewport }
+        render status: 500,
+               locals: locals.merge(
+                 seo_pagination_links: seo_pagination_links(params, @listings.current_page, @listings.total_pages))
       }
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,9 +117,10 @@ module ApplicationHelper
     end
   end
 
-  def pageless(total_pages, target_id, url=nil, loader_message='Loading more results')
+  def pageless(total_pages, target_id, url=nil, loader_message='Loading more results', current_page = 1)
 
     opts = {
+      :currentPage => current_page,
       :totalPages => total_pages,
       :url        => url,
       :loaderMsg  => loader_message,

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -153,7 +153,7 @@
           .home-loading-more
             = will_paginate(@listings)
             - item_container = if @view_type.eql?("grid") then '.home-fluid-thumbnail-grid' else '.home-listings' end
-            = pageless(@listings.total_pages, item_container, request.fullpath, t('.loading_more_content'))
+            = pageless(@listings.total_pages, item_container, current_search_path_without_page, t('.loading_more_content'), current_page)
       - else
         .home-no-listings
           - if params[:q] || params[:category] || params[:share_type] # Some filter in use


### PR DESCRIPTION
Steps to reproduce:

Prerequisite: marketplace with more than 50 listings

1. Go to URL /?page=2
2. Scroll down to fetch new listings

Expected result: Page 3 listings are loaded

Actual result: Page 2 listings are loaded