### PR TITLE
Harmony API JWT authentication

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -230,6 +230,7 @@ Metrics/ModuleLength:
 # Offense count: 8
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
+  CountKeywordArgs: false
   Max: 7
 
 # Offense count: 48

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -264,7 +264,11 @@ class ListingsController < ApplicationController
     listing_uuid = UUIDUtils.create
 
     if FeatureFlagHelper.feature_enabled?(:availability) && shape.present? && shape[:availability] == :booking
-      bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid_object)
+      auth_context = {
+        marketplace_id: @current_community.uuid_object,
+        actor_id: @current_user.uuid_object
+      }
+      bookable_res = create_bookable(@current_community.uuid_object, listing_uuid, @current_user.uuid_object, auth_context)
       unless bookable_res.success
         flash[:error] = t("listings.error.create_failed_to_connect_to_booking_service")
         return redirect_to new_listing_path
@@ -403,7 +407,12 @@ class ListingsController < ApplicationController
        shape[:availability] == :booking &&
        @listing.availability.to_sym != :booking
 
-      bookable_res = create_bookable(@current_community.uuid_object, @listing.uuid_object, @current_user.uuid_object)
+      auth_context = {
+        marketplace_id: @current_community.uuid_object,
+        actor_id: @current_user.uuid_object
+      }
+
+      bookable_res = create_bookable(@current_community.uuid_object, @listing.uuid_object, @current_user.uuid_object, auth_context)
       unless bookable_res.success
         flash[:error] = t("listings.error.update_failed_to_connect_to_booking_service")
         return redirect_to edit_listing_path(@listing)
@@ -514,7 +523,7 @@ class ListingsController < ApplicationController
 
   private
 
-  def create_bookable(community_uuid, listing_uuid, author_uuid)
+  def create_bookable(community_uuid, listing_uuid, author_uuid, auth_context)
     res = HarmonyClient.post(
       :create_bookable,
       body: {
@@ -523,7 +532,8 @@ class ListingsController < ApplicationController
         authorId: author_uuid
       },
       opts: {
-        max_attempts: 3
+        max_attempts: 3,
+        auth_context: auth_context
       })
 
     if !res[:success] && res[:data][:status] == 409

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -96,7 +96,8 @@ class PreauthorizeTransactionsController < ApplicationController
                                  quantity_selector:,
                                  shipping_enabled:,
                                  pickup_enabled:,
-                                 availability_enabled:)
+                                 availability_enabled:,
+                                 auth_context:)
 
       validate_delivery_method(tx_params: tx_params, shipping_enabled: shipping_enabled, pickup_enabled: pickup_enabled)
         .and_then { validate_booking(tx_params: tx_params, quantity_selector: quantity_selector) }
@@ -105,7 +106,8 @@ class PreauthorizeTransactionsController < ApplicationController
             validate_booking_timeslots(tx_params: tx_params,
                                        marketplace_uuid: marketplace_uuid,
                                        listing_uuid: listing_uuid,
-                                       quantity_selector: quantity_selector)
+                                       quantity_selector: quantity_selector,
+                                       auth_context: auth_context)
           else
             Result::Success.new(result)
           end
@@ -172,7 +174,7 @@ class PreauthorizeTransactionsController < ApplicationController
       }
     end
 
-    def validate_booking_timeslots(tx_params:, marketplace_uuid:, listing_uuid:, quantity_selector:)
+    def validate_booking_timeslots(tx_params:, marketplace_uuid:, listing_uuid:, quantity_selector:, auth_context:)
       start_on, end_on = tx_params.values_at(:start_on, :end_on)
 
       # The calendar UI doesn't give the exclusive end date for the
@@ -189,6 +191,9 @@ class PreauthorizeTransactionsController < ApplicationController
           refId: listing_uuid,
           start: start_on,
           end: end_adjusted
+        },
+        opts: {
+          auth_context: auth_context
         }
       ).rescue {
         Result::Error.new(nil, code: :harmony_api_error)
@@ -225,13 +230,19 @@ class PreauthorizeTransactionsController < ApplicationController
         shipping_enabled: listing.require_shipping_address,
         pickup_enabled: listing.pickup_enabled)
 
+      auth_context = {
+        marketplace_id: @current_community.uuid_object,
+        actor_id: @current_user.uuid_object
+      }
+
       Validator.validate_initiate_params(marketplace_uuid: @current_community.uuid_object,
                                          listing_uuid: listing.uuid_object,
                                          tx_params: tx_params,
                                          quantity_selector: listing.quantity_selector&.to_sym,
                                          shipping_enabled: listing.require_shipping_address,
                                          pickup_enabled: listing.pickup_enabled,
-                                         availability_enabled: listing.availability.to_sym == :booking)
+                                         availability_enabled: listing.availability.to_sym == :booking,
+                                         auth_context: auth_context)
     }
 
     validation_result.on_success { |tx_params|

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -87,6 +87,14 @@ class Transaction < ActiveRecord::Base
     self.booking_uuid = UUIDUtils.raw(uuid)
   end
 
+  def community_uuid_object
+    if self[:community_uuid].nil?
+      nil
+    else
+      UUIDUtils.parse_raw(self[:community_uuid])
+    end
+  end
+
   def status
     current_state
   end

--- a/app/services/harmony_client.rb
+++ b/app/services/harmony_client.rb
@@ -20,6 +20,8 @@ HarmonyClient = ServiceClient::Client.new(
     ServiceClient::Middleware::Logger.new,
     ServiceClient::Middleware::Timing.new,
     ServiceClient::Middleware::BodyEncoder.new(:transit_json),
-    ServiceClient::Middleware::ParamEncoder.new
+    ServiceClient::Middleware::ParamEncoder.new,
+    ServiceClient::Middleware::JwtAuthenticator.new(APP_CONFIG.harmony_api_disable_authentication,
+                                                    APP_CONFIG.harmony_api_token_secret),
   ]
 )

--- a/app/services/transaction_service/process/preauthorize.rb
+++ b/app/services/transaction_service/process/preauthorize.rb
@@ -160,6 +160,11 @@ module TransactionService::Process
       end_on = tx[:booking][:end_on]
       end_adjusted = tx[:unit_type] == :day ? end_on + 1.days : end_on
 
+      auth_context = {
+        marketplace_id: tx[:community_uuid],
+        actor_id: UUIDUtils.base64_to_uuid(tx[:starter_id])
+      }
+
       HarmonyClient.post(
         :initiate_booking,
         body: {
@@ -171,7 +176,8 @@ module TransactionService::Process
           end: end_adjusted
         },
         opts: {
-          max_attempts: 3
+          max_attempts: 3,
+          auth_context: auth_context
         }).rescue { |error_msg, data|
 
         new_data =

--- a/app/utils/service_client/middleware/jwt_authenticator.rb
+++ b/app/utils/service_client/middleware/jwt_authenticator.rb
@@ -1,0 +1,36 @@
+module ServiceClient
+  module Middleware
+
+    AuthContext = EntityUtils.define_builder(
+      [:marketplace_id, :uuid, :mandatory],
+      [:actor_id, :uuid, :mandatory]
+    )
+
+    class JwtAuthenticator < MiddlewareBase
+
+      def initialize(disable_authentication, token_secret)
+        @_disabled = disable_authentication
+        @_secret = token_secret
+      end
+
+      def enter(ctx)
+        unless @_disabled
+          token = create_token(ctx[:opts][:auth_context])
+          ctx[:req][:headers]["Authorization"] = "Token #{token}"
+        end
+        ctx
+      end
+
+      private
+
+      def create_token(auth_context)
+        context = AuthContext.call(auth_context)
+        payload = {
+          marketplaceId: context[:marketplace_id],
+          actorId: context[:actor_id]
+        }
+        JWTUtils.encode(payload, @_secret, exp: 5.minutes.from_now)
+      end
+    end
+  end
+end

--- a/app/view_utils/topbar_helper.rb
+++ b/app/view_utils/topbar_helper.rb
@@ -2,7 +2,6 @@ module TopbarHelper
 
   module_function
 
-  # rubocop:disable Metrics/ParameterLists
   def topbar_props(community:, path_after_locale_change:, user: nil, search_placeholder: nil,
                    locale_param: nil, current_path: nil, landing_page: false, host_with_port:)
 
@@ -71,7 +70,6 @@ module TopbarHelper
       unReadMessagesCount: MarketplaceService::Inbox::Query.notification_count(user&.id, community.id)
     }
   end
-  # rubocop:enable Metrics/ParameterLists
 
   def links(community:, user:, locale_param:, host_with_port:)
     user_links = Maybe(community.menu_links)

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -286,6 +286,8 @@ default: &default_settings
 
   # Harmony service API connection
   harmony_api_url:
+  harmony_api_disable_authentication: false
+  harmony_api_token_secret: secret_key1
 
   # Perform Thinking Sphinx incremental indexing delayed jobs
   use_thinking_sphinx_indexing: true

--- a/spec/utils/service_client/middleware/jwt_authenticator_spec.rb
+++ b/spec/utils/service_client/middleware/jwt_authenticator_spec.rb
@@ -1,0 +1,62 @@
+require 'active_support/all'
+require 'uuidtools'
+require 'possibly'
+require 'jwt'
+
+[
+  "app/services/result",
+  "app/utils/entity_utils",
+  "app/utils/uuid_utils",
+  "app/utils/jwt_utils",
+  "app/utils/hash_utils",
+  "app/utils/service_client/client",
+  "app/utils/service_client/middleware/middleware_base",
+  "app/utils/service_client/middleware/jwt_authenticator",
+].each { |file| require_relative "../../../../#{file}" }
+
+describe ServiceClient::Middleware::JwtAuthenticator do
+
+  SECRET = "secret"
+
+  let(:authenticator) { ServiceClient::Middleware::JwtAuthenticator.new(false, SECRET) }
+
+  def req_token(context)
+    context[:req][:headers]["Authorization"].split(" ")[1]
+  end
+
+  def token_data(token)
+    res = JWTUtils.decode(token, SECRET, verify_sub: false)
+    if res.success
+      res.data
+    end
+  end
+
+  it "encodes an authorization header" do
+    m_id = UUIDUtils.create
+    a_id = UUIDUtils.create
+    auth_context = {
+      marketplace_id: m_id,
+      actor_id: a_id
+    }
+
+    ctx = authenticator.enter({req: {headers: {}},
+                               opts: {auth_context: auth_context}})
+    expect(token_data(req_token(ctx))).to eq({"marketplaceId" => m_id.to_s,
+                                              "actorId"       => a_id.to_s})
+  end
+
+  it "fails with a missing auth context" do
+    ctx = {req: {headers: {}}, opts: {}}
+    expect { authenticator.enter(ctx) }.to raise_error(TypeError)
+  end
+
+  it "fails with an invalid missing auth context" do
+    auth_context = {
+      marketplace_id: 1,
+      actor_id: 2
+    }
+    ctx = {req: {headers: {}}, opts: {auth_context: auth_context}}
+    expect { authenticator.enter(ctx) }.to raise_error(ArgumentError)
+  end
+
+end


### PR DESCRIPTION
This PR adds JWT authentication to all HarmonyClient API calls if the authentication configuration is enabled. The token needs an authentication context hash with `:marketplace_id` and `:actor_id` keys with their corresponding UUIDs as values.