### PR TITLE
Don't throw exception in landing page if category is missing

### DIFF
--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -97,11 +97,9 @@ module CustomLandingPage
       end
 
       def call(type, id, _)
-        unless @_data.key?(id)
-          raise LinkResolvingError.new("Unknown category id '#{id}'.")
+        if @_data.key?(id)
+          @_data[id].merge("id" => id, "type" => type)
         end
-
-        @_data[id].merge("id" => id, "type" => type)
       end
     end
 


### PR DESCRIPTION
This PR changes the CategoryLinkResolver so that it doesn't throw an exception if category is not found, but instead returns `nil`. No other changes is needed, [the view layer already tolerates `nil` value](https://github.com/sharetribe/sharetribe/blob/66e4dcf88d12989c7db4b5baa0b46137e4a712c1/app/views/landing_page/_categories.erb#L33)