### PR TITLE
Listing UUID API

### DIFF
--- a/app/controllers/free_transactions_controller.rb
+++ b/app/controllers/free_transactions_controller.rb
@@ -30,7 +30,7 @@ class FreeTransactionsController < ApplicationController
             community_id: @current_community.id,
             community_uuid: @current_community.uuid_object,
             listing_id: @listing.id,
-            listing_uuid: @listing.uuid,
+            listing_uuid: @listing.uuid_object,
             listing_title: @listing.title,
             starter_id: @current_user.id,
             listing_author_id: @listing.author.id,

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -261,7 +261,7 @@ class ListingsController < ApplicationController
     params[:listing].delete("origin_loc_attributes") if params[:listing][:origin_loc_attributes][:address].blank?
 
     shape = get_shape(Maybe(params)[:listing][:listing_shape_id].to_i.or_else(nil))
-    listing_uuid = UUIDTools::UUID.timestamp_create
+    listing_uuid = UUIDUtils.create
 
     if FeatureFlagHelper.feature_enabled?(:availability) && shape.present? && shape[:availability] == :booking
       bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid_object)
@@ -289,7 +289,7 @@ class ListingsController < ApplicationController
     m_unit = select_unit(listing_unit, shape)
 
     listing_params = create_listing_params(listing_params).merge(
-        uuid: listing_uuid.raw,
+        uuid_object: listing_uuid,
         community_id: @current_community.id,
         listing_shape_id: shape[:id],
         transaction_process_id: shape[:transaction_process_id],

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -264,7 +264,7 @@ class ListingsController < ApplicationController
     listing_uuid = UUIDTools::UUID.timestamp_create
 
     if FeatureFlagHelper.feature_enabled?(:availability) && shape.present? && shape[:availability] == :booking
-      bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid)
+      bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid_object)
       unless bookable_res.success
         flash[:error] = t("listings.error.something_went_wrong_plain")
         return redirect_to new_listing_path

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -226,7 +226,7 @@ class PreauthorizeTransactionsController < ApplicationController
         pickup_enabled: listing.pickup_enabled)
 
       Validator.validate_initiate_params(marketplace_uuid: @current_community.uuid_object,
-                                         listing_uuid: listing.uuid,
+                                         listing_uuid: listing.uuid_object,
                                          tx_params: tx_params,
                                          quantity_selector: listing.quantity_selector&.to_sym,
                                          shipping_enabled: listing.require_shipping_address,
@@ -541,7 +541,7 @@ class PreauthorizeTransactionsController < ApplicationController
           community_id: opts[:community].id,
           community_uuid: opts[:community].uuid_object,
           listing_id: opts[:listing].id,
-          listing_uuid: opts[:listing].uuid,
+          listing_uuid: opts[:listing].uuid_object,
           listing_title: opts[:listing].title,
           starter_id: opts[:user].id,
           listing_author_id: opts[:listing].author.id,

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -77,7 +77,7 @@ class TransactionsController < ApplicationController
               community_id: @current_community.id,
               community_uuid: @current_community.uuid_object,
               listing_id: listing_id,
-              listing_uuid: listing_model.uuid,
+              listing_uuid: listing_model.uuid_object,
               listing_title: listing_model.title,
               starter_id: @current_user.id,
               listing_author_id: author_model.id,

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -106,17 +106,21 @@ class Listing < ActiveRecord::Base
     self.updates_email_at ||= Time.now
   end
 
-  def uuid
+  def uuid_object
     if self[:uuid].nil?
       nil
     else
-      UUIDTools::UUID.parse_raw(self[:uuid])
+      UUIDUtils.parse_raw(self[:uuid])
     end
+  end
+
+  def uuid_object=(uuid)
+    self.uuid = UUIDUtils.raw(uuid)
   end
 
   before_create :add_uuid
   def add_uuid
-    self.uuid ||= UUIDTools::UUID.timestamp_create.raw
+    self.uuid ||= UUIDUtils.create_raw
   end
 
   before_validation do

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -176,7 +176,7 @@ class Person < ActiveRecord::Base
     set_default_preferences unless self.preferences
   end
 
-  def uuid
+  def uuid_object
     UUIDTools::UUID.parse_raw(Base64.urlsafe_decode64(self.id))
   end
 

--- a/app/utils/uuid_utils.rb
+++ b/app/utils/uuid_utils.rb
@@ -2,8 +2,12 @@ module UUIDUtils
 
   module_function
 
+  def create
+    UUIDTools::UUID.timestamp_create
+  end
+
   def create_raw
-    raw(UUIDTools::UUID.timestamp_create)
+    raw(create)
   end
 
   def parse_raw(raw_uuid)

--- a/db/migrate/20160928080048_rearrange_listing_uuid_bytes.rb
+++ b/db/migrate/20160928080048_rearrange_listing_uuid_bytes.rb
@@ -1,0 +1,14 @@
+class RearrangeListingUuidBytes < ActiveRecord::Migration
+  def up
+    mysql_conn = ActiveRecord::Base.connection.raw_connection
+
+    Listing.pluck(:id).each_slice(1000) { |ids|
+      ActiveRecord::Base.transaction do
+        ids.each { |id|
+          statement = mysql_conn.prepare("UPDATE listings SET uuid=? where id=?")
+          statement.execute(UUIDUtils.create_raw, id)
+        }
+      end
+    }
+  end
+end

--- a/db/migrate/20160928080819_copy_rearranged_uuids_to_transactions.rb
+++ b/db/migrate/20160928080819_copy_rearranged_uuids_to_transactions.rb
@@ -1,0 +1,6 @@
+class CopyRearrangedUuidsToTransactions < ActiveRecord::Migration
+  def up
+    execute "UPDATE transactions, listings SET transactions.listing_uuid = listings.uuid WHERE transactions.listing_id = listings.id"
+    execute "UPDATE transactions, communities SET transactions.community_uuid = communities.uuid WHERE transactions.community_id = communities.id"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 --
 -- Host: 127.0.0.1    Database: sharetribe_development
 -- ------------------------------------------------------
--- Server version	5.6.32-log
+-- Server version	5.7.15-log
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -1586,7 +1586,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-26 16:22:39
+-- Dump completed on 2016-09-28 11:10:16
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3144,4 +3144,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160920103321');
 INSERT INTO schema_migrations (version) VALUES ('20160921130544');
 
 INSERT INTO schema_migrations (version) VALUES ('20160926111847');
+
+INSERT INTO schema_migrations (version) VALUES ('20160928080048');
+
+INSERT INTO schema_migrations (version) VALUES ('20160928080819');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -121,7 +121,7 @@ FactoryGirl.define do
     commission_from_seller 0
     automatic_confirmation_after_days 14
     listing_quantity 1
-    listing_uuid { listing.uuid.raw }
+    listing_uuid { listing.uuid } # raw UUID
     community_uuid { community.uuid } # raw UUID
   end
 

--- a/spec/services/transaction_service/paypal_events_spec.rb
+++ b/spec/services/transaction_service/paypal_events_spec.rb
@@ -68,7 +68,7 @@ describe TransactionService::PaypalEvents do
       starter_id: @payer.id,
       listing_id: @listing.id,
       listing_title: @listing.title,
-      listing_uuid: @listing.uuid.raw,
+      listing_uuid: @listing.uuid, # raw UUID
       unit_price: @listing.price,
       listing_author_id: @listing.author_id,
       listing_quantity: 1,

--- a/spec/services/transaction_service/store/transaction_spec.rb
+++ b/spec/services/transaction_service/store/transaction_spec.rb
@@ -24,7 +24,7 @@ describe TransactionService::Store::Transaction do
       community_uuid: @community.uuid_object,
       starter_id: @payer.id,
       listing_id: @listing.id,
-      listing_uuid: @listing.uuid,
+      listing_uuid: @listing.uuid_object,
       listing_title: @listing.title,
       unit_price: @listing.price,
       availability: @listing.availability,


### PR DESCRIPTION
Builds on top of #2585 

UUID handling for different models will be changed to follow the convention of .uuid accessing the raw binary UUID and .uuid_object accessing the UUIDTools::UUID instance.

This PR changes the Listing model to use the rearranged raw binary UUIDs as the storage format, but offers a convenience API on top of those.