### PR TITLE
Some IE11/Win10 environment has a bug that dropdown sends (blur event),

### DIFF
--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
@@ -31,7 +31,7 @@ class AvatarDropdown extends Component {
   handleBlur(event) {
     // FocusEvent is fired faster than the link elements native click handler
     // gets its own event. Therefore, we need to check the origin of this FocusEvent.
-    if (!this.profileDropdown.contains(event.relatedTarget)) {
+    if (this.state.isOpen && !this.profileDropdown.contains(event.relatedTarget)) {
       this.setState({ isOpen: false });// eslint-disable-line react/no-set-state
     }
   }


### PR DESCRIPTION
before native click event. This happens even after our check for origin of focus.
This fix tries to isolate click based state handling even more.