### PR TITLE
Accept booking

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -32,6 +32,7 @@
 #  delivery_method                   :string(31)       default("none")
 #  shipping_price_cents              :integer
 #  availability                      :string(32)       default("none")
+#  booking_uuid                      :binary(16)
 #  deleted                           :boolean          default(FALSE)
 #
 # Indexes

--- a/app/services/harmony_client.rb
+++ b/app/services/harmony_client.rb
@@ -1,10 +1,16 @@
 HarmonyClient = ServiceClient::Client.new(
   APP_CONFIG.harmony_api_url,
   {
-    initiate_booking: "/bookings/initiate",
+    # Bookables
     create_bookable: "/bookables/create",
     show_bookable: "/bookables/show",
-    query_timeslots: "/timeslots/query"
+
+    # Timeslots
+    query_timeslots: "/timeslots/query",
+
+    # Bookings
+    initiate_booking: "/bookings/initiate",
+    accept_booking: "/bookings/accept"
   },
   [
     ServiceClient::Middleware::Retry.new,

--- a/app/services/transaction_service/paypal_events.rb
+++ b/app/services/transaction_service/paypal_events.rb
@@ -106,7 +106,9 @@ module TransactionService::PaypalEvents
     # transition to paid so that we have the full payment info
     # available at the time we send payment receipts.
     TransactionService::Transaction.charge_commission(tx[:id])
-    MarketplaceService::Transaction::Command.transition_to(tx[:id], :paid)
+    TransactionService::Transaction.finalize_complete_preauthorization(
+      community_id: tx[:community_id],
+      transaction_id: tx[:id])
   end
 
   def preauthorized_to_pending_ext(tx, pending_reason)
@@ -118,8 +120,10 @@ module TransactionService::PaypalEvents
   end
 
   def pending_ext_to_paid(tx)
-    MarketplaceService::Transaction::Command.transition_to(tx[:id], :paid)
     TransactionService::Transaction.charge_commission(tx[:id])
+    TransactionService::Transaction.finalize_complete_preauthorization(
+      community_id: tx[:community_id],
+      transaction_id: tx[:id])
   end
 
   def delete_transaction(cid:, tx_id:)

--- a/app/services/transaction_service/process/preauthorize.rb
+++ b/app/services/transaction_service/process/preauthorize.rb
@@ -141,7 +141,7 @@ module TransactionService::Process
       res = Gateway.unwrap_completion(
         gateway_adapter.complete_preauthorization(tx: tx)) do
 
-        Transition.transition_to(tx[:id], :paid)
+        finalize_complete_preauthorization(tx: tx, gateway_adapter: gateway_adapter)
       end
 
       if res[:success] && message.present?
@@ -149,6 +149,10 @@ module TransactionService::Process
       end
 
       res
+    end
+
+    def finalize_complete_preauthorization(tx:, gateway_adapter:)
+      Transition.transition_to(tx[:id], :paid)
     end
 
     def complete(tx:, message:, sender_id:, gateway_adapter:)

--- a/app/services/transaction_service/process/preauthorize.rb
+++ b/app/services/transaction_service/process/preauthorize.rb
@@ -91,6 +91,15 @@ module TransactionService::Process
                 }.on_error { |payment_error_msg, payment_data|
                   logger.error("Failed to void payment after failed booking", :failed_void_payment, tx.slice(:community_id, :id).merge(error_msg: payment_error_msg))
                 }
+              }.on_success { |data|
+                response_body = data[:body]
+                booking = response_body[:data]
+
+                TxStore.update_booking_uuid(
+                  community_id: tx[:community_id],
+                  transaction_id: tx[:id],
+                  booking_uuid: booking[:id]
+                )
               }
             end
 

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -154,6 +154,21 @@ module TransactionService::Transaction
       .or_else(res)
   end
 
+  def finalize_complete_preauthorization(community_id:, transaction_id:)
+    tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
+
+    tx_process = tx_process(tx[:payment_process])
+    gw = gateway_adapter(tx[:payment_gateway])
+
+    res = tx_process.finalize_complete_preauthorization(
+      tx: tx,
+      gateway_adapter: gw)
+
+    res.and_then { |tx_fields|
+      Result::Success.new(DataTypes.create_transaction_response(query(tx[:id])))
+    }
+  end
+
   def complete(community_id:, transaction_id:, message: nil, sender_id: nil)
     tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
 

--- a/db/migrate/20161004141208_add_booking_uuid_to_transactions.rb
+++ b/db/migrate/20161004141208_add_booking_uuid_to_transactions.rb
@@ -1,0 +1,12 @@
+class AddBookingUuidToTransactions < ActiveRecord::Migration
+  def up
+    # `add_column` with `:binary, limit: 16` uses the VARBINARY type,
+    # but we want to use the BINARY type, which is why we use plain
+    # SQL here.
+    execute "ALTER TABLE transactions ADD booking_uuid BINARY(16) AFTER `availability`"
+  end
+
+  def down
+    remove_column :transactions, :booking_uuid
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1566,6 +1566,7 @@ CREATE TABLE `transactions` (
   `delivery_method` varchar(31) DEFAULT 'none',
   `shipping_price_cents` int(11) DEFAULT NULL,
   `availability` varchar(32) DEFAULT 'none',
+  `booking_uuid` binary(16) DEFAULT NULL,
   `deleted` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `transactions_on_cid_and_deleted` (`community_id`,`deleted`) USING BTREE,
@@ -1586,7 +1587,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-09-30 10:30:17
+-- Dump completed on 2016-10-04 17:13:09
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3154,4 +3155,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160929114326');
 INSERT INTO schema_migrations (version) VALUES ('20160929124124');
 
 INSERT INTO schema_migrations (version) VALUES ('20160930070122');
+
+INSERT INTO schema_migrations (version) VALUES ('20161004141208');
 


### PR DESCRIPTION
Accept booking after the preauthorize payment is completed.

Built on top of #2614 

**Open questions**

- For simplicity, the transaction is now moved to `paid` state even if the booking accept fails. Is this the right thing to do? If not, what's the state where the transaction is left if the preauthorized payment is completed, but the booking is still in `initiated` state?