### PR TITLE
Retry only on error and if status is 5xx

### DIFF
--- a/app/utils/service_client/middleware/retry.rb
+++ b/app/utils/service_client/middleware/retry.rb
@@ -41,8 +41,10 @@ module ServiceClient
         ctx.fetch(:enter_queue).dup + [self]
       end
 
+      # Retries if all attempts are not used and
+      # status is 5xx
       def leave_needs_retry?(ctx)
-        !max_attempts?(ctx) && !ctx.fetch(:res).fetch(:success)
+        !max_attempts?(ctx) && (500..599).cover?(ctx.fetch(:res).fetch(:status))
       end
 
       def error_needs_retry?(ctx)


### PR DESCRIPTION
Change the Retry middleware that it retries only is status is `5xx` or an exception happens.