### PR TITLE
New member notification goes to all notification addresses of admin

### DIFF
--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -256,7 +256,7 @@ class PersonMailer < ActionMailer::Base
     @person = new_member
     @email = new_member.emails.last.address
     with_locale(admin.locale, community.locales.map(&:to_sym), community.id) do
-      address = admin.confirmed_notification_email_to
+      address = admin.confirmed_notification_emails_to
       if address.present?
         premailer_mail(:to => address,
                        :from => community_specific_sender(community),


### PR DESCRIPTION
Mighty one letter PR... :D 
But it is an important S!
Otherwise admin gets the notification only to their first notification address, and this caused confusion. Sounds like edge case, but now it's fixed, and shouldn't confuse anymore.. :)