### PR TITLE
Return map item label, fix markerclusterer label references

### DIFF
--- a/app/assets/javascripts/googlemaps.js
+++ b/app/assets/javascripts/googlemaps.js
@@ -539,6 +539,16 @@ function addListingMarkers(listings, viewport) {
           title: entry["title"]
         });
 
+        // Marker icon based on category
+        var label = new Label({
+                       map: map
+                  });
+                  label.set('zIndex', 1234);
+                  label.bindTo('position', marker, 'position');
+                  label.set('text', "");
+                  label.set('color', "#FFF");
+        marker.set("label", label);
+
         markers.push(marker);
         markerContents.push(entry["id"]);
         markersArr.push(marker);

--- a/app/assets/javascripts/markerclusterer.js.erb
+++ b/app/assets/javascripts/markerclusterer.js.erb
@@ -835,20 +835,20 @@ Cluster.prototype.addMarker = function(marker, markerIndex) {
   if (len < this.minClusterSize_ && marker.getMap() != this.map_) {
     // Min cluster size not reached so show the marker.
     marker.setMap(this.map_);
-    marker.get("label").setMap(this.map_);
+    marker.set("label", "");
   }
 
   if (len == this.minClusterSize_) {
     // Hide the markers that were showing.
     for (var i = 0; i < len; i++) {
-      this.markers_[i].get("label").setMap(null);
+      this.markers_[i].set("label", "");
       this.markers_[i].setMap(null);
     }
   }
 
   if (len >= this.minClusterSize_) {
     marker.setMap(null);
-    marker.get("label").setMap(null);
+    marker.set("label", "");
   }
 
   this.updateIcon();


### PR DESCRIPTION
Our `markerclusterer.js` seems to be incompatible with our map marker objects