### PR TITLE
Move Topbar inside SearchPage (other pages still use TopbarApp)

### DIFF
--- a/app/views/layouts/react_page.haml
+++ b/app/views/layouts/react_page.haml
@@ -16,11 +16,6 @@
       - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)
       - key_param = maps_key ? "&key=#{maps_key}" : ""
       = javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places#{key_param}"
-    - props = topbar_props
-    - cache props do
-      = react_component("TopbarApp", props: props, prerender: true, id: 'topbar-container')
-  - else
-    = render partial: 'layouts/global_header', locals: header_props()
 
   - if display_expiration_notice?
     = render partial: "layouts/expiration_notice",

--- a/app/views/search_page/search_page.erb
+++ b/app/views/search_page/search_page.erb
@@ -16,6 +16,7 @@
   },
 
   data: bootstrapped_data,
+  topbar: topbar_props,
   }
 %>
 <%= react_component("SearchPageApp", props: props, prerender: true, id: 'searchpage-container') %>

--- a/client/app/components/sections/SearchPage/SearchPage.js
+++ b/client/app/components/sections/SearchPage/SearchPage.js
@@ -2,7 +2,9 @@ import { Component, PropTypes } from 'react';
 import r, { div } from 'r-dom';
 import Immutable from 'immutable';
 import styleVariables from '../../../assets/styles/variables';
+import { routes as routesProp } from '../../../utils/PropTypes';
 
+import Topbar from '../../sections/Topbar/Topbar';
 import ListingCard from '../../composites/ListingCard/ListingCard';
 import ListingCardPanel from '../../composites/ListingCardPanel/ListingCardPanel';
 import Branding from '../../composites/Branding/Branding';
@@ -38,6 +40,10 @@ class SearchPage extends Component {
     const { marketplace_color1: marketplaceColor1, displayBrandingInfo, linkToSharetribe } = { ...DEFAULT_CONTEXT, ...this.props.marketplace };
     const displayBranding = this.props.marketplace && displayBrandingInfo && linkToSharetribe;
     return div({ className: css.searchPage }, [
+      r(Topbar, {
+        ...this.props.topbar,
+        routes: this.props.routes,
+      }),
       r(ListingCardPanel,
         { className: css.listingContainer },
         this.listings.map((listing) =>
@@ -73,6 +79,8 @@ SearchPage.propTypes = {
     displayBrandingInfo: bool,
     linkToSharetribe: string,
   }),
+  routes: routesProp,
+  topbar: shape(Topbar.propTypes).isRequired,
 };
 
 export default SearchPage;

--- a/client/app/components/sections/SearchPage/SearchPageContainer.js
+++ b/client/app/components/sections/SearchPage/SearchPageContainer.js
@@ -33,6 +33,7 @@ const mapStateToProps = function mapStateToProps(state) {
     searchPage: state.searchPage.set('listings', listings),
     marketplace: state.marketplace,
     routes: state.routes,
+    topbar: state.topbar,
   };
 };
 

--- a/client/app/reducers/reducersIndex.js
+++ b/client/app/reducers/reducersIndex.js
@@ -14,4 +14,5 @@ export default {
   routes: routesReducer,
   listings: (state = {}) => state,
   profiles: (state = {}) => state,
+  topbar: (state = {}) => state,
 };

--- a/client/app/startup/SearchPageApp.js
+++ b/client/app/startup/SearchPageApp.js
@@ -57,6 +57,13 @@ export default (props) => {
   const routes = subset([
     'listing',
     'person',
+    'new_listing',
+    'person_inbox',
+    'person_settings',
+    'logout',
+    'admin',
+    'login',
+    'sign_up',
   ], { locale });
 
   const bootstrappedData = TransitImmutableConverter.fromJSON(props.data);
@@ -79,7 +86,9 @@ export default (props) => {
     profiles,
     routes,
     searchPage,
+    topbar: { ...props.topbar, routes },
   };
+
   const combinedReducer = combineReducers(reducers);
 
   const store = applyMiddleware(middleware)(createStore)(combinedReducer, combinedProps);


### PR DESCRIPTION
What happens after this PR
- TopbarApp is used on basic layout (application.haml)
- However, when react_page.haml layout is used Topbar's props are passed to SearchPageApp and Topbar is initialized inside SearchPage.js