### PR TITLE
downcase username before checking availability on blacklist

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -218,7 +218,7 @@ class Person < ActiveRecord::Base
   end
 
   def self.username_available?(username, community_id)
-    !username.in?(USERNAME_BLACKLIST) &&
+    !username.downcase.in?(USERNAME_BLACKLIST) &&
       !Person
         .where("username = :username AND (is_admin = '1' OR community_id = :cid)", username: username, cid: community_id)
         .present?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -218,7 +218,7 @@ class Person < ActiveRecord::Base
   end
 
   def self.username_available?(username, community_id)
-    !username.downcase.in?(USERNAME_BLACKLIST) &&
+    !USERNAME_BLACKLIST.include?(username.downcase) &&
       !Person
         .where("username = :username AND (is_admin = '1' OR community_id = :cid)", username: username, cid: community_id)
         .present?


### PR DESCRIPTION
Before this, the username availability check in the UI didn't complain for "ADmin" although "admin" is in the blacklist.
Now compares always downcase version to the list where all is downcases.
