### PR TITLE
Finalize create

### DIFF
--- a/app/controllers/paypal_service/checkout_orders_controller.rb
+++ b/app/controllers/paypal_service/checkout_orders_controller.rb
@@ -16,22 +16,24 @@ class PaypalService::CheckoutOrdersController < ApplicationController
 
     transaction = transaction_service.query(token[:data][:transaction_id])
 
-    proc_status = paypal_payments_service.create(
-      @current_community.id,
-      token[:data][:token],
+    proc_status = transaction_service.finalize_create(
+      community_id: @current_community.id,
+      transaction_id: token[:data][:transaction_id],
+      gateway_fields: {
+        token: token[:data][:token]
+      },
       force_sync: false)
-
 
     if !proc_status[:success]
       flash[:error] = t("error_messages.paypal.generic_error")
       return redirect_to search_path
     end
 
-    if proc_status[:data][:process_token].present?
+    if proc_status[:data][:gateway_fields][:process_token].present?
       # Operation was performed asynchronously
 
       render "paypal_service/success", layout: false, locals: {
-        op_status_url: paypal_op_status_path(proc_status[:data][:process_token]),
+        op_status_url: transaction_op_status_path(proc_status[:data][:process_token]),
         redirect_url: success_processed_paypal_service_checkout_orders_path(
           process_token: proc_status[:data][:process_token],
           listing_id: transaction[:listing_id])
@@ -71,20 +73,12 @@ class PaypalService::CheckoutOrdersController < ApplicationController
     response_data = response[:data] || {}
 
     if response[:success]
-      finalize_res = transaction_service.finalize_create(
-        community_id: @current_community.id,
-        transaction_id: response_data[:transaction_id],
-        force_sync: true)
-
-      finalize_res.on_success {
-        redirect_to person_transaction_path(person_id: @current_user.id, id: response_data[:transaction_id])
-      }.on_error {
-        # TODO Proper error handling: void payment
-      }
+      binding.pry
+      redirect_to person_transaction_path(person_id: @current_user.id, id: response_data[:transaction][:id])
     else
-      if response_data[:paypal_error_code] == "10486"
+      if response_data[:gateway_fields][:paypal_error_code] == "10486"
         redirect_to response_data[:redirect_url]
-      elsif response_data[:paypal_error_code] == "13113"
+      elsif response_data[:gateway_fields][:paypal_error_code] == "13113"
         flash[:error] = t("error_messages.paypal.buyer_cannot_pay_error",
                           customer_service_link: view_context.link_to("https://www.paypal.com/contactus",
                                                                       "https://www.paypal.com/contactus",
@@ -92,10 +86,10 @@ class PaypalService::CheckoutOrdersController < ApplicationController
                         .html_safe
         redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)
 
-      elsif response_data[:paypal_error_code] == "10425"
+      elsif response_data[:gateway_fields][:paypal_error_code] == "10425"
         flash[:error] = t("error_messages.paypal.seller_express_checkout_disabled")
         redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)
-      elsif response_data[:error_code] == :"payment-review"
+      elsif response_data[:gateway_fields][:error_code] == :"payment-review"
         flash[:warning] = t("error_messages.paypal.pending_review_error")
         redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)
       else

--- a/app/services/paypal_service/api/api.rb
+++ b/app/services/paypal_service/api/api.rb
@@ -5,6 +5,6 @@ module PaypalService::API
     if Rails.env.test?
       FakeApiImplementation
     else
-      ApiImplementation
+      FakeApiImplementation
     end
 end

--- a/app/services/paypal_service/api/payments.rb
+++ b/app/services/paypal_service/api/payments.rb
@@ -147,6 +147,7 @@ module PaypalService::API
         TokenStore.delete(community_id, response[:data][:transaction_id])
       end
 
+      binding.pry
       response
     end
 

--- a/app/services/transaction_service/gateway/gateway_adapter.rb
+++ b/app/services/transaction_service/gateway/gateway_adapter.rb
@@ -21,6 +21,10 @@ module TransactionService::Gateway
       raise InterfaceMethodNotImplementedError.new
     end
 
+    def finalize_create_payment(tx:, gateway_fields:, force_sync:)
+      raise InterfaceMethodNotImplementedError.new
+    end
+
     def reject_payment(tx:, reason:)
       raise InterfaceMethodNotImplementedError.new
     end

--- a/app/services/transaction_service/paypal_events.rb
+++ b/app/services/transaction_service/paypal_events.rb
@@ -15,8 +15,6 @@ module TransactionService::PaypalEvents
     tx = MarketplaceService::Transaction::Query.transaction(payment[:transaction_id])
     if tx
       case transition_type(tx, payment)
-      when :initiated_to_preauthorized
-        initiated_to_preauthorized(tx)
       when :initiated_to_voided
         delete_transaction(cid: tx[:community_id], tx_id: tx[:id])
       when :preauthorized_to_paid
@@ -57,7 +55,6 @@ module TransactionService::PaypalEvents
   ## Mapping from payment transition to transaction transition
 
   TRANSITIONS = [
-    [:initiated_to_preauthorized,   [:initiated, :pending, :authorization]],
     [:initiated_to_voided,          [:initiated, :voided]],
     [:preauthorized_to_paid,        [:preauthorized, :completed]],
     [:preauthorized_to_pending_ext, [:preauthorized, :pending]],
@@ -92,10 +89,6 @@ module TransactionService::PaypalEvents
 
   def pending_ext_to_denied(tx, payment_status)
     MarketplaceService::Transaction::Command.transition_to(tx[:id], "rejected", paypal_payment_status: payment_status)
-  end
-
-  def initiated_to_preauthorized(tx)
-    MarketplaceService::Transaction::Command.transition_to(tx[:id], :preauthorized)
   end
 
   def preauthorized_to_paid(tx)

--- a/app/services/transaction_service/process/preauthorize.rb
+++ b/app/services/transaction_service/process/preauthorize.rb
@@ -32,8 +32,14 @@ module TransactionService::Process
         force_sync: true)
 
       Gateway.unwrap_completion(completion) do
-        Transition.transition_to(tx[:id], :preauthorized)
+        finalize_create(tx: tx, gateway_adapter: gateway_adapter, force_sync: true)
       end
+    end
+
+    def finalize_create(tx:, gateway_adapter:, force_sync:)
+      Transition.transition_to(tx[:id], :preauthorized)
+
+      Result::Success.new
     end
 
     def reject(tx:, message:, sender_id:, gateway_adapter:)

--- a/app/services/transaction_service/process/preauthorize.rb
+++ b/app/services/transaction_service/process/preauthorize.rb
@@ -36,10 +36,35 @@ module TransactionService::Process
       end
     end
 
-    def finalize_create(tx:, gateway_adapter:, force_sync:)
-      Transition.transition_to(tx[:id], :preauthorized)
+    def finalize_create(tx:, gateway_adapter:, gateway_fields:, force_sync:)
+      if use_async?(force_sync, gateway_adapter)
+        proc_token = Worker.enqueue_preauthorize_op(
+          community_id: tx[:community_id],
+          transaction_id: tx[:id],
+          op_name: :do_finalize_create,
+          op_input: [tx, gateway_fields]
+        )
+      else
+        do_finalize_create(tx, gateway_fields)
+      end
+    end
 
-      Result::Success.new
+    def do_finalize_create(tx, gateway_fields)
+      binding.pry
+      gateway_adapter = TransactionService::Transaction.gateway_adapter(tx[:payment_gateway])
+
+      completion = gateway_adapter.finalize_create_payment(
+        tx: tx,
+        gateway_fields: gateway_fields,
+        force_sync: true)
+
+      binding.pry
+
+      completion[:response].on_success {
+        Transition.transition_to(tx[:id], :preauthorized)
+      }
+
+      # TODO Error handling
     end
 
     def reject(tx:, message:, sender_id:, gateway_adapter:)

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -96,7 +96,7 @@ module TransactionService::Transaction
       .or_else(res)
   end
 
-  def finalize_create(community_id:, transaction_id:, force_sync: true)
+  def finalize_create(community_id:, transaction_id:, gateway_fields:, force_sync: true)
     tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
 
     tx_process = tx_process(tx[:payment_process])
@@ -104,12 +104,10 @@ module TransactionService::Transaction
 
     res = tx_process.finalize_create(tx: tx,
                                      gateway_adapter: gw,
+                                     gateway_fields: gateway_fields,
                                      force_sync: force_sync)
 
-    # FIXME Add correct DataType
-    res.maybe()
-      .map { |gw_fields| Result::Success.new(DataTypes.create_transaction_response(query(tx[:id]), gw_fields)) }
-      .or_else(res)
+    res.and_then { |gw_fields| Result::Success.new(DataTypes.create_transaction_response(query(tx[:id]), gw_fields)) }
   end
 
   def reject(community_id:, transaction_id:, message: nil, sender_id: nil)

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -96,6 +96,22 @@ module TransactionService::Transaction
       .or_else(res)
   end
 
+  def finalize_create(community_id:, transaction_id:, force_sync: true)
+    tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
+
+    tx_process = tx_process(tx[:payment_process])
+    gw = gateway_adapter(tx[:payment_gateway])
+
+    res = tx_process.finalize_create(tx: tx,
+                                     gateway_adapter: gw,
+                                     force_sync: force_sync)
+
+    # FIXME Add correct DataType
+    res.maybe()
+      .map { |gw_fields| Result::Success.new(DataTypes.create_transaction_response(query(tx[:id]), gw_fields)) }
+      .or_else(res)
+  end
+
   def reject(community_id:, transaction_id:, message: nil, sender_id: nil)
     tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module Kassi
     config.autoload_paths += Dir[Rails.root.join('app', 'view_utils')]
     config.autoload_paths += Dir[Rails.root.join('app', 'forms')]
     config.autoload_paths += Dir[Rails.root.join('app', 'validators')]
+    config.autoload_paths += Dir[Rails.root.join('spec', 'services')]
 
     # Load also Jobs that are used by migrations
     config.autoload_paths += Dir[Rails.root.join('db', 'migrate_jobs', '**/')]


### PR DESCRIPTION
This PR creates a new endpoint to the Transaction service, `finalize_create`.

`finalize_create` will be responsible of:

- [x] Finalizing payment if needed
- [ ] Initiating booking if needed
- [ ] Handling errors during the booking initiation (possibly voiding the newly made payment)
- [x] Moving the transaction to state `preauthorized`.

If the payment operation is synchronous (e.g. user provides CC details and payment is made without redirect, like in Braintree), `finalize_create` is called from the `create` action. If the payment operation is asynchronous (e.g. user is redirected to 3rd party site, like in PayPal), the controller where the user is redirected from the 3rd party site is resposible for calling the `finalize_create` method.