### PR TITLE
Add missing listing_id to handle_proc_result method

### DIFF
--- a/app/controllers/paypal_service/checkout_orders_controller.rb
+++ b/app/controllers/paypal_service/checkout_orders_controller.rb
@@ -37,7 +37,7 @@ class PaypalService::CheckoutOrdersController < ApplicationController
           listing_id: transaction[:listing_id])
       }
     else
-      handle_proc_result(proc_status)
+      handle_proc_result(proc_status, transaction[:listing_id])
     end
 
   end
@@ -51,7 +51,7 @@ class PaypalService::CheckoutOrdersController < ApplicationController
       return redirect_to error_not_found_path
     end
 
-    handle_proc_result(proc_status[:data][:result])
+    handle_proc_result(proc_status[:data][:result], listing_id)
   end
 
   def cancel
@@ -67,7 +67,7 @@ class PaypalService::CheckoutOrdersController < ApplicationController
 
   private
 
-  def handle_proc_result(response)
+  def handle_proc_result(response, listing_id)
     response_data = response[:data] || {}
 
     if response[:success]


### PR DESCRIPTION
This PR fixes a regression that caused app to fail because of an undefined local variable `listing_id`.

The issue only appeared if user was doing PayPal payment and that payment failed for some reason.

How to test:

This is pretty difficult to test, but I tested it quite brutally by just adding `response[:success] = false` to the `handle_proc_result` method in `CheckoutOrdersController`:

```ruby
def handle_proc_result(response, listing_id)
  response[:success] = false
  response_data = response[:data] || {}

  ...
```


