### PR TITLE
Create bookable in Harmony API when creating a listing

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -176,6 +176,10 @@ class Person < ActiveRecord::Base
     set_default_preferences unless self.preferences
   end
 
+  def uuid
+    UUIDTools::UUID.parse_raw(Base64.urlsafe_decode64(self.id))
+  end
+
   # Creates a new email
   def email_attributes=(attributes)
     ActiveSupport::Deprecation.warn(

--- a/app/services/harmony_client.rb
+++ b/app/services/harmony_client.rb
@@ -1,0 +1,16 @@
+HarmonyClient = ServiceClient::Client.new(
+  APP_CONFIG.harmony_api_url,
+  {
+    initiate_booking: "/bookings/initiate",
+    create_bookable: "/bookables/create",
+    show_bookable: "/bookables/show",
+    query_timeslots: "/timeslots/query"
+  },
+  [
+    ServiceClient::Middleware::RequestID.new,
+    ServiceClient::Middleware::Timeout.new,
+    ServiceClient::Middleware::Logger.new,
+    ServiceClient::Middleware::Timing.new,
+    ServiceClient::Middleware::BodyEncoder.new(:transit_json)
+  ]
+)

--- a/app/utils/service_client/middleware/body_encoder.rb
+++ b/app/utils/service_client/middleware/body_encoder.rb
@@ -26,6 +26,16 @@ module ServiceClient
       end
     end
 
+    class TextEncoder
+      def encode(body)
+        body.to_s unless body.nil?
+      end
+
+      def decode(body)
+        body
+      end
+    end
+
     # Encodes the body to given encoding.
     #
     # The encoding is given to the constructor and that encoding is
@@ -40,6 +50,7 @@ module ServiceClient
         {encoding: :json, media_type: "application/json", encoder: JSONEncoder.new},
         {encoding: :transit_json, media_type: "application/transit+json", encoder: TransitEncoder.new(:json)},
         {encoding: :transit_msgpack, media_type: "application/transit+msgpack", encoder: TransitEncoder.new(:transit_msgpack)},
+        {encoding: :text, media_type: "text/plain", encoder: TextEncoder.new},
       ]
 
       class ParsingError < StandardError

--- a/app/utils/transit_utils.rb
+++ b/app/utils/transit_utils.rb
@@ -1,14 +1,46 @@
 module TransitUtils
+
+  class UUIDWriteHandler
+    def tag(_)
+      "u"
+    end
+
+    def rep(u)
+      Transit::UUID.new(u.to_s)
+    end
+
+    def string_rep(u)
+      u.to_s
+    end
+  end
+
+  class UUIDReadHandler
+    def from_rep(u)
+      UUIDTools::UUID.parse(u)
+    end
+  end
+
   module_function
 
   def encode(content, encoding)
     io = StringIO.new('', 'w+')
-    writer = Transit::Writer.new(encoding, io)
+
+    writer = Transit::Writer.new(
+      encoding,
+      io,
+      handlers: {
+        UUIDTools::UUID => UUIDWriteHandler.new
+      })
     writer.write(content)
     io.string
   end
 
   def decode(content, encoding)
-    Transit::Reader.new(encoding, StringIO.new(content)).read
+    Transit::Reader.new(
+      encoding,
+      StringIO.new(content),
+      handlers: {
+        "u" => UUIDReadHandler.new
+      }).read
   end
 end

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -284,6 +284,9 @@ default: &default_settings
   external_search_scale_min: 5
   external_search_offset_min: 0
 
+  # Harmony service API connection
+  harmony_api_url:
+
   # Perform Thinking Sphinx incremental indexing delayed jobs
   use_thinking_sphinx_indexing: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1367,6 +1367,7 @@ en:
       open_in_google_maps: "Open in Google Maps"
     error:
       something_went_wrong: "Something went wrong, error code: %{error_code}"
+      something_went_wrong_plain: "Something went wrong"
     follow_links:
       follow: "Get emails about new comments"
       unfollow: "Don't get emails about new comments"


### PR DESCRIPTION
This PR is the first step in integrating the new Harmony API to the application.

Using a new Harmony service client, a bookable is created in Harmony before a listing is created in the application. The following scenarios are accounted for:

1. Bookable creation succeeds -> listing creation continues
2. Bookable already created -> listing creation continues
3. Bookable creation fails -> listing is not created, error is shown to the user