### PR TITLE
Check address before sending email

### DIFF
--- a/app/jobs/community_joined_job.rb
+++ b/app/jobs/community_joined_job.rb
@@ -16,8 +16,10 @@ class CommunityJoinedJob < Struct.new(:person_id, :community_id)
 
     if community.email_admins_about_new_members?
       community.admins.each do |admin|
-        MailCarrier.deliver_now(
-          PersonMailer.new_member_notification(new_member, community, admin))
+        email = PersonMailer.new_member_notification(new_member, community, admin)
+        if email.present?
+          MailCarrier.deliver_now(email)
+        end
       end
     end
   end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -256,10 +256,13 @@ class PersonMailer < ActionMailer::Base
     @person = new_member
     @email = new_member.emails.last.address
     with_locale(admin.locale, community.locales.map(&:to_sym), community.id) do
-      premailer_mail(:to => admin.confirmed_notification_emails_to,
-                     :from => community_specific_sender(community),
-                     :subject => "New member in #{@community.full_name(@person.locale)}",
-                     :template_name => "new_member_notification")
+      address = admin.confirmed_notification_email_to
+      if address.present?
+        premailer_mail(:to => address,
+                       :from => community_specific_sender(community),
+                       :subject => "New member in #{@community.full_name(@person.locale)}",
+                       :template_name => "new_member_notification")
+      end
     end
   end
 


### PR DESCRIPTION
If the email preference "Send admins an email whenever a new user signs up" is checked in admin/settings for a marketplace, admins get a notification email every time a user signs up to the marketplace. The notification email localisation was fixed in #2547 but afterwards there have been errors or missing SMTP To addresses and multiple emails sent for each new signup.

This PR fixes at least the missing To field error by checking the address before sending the email. The address is also taken from `admin.confirmed_notification_email_to` instead of `admin.confirmed_notification_emails_to` which might or might not fix the multiple emails problem. However, in the specific case reported to the support system, those admins only had a single email address, so the problem most likely comes from somewhere else.