### PR TITLE
Remove broken marker labels

### DIFF
--- a/app/assets/javascripts/googlemaps.js
+++ b/app/assets/javascripts/googlemaps.js
@@ -539,15 +539,6 @@ function addListingMarkers(listings, viewport) {
           title: entry["title"]
         });
 
-        // Marker icon based on category
-        var label = new Label({
-                       map: map
-                  });
-                  label.set('zIndex', 1234);
-                  label.bindTo('position', marker, 'position');
-                  label.set('text', "");
-                  label.set('color', "#FFF");
-        marker.set("label", label);
         markers.push(marker);
         markerContents.push(entry["id"]);
         markersArr.push(marker);


### PR DESCRIPTION
For some reason, we tried to set an empty label to all map markers. The code was broken, so it was displayed as `[Object object]`. Not setting the label at all works better.