### PR TITLE
Facebook SDK version

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -328,7 +328,8 @@ class Person < ActiveRecord::Base
 
   def store_picture_from_facebook()
     if self.facebook_id
-      resp = RestClient.get("http://graph.facebook.com/#{self.facebook_id}/picture?type=large&redirect=false")
+      resp = RestClient.get(
+        "http://graph.facebook.com/#{FacebookSdkVersion::SERVER}/#{self.facebook_id}/picture?type=large&redirect=false")
       url = JSON.parse(resp)["data"]["url"]
       self.picture_from_url(url)
     end

--- a/app/views/layouts/_facebook_sdk.haml
+++ b/app/views/layouts/_facebook_sdk.haml
@@ -7,7 +7,7 @@ appId      : '#{Maybe(@current_community).facebook_connect_id.or_else(APP_CONFIG
 channelUrl : '//#{@current_community ? @current_community.full_domain : "www." + APP_CONFIG.domain}/channel.html', // Channel file for x-domain comms
 status     : false,                                 // Check Facebook Login status
 xfbml      : true,                                  // Look for social plugins on the page
-version    : 'v2.3'
+version    : '#{FacebookSdkVersion::CLIENT}'
 });
 // Additional initialization code such as adding Event Listeners goes here
 };

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,8 @@ require File.expand_path('../config_loader', __FILE__)
 
 require File.expand_path('../available_locales', __FILE__)
 
+require File.expand_path('../facebook_sdk_version', __FILE__)
+
 # Load the logger
 require File.expand_path('../../lib/sharetribe_logger', __FILE__)
 

--- a/config/facebook_sdk_version.rb
+++ b/config/facebook_sdk_version.rb
@@ -1,0 +1,10 @@
+#
+# This file defines the Facebook SDK version that is currently in use
+#
+module FacebookSdkVersion
+  # Server-side SDK version
+  SERVER = "v2.2"
+
+  # The client-side JavaScript SDK version
+  CLIENT = "v2.3"
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -253,7 +253,7 @@ Devise.setup do |config|
 
   # This will configure a setup phase hook, that will use SessionsController#facebook_setup as callback
   # It allows dynamic configuring on community basis
-  facebook_api_version = "v2.2"
+  facebook_api_version = FacebookSdkVersion::SERVER
 
   config.omniauth :facebook,
                   setup: true,

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,10 @@ This guide contains information how to run tests.
 
 This guide shows how to write fast RSpec tests without requiring Rails environment
 
+#### [Upgrade Facebook SDK version](./upgrade-facebook-sdk-version.md)
+
+This guide shows how upgrade the Facebook SDK version
+
 ## Process documentation
 
 Documentation of the development process.

--- a/docs/upgrade-facebook-sdk-version.md
+++ b/docs/upgrade-facebook-sdk-version.md
@@ -1,0 +1,16 @@
+# Upgrade Facebook SDK version
+
+Facebook is drooping support to its old SDK versions periodically. When ever this happens, we need to make sure we are not using an unsupported SDK. This guide shows how to upgrade Facebook SDK version.
+
+## What changes are required
+
+Use Facebook's [API Upgrade Tool](https://developers.facebook.com/tools/api_versioning/) to see the changes between different API versions.
+
+## Upgrade the SDK version
+
+Edit the file [config/facebook_sdk_version.rb](/config/facebook_sdk_version.rb). There are two configurations in that file
+
+* `SERVER`: The current server-side SDK version
+* `CLIENT`: The current client-side JavaScript SDK version
+
+Make the version change and test that everything works.


### PR DESCRIPTION
- [x] Add a common place where the Facebook SDK version is defined
- [x] Add version number to the profile picture call (this will give us better debugging output when using Facebook's API Upgrade tool)
- [x] Write doc about version upgrade 

This PR does NOT change the actual Facebook API versions. We're currently using version 2.2, which will reach its end of life at 27 March 2017