### PR TITLE
Add background color to mobile menu text avatar as well

### DIFF
--- a/client/app/components/sections/Topbar/Topbar.js
+++ b/client/app/components/sections/Topbar/Topbar.js
@@ -207,7 +207,7 @@ class Topbar extends Component {
       this.props.routes.person_path(loggedInUsername) :
       null;
     const mobileMenuAvatarProps = this.props.avatarDropdown && loggedInUsername ?
-      { ...this.props.avatarDropdown.avatar, url: profileRoute } :
+      { ...this.props.avatarDropdown.avatar, url: profileRoute, color: marketplaceColor1 } :
       null;
     const mobileMenuProps = hasMenuProps ?
       Object.assign({}, this.props.menu, {


### PR DESCRIPTION
We forgot to relay the bg color parameter to the mobile menu avatar instance.

Before:
<img width="363" alt="screenshot 2016-10-13 11 19 58" src="https://cloud.githubusercontent.com/assets/432030/19341684/29b2f0e6-9137-11e6-96cc-ff8f799d5773.png">

After:
<img width="364" alt="screenshot 2016-10-13 11 20 16" src="https://cloud.githubusercontent.com/assets/432030/19341687/2c69bfa4-9137-11e6-8e1f-4384842f66f0.png">
