### PR TITLE
Wrong storybook import broke tests

### DIFF
--- a/client/app/components/composites/Branding/Branding.story.js
+++ b/client/app/components/composites/Branding/Branding.story.js
@@ -1,8 +1,9 @@
 import r from 'r-dom';
-import { storiesOf } from '@kadira/storybook';
 import { storify } from '../../Styleguide/withProps';
 
 import Branding from './Branding';
+
+const { storiesOf } = storybookFacade;
 
 const containerStyle = { style: { minWidth: '100px', background: 'white' } };
 


### PR DESCRIPTION
Leftover from earlier branch merged later, we included Storybook dependencies in the old way that doesn't work with `npm test`.