### PR TITLE
Rearranged marketplace UUIDs

### DIFF
--- a/app/controllers/free_transactions_controller.rb
+++ b/app/controllers/free_transactions_controller.rb
@@ -28,7 +28,7 @@ class FreeTransactionsController < ApplicationController
         {
           transaction: {
             community_id: @current_community.id,
-            community_uuid: @current_community.uuid,
+            community_uuid: @current_community.uuid_object,
             listing_id: @listing.id,
             listing_uuid: @listing.uuid,
             listing_title: @listing.title,

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -264,7 +264,7 @@ class ListingsController < ApplicationController
     listing_uuid = UUIDTools::UUID.timestamp_create
 
     if FeatureFlagHelper.feature_enabled?(:availability) && shape.present? && shape[:availability] == :booking
-      bookable_res = create_bookable(@current_community.uuid, listing_uuid, @current_user.uuid)
+      bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid)
       unless bookable_res.success
         flash[:error] = t("listings.error.something_went_wrong_plain")
         return redirect_to new_listing_path

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -225,7 +225,7 @@ class PreauthorizeTransactionsController < ApplicationController
         shipping_enabled: listing.require_shipping_address,
         pickup_enabled: listing.pickup_enabled)
 
-      Validator.validate_initiate_params(marketplace_uuid: @current_community.uuid,
+      Validator.validate_initiate_params(marketplace_uuid: @current_community.uuid_object,
                                          listing_uuid: listing.uuid,
                                          tx_params: tx_params,
                                          quantity_selector: listing.quantity_selector&.to_sym,
@@ -539,7 +539,7 @@ class PreauthorizeTransactionsController < ApplicationController
 
     transaction = {
           community_id: opts[:community].id,
-          community_uuid: opts[:community].uuid,
+          community_uuid: opts[:community].uuid_object,
           listing_id: opts[:listing].id,
           listing_uuid: opts[:listing].uuid,
           listing_title: opts[:listing].title,

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -75,7 +75,7 @@ class TransactionsController < ApplicationController
           {
             transaction: {
               community_id: @current_community.id,
-              community_uuid: @current_community.uuid,
+              community_uuid: @current_community.uuid_object,
               listing_id: listing_id,
               listing_uuid: listing_model.uuid,
               listing_title: listing_model.title,

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -253,17 +253,21 @@ class Community < ActiveRecord::Base
 
   before_save :cache_previous_image_urls
 
-  def uuid
+  def uuid_object
     if self[:uuid].nil?
       nil
     else
-      UUIDTools::UUID.parse_raw(self[:uuid])
+      UUIDUtils.parse_raw(self[:uuid])
     end
+  end
+
+  def uuid_object=(uuid)
+    self.uuid = UUIDUtils.raw(uuid)
   end
 
   before_create :add_uuid
   def add_uuid
-    self.uuid ||= UUIDTools::UUID.timestamp_create.raw
+    self.uuid ||= UUIDUtils.create_raw
   end
 
   validates_format_of :twitter_handle, with: /\A[A-Za-z0-9_]{1,15}\z/, allow_nil: true

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -605,6 +605,12 @@ class Community < ActiveRecord::Base
     favicon.processing?
   end
 
+  def as_json(options)
+    attrs = super(options)
+    uuid = UUIDUtils.parse_raw(attrs["uuid"])
+    attrs.merge({"uuid" => uuid.to_s})
+  end
+
   private
 
   def initialize_settings

--- a/db/migrate/20160926111847_rearrange_community_uuid_bytes.rb
+++ b/db/migrate/20160926111847_rearrange_community_uuid_bytes.rb
@@ -1,0 +1,14 @@
+class RearrangeCommunityUuidBytes < ActiveRecord::Migration
+  def up
+    mysql_conn = ActiveRecord::Base.connection.raw_connection
+
+    Community.pluck(:id).each_slice(1000) { |ids|
+      ActiveRecord::Base.transaction do
+        ids.each { |id|
+          statement = mysql_conn.prepare("UPDATE communities SET uuid=? where id=?")
+          statement.execute(UUIDUtils.create_raw, id)
+        }
+      end
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1586,7 +1586,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-21 20:21:21
+-- Dump completed on 2016-09-26 16:22:39
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3142,4 +3142,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160920102507');
 INSERT INTO schema_migrations (version) VALUES ('20160920103321');
 
 INSERT INTO schema_migrations (version) VALUES ('20160921130544');
+
+INSERT INTO schema_migrations (version) VALUES ('20160926111847');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -122,7 +122,7 @@ FactoryGirl.define do
     automatic_confirmation_after_days 14
     listing_quantity 1
     listing_uuid { listing.uuid.raw }
-    community_uuid { community.uuid.raw }
+    community_uuid { community.uuid } # raw UUID
   end
 
   factory :conversation do

--- a/spec/services/transaction_service/paypal_events_spec.rb
+++ b/spec/services/transaction_service/paypal_events_spec.rb
@@ -64,7 +64,7 @@ describe TransactionService::PaypalEvents do
       payment_process: :preauthorize,
       payment_gateway: :paypal,
       community_id: @cid,
-      community_uuid: @community.uuid.raw,
+      community_uuid: @community.uuid, # raw UUID
       starter_id: @payer.id,
       listing_id: @listing.id,
       listing_title: @listing.title,

--- a/spec/services/transaction_service/store/transaction_spec.rb
+++ b/spec/services/transaction_service/store/transaction_spec.rb
@@ -21,7 +21,7 @@ describe TransactionService::Store::Transaction do
       payment_process: :preauthorize,
       payment_gateway: :paypal,
       community_id: @cid,
-      community_uuid: @community.uuid,
+      community_uuid: @community.uuid_object,
       starter_id: @payer.id,
       listing_id: @listing.id,
       listing_uuid: @listing.uuid,


### PR DESCRIPTION
Currently marketplaces have the `UUIDTools::UUID` instances of their UUID values accessible through the `.uuid` method and the raw binary value is stored to the DB as UUIDTools encodes it.

This PR changes the Communities so that the raw binary DB presentation is rearranged for efficient insertion, and the `UUIDTools::UUID` instance is accessible through the `.uuid_object` method.