### PR TITLE
Transit uuid not available yet

### DIFF
--- a/client/app/components/composites/ListingCard/ListingCard.js
+++ b/client/app/components/composites/ListingCard/ListingCard.js
@@ -61,7 +61,6 @@ class ListingCard extends Component {
 
     return div({
       className: classNames('ListingCard', css.listing, this.props.className),
-      'data-listing-id': listing.id,
       onClick: this.clickHandler,
     }, [
       a({

--- a/client/app/components/sections/SearchPage/SearchPage.js
+++ b/client/app/components/sections/SearchPage/SearchPage.js
@@ -24,8 +24,9 @@ class SearchPage extends Component {
   }
 
   listingProps(listing, color) {
+    const listingKey = listing.id.toString();
     return {
-      key: `card_${listing.id}`,
+      key: `card_${listingKey}`,
       color,
       listing,
     };

--- a/client/app/models/ListingModel.js
+++ b/client/app/models/ListingModel.js
@@ -38,11 +38,12 @@ const parseListingImages = (images) => new ListingImage({
 
 export const parse = (l) => new ListingModel({
   id: l.get(':id'),
-  images: l.getIn([':attributes', ':images']).map(parseListingImages),
-  authorId: l.getIn([':relationships', ':author', ':id']),
+  extId: l.getIn([':attributes', ':extId']),
   distance: l.getIn([':attributes', ':distance']),
+  images: l.getIn([':attributes', ':images']).map(parseListingImages),
   price: l.getIn([':attributes', ':price']),
   title: l.getIn([':attributes', ':title']),
+  authorId: l.getIn([':relationships', ':author', ':id']),
 });
 
 export default ListingModel;

--- a/client/app/utils/transitImmutableConverter.js
+++ b/client/app/utils/transitImmutableConverter.js
@@ -4,7 +4,11 @@ import { parse as parseImage } from '../models/ImageModel';
 import { Distance, Money } from '../models/ListingModel';
 
 // Outside of this file we should only pass UUID references, no need to export
-const UUID = Immutable.Record({ value: '' });
+class UUID extends Immutable.Record({ value: '' }) {
+  toString() {
+    return this.value;
+  }
+}
 const toUUID = (transitUuid) => new UUID({ value: transitUuid.toString() });
 
 const toDistance = ([value, unit]) => new Distance({ value, unit });


### PR DESCRIPTION
Test data gives us UUIDs and (in some point in the future) we should get those from real data too.
Currently DiscoveryAPI will give us strings instead.

Related:
Why key is needed: http://revelry.co/dynamic-child-components-with-react/
Problem: https://github.com/uber/r-dom/issues/19 (i.e. we just need to remember this)