### PR TITLE
Give text avatars a background color based on profile name

### DIFF
--- a/client/app/components/composites/ListingCard/ListingCard.js
+++ b/client/app/components/composites/ListingCard/ListingCard.js
@@ -3,7 +3,7 @@ import r, { a, div, img } from 'r-dom';
 import classNames from 'classnames';
 import { t, fullLocaleCode, localizedString } from '../../../utils/i18n';
 import { canUseDOM } from '../../../utils/featureDetection';
-import { tint } from '../../../utils/colors';
+import { tint, avatarColor } from '../../../utils/colors';
 import { formatDistance, formatMoney } from '../../../utils/numbers';
 import ListingModel from '../../../models/ListingModel';
 
@@ -13,7 +13,6 @@ import noImageIcon from './images/noImageIcon.svg';
 import distanceIcon from './images/distanceIcon.svg';
 
 const TINT_PERCENTAGE = 20;
-
 
 class ListingCard extends Component {
 
@@ -100,7 +99,7 @@ class ListingCard extends Component {
         }, r(Avatar, {
           url: listing.author.profileURL,
           image: listing.author.avatarImage ? listing.author.avatarImage.thumb : null,
-          color: this.props.color,
+          color: avatarColor(`${listing.author.givenName}${listing.author.familyName}`) || this.props.color,
           givenName: listing.author.givenName,
           familyName: listing.author.familyName,
         })),

--- a/client/app/utils/colors.js
+++ b/client/app/utils/colors.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 const COLOR_FF = 255;
 const HEXADECIMAL = 16;
 const PERCENTAGE_100 = 100.0;
+const HUE_RANGE = 360;
 
 const hexToRGB = _.memoize((hexadecimal) => {
   // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
@@ -56,4 +57,34 @@ const tint = _.memoize((hex, tintPercentage) => {
   };
 });
 
-export { brightness, hexToRGB, tint };
+/**
+ * Calculate a 32 bit FNV-1a hash
+ * Found here: https://gist.github.com/vaiorabbit/5657561
+ * Ref.: http://isthe.com/chongo/tech/comp/fnv/
+ *
+ * @param {string} str the input value
+ * @returns {string}
+ */
+const hashFnv32a = function hashFnv32a(str) {
+    /* eslint-disable */
+    var i, l,
+        hval = 0x811c9dc5;
+
+    for (i = 0, l = str.length; i < l; i++) {
+        hval ^= str.charCodeAt(i);
+        hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
+    }
+    return hval >>> 0;
+    /* eslint-enable */
+};
+
+const avatarColor = (name) => {
+  if (!name) {
+    return null;
+  } else {
+    const hue = hashFnv32a(name) % HUE_RANGE;
+    return `hsl(${hue}, 40%, 70%)`;
+  }
+};
+
+export { brightness, hexToRGB, tint, avatarColor };


### PR DESCRIPTION
Semi-random colors for prettier text avatars (disregard the missing translation messages):

![screenshot 2016-10-17 14 37 19](https://cloud.githubusercontent.com/assets/432030/19436548/7a824f7c-9479-11e6-9aa0-6c95c57bfa8d.png)
