### PR TITLE
Keep search params in filter form when using new topbar

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -63,7 +63,10 @@
 
   - if is_homepage
     %form{method: "get", id: "homepage-filters"}
-      - params.except("action", "controller", "q", "lc", "ls", "view", "utf8", "boundingbox", "distance_max").each do |param, value|
+      - # New top bar search params are in different form and they have to be retained here
+      - search_params = ["q", "lc", "ls", "boundingbox", "distance_max"]
+      - excluded_params = search_params unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
+      - params.except("action", "controller", "view", "utf8", *excluded_params).each do |param, value|
         - unless param.match(/^filter_option/) || param.match(/^checkbox_filter_option/) || param.match(/^nf_/) || param.match(/^price_/)
           = hidden_field_tag param, value
       = hidden_field_tag "view", @view_type


### PR DESCRIPTION
When not using new top bar, location- and keyword-related query parameters were stored as hidden parameters on the page. That way, when filters were changed, the previous parameters were sent as well.

With new top bar, the search params aren't stored in the same form, so location and keyword were lost when altering search filters. This PR adds hidden fields for search parameters when using new top bar.