### PR TITLE
Use person uuids

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -97,6 +97,22 @@ class Transaction < ActiveRecord::Base
     end
   end
 
+  def starter_uuid_object
+    if self[:starter_uuid].nil?
+      nil
+    else
+      UUIDUtils.parse_raw(self[:starter_uuid])
+    end
+  end
+
+  def listing_author_uuid_object
+    if self[:listing_author_uuid].nil?
+      nil
+    else
+      UUIDUtils.parse_raw(self[:listing_author_uuid])
+    end
+  end
+
   def status
     current_state
   end

--- a/app/services/marketplace_service/transaction.rb
+++ b/app/services/marketplace_service/transaction.rb
@@ -19,7 +19,9 @@ module MarketplaceService
         :author_skipped_feedback,
         :starter_skipped_feedback,
         :starter_id,
+        :starter_uuid,
         :listing_author_id,
+        :listing_author_uuid,
         :testimonials,
         :transitions,
         :payment_total,
@@ -106,6 +108,8 @@ module MarketplaceService
           availability: transaction_model.availability.to_sym,
           booking_uuid: transaction_model.booking_uuid_object,
           community_uuid: transaction_model.community_uuid_object,
+          starter_uuid: transaction_model.starter_uuid_object,
+          listing_author_uuid: transaction_model.listing_author_uuid_object,
           __model: transaction_model
         })]
       end
@@ -374,7 +378,7 @@ module MarketplaceService
 
         auth_context = {
           marketplace_id: transaction[:community_uuid],
-          actor_id: UUIDUtils.base64_to_uuid(transaction[:listing_author_id])
+          actor_id: transaction[:listing_author_uuid]
         }
 
         HarmonyClient.post(
@@ -383,7 +387,7 @@ module MarketplaceService
             id: transaction[:booking_uuid]
           },
           body: {
-            actorId: UUIDUtils.base64_to_uuid(transaction[:listing_author_id]),
+            actorId: transaction[:listing_author_uuid],
             reason: :provider_accepted
           },
           opts: {
@@ -401,7 +405,7 @@ module MarketplaceService
 
         auth_context = {
           marketplace_id: transaction[:community_uuid],
-          actor_id: UUIDUtils.base64_to_uuid(transaction[:listing_author_id])
+          actor_id: transaction[:listing_author_uuid]
         }
 
         HarmonyClient.post(
@@ -410,7 +414,7 @@ module MarketplaceService
             id: transaction[:booking_uuid]
           },
           body: {
-            actorId: UUIDUtils.base64_to_uuid(transaction[:listing_author_id]),
+            actorId: transaction[:listing_author_uuid],
 
             # Passing the reason to the event handler is a bit
             # cumbersome. We decided to skip it for now. That's why

--- a/app/services/transaction_service/process/preauthorize.rb
+++ b/app/services/transaction_service/process/preauthorize.rb
@@ -162,7 +162,7 @@ module TransactionService::Process
 
       auth_context = {
         marketplace_id: tx[:community_uuid],
-        actor_id: UUIDUtils.base64_to_uuid(tx[:starter_id])
+        actor_id: tx[:starter_uuid]
       }
 
       HarmonyClient.post(
@@ -170,7 +170,7 @@ module TransactionService::Process
         body: {
           marketplaceId: tx[:community_uuid],
           refId: tx[:listing_uuid],
-          customerId: UUIDUtils.base64_to_uuid(tx[:starter_id]),
+          customerId: tx[:starter_uuid],
           initialStatus: :paid,
           start: tx[:booking][:start_on],
           end: end_adjusted

--- a/app/services/transaction_service/store/transaction.rb
+++ b/app/services/transaction_service/store/transaction.rb
@@ -5,15 +5,15 @@ module TransactionService::Store::Transaction
 
   NewTransaction = EntityUtils.define_builder(
     [:community_id, :fixnum, :mandatory],
-    [:community_uuid, :uuid, :mandatory],
+    [:community_uuid, :string, :mandatory, transform_with: UUIDUtils::RAW], # :string type for raw bytes
     [:listing_id, :fixnum, :mandatory],
-    [:listing_uuid, :uuid, :mandatory],
+    [:listing_uuid, :string, :mandatory, transform_with: UUIDUtils::RAW], # :string type for raw bytes
     [:starter_id, :string, :mandatory],
-    [:starter_uuid, :uuid, :mandatory],
+    [:starter_uuid, :string, :mandatory, transform_with: UUIDUtils::RAW], # :string type for raw bytes
     [:listing_quantity, :fixnum, default: 1],
     [:listing_title, :string, :mandatory],
     [:listing_author_id, :string, :mandatory],
-    [:listing_author_uuid, :uuid, :mandatory],
+    [:listing_author_uuid, :string, :mandatory, transform_with: UUIDUtils::RAW], # :string type for raw bytes
     [:unit_type, :to_symbol, one_of: [:hour, :day, :night, :week, :month, :custom, nil]],
     [:unit_price, :money, default: Money.new(0)],
     [:unit_tr_key, :string],
@@ -33,15 +33,15 @@ module TransactionService::Store::Transaction
   Transaction = EntityUtils.define_builder(
     [:id, :fixnum, :mandatory],
     [:community_id, :fixnum, :mandatory],
-    [:community_uuid, :uuid], # This will be mandatory once the migrations have run
+    [:community_uuid, :uuid, :mandatory, transform_with: UUIDUtils::PARSE_RAW],
     [:listing_id, :fixnum, :mandatory],
-    [:listing_uuid, :uuid, :mandatory], # This will be mandatory once the migrations have run
+    [:listing_uuid, :uuid, :mandatory, transform_with: UUIDUtils::PARSE_RAW],
     [:starter_id, :string, :mandatory],
-    [:starter_uuid, :uuid, :mandatory],
+    [:starter_uuid, :uuid, :mandatory, transform_with: UUIDUtils::PARSE_RAW],
     [:listing_quantity, :fixnum, :mandatory],
     [:listing_title, :string, :mandatory],
     [:listing_author_id, :string, :mandatory],
-    [:listing_author_uuid, :uuid, :mandatory],
+    [:listing_author_uuid, :uuid, :mandatory, transform_with: UUIDUtils::PARSE_RAW],
     [:unit_type, :to_symbol, one_of: [:hour, :day, :night, :week, :month, :custom, nil]],
     [:unit_price, :money, default: Money.new(0)],
     [:unit_tr_key, :string],
@@ -87,12 +87,8 @@ module TransactionService::Store::Transaction
 
   def create(opts)
     tx_data = HashUtils.compact(NewTransaction.call(opts))
-    tx_model = TransactionModel.new(tx_data
-                                      .except(:content, :booking_fields)
-                                      .merge(listing_uuid: UUIDUtils.raw(tx_data[:listing_uuid]),
-                                             community_uuid: UUIDUtils.raw(tx_data[:community_uuid]),
-                                             starter_uuid: UUIDUtils.raw(tx_data[:starter_uuid]),
-                                             listing_author_uuid: UUIDUtils.raw(tx_data[:listing_author_uuid])))
+    tx_model = TransactionModel.new(tx_data.except(:content, :booking_fields))
+
     build_conversation(tx_model, tx_data)
     build_booking(tx_model, tx_data)
 
@@ -178,12 +174,6 @@ module TransactionService::Store::Transaction
 
         hash = add_opt_shipping_address(hash, m)
         hash = add_opt_booking(hash, m)
-
-        hash[:listing_uuid]        = UUIDUtils.parse_raw(hash[:listing_uuid]) if hash[:listing_uuid].present?
-        hash[:community_uuid]      = UUIDUtils.parse_raw(hash[:community_uuid]) if hash[:community_uuid].present?
-        hash[:starter_uuid]        = UUIDUtils.parse_raw(hash[:starter_uuid]) if hash[:starter_uuid].present?
-        hash[:listing_author_uuid] = UUIDUtils.parse_raw(hash[:listing_author_uuid]) if hash[:listing_author_uuid].present?
-        hash[:booking_uuid]        = UUIDUtils.parse_raw(hash[:booking_uuid]) if hash[:booking_uuid].present?
 
         hash
       }

--- a/app/services/transaction_service/store/transaction.rb
+++ b/app/services/transaction_service/store/transaction.rb
@@ -89,8 +89,8 @@ module TransactionService::Store::Transaction
     tx_data = HashUtils.compact(NewTransaction.call(opts))
     tx_model = TransactionModel.new(tx_data
                                       .except(:content, :booking_fields)
-                                      .merge(listing_uuid: tx_data[:listing_uuid].raw,
-                                             community_uuid: tx_data[:community_uuid].raw,
+                                      .merge(listing_uuid: UUIDUtils.raw(tx_data[:listing_uuid]),
+                                             community_uuid: UUIDUtils.raw(tx_data[:community_uuid]),
                                              starter_uuid: UUIDUtils.raw(tx_data[:starter_uuid]),
                                              listing_author_uuid: UUIDUtils.raw(tx_data[:listing_author_uuid])))
     build_conversation(tx_model, tx_data)
@@ -179,8 +179,8 @@ module TransactionService::Store::Transaction
         hash = add_opt_shipping_address(hash, m)
         hash = add_opt_booking(hash, m)
 
-        hash[:listing_uuid]        = UUIDTools::UUID.parse_raw(hash[:listing_uuid]) if hash[:listing_uuid].present?
-        hash[:community_uuid]      = UUIDTools::UUID.parse_raw(hash[:community_uuid]) if hash[:community_uuid].present?
+        hash[:listing_uuid]        = UUIDUtils.parse_raw(hash[:listing_uuid]) if hash[:listing_uuid].present?
+        hash[:community_uuid]      = UUIDUtils.parse_raw(hash[:community_uuid]) if hash[:community_uuid].present?
         hash[:starter_uuid]        = UUIDUtils.parse_raw(hash[:starter_uuid]) if hash[:starter_uuid].present?
         hash[:listing_author_uuid] = UUIDUtils.parse_raw(hash[:listing_author_uuid]) if hash[:listing_author_uuid].present?
         hash[:booking_uuid]        = UUIDUtils.parse_raw(hash[:booking_uuid]) if hash[:booking_uuid].present?

--- a/app/utils/uuid_utils.rb
+++ b/app/utils/uuid_utils.rb
@@ -18,10 +18,6 @@ module UUIDUtils
     to_rearranged(uuid.raw)
   end
 
-  def base64_to_uuid(base64)
-    UUIDTools::UUID.parse_raw(Base64.urlsafe_decode64(base64))
-  end
-
   # private
 
   def to_rearranged(b)

--- a/app/utils/uuid_utils.rb
+++ b/app/utils/uuid_utils.rb
@@ -1,5 +1,39 @@
 module UUIDUtils
 
+  # This lambda can be used as a Entity transformer.
+  #
+  # Usage:
+  #
+  # [:listing_uuid, :uuid, transform_with: UUIDUtils::PARSE_RAW]
+  #
+  PARSE_RAW = ->(v) {
+    case v
+    when nil
+      nil
+    when UUIDTools::UUID
+      v
+    else
+      parse_raw(v)
+    end
+  }
+
+  # This lambda can be used as a Entity transformer.
+  #
+  # Usage:
+  #
+  # [:listing_uuid, :uuid, transform_with: UUIDUtils::RAW]
+  #
+  RAW = ->(v) {
+    case v
+    when nil
+      nil
+    when String
+      v
+    else
+      raw(v)
+    end
+  }
+
   module_function
 
   def create

--- a/db/migrate/20161019125057_copy_again_uuids_to_transactions.rb
+++ b/db/migrate/20161019125057_copy_again_uuids_to_transactions.rb
@@ -1,0 +1,10 @@
+class CopyAgainUuidsToTransactions < ActiveRecord::Migration
+  def up
+    execute "UPDATE transactions, listings SET transactions.listing_uuid = listings.uuid WHERE transactions.listing_id = listings.id"
+    execute "UPDATE transactions, communities SET transactions.community_uuid = communities.uuid WHERE transactions.community_id = communities.id"
+  end
+
+  def down
+    # No-op. We lost the previous data so there's nothing we can do.
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1596,7 +1596,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-10-18 14:01:12
+-- Dump completed on 2016-10-19 15:53:24
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3184,4 +3184,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161018100657');
 INSERT INTO schema_migrations (version) VALUES ('20161018105036');
 
 INSERT INTO schema_migrations (version) VALUES ('20161018105521');
+
+INSERT INTO schema_migrations (version) VALUES ('20161019125057');
 

--- a/spec/services/transaction_service/store/transaction_spec.rb
+++ b/spec/services/transaction_service/store/transaction_spec.rb
@@ -49,6 +49,23 @@ describe TransactionService::Store::Transaction do
       expect(tx[:starter_uuid]).to eq(@payer.uuid_object)
       expect(tx[:listing_author_uuid]).to eq(@listing.author.uuid_object)
     end
+
+    it "stores UUIDs in rearranged format" do
+      created_tx = transaction_store.create(@transaction_info)
+
+      tx = transaction_store.get(created_tx[:id])
+
+      expect(tx[:starter_uuid]).to eq(@payer.uuid_object)
+      expect(tx[:listing_author_uuid]).to eq(@listing.author.uuid_object)
+      expect(tx[:community_uuid]).to eq(@community.uuid_object)
+      expect(tx[:listing_uuid]).to eq(@listing.uuid_object)
+
+      model = ::Transaction.find(tx[:id])
+      expect(model.starter_uuid).to eq(UUIDUtils.raw(@payer.uuid_object))
+      expect(model.listing_author_uuid).to eq(UUIDUtils.raw(@listing.author.uuid_object))
+      expect(model.community_uuid).to eq(UUIDUtils.raw(@community.uuid_object))
+      expect(model.listing_uuid).to eq(UUIDUtils.raw(@listing.uuid_object))
+    end
   end
 
   context "#delete" do

--- a/spec/services/transaction_service/store/transaction_spec.rb
+++ b/spec/services/transaction_service/store/transaction_spec.rb
@@ -49,23 +49,6 @@ describe TransactionService::Store::Transaction do
       expect(tx[:starter_uuid]).to eq(@payer.uuid_object)
       expect(tx[:listing_author_uuid]).to eq(@listing.author.uuid_object)
     end
-
-    it "stores UUIDs in rearranged format" do
-      created_tx = transaction_store.create(@transaction_info)
-
-      tx = transaction_store.get(created_tx[:id])
-
-      expect(tx[:starter_uuid]).to eq(@payer.uuid_object)
-      expect(tx[:listing_author_uuid]).to eq(@listing.author.uuid_object)
-      expect(tx[:community_uuid]).to eq(@community.uuid_object)
-      expect(tx[:listing_uuid]).to eq(@listing.uuid_object)
-
-      model = ::Transaction.find(tx[:id])
-      expect(model.starter_uuid).to eq(UUIDUtils.raw(@payer.uuid_object))
-      expect(model.listing_author_uuid).to eq(UUIDUtils.raw(@listing.author.uuid_object))
-      expect(model.community_uuid).to eq(UUIDUtils.raw(@community.uuid_object))
-      expect(model.listing_uuid).to eq(UUIDUtils.raw(@listing.uuid_object))
-    end
   end
 
   context "#delete" do


### PR DESCRIPTION
- [x] Use new UUIDs as `actorId` in Harmony calls
- [x] Fix `listing_uuid` and `community_uuid` saving issue. They weren't rearranged before saving
- [x] Add `UUIDUtils::PARSE_RAW` and `UUIDUtils::RAW` Entity transformers
- [x] Copy `listing_uuid` and `community_uuid` values to `transactions` table