### PR TITLE
Limit effect of bot crawling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Updated NPM packages [#2655](https://github.com/sharetribe/sharetribe/pull/2665)
 - Update react_on_rails gem [#2655](https://github.com/sharetribe/sharetribe/pull/2665)
 - Upgrade Facebook SDK from v2.2 to v2.8 [#2666](https://github.com/sharetribe/sharetribe/pull/2666)
+- Instruct crawlers not to follow auth paths, add crawling delay for bots that support the directive [#2693](https://github.com/sharetribe/sharetribe/pull/2693)
 
 ### Fixed
 

--- a/lib/rack_middleware/robots_generator.rb
+++ b/lib/rack_middleware/robots_generator.rb
@@ -73,7 +73,8 @@ class RobotsGenerator
   def self.index_content(req)
     [
       "User-agent: *",
-      "Allow: /",
+      "Disallow: /*auth$",
+      "Crawl-Delay: 5",
       "Sitemap: #{req.scheme}://#{req.host_with_port}/sitemap.xml.gz"
     ].join("\n")
   end


### PR DESCRIPTION
Disallow auth pages, add crawl delay for the bots that support the directive.
