### PR TITLE
Do not send testimonial reminders if user has disabled those

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Correctly add https or http to links generated in `community.rb` [#2459](https://github.com/sharetribe/sharetribe/pull/2459)
 - Transactions in `initiated` state showed wrong total price in the transaction page if the item quantity was more than one [#2452](https://github.com/sharetribe/sharetribe/pull/2452)
 - Fix bug in infinite scroll: The current page was not taken into account [#2532](https://github.com/sharetribe/sharetribe/pull/2532)
+- Fix bug: Testimonial reminders were sent even if user had disabled them [#2557](https://github.com/sharetribe/sharetribe/pull/2557)
 
 ## [5.11.0] - 2016-08-24
 


### PR DESCRIPTION
Steps to reproduce:

1. Create a listing as user A
2. Go to user A Profile > Notifications and uncheck "...I have forgotten to give feedback on an event".
3. Log in as user B and buy the listing from A
4. Log in as user A and accept the request
5. Log in as user B and confirm
6. Wait for 3 days (or change the value of `run_at` column in `delayed_jobs` table to run the TestimonialReminderJob immediately)

Expected result: User A doesn't get the reminder

Actual result: User A gets the reminder