### PR TITLE
Add uuid column to communities

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -3,6 +3,7 @@
 # Table name: communities
 #
 #  id                                         :integer          not null, primary key
+#  uuid                                       :binary(16)
 #  ident                                      :string(255)
 #  domain                                     :string(255)
 #  use_domain                                 :boolean          default(FALSE), not null
@@ -252,6 +253,19 @@ class Community < ActiveRecord::Base
   process_in_background :favicon
 
   before_save :cache_previous_image_urls
+
+  def uuid
+    if self[:uuid].nil?
+      nil
+    else
+      UUIDTools::UUID.parse_raw(self[:uuid])
+    end
+  end
+
+  before_create :add_uuid
+  def add_uuid
+    self.uuid ||= UUIDTools::UUID.timestamp_create.raw
+  end
 
   validates_format_of :twitter_handle, with: /\A[A-Za-z0-9_]{1,15}\z/, allow_nil: true
 

--- a/db/migrate/20160914070509_add_uuid_column_to_communities.rb
+++ b/db/migrate/20160914070509_add_uuid_column_to_communities.rb
@@ -1,0 +1,9 @@
+class AddUuidColumnToCommunities < ActiveRecord::Migration
+  def up
+    execute "ALTER TABLE communities ADD uuid BINARY(16) AFTER `id`"
+  end
+
+  def down
+    remove_column :communities, :uuid
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -200,6 +200,7 @@ DROP TABLE IF EXISTS `communities`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `communities` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `uuid` binary(16) DEFAULT NULL,
   `ident` varchar(255) DEFAULT NULL,
   `domain` varchar(255) DEFAULT NULL,
   `use_domain` tinyint(1) NOT NULL DEFAULT '0',
@@ -1558,7 +1559,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-13 14:37:34
+-- Dump completed on 2016-09-14 10:12:45
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3096,4 +3097,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160908091353');
 INSERT INTO schema_migrations (version) VALUES ('20160913110411');
 
 INSERT INTO schema_migrations (version) VALUES ('20160913112734');
+
+INSERT INTO schema_migrations (version) VALUES ('20160914070509');
 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -4,6 +4,7 @@
 # Table name: communities
 #
 #  id                                         :integer          not null, primary key
+#  uuid                                       :binary(16)
 #  ident                                      :string(255)
 #  domain                                     :string(255)
 #  use_domain                                 :boolean          default(FALSE), not null


### PR DESCRIPTION
This PR is the first phase of adding UUIDs to marketplaces:

 - Add uuid column to the communities table to hold the binary value of the uuid
 - Start adding new uuid values to created marketplaces

The second phase will add uuids to existing marketplaces and adds constraints to the uuid value (not null, unique index).