### PR TITLE
Change UUID accessor method name

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -264,7 +264,7 @@ class ListingsController < ApplicationController
     listing_uuid = UUIDTools::UUID.timestamp_create
 
     if FeatureFlagHelper.feature_enabled?(:availability) && shape.present? && shape[:availability] == :booking
-      bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid)
+      bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid_object)
       unless bookable_res.success
         flash[:error] = t("listings.error.something_went_wrong_plain")
         return redirect_to new_listing_path

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -176,7 +176,7 @@ class Person < ActiveRecord::Base
     set_default_preferences unless self.preferences
   end
 
-  def uuid
+  def uuid_object
     UUIDTools::UUID.parse_raw(Base64.urlsafe_decode64(self.id))
   end
 


### PR DESCRIPTION
UUID handling for different models will be changed to follow the convention of `.uuid` accessing the raw binary UUID and `.uuid_object` accessing the `UUIDTools::UUID` instance.

This PR changes the Person model to follow this convention in the UUID instance method.