### PR TITLE
Improve error messages on booking error

### DIFF
--- a/app/services/transaction_service/data_types/transaction.rb
+++ b/app/services/transaction_service/data_types/transaction.rb
@@ -35,7 +35,7 @@ module TransactionService::DataTypes::Transaction
     [:booking, :hash])
 
   TransactionResponse = EntityUtils.define_builder(
-    [:transaction, :hash, :mandatory],
+    [:transaction, :hash, :optional],
     [:gateway_fields, :hash, :optional],
     [:transaction_service_fields, :hash, :optional])
 

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -4,8 +4,10 @@ module TransactionService::Transaction
   end
 
   DataTypes = TransactionService::DataTypes::Transaction
+  ProcessStatus = TransactionService::DataTypes::ProcessStatus
 
   TxStore = TransactionService::Store::Transaction
+  ProcessTokenStore = TransactionService::Store::ProcessToken
 
   DEPRECATED_GATEWAYS = [:braintree, :checkout]
 
@@ -100,30 +102,38 @@ module TransactionService::Transaction
   end
 
   def finalize_create(community_id:, transaction_id:, force_sync: true)
-    tx = TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id)
+    # Transaction may be nil, if it has been deleted due to voided payment
+    m_tx = Maybe(TxStore.get_in_community(community_id: community_id, transaction_id: transaction_id))
 
-    if tx.nil?
+    proc_response =
+      if !force_sync
+        # Try to find existing process token
+        # This may happen if finalize_create action has been called already, for example
+        # as a reaction to payment event
 
-      # Transaction doesn't exist.
-      #
-      # This may happen if the finalize_create action has been called already, and it failed.
-      # If the finalization fails (e.g. booking fails), we void the payment and delete the
-      # transaction.
+        proc_token = ProcessTokenStore.get_by_transaction(community_id: community_id,
+                                                          transaction_id: transaction_id,
+                                                          op_name: :do_finalize_create)
 
-      return Result::Error.new("Can't find transaction, id: #{transaction_id}, community_id: #{community_id}", {code: :tx_not_existing})
-    end
+        proc_status_response(proc_token) if proc_token
+      end
 
-    tx_process = tx_process(tx[:payment_process])
-    gw = gateway_adapter(tx[:payment_gateway])
+    res =
+      if proc_response
+        proc_response
+      else
+        tx_process = tx_process(tx[:payment_process])
+        gw = gateway_adapter(tx[:payment_gateway])
 
-    res = tx_process.finalize_create(
-      tx: tx,
-      gateway_adapter: gw,
-      force_sync: force_sync)
+        tx_process.finalize_create(
+          tx: tx,
+          gateway_adapter: gw,
+          force_sync: force_sync)
+      end
 
     res.and_then { |tx_fields|
       Result::Success.new(DataTypes.create_transaction_response(
-                            query(tx[:id]),
+                            m_tx.map { |tx| query(tx[:id]) }.or_else(nil),
                             {},
                             tx_fields))
     }
@@ -276,5 +286,13 @@ module TransactionService::Transaction
 
   def paypal_billing_agreement_api
     PaypalService::API::Api.billing_agreements
+  end
+
+  def proc_status_response(proc_token)
+    Result::Success.new(
+      ProcessStatus.create_process_status({
+                                            process_token: proc_token[:process_token],
+                                            completed: proc_token[:op_completed],
+                                            result: proc_token[:op_output]}))
   end
 end

--- a/app/services/transaction_service/transaction.rb
+++ b/app/services/transaction_service/transaction.rb
@@ -121,7 +121,17 @@ module TransactionService::Transaction
     res =
       if proc_response
         proc_response
+      elsif m_tx.is_none?
+
+        # Transaction doesn't exist.
+        #
+        # This may happen if the finalize_create action has been called already, and it failed.
+        # If the finalization fails (e.g. booking fails), we void the payment and delete the
+        # transaction.
+        Result::Error.new("Can't find transaction, id: #{transaction_id}, community_id: #{community_id}", {code: :tx_not_existing})
       else
+        tx = m_tx.get
+
         tx_process = tx_process(tx[:payment_process])
         gw = gateway_adapter(tx[:payment_gateway])
 

--- a/config/locales/unreleased_features/en.yml
+++ b/config/locales/unreleased_features/en.yml
@@ -12,7 +12,7 @@ en:
       error_in_checking_availability: "Could not check availability for the selected dates"
   error_messages:
     booking:
-      booking_failed_payment_voided: "Failed to create a booking. Your payment will be refunded."
+      booking_failed_payment_voided: "Booking failed due to an unexpected error. Please try again later. You haven't been charged."
       double_booking_payment_voided: "Unfortunately the dates you chose are no longer available. Please choose another dates. You haven’t been charged."
   listings:
     error:

--- a/config/locales/unreleased_features/en.yml
+++ b/config/locales/unreleased_features/en.yml
@@ -13,6 +13,7 @@ en:
   error_messages:
     booking:
       booking_failed_payment_voided: "Failed to create a booking. Your payment will be refunded."
+      double_booking_payment_voided: "Unfortunately the dates you chose are no longer available. Please choose another dates. You haven’t been charged."
   listings:
     error:
       create_failed_to_connect_to_booking_service: "Listing creation failed: Failed to connect to the booking service. Please try again."

--- a/config/locales/unreleased_features/en.yml
+++ b/config/locales/unreleased_features/en.yml
@@ -13,7 +13,7 @@ en:
   error_messages:
     booking:
       booking_failed_payment_voided: "Booking failed due to an unexpected error. Please try again later. You haven't been charged."
-      double_booking_payment_voided: "Unfortunately the dates you chose are no longer available. Please choose another dates. You haven’t been charged."
+      double_booking_payment_voided: "Unfortunately the dates you chose are no longer available. Please choose different dates. You haven’t been charged."
   listings:
     error:
       create_failed_to_connect_to_booking_service: "Listing creation failed: Failed to connect to the booking service. Please try again."


### PR DESCRIPTION
This PR adds better error messages if booking fails. It also differentiates two cases: double booking and other booking error, i.e. connection error.

This PR also changes the "process token" logic a bit. The `finalize_create` method fetches now an existing `process_token` and returns that if it exist. This way the view can show the error message that is stored to the process_token result.