### PR TITLE
Remove migrations that could not be run.

### DIFF
--- a/db/migrate/20160928080048_rearrange_listing_uuid_bytes.rb
+++ b/db/migrate/20160928080048_rearrange_listing_uuid_bytes.rb
@@ -1,14 +1,7 @@
 class RearrangeListingUuidBytes < ActiveRecord::Migration
   def up
-    mysql_conn = ActiveRecord::Base.connection.raw_connection
-
-    Listing.pluck(:id).each_slice(1000) { |ids|
-      ActiveRecord::Base.transaction do
-        ids.each { |id|
-          statement = mysql_conn.prepare("UPDATE listings SET uuid=? where id=?")
-          statement.execute(UUIDUtils.create_raw, id)
-        }
-      end
-    }
+    # This migration could not be completed. Therefore it is changed
+    # into blank and another migration will do the same thing in a
+    # more efficient way.
   end
 end

--- a/db/migrate/20160928080819_copy_rearranged_uuids_to_transactions.rb
+++ b/db/migrate/20160928080819_copy_rearranged_uuids_to_transactions.rb
@@ -1,6 +1,6 @@
 class CopyRearrangedUuidsToTransactions < ActiveRecord::Migration
   def up
-    execute "UPDATE transactions, listings SET transactions.listing_uuid = listings.uuid WHERE transactions.listing_id = listings.id"
-    execute "UPDATE transactions, communities SET transactions.community_uuid = communities.uuid WHERE transactions.community_id = communities.id"
+    # The previous migration could not be completed and these both are
+    # chagned to no-ops.
   end
 end


### PR DESCRIPTION
Changing the UUID wasn't efficient enough and the migrations could not
be run.