### PR TITLE
Fixing one icon in CLP

### DIFF
--- a/app/views/landing_page/_icon.erb
+++ b/app/views/landing_page/_icon.erb
@@ -297,7 +297,7 @@
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10"><circle cx="12" cy="12" r="11.5"/><path d="M19.5 13.5c0 3.643-3.358 7-7.5 7-4.142 0-7.5-3.357-7.5-7h15zM9.5 8c0 2.646-4 2.643-4 0M14.5 8c0 2.645 4 2.643 4 0"/></g></svg>
 
 <% when "person-check-1" %>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="none" stroke-linejoin="round" stroke-miterlimit="10"><path stroke-linecap="round" d="M21 17l-3 3-2-2"/><circle cx="18.5" cy="18.5" r="5"/><g><path stroke-linecap="round" d="M12.5 14.5v-2.804M7.5 11.696V14.5l-5.01 1.79C1.298 16.715.5 17.846.5 19.113V21.5h11"/><ellipse cx="10" cy="6.5" rx="5" ry="6"/><path d="M14.953 5.953c-.168.02-.284.014-.453.047-1.703.328-2.797-.29-3.734-1.93C10.203 5.148 8.444 6 7 6c-.71 0-1.323-.146-1.936-.466"/></g></g></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="none" stroke-linejoin="round" stroke-miterlimit="10"><path stroke-linecap="round" d="M21 17l-3 3-2-2"/><circle cx="18.5" cy="18.5" r="5"/><path stroke-linecap="round" d="M12.5 14.5v-2.804M7.5 11.696V14.5l-5.01 1.79C1.298 16.715.5 17.846.5 19.113V21.5h11"/><ellipse cx="10" cy="6.5" rx="5" ry="6"/><path d="M14.953 5.953c-.168.02-.284.014-.453.047-1.703.328-2.797-.29-3.734-1.93C10.203 5.148 8.444 6 7 6c-.71 0-1.323-.146-1.936-.466"/></g></svg>
 
 <% end %>
 


### PR DESCRIPTION
This removes the double <g> in the last icon of the CLP icons file