### PR TITLE
Facebook upgrade v2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Updated Node.js to the latest LTS (long term support) version 6.9 [#2655](https://github.com/sharetribe/sharetribe/pull/2665)
 - Updated NPM packages [#2655](https://github.com/sharetribe/sharetribe/pull/2665)
 - Update react_on_rails gem [#2655](https://github.com/sharetribe/sharetribe/pull/2665)
+- Upgrade Facebook SDK from v2.2 to v2.8 [#2666](https://github.com/sharetribe/sharetribe/pull/2666)
 
 ### Fixed
 

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'web_translate_it', "~>2.1.8"
 gem 'rails-i18n', '~> 4.0.8'
 gem 'devise', "~>3.5.0"
 gem 'devise-encryptable', '~> 0.2.0'
-gem "omniauth-facebook", "~> 3.0.0"
+gem "omniauth-facebook", "~> 4.0.0"
 
 # Dynamic form adds helpers that are needed, e.g. error_messages
 gem 'dynamic_form', "~>1.1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     haml (4.0.7)
       tilt
-    hashie (3.4.4)
+    hashie (3.4.6)
     hike (1.2.3)
     htmlentities (4.3.4)
     http-cookie (1.0.2)
@@ -323,7 +323,7 @@ GEM
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
-    omniauth-facebook (3.0.0)
+    omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
@@ -586,7 +586,7 @@ DEPENDENCIES
   mysql2 (~> 0.4.4)
   newrelic_rpm (~> 3.9.1.236)
   oauth2!
-  omniauth-facebook (~> 3.0.0)
+  omniauth-facebook (~> 4.0.0)
   paperclip (~> 5.1.0)
   passenger (~> 5.0.18)
   paypal-sdk-merchant (~> 1.116.0)

--- a/config/facebook_sdk_version.rb
+++ b/config/facebook_sdk_version.rb
@@ -3,8 +3,8 @@
 #
 module FacebookSdkVersion
   # Server-side SDK version
-  SERVER = "v2.3"
+  SERVER = "v2.8"
 
   # The client-side JavaScript SDK version
-  CLIENT = "v2.3"
+  CLIENT = "v2.8"
 end

--- a/config/facebook_sdk_version.rb
+++ b/config/facebook_sdk_version.rb
@@ -3,7 +3,7 @@
 #
 module FacebookSdkVersion
   # Server-side SDK version
-  SERVER = "v2.2"
+  SERVER = "v2.3"
 
   # The client-side JavaScript SDK version
   CLIENT = "v2.3"


### PR DESCRIPTION
This PR upgrades the facebook-omniauth gem and the Facebook SDK version from 2.2 -> 2.8. After quick testing at staging it looks that this upgrade doesn't break anything.
