### PR TITLE
Validate booking slots

### DIFF
--- a/app/services/harmony_client.rb
+++ b/app/services/harmony_client.rb
@@ -11,6 +11,7 @@ HarmonyClient = ServiceClient::Client.new(
     ServiceClient::Middleware::Timeout.new,
     ServiceClient::Middleware::Logger.new,
     ServiceClient::Middleware::Timing.new,
-    ServiceClient::Middleware::BodyEncoder.new(:transit_json)
+    ServiceClient::Middleware::BodyEncoder.new(:transit_json),
+    ServiceClient::Middleware::ParamEncoder.new
   ]
 )

--- a/app/utils/service_client/middleware/param_encoder.rb
+++ b/app/utils/service_client/middleware/param_encoder.rb
@@ -1,0 +1,28 @@
+module ServiceClient
+  module Middleware
+
+    class ParamEncoder < MiddlewareBase
+      def enter(ctx)
+        params = ctx[:req][:params]
+        ctx[:req][:params] = encode(params)
+        ctx
+      end
+
+      private
+
+      def encode(params)
+        Hash[params.map { |k, v| encode_param(k, v) }]
+      end
+
+      def encode_param(k, v)
+        case v
+        when Date
+          # Convert to format: 2016-09-20T06:36:58.085Z
+          [k, v.strftime("%FT%T.%LZ")]
+        else
+          [k, v.to_s]
+        end
+      end
+    end
+  end
+end

--- a/app/utils/service_client/middleware/result_mapper.rb
+++ b/app/utils/service_client/middleware/result_mapper.rb
@@ -12,7 +12,7 @@ module ServiceClient
               body: res[:body]
             )
           else
-            Result::Error.new(res[:body],
+            Result::Error.new(res[:body].to_s,
                               status: res[:status],
                               body: res[:body]
                              )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1599,6 +1599,8 @@ en:
       night: night
       nights: nights
       invalid_parameters: "Invalid values for new transaction"
+      dates_not_available: "Selected dates are not available"
+      error_in_checking_availability: "Could not check availavility for selected days"
     transaction_agreement_checkbox:
       read_more: View.
   mapview:

--- a/spec/services/result.rb
+++ b/spec/services/result.rb
@@ -92,6 +92,17 @@ describe Result do
       end
     end
 
+    describe "#rescue" do
+
+      it "returns the original success when rescued" do
+        expect_success(success.rescue { Result::Success.new(nil) }, 1)
+      end
+
+      it "returns the original success" do
+        expect_success(success.rescue { Result::Error.new(nil) }, 1)
+      end
+    end
+
     describe "#maybe" do
 
       it "returns Some(value)" do
@@ -184,6 +195,32 @@ describe Result do
 
       it "is a no-op" do
         expect_error(error.and_then { |v| Result::Success(v + 1) }, :error, 1)
+      end
+    end
+
+    describe "#rescue" do
+
+      it "rescues an error into a success" do
+        msg = "ok"
+        expect_success(error.rescue { Result::Success.new(msg) }, msg)
+      end
+
+      it "rescues an error into the same error" do
+        original_msg = error[:error_msg]
+        original_data = error[:data]
+        expect_error(error.rescue { |m, d| Result::Error.new(m, d) }, original_msg, original_data)
+      end
+
+      it "rescues an error into another error" do
+        new_msg = "new error message"
+        original_msg = error[:error_msg]
+        original_data = error[:data]
+        expect_error(
+          error.rescue { |m, d|
+            Result::Error.new(new_msg, { msg: m, data: d })
+          },
+          new_msg,
+          { msg: original_msg, data: original_data })
       end
     end
 

--- a/spec/utils/service_client/middleware/param_encoder_spec.rb
+++ b/spec/utils/service_client/middleware/param_encoder_spec.rb
@@ -1,0 +1,25 @@
+[
+  "app/utils/service_client/middleware/middleware_base",
+  "app/utils/service_client/middleware/param_encoder",
+].each { |file| require_relative "../../../../#{file}" }
+
+describe ServiceClient::Middleware::ParamEncoder do
+
+  let(:param_encoder) { ServiceClient::Middleware::ParamEncoder.new }
+
+  it "encodes values" do
+    d = DateTime.new(2016, 1, 31, 23, 30, 59)
+    params = {
+      string_value: "some string",
+      num_value: 123,
+      date_value: d
+    }
+    ctx = param_encoder.enter({ req: { params: params }})
+    expected = {
+      string_value: "some string",
+      num_value: "123",
+      date_value: "2016-01-31T23:30:59.000Z"
+    }
+    expect(ctx[:req][:params]).to eq(expected)
+  end
+end


### PR DESCRIPTION
This PR checks that the booking dates (between start date inclusive, end date exclusive) are available in the Harmony API before moving into payment.

## TODO

- [X] Date query param encoder to HarmonyClient
- [x] Query timeslots from Harmony
- [x] Validate all days/nights are available in Harmony response
- [x] Only validate timeslots with feature flag and availability turned on
- [x] Git cleanup