### PR TITLE
Fix text avatar squashing in tablet viewport

### DIFF
--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -143,6 +143,7 @@ module.exports = {
   '--Topbar_fontSizeMobile': fontSizeMobile,
 
   '--Topbar_avatarSize': topbarItemHeight,
+  '--Topbar_avatarMediumSize': topbarMediumItemHeight,
   '--Topbar_avatarPadding': '18px 0',
   '--Topbar_avatarTabletPadding': '12px 0',
   '--Topbar_avatarMobilePadding': '8px 0',

--- a/client/app/components/sections/Topbar/Topbar.css
+++ b/client/app/components/sections/Topbar/Topbar.css
@@ -145,11 +145,12 @@
 
     @media (--medium-viewport) {
       display: flex;
-      width: var(--Topbar_avatarSize);
+      width: var(--Topbar_avatarMediumSize);
       padding: var(--Topbar_avatarTabletPadding);
     }
 
     @media (--large-viewport) {
+      width: var(--Topbar_avatarSize);
       padding: var(--Topbar_avatarPadding);
     }
   }


### PR DESCRIPTION
Avatar needs more specific sizes with text content.

Before:
<img width="282" alt="screenshot 2016-10-12 16 16 27" src="https://cloud.githubusercontent.com/assets/432030/19311504/5c93e402-9097-11e6-86d0-04f66a1f81ea.png">

After:
<img width="230" alt="screenshot 2016-10-12 16 16 18" src="https://cloud.githubusercontent.com/assets/432030/19311506/6078f364-9097-11e6-8178-bfe64b26d5b6.png">
