### PR TITLE
Avoid DB connections during assets:precompile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem "omniauth-facebook", "~> 3.0.0"
 # Dynamic form adds helpers that are needed, e.g. error_messages
 gem 'dynamic_form', "~>1.1.4"
 gem "truncate_html", "~>0.9.1"
-gem 'money-rails', "~>1.3.0"
+gem 'money-rails', "~>1.4.0"
 
 # The latest release (0.9.0) is not Rails 4 compatible
 gem 'mercury-rails',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,12 +294,12 @@ GEM
     mime-types (2.99.2)
     mimemagic (0.3.2)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     monetize (1.1.0)
       money (~> 6.5.0)
     money (6.5.1)
       i18n (>= 0.6.4, <= 0.7.0)
-    money-rails (1.3.0)
+    money-rails (1.4.1)
       activesupport (>= 3.0)
       monetize (~> 1.1.0)
       money (~> 6.5.0)
@@ -582,7 +582,7 @@ DEPENDENCIES
   memcachier (~> 0.0.2)
   mercury-rails!
   meta_request (~> 0.3)
-  money-rails (~> 1.3.0)
+  money-rails (~> 1.4.0)
   mysql2 (~> 0.4.4)
   newrelic_rpm (~> 3.9.1.236)
   oauth2!


### PR DESCRIPTION
I'm unable to compile the assets when building a docker image because the `assets:precompile` task attempts to establish a connection to the database. The problem is related to the [initializer of money-rails 1.3.0](https://github.com/RubyMoney/money-rails/blob/v1.3.0/lib/money-rails/hooks.rb#L18) that invoking `ActiveRecord::Base.connection` triggers a new connection to the database.

Since the 1.4.0, this bug has been fixed in money-rails ([see the new initializer](https://github.com/RubyMoney/money-rails/blob/v1.4.1/lib/money-rails/hooks.rb#L20)). It seems there are no regressions in the test suite, and the `assets:precompile` task is now running fine.

Given I'm still not confident with the codebase I didn't dare to update money-rails to the latest version (1.7.0).
