### PR TITLE
Fixes regression: Add quantity pickers to free transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Transactions in `initiated` state showed wrong total price in the transaction page if the item quantity was more than one [#2452](https://github.com/sharetribe/sharetribe/pull/2452)
 - Fix bug in infinite scroll: The current page was not taken into account [#2532](https://github.com/sharetribe/sharetribe/pull/2532)
 - Fix bug: Testimonial reminders were sent even if user had disabled them [#2557](https://github.com/sharetribe/sharetribe/pull/2557)
+- Fix regression: Add quantity pickers to non-payment transactions [#2568](https://github.com/sharetribe/sharetribe/pull/2568)
 
 ## [5.11.0] - 2016-08-24
 

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -22,91 +22,87 @@
 
     = form_tag form_path, :method => :get, :id => "booking-dates" do
 
-      - # Currently we show the selectors only for preauth process.
-      - # However, there has been a plan to introduce these in other
-      - # Processes (free) as well - rap1ds, 2.6.2015
-      - if process == :preauthorize
-        - if [:day, :night].include?(@listing.quantity_selector&.to_sym)
-          - days = [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
-          - months = [:january, :february, :march, :april, :may, :june, :july, :august, :september, :october, :november, :december]
-          - translated_days = days.map { |day_symbol| t("datepicker.days.#{day_symbol}") }.to_json
-          - translated_days_short = days.map { |day_symbol| t("datepicker.days_short.#{day_symbol}") }.to_json
-          - translated_days_min = days.map { |day_symbol| t("datepicker.days_min.#{day_symbol}") }.to_json
-          - translated_months = months.map { |day_symbol| t("datepicker.months.#{day_symbol}") }.to_json
-          - translated_months_short = months.map { |day_symbol| t("datepicker.months_short.#{day_symbol}") }.to_json
+      - if [:day, :night].include?(@listing.quantity_selector&.to_sym)
+        - days = [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
+        - months = [:january, :february, :march, :april, :may, :june, :july, :august, :september, :october, :november, :december]
+        - translated_days = days.map { |day_symbol| t("datepicker.days.#{day_symbol}") }.to_json
+        - translated_days_short = days.map { |day_symbol| t("datepicker.days_short.#{day_symbol}") }.to_json
+        - translated_days_min = days.map { |day_symbol| t("datepicker.days_min.#{day_symbol}") }.to_json
+        - translated_months = months.map { |day_symbol| t("datepicker.months.#{day_symbol}") }.to_json
+        - translated_months_short = months.map { |day_symbol| t("datepicker.months_short.#{day_symbol}") }.to_json
 
-          - content_for :extra_javascript do
-            :javascript
-              $.fn.datepicker.dates['#{I18n.locale}'] = {
-                days: #{translated_days},
-                daysShort: #{translated_days_short},
-                daysMin: #{translated_days_min},
-                months: #{translated_months},
-                monthsShort: #{translated_months_short},
-                today: "#{t("datepicker.today")}",
-                weekStart: #{t("datepicker.week_start", default: 0)},
-                clear: "#{t("datepicker.clear")}",
-                format: "#{t("datepicker.format")}"
-              }
-              $.validator.addMethod("night_selected",
-                function(value, element, params) {
-                  var startVal = $(params.startOnSelector).val()
-                  if (!!startVal == false) {
-                    return true;
-                  } else {
-                    return startVal !== value
-                  }
-                });
-              var rules = #{@listing.quantity_selector&.to_sym == :night} ? {
-                "end_on": {night_selected: {startOnSelector: "#start-on"}}
-              } : {};
-              $("#booking-dates").validate({
-                rules: rules,
-                submitHandler: function(form) {
-                  var $form = $(form);
-                  $form.find("#start-on").attr("name", "");
-                  $form.find("#end-on").attr("name", "");
-
-                  form.submit();
+        - content_for :extra_javascript do
+          :javascript
+            $.fn.datepicker.dates['#{I18n.locale}'] = {
+              days: #{translated_days},
+              daysShort: #{translated_days_short},
+              daysMin: #{translated_days_min},
+              months: #{translated_months},
+              monthsShort: #{translated_months_short},
+              today: "#{t("datepicker.today")}",
+              weekStart: #{t("datepicker.week_start", default: 0)},
+              clear: "#{t("datepicker.clear")}",
+              format: "#{t("datepicker.format")}"
+            }
+            $.validator.addMethod("night_selected",
+              function(value, element, params) {
+                var startVal = $(params.startOnSelector).val()
+                if (!!startVal == false) {
+                  return true;
+                } else {
+                  return startVal !== value
                 }
               });
+            var rules = #{@listing.quantity_selector&.to_sym == :night} ? {
+              "end_on": {night_selected: {startOnSelector: "#start-on"}}
+            } : {};
+            $("#booking-dates").validate({
+              rules: rules,
+              submitHandler: function(form) {
+                var $form = $(form);
+                $form.find("#start-on").attr("name", "");
+                $form.find("#end-on").attr("name", "");
 
-              window.ST.initializeFromToDatePicker('datepicker');
-          .input-daterange.input-group.clearfix#datepicker{:data => {:locale => I18n.locale, :dateformat => t("datepicker.format")}}
-            .datepicker-start-wrapper
-              = label_tag t(".booking_from")
-              %input.input-sm.form-control.required#start-on{:type => 'text', :name => "start_on", :placeholder => t("datepicker.format"), :data => { :output => "booking-start-output" } }
-              %input#booking-start-output{:type => 'hidden', :name => 'start_on'}
-
-            .datepicker-end-wrapper
-              = label_tag t(".booking_to")
-              %input.input-sm.form-control.required#end-on{:type => 'text', :name => "end_on", :placeholder => t("datepicker.format"), :data => { :output => "booking-end-output" }}
-              %input#booking-end-output{:type => 'hidden', :name => 'end_on'}
-        - elsif listing_unit_type.present?
-          - delivery_type = delivery_opts.length > 0 ? delivery_opts.first[:name].to_s : ""
-          - shipping_price_additional = delivery_opts.length > 0 ? delivery_opts.first[:shipping_price_additional] : nil
-          - content_for :extra_javascript do
-            :javascript
-              $("#booking-dates").validate({
-                errorPlacement: function(error, element) {
-                  if (element.is("#quantity")) {
-                    error.insertAfter(".quantity-wrapper");
-                  } else {
-                    error.insertAfter(element);
-                  }
-                }
-              });
-              window.ST.initializeQuantityValidation({validate: "positiveIntegers", input: "quantity", errorMessage: "#{t("errors.messages.positive_number")}" });
-              if ("#{delivery_type}" == "shipping" && #{shipping_price_additional != nil}) {
-                window.ST.initializeShippingPriceTotal('#quantity', '.delivery-price-value', '#{Maybe(delivery_opts)[0][:price].currency.decimal_mark.or_else(".")}');
+                form.submit();
               }
+            });
 
-          .quantity-wrapper.input-group.clearfix
-            .quantity-label-wrapper
-              %label.quantity-label{for: 'quantity'}
-                = ListingViewUtils.translate_quantity(@listing.unit_type, @listing.unit_selector_tr_key)
-            .quantity-input.input-sm.required
-              %input#quantity{type: 'number', placeholder: t("listings.quantity_placeholder"), name: 'quantity', value: 1, min: 1, step: 1}
+            window.ST.initializeFromToDatePicker('datepicker');
+        .input-daterange.input-group.clearfix#datepicker{:data => {:locale => I18n.locale, :dateformat => t("datepicker.format")}}
+          .datepicker-start-wrapper
+            = label_tag t(".booking_from")
+            %input.input-sm.form-control.required#start-on{:type => 'text', :name => "start_on", :placeholder => t("datepicker.format"), :data => { :output => "booking-start-output" } }
+            %input#booking-start-output{:type => 'hidden', :name => 'start_on'}
+
+          .datepicker-end-wrapper
+            = label_tag t(".booking_to")
+            %input.input-sm.form-control.required#end-on{:type => 'text', :name => "end_on", :placeholder => t("datepicker.format"), :data => { :output => "booking-end-output" }}
+            %input#booking-end-output{:type => 'hidden', :name => 'end_on'}
+      - elsif listing_unit_type.present?
+        - delivery_type = delivery_opts.length > 0 ? delivery_opts.first[:name].to_s : ""
+        - shipping_price_additional = delivery_opts.length > 0 ? delivery_opts.first[:shipping_price_additional] : nil
+        - content_for :extra_javascript do
+          :javascript
+            $("#booking-dates").validate({
+              errorPlacement: function(error, element) {
+                if (element.is("#quantity")) {
+                  error.insertAfter(".quantity-wrapper");
+                } else {
+                  error.insertAfter(element);
+                }
+              }
+            });
+            window.ST.initializeQuantityValidation({validate: "positiveIntegers", input: "quantity", errorMessage: "#{t("errors.messages.positive_number")}" });
+            if ("#{delivery_type}" == "shipping" && #{shipping_price_additional != nil}) {
+              window.ST.initializeShippingPriceTotal('#quantity', '.delivery-price-value', '#{Maybe(delivery_opts)[0][:price].currency.decimal_mark.or_else(".")}');
+            }
+
+        .quantity-wrapper.input-group.clearfix
+          .quantity-label-wrapper
+            %label.quantity-label{for: 'quantity'}
+              = ListingViewUtils.translate_quantity(@listing.unit_type, @listing.unit_selector_tr_key)
+          .quantity-input.input-sm.required
+            %input#quantity{type: 'number', placeholder: t("listings.quantity_placeholder"), name: 'quantity', value: 1, min: 1, step: 1}
 
       = render partial: "delivery_opts", locals: { delivery_opts: delivery_opts, is_author: is_author }
 


### PR DESCRIPTION
This change fixes a regression that cause unit pickers to disappear from free transactions. The regression was introduced when Braintree was removed: https://github.com/sharetribe/sharetribe/commit/0576ef49dcc407bafb7bdc74b79caa61111d4a07#diff-52a764327d103b36fc6eaf963791edc1L28

History: When units were first introduced, the unit pickers were enabled only for non-free transactions. However, quite soon after that we changed it so that also free transactions can have unit pickers. During the Braintree removal, we mistakenly changed the `if` logic so that the only `preauthorize` transactions can have unit pickers. This was probably due to the fact that the comment above the if-block was misleading and out-dated.

Review tip: The diff contains a lot of whitespace changes, so [turning off the whitespaces from the diff](https://github.com/sharetribe/sharetribe/pull/2568/files?w=1) might make the review easier.