### PR TITLE
Moved some translation keys back to main locale file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -884,6 +884,12 @@ en:
       remember_to_accept: "Remember to accept the request from %{requester} about listing \"%{listing_title}\". %{requester} has already paid for the listing. You have to accept the request in order to receive the payment."
       one_day_left: "If you don't accept the request within one day the request will be automatically rejected and you will not get paid."
       click_here_to_reply: "Click here to respond to the request"
+    welcome_email:
+      welcome_email_subject: "Welcome to %{service_name}"
+      welcome_to_marketplace: "Welcome to %{service_name}! Glad to have you on board."
+      love_marketplace_crew: "Love,<br /><i>%{service_name} crew</i>"
+      welcome_email_footer_text: "What kind of emails do you want to receive from %{service_name}? %{settings_link}"
+      settings_link_text: "Check your settings"
     new_listing_by_followed_person:
       subject: "%{author_name} has posted a new listing in %{service_name}"
       has_posted_a_new_listing: "%{author_name} has posted a new listing:"

--- a/config/locales/welcome_email/de.yml
+++ b/config/locales/welcome_email/de.yml
@@ -1,11 +1,6 @@
 de:
   emails:
     welcome_email:
-      welcome_email_subject: "Willkommen bei %{service_name}"
-      welcome_to_marketplace: "Willkommen bei %{service_name}! Schön, dass du dabei bist."
-      love_marketplace_crew: "Herzliche Grüße,<br /><i>das %{service_name} Team</i>"
-      welcome_email_footer_text: "Welche Art von E-Mails willst du von %{service_name} empfangen? %{settings_link}"
-      settings_link_text: "Überprüfe Deine Einstellungen"
       welcome_email_subject_for_marketplace_creator: "Willkommen bei Sharetribe"
       welcome_to_marketplace_creator: "Willkommen bei Sharetribe, %{name}!"
       congrats_for_creating_your_marketplace: "Herzlichen Glückwunsch für die Erstellung deines Marktplatzes! Das war einfach, nicht wahr?"

--- a/config/locales/welcome_email/en.yml
+++ b/config/locales/welcome_email/en.yml
@@ -1,11 +1,6 @@
 en:
   emails:
     welcome_email:
-      welcome_email_subject: "Welcome to %{service_name}"
-      welcome_to_marketplace: "Welcome to %{service_name}! Glad to have you on board."
-      love_marketplace_crew: "Love,<br /><i>%{service_name} crew</i>"
-      welcome_email_footer_text: "What kind of emails do you want to receive from %{service_name}? %{settings_link}"
-      settings_link_text: "Check your settings"
       welcome_email_subject_for_marketplace_creator: "Welcome to Sharetribe"
       welcome_to_marketplace_creator: "Welcome to Sharetribe, %{name}!"
       congrats_for_creating_your_marketplace: "Congrats for creating your marketplace! That was easy, wasn't it?"

--- a/config/locales/welcome_email/es-ES.yml
+++ b/config/locales/welcome_email/es-ES.yml
@@ -1,11 +1,6 @@
 es-ES:
   emails:
     welcome_email:
-      welcome_email_subject: "Ya formas parte de %{service_name}"
-      welcome_to_marketplace: "¡Bienvenido a %{service_name}! Nos encanta que estés con nosotros."
-      love_marketplace_crew: "Un saludo del equipo de <br /><i>%{service_name} </i>"
-      welcome_email_footer_text: "¿Qué clase de correos deseas recibir de %{service_name}? %{settings_link}"
-      settings_link_text: "Revisa tu configuración"
       welcome_email_subject_for_marketplace_creator: "Bienvenido a Sharetribe"
       welcome_to_marketplace_creator: "¡Bienvenido a Sharetribe, %{name}!"
       congrats_for_creating_your_marketplace: "¡Enhorabuena! Ya has creado tu marketplace, ha sido fácil ¿verdad?"

--- a/config/locales/welcome_email/fi.yml
+++ b/config/locales/welcome_email/fi.yml
@@ -1,11 +1,6 @@
 fi:
   emails:
     welcome_email:
-      welcome_email_subject: "Tervetuloa %{community}-palveluun"
-      welcome_to_marketplace: "Tervetuloa %{service_name}-palvelun jäseneksi! Mukavaa kun liityit."
-      love_marketplace_crew: "Terveisin,<br /><i>%{service_name}-tiimi</i>"
-      welcome_email_footer_text: "Millaisia sähköpostiviestejä haluat saada %{service_name}-palvelusta? %{settings_link}"
-      settings_link_text: "Tarkista sähköpostiasetuksesi"
       welcome_email_subject_for_marketplace_creator: "Tervetuloa Sharetribeen"
       welcome_to_marketplace_creator: "Tervetuloa Sharetribeen, %{name}!"
       congrats_for_creating_your_marketplace: "Onneksi olkoon, sivustosi on nyt luotu! Se oli helppoa, eikö vain?"

--- a/config/locales/welcome_email/fr.yml
+++ b/config/locales/welcome_email/fr.yml
@@ -1,11 +1,6 @@
 fr:
   emails:
     welcome_email:
-      welcome_email_subject: "Bienvenue sur %{service_name}"
-      welcome_to_marketplace: "Bienvenue sur %{service_name} ! Ravi que vous nous ayez rejoint."
-      love_marketplace_crew: "Love,<br /><i>L'équipe de %{service_name}</i>"
-      welcome_email_footer_text: "Quels types d'emails souhaitez vous recevoir de la part de %{service_name} ? %{settings_link}"
-      settings_link_text: "Vérifiez vos paramètres"
       welcome_email_subject_for_marketplace_creator: "Bienvenue sur Sharetribe"
       welcome_to_marketplace_creator: "Bienvenue sur Sharetribe, %{name} !"
       congrats_for_creating_your_marketplace: "Félicitations pour la création de votre place de marché ! C'était simple, non ?"


### PR DESCRIPTION
When moving some translation keys related to the welcome email to their own yml file in order to remove them from WTI (see [this PR](https://github.com/sharetribe/sharetribe/pull/2611/files)), I actually moved too many of them: some translation keys related to the user welcome emails, and not only the new admin welcome email, were moved too.

This of course shouldn't have happened.

This PR moves the correct keys to the main yml file and removes them from the dedicated welcome_email yml files.

And unless there's an easier and faster way (for me ;-)), I'll simply add the translation (fr, es-ES, ...) back to WTI directly.