### PR TITLE
Fix: min-width should not be applied to centered logo

### DIFF
--- a/client/app/components/sections/Topbar/Topbar.css
+++ b/client/app/components/sections/Topbar/Topbar.css
@@ -61,7 +61,6 @@
   /* End of base style overrides. */
 
   & .topbarLogo {
-    min-width: var(--Topbar_logoMinWidth);
     max-height: var(--Topbar_logoMaxHeightMobile);
     max-width: 70%;
 
@@ -73,6 +72,7 @@
     }
 
     @media (--medium-viewport) {
+      min-width: var(--Topbar_logoMinWidth);
       max-height: var(--Topbar_logoMaxHeightTablet);
       max-width: 38%;
     }


### PR DESCRIPTION
(it was set to prevent jumping menu)