### PR TITLE
Add UUIDs to listings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,3 +183,5 @@ gem 'js-routes', '~> 1.2.5'
 
 # Color utilities needed for landing page
 gem 'color', '~> 1.8'
+
+gem 'uuidtools', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.2)
     unicode-display_width (0.3.1)
+    uuidtools (2.1.5)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -616,6 +617,7 @@ DEPENDENCIES
   truncate_html (~> 0.9.1)
   ts-delayed-delta (~> 2.0.2)!
   uglifier (~> 2.7.2)
+  uuidtools (~> 2.1)
   web-console (~> 2.0)
   web_translate_it (~> 2.1.8)
   will_paginate (~> 3.0.5)
@@ -625,4 +627,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.0

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -104,6 +104,19 @@ class Listing < ActiveRecord::Base
     self.updates_email_at ||= Time.now
   end
 
+  def uuid
+    if self[:uuid].nil?
+      nil
+    else
+      UUIDTools::UUID.parse_raw(self[:uuid])
+    end
+  end
+
+  before_create :add_uuid
+  def add_uuid
+    self.uuid ||= UUIDTools::UUID.timestamp_create.raw
+  end
+
   before_validation do
     # Normalize browser line-breaks.
     # Reason: Some browsers send line-break as \r\n which counts for 2 characters making the

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -4,6 +4,7 @@
 # Table name: listings
 #
 #  id                              :integer          not null, primary key
+#  uuid                            :binary(16)
 #  community_id                    :integer          not null
 #  author_id                       :string(255)
 #  category_old                    :string(255)

--- a/db/migrate/20160908091353_add_uuid_column_to_listings.rb
+++ b/db/migrate/20160908091353_add_uuid_column_to_listings.rb
@@ -1,0 +1,14 @@
+class AddUuidColumnToListings < ActiveRecord::Migration
+  def up
+    # `add_column` with `:binary, limit: 16` uses the VARBINARY type,
+    # but we want to use the BINARY type, which is why we use plain
+    # SQL here.
+    execute "ALTER TABLE listings ADD uuid BINARY(16) AFTER `id`"
+    # NOT NULL and UNIQUE constraints are coming in separate
+    # migrations once the old data is migrated
+  end
+
+  def down
+    remove_column :listings, :uuid
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -816,6 +816,7 @@ DROP TABLE IF EXISTS `listings`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `listings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `uuid` binary(16) DEFAULT NULL,
   `community_id` int(11) NOT NULL,
   `author_id` varchar(255) DEFAULT NULL,
   `category_old` varchar(255) DEFAULT NULL,
@@ -1556,7 +1557,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-13 11:40:21
+-- Dump completed on 2016-09-13 13:53:27
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3088,4 +3089,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160902103712');
 INSERT INTO schema_migrations (version) VALUES ('20160902104733');
 
 INSERT INTO schema_migrations (version) VALUES ('20160907095103');
+
+INSERT INTO schema_migrations (version) VALUES ('20160908091353');
 

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -3,6 +3,7 @@
 # Table name: listings
 #
 #  id                              :integer          not null, primary key
+#  uuid                            :binary(16)
 #  community_id                    :integer          not null
 #  author_id                       :string(255)
 #  category_old                    :string(255)


### PR DESCRIPTION
This PR adds a Version 1 [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) (sortable due to timestamp) to listings. UUIDs are stored as `BINARY(16)` in the Database to be efficient with storage.

UUIDs are generated automatically for new listings, and reading a UUID from a listing makes the binary -> `UUIDTools::UUID` conversion automatically. Migrations to add UUIDs to existing listings will come in separate PRs as well as constraints for uniqueness and non-nullness of the column value.