### PR TITLE
Fix preview link target for CLP users

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -334,7 +334,7 @@ module ApplicationHelper
       :topic => :general,
       :text => t("admin.left_hand_navigation.preview"),
       :icon_class => icon_class("eye"),
-      :path => homepage_without_locale_path(big_cover_photo: true),
+      :path => homepage_without_locale_path(big_cover_photo: true, locale: nil),
       :name => "preview",
     }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -334,7 +334,7 @@ module ApplicationHelper
       :topic => :general,
       :text => t("admin.left_hand_navigation.preview"),
       :icon_class => icon_class("eye"),
-      :path => search_path(big_cover_photo: true),
+      :path => homepage_without_locale_path(big_cover_photo: true),
       :name => "preview",
     }
 


### PR DESCRIPTION
One line fix to make sure preview link in admin panel has correct target (landing page of the marketplace) also when custom landing page is in use.