### PR TITLE
Revert redirect logic in Sitemap#generate

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -33,14 +33,10 @@ class SitemapController < ActionController::Metal
 
   def generate
     com = community(request)
-    reason = redirect_reason(request)
 
-    if APP_CONFIG.asset_host.present? && !URLUtils.asset_host?(host: request.host_with_port, asset_host: APP_CONFIG.asset_host)
-      redirect_to ActionController::Base.helpers.asset_path(
-                    "/sitemap/#{request.host}/generate.xml.gz")
-    elsif !do_host_redirect!(com, reason) && !render_not_found!(reason) && can_show_sitemap?(com)
-      render_site_map(com)
-    end
+    return unless can_show_sitemap?(com)
+
+    render_site_map(com)
   end
 
   private


### PR DESCRIPTION
The #generate action has a bit different strategy for marketplace lookup and that's why the MarketplaceLookup middleware can't find the correct marketplace nor can it define the redirect reason.