### PR TITLE
Add UUIDs to all listings

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -4,7 +4,7 @@
 # Table name: listings
 #
 #  id                              :integer          not null, primary key
-#  uuid                            :binary(16)
+#  uuid                            :binary(16)       not null
 #  community_id                    :integer          not null
 #  author_id                       :string(255)
 #  category_old                    :string(255)
@@ -56,6 +56,7 @@
 #  index_listings_on_listing_shape_id  (listing_shape_id)
 #  index_listings_on_new_category_id   (category_id)
 #  index_listings_on_open              (open)
+#  index_listings_on_uuid              (uuid) UNIQUE
 #  person_listings                     (community_id,author_id)
 #  updates_email_listings              (community_id,open,updates_email_at)
 #

--- a/db/migrate/20160913110411_add_uuid_to_existing_listings.rb
+++ b/db/migrate/20160913110411_add_uuid_to_existing_listings.rb
@@ -1,0 +1,5 @@
+class AddUuidToExistingListings < ActiveRecord::Migration
+  def change
+    execute "UPDATE listings SET uuid=UNHEX(REPLACE(UUID(), '-', '')) WHERE uuid IS NULL"
+  end
+end

--- a/db/migrate/20160913112734_add_unique_index_and_not_null_to_listing_uuids.rb
+++ b/db/migrate/20160913112734_add_unique_index_and_not_null_to_listing_uuids.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexAndNotNullToListingUuids < ActiveRecord::Migration
+  def change
+    change_column_null :listings, :uuid, false
+    add_index :listings, :uuid, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1557,7 +1557,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-13 13:53:27
+-- Dump completed on 2016-09-13 14:24:39
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3091,4 +3091,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160902104733');
 INSERT INTO schema_migrations (version) VALUES ('20160907095103');
 
 INSERT INTO schema_migrations (version) VALUES ('20160908091353');
+
+INSERT INTO schema_migrations (version) VALUES ('20160913110411');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -816,7 +816,7 @@ DROP TABLE IF EXISTS `listings`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `listings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `uuid` binary(16) DEFAULT NULL,
+  `uuid` binary(16) NOT NULL,
   `community_id` int(11) NOT NULL,
   `author_id` varchar(255) DEFAULT NULL,
   `category_old` varchar(255) DEFAULT NULL,
@@ -859,6 +859,7 @@ CREATE TABLE `listings` (
   `shipping_price_cents` int(11) DEFAULT NULL,
   `shipping_price_additional_cents` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `index_listings_on_uuid` (`uuid`),
   KEY `index_listings_on_new_category_id` (`category_id`) USING BTREE,
   KEY `person_listings` (`community_id`,`author_id`) USING BTREE,
   KEY `homepage_query` (`community_id`,`open`,`sort_date`,`deleted`) USING BTREE,
@@ -1557,7 +1558,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-13 14:24:39
+-- Dump completed on 2016-09-13 14:37:34
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3093,4 +3094,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160907095103');
 INSERT INTO schema_migrations (version) VALUES ('20160908091353');
 
 INSERT INTO schema_migrations (version) VALUES ('20160913110411');
+
+INSERT INTO schema_migrations (version) VALUES ('20160913112734');
 

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -3,7 +3,7 @@
 # Table name: listings
 #
 #  id                              :integer          not null, primary key
-#  uuid                            :binary(16)
+#  uuid                            :binary(16)       not null
 #  community_id                    :integer          not null
 #  author_id                       :string(255)
 #  category_old                    :string(255)
@@ -55,6 +55,7 @@
 #  index_listings_on_listing_shape_id  (listing_shape_id)
 #  index_listings_on_new_category_id   (category_id)
 #  index_listings_on_open              (open)
+#  index_listings_on_uuid              (uuid) UNIQUE
 #  person_listings                     (community_id,author_id)
 #  updates_email_listings              (community_id,open,updates_email_at)
 #


### PR DESCRIPTION
This PR is the second phase of adding UUIDs to listings and builds on top of #2534 

With new listings getting a UUID after the first phase, this adds UUIDs to existing listings and forces the table constraints so that the uuid cannot be null and has to be unique.