### PR TITLE
Allow admin to access admin panel features without confirmed email

### DIFF
--- a/app/controllers/admin/admin_area_controller.rb
+++ b/app/controllers/admin/admin_area_controller.rb
@@ -1,0 +1,9 @@
+# This controller is parent for all controllers handling the admin area functions
+
+class Admin::AdminAreaController < ApplicationController
+
+  before_filter :ensure_is_admin
+
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+end

--- a/app/controllers/admin/admin_base_controller.rb
+++ b/app/controllers/admin/admin_base_controller.rb
@@ -1,6 +1,6 @@
 # This controller is parent for all controllers handling the admin area functions
 
-class Admin::AdminAreaController < ApplicationController
+class Admin::AdminBaseController < ApplicationController
 
   before_filter :ensure_is_admin
 

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,9 +1,4 @@
-class Admin::CategoriesController < ApplicationController
-
-  before_filter :ensure_is_admin
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
+class Admin::CategoriesController < Admin::AdminAreaController
 
   def index
     @selected_left_navi_link = "listing_categories"

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -2,6 +2,9 @@ class Admin::CategoriesController < ApplicationController
 
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   def index
     @selected_left_navi_link = "listing_categories"
     @categories = @current_community.top_level_categories.includes(:translations, children: :translations)

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CategoriesController < Admin::AdminAreaController
+class Admin::CategoriesController < Admin::AdminBaseController
 
   def index
     @selected_left_navi_link = "listing_categories"

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -4,6 +4,9 @@ class Admin::CommunitiesController < ApplicationController
   before_filter :ensure_is_admin
   before_filter :ensure_white_label_plan, only: [:create_sender_address]
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   def edit_look_and_feel
     @selected_left_navi_link = "tribe_look_and_feel"
     @community = @current_community

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -1,11 +1,7 @@
-class Admin::CommunitiesController < ApplicationController
+class Admin::CommunitiesController < Admin::AdminAreaController
   include CommunitiesHelper
 
-  before_filter :ensure_is_admin
   before_filter :ensure_white_label_plan, only: [:create_sender_address]
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
 
   def edit_look_and_feel
     @selected_left_navi_link = "tribe_look_and_feel"

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CommunitiesController < Admin::AdminAreaController
+class Admin::CommunitiesController < Admin::AdminBaseController
   include CommunitiesHelper
 
   before_filter :ensure_white_label_plan, only: [:create_sender_address]

--- a/app/controllers/admin/community_customizations_controller.rb
+++ b/app/controllers/admin/community_customizations_controller.rb
@@ -1,8 +1,4 @@
-class Admin::CommunityCustomizationsController < ApplicationController
-  before_filter :ensure_is_admin
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
+class Admin::CommunityCustomizationsController < Admin::AdminAreaController
 
   def edit_details
     @selected_left_navi_link = "tribe_details"

--- a/app/controllers/admin/community_customizations_controller.rb
+++ b/app/controllers/admin/community_customizations_controller.rb
@@ -1,6 +1,9 @@
 class Admin::CommunityCustomizationsController < ApplicationController
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   def edit_details
     @selected_left_navi_link = "tribe_details"
     # @community_customization is fetched in application_controller

--- a/app/controllers/admin/community_customizations_controller.rb
+++ b/app/controllers/admin/community_customizations_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CommunityCustomizationsController < Admin::AdminAreaController
+class Admin::CommunityCustomizationsController < Admin::AdminBaseController
 
   def edit_details
     @selected_left_navi_link = "tribe_details"

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -1,6 +1,6 @@
 require 'csv'
 
-class Admin::CommunityMembershipsController < Admin::AdminAreaController
+class Admin::CommunityMembershipsController < Admin::AdminBaseController
 
   def index
     @selected_left_navi_link = "manage_members"

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -1,10 +1,6 @@
 require 'csv'
 
-class Admin::CommunityMembershipsController < ApplicationController
-  before_filter :ensure_is_admin
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
+class Admin::CommunityMembershipsController < Admin::AdminAreaController
 
   def index
     @selected_left_navi_link = "manage_members"

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -3,6 +3,9 @@ require 'csv'
 class Admin::CommunityMembershipsController < ApplicationController
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   def index
     @selected_left_navi_link = "manage_members"
     @community = @current_community

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -1,6 +1,6 @@
 require 'csv'
 
-class Admin::CommunityTransactionsController < Admin::AdminAreaController
+class Admin::CommunityTransactionsController < Admin::AdminBaseController
   TransactionQuery = MarketplaceService::Transaction::Query
 
   def index

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -4,6 +4,9 @@ class Admin::CommunityTransactionsController < ApplicationController
   TransactionQuery = MarketplaceService::Transaction::Query
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   def index
     @selected_left_navi_link = "transactions"
     pagination_opts = PaginationViewUtils.parse_pagination_opts(params)

--- a/app/controllers/admin/community_transactions_controller.rb
+++ b/app/controllers/admin/community_transactions_controller.rb
@@ -1,11 +1,7 @@
 require 'csv'
 
-class Admin::CommunityTransactionsController < ApplicationController
+class Admin::CommunityTransactionsController < Admin::AdminAreaController
   TransactionQuery = MarketplaceService::Transaction::Query
-  before_filter :ensure_is_admin
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
 
   def index
     @selected_left_navi_link = "transactions"

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -3,6 +3,9 @@ class Admin::CustomFieldsController < ApplicationController
   before_filter :ensure_is_admin
   before_filter :field_type_is_valid, :only => [:new, :create]
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   CHECKBOX_TO_BOOLEAN = ->(v) {
     if v == false || v == true
       v

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -1,10 +1,6 @@
-class Admin::CustomFieldsController < ApplicationController
+class Admin::CustomFieldsController < Admin::AdminAreaController
 
-  before_filter :ensure_is_admin
   before_filter :field_type_is_valid, :only => [:new, :create]
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
 
   CHECKBOX_TO_BOOLEAN = ->(v) {
     if v == false || v == true

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -1,4 +1,4 @@
-class Admin::CustomFieldsController < Admin::AdminAreaController
+class Admin::CustomFieldsController < Admin::AdminBaseController
 
   before_filter :field_type_is_valid, :only => [:new, :create]
 

--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-class Admin::EmailsController < Admin::AdminAreaController
+class Admin::EmailsController < Admin::AdminBaseController
 
   def new
     @selected_tribe_navi_tab = "admin"

--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -1,10 +1,5 @@
 # encoding: utf-8
-class Admin::EmailsController < ApplicationController
-
-  before_filter :ensure_is_admin
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
+class Admin::EmailsController < Admin::AdminAreaController
 
   def new
     @selected_tribe_navi_tab = "admin"

--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -3,6 +3,9 @@ class Admin::EmailsController < ApplicationController
 
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   def new
     @selected_tribe_navi_tab = "admin"
     @selected_left_navi_link = "email_members"

--- a/app/controllers/admin/getting_started_guide_controller.rb
+++ b/app/controllers/admin/getting_started_guide_controller.rb
@@ -2,6 +2,9 @@ class Admin::GettingStartedGuideController < ApplicationController
 
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   rescue_from ReactOnRails::PrerenderError do |err|
     Rails.logger.error(err.message)
     Rails.logger.error(err.backtrace.join("\n"))

--- a/app/controllers/admin/getting_started_guide_controller.rb
+++ b/app/controllers/admin/getting_started_guide_controller.rb
@@ -1,4 +1,4 @@
-class Admin::GettingStartedGuideController < Admin::AdminAreaController
+class Admin::GettingStartedGuideController < Admin::AdminBaseController
 
   rescue_from ReactOnRails::PrerenderError do |err|
     Rails.logger.error(err.message)

--- a/app/controllers/admin/getting_started_guide_controller.rb
+++ b/app/controllers/admin/getting_started_guide_controller.rb
@@ -1,9 +1,4 @@
-class Admin::GettingStartedGuideController < ApplicationController
-
-  before_filter :ensure_is_admin
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
+class Admin::GettingStartedGuideController < Admin::AdminAreaController
 
   rescue_from ReactOnRails::PrerenderError do |err|
     Rails.logger.error(err.message)

--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -3,6 +3,9 @@ class Admin::ListingShapesController < ApplicationController
 
   before_filter :set_url_name
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   LISTING_SHAPES_NAVI_LINK = "listing_shapes"
 
   Shape = ListingShapeDataTypes::Shape

--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -1,4 +1,4 @@
-class Admin::ListingShapesController < Admin::AdminAreaController
+class Admin::ListingShapesController < Admin::AdminBaseController
 
   before_filter :set_url_name
 

--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -1,10 +1,6 @@
-class Admin::ListingShapesController < ApplicationController
-  before_filter :ensure_is_admin
+class Admin::ListingShapesController < Admin::AdminAreaController
 
   before_filter :set_url_name
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
 
   LISTING_SHAPES_NAVI_LINK = "listing_shapes"
 

--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -2,6 +2,9 @@ class Admin::PaypalPreferencesController < ApplicationController
   before_filter :ensure_is_admin
   before_filter :ensure_paypal_provisioned
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   PaypalAccountForm = FormUtils.define_form("PaypalAccountForm", :paypal_email, :commission_from_seller)
     .with_validations { validates_presence_of :paypal_email }
 

--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -1,9 +1,6 @@
-class Admin::PaypalPreferencesController < ApplicationController
-  before_filter :ensure_is_admin
-  before_filter :ensure_paypal_provisioned
+class Admin::PaypalPreferencesController < Admin::AdminAreaController
 
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
+  before_filter :ensure_paypal_provisioned
 
   PaypalAccountForm = FormUtils.define_form("PaypalAccountForm", :paypal_email, :commission_from_seller)
     .with_validations { validates_presence_of :paypal_email }

--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -1,4 +1,4 @@
-class Admin::PaypalPreferencesController < Admin::AdminAreaController
+class Admin::PaypalPreferencesController < Admin::AdminBaseController
 
   before_filter :ensure_paypal_provisioned
 

--- a/app/controllers/admin/plans_controller.rb
+++ b/app/controllers/admin/plans_controller.rb
@@ -1,4 +1,4 @@
-class Admin::PlansController < Admin::AdminAreaController
+class Admin::PlansController < Admin::AdminBaseController
 
   # Redirect to external plan service. Nothing else.
   def show

--- a/app/controllers/admin/plans_controller.rb
+++ b/app/controllers/admin/plans_controller.rb
@@ -2,6 +2,9 @@ class Admin::PlansController < ApplicationController
 
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   # Redirect to external plan service. Nothing else.
   def show
     marketplace_default_name = @current_community.name(@current_community.default_locale)

--- a/app/controllers/admin/plans_controller.rb
+++ b/app/controllers/admin/plans_controller.rb
@@ -1,9 +1,4 @@
-class Admin::PlansController < ApplicationController
-
-  before_filter :ensure_is_admin
-
-  #Allow admin to access admin panel before email confirmation
-  skip_filter :cannot_access_without_confirmation
+class Admin::PlansController < Admin::AdminAreaController
 
   # Redirect to external plan service. Nothing else.
   def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -205,7 +205,7 @@ class ApplicationController < ActionController::Base
   def ensure_user_belongs_to_community
     return unless @current_user
 
-    if !@current_user.is_admin? && @current_user.accepted_community != @current_community
+    if !@current_user.has_admin_rights? && @current_user.accepted_community != @current_community
 
       logger.info(
         "Automatically logged out user that doesn't belong to community",

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -110,6 +110,7 @@ class CommunityMembershipsController < ApplicationController
   end
 
   def confirmation_pending
+    render :confirmation_pending, locals: {support_email: APP_CONFIG.support_email}
   end
 
   # Ajax end-points for front-end validation

--- a/app/controllers/infos_controller.rb
+++ b/app/controllers/infos_controller.rb
@@ -1,5 +1,8 @@
 class InfosController < ApplicationController
 
+  #Allow infos to be viewed before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   def about
     @selected_tribe_navi_tab = "about"
     @selected_left_navi_link = "about"

--- a/app/controllers/int_api/marketplace_api.md
+++ b/app/controllers/int_api/marketplace_api.md
@@ -20,7 +20,7 @@ Request body:
 Response 201 Created, body:
 
 ```ruby
-{ marketplace_url: "https://imaginationtraders.sharetribe.com"
+{ marketplace_url: "https://imaginationtraders.sharetribe.com/en/admin/getting_started_guide"
 }
 ```
 

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -46,8 +46,12 @@ class IntApi::MarketplacesController < ApplicationController
         locale: params[:marketplace_language]},
         marketplace[:id]).data
 
+    # make the marketplace creator land to the admin panel
+    url = "#{marketplace[:url]}/admin"
+
+    # make the marketplace creator be logged in via Auth Token
     auth_token = UserService::API::AuthTokens.create_login_token(user[:id])
-    url = URLUtils.append_query_param(marketplace[:url], "auth", auth_token[:token])
+    url = URLUtils.append_query_param(url, "auth", auth_token[:token])
 
     # Enable specific features for all new trials
     FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], person_id: user[:id], features: [:topbar_v1])

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -46,15 +46,8 @@ class IntApi::MarketplacesController < ApplicationController
         locale: params[:marketplace_language]},
         marketplace[:id]).data
 
-    # make the marketplace creator land to the admin panel
-    url_params = {host: marketplace[:url]}
-
-    #include port separately to url_params if it was present
-    if marketplace[:url] && marketplace[:url].split(':')[2]
-      url_params[:port] = marketplace[:url].split(':')[2]
-    end
-
-    url = admin_getting_started_guide_url(url_params)
+    base_url = URI.new(marketplace[:url])
+    url = admin_getting_started_guide_url(host: base_url.host, port: base_url.port)
 
     # make the marketplace creator be logged in via Auth Token
     auth_token = UserService::API::AuthTokens.create_login_token(user[:id])

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -51,7 +51,7 @@ class IntApi::MarketplacesController < ApplicationController
 
     #include port separately to url_params if it was present
     if marketplace[:url] && marketplace[:url].split(':')[2]
-      url_params.merge!(port: marketplace[:url].split(':')[2])
+      url_params[:port] = marketplace[:url].split(':')[2]
     end
 
     url = admin_getting_started_guide_url(url_params)

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -47,7 +47,14 @@ class IntApi::MarketplacesController < ApplicationController
         marketplace[:id]).data
 
     # make the marketplace creator land to the admin panel
-    url = "#{marketplace[:url]}/admin"
+    url_params = {host: marketplace[:url]}
+
+    #include port separately to url_params if it was present
+    if marketplace[:url] && marketplace[:url].split(':')[2]
+      url_params.merge!(port: marketplace[:url].split(':')[2])
+    end
+
+    url = admin_getting_started_guide_url(url_params)
 
     # make the marketplace creator be logged in via Auth Token
     auth_token = UserService::API::AuthTokens.create_login_token(user[:id])

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -46,7 +46,7 @@ class IntApi::MarketplacesController < ApplicationController
         locale: params[:marketplace_language]},
         marketplace[:id]).data
 
-    base_url = URI.new(marketplace[:url])
+    base_url = URI(marketplace[:url])
     url = admin_getting_started_guide_url(host: base_url.host, port: base_url.port)
 
     # make the marketplace creator be logged in via Auth Token

--- a/app/controllers/mercury_update_controller.rb
+++ b/app/controllers/mercury_update_controller.rb
@@ -4,6 +4,9 @@ class MercuryUpdateController < ApplicationController
 
   before_filter :ensure_is_admin
 
+  #Allow admin to access admin panel before email confirmation
+  skip_filter :cannot_access_without_confirmation
+
   # Update content with WYSIWYG editor Mercury
   def update
     param_hash = params[:content].inject({}) do |memo, content_hash|

--- a/app/views/community_memberships/_confirmation_form.haml
+++ b/app/views/community_memberships/_confirmation_form.haml
@@ -2,7 +2,7 @@
   initialize_confirmation_pending_form("#{I18n.locale}","#{email_not_accepted_message}");
 
 - email_to_confirm = @current_user.latest_pending_email_address(@current_community)
-- contact_support_link = link_to t("sessions.confirmation_pending.contact_support_link_text"), "mailto:#{support_email}", "data-uv-trigger" => "contact"
+- contact_support_link = link_to t("sessions.confirmation_pending.contact_support_link_text"), "mailto:#{support_email}"
 - admin_dashboard_link = link_to t("sessions.confirmation_pending.admin_dashboard_link_text"), admin_getting_started_guide_path
 
 - if @current_user.has_admin_rights?

--- a/app/views/community_memberships/_confirmation_form.haml
+++ b/app/views/community_memberships/_confirmation_form.haml
@@ -2,11 +2,14 @@
   initialize_confirmation_pending_form("#{I18n.locale}","#{email_not_accepted_message}");
 
 - email_to_confirm = @current_user.latest_pending_email_address(@current_community)
+- contact_support_link = link_to t("sessions.confirmation_pending.contact_support_link_text"), "mailto:#{support_email}", "data-uv-trigger" => "contact"
+- admin_dashboard_link = link_to t("sessions.confirmation_pending.admin_dashboard_link_text"), admin_getting_started_guide_path
 
 - if @current_user.has_admin_rights?
   %h2= t("sessions.confirmation_pending.account_confirmation_instructions_title_admin")
-  %p= t("sessions.confirmation_pending.your_marketplace_has_now_been_created")
-  %p= t("sessions.confirmation_pending.account_confirmation_instructions_admin")
+  %p= t("sessions.confirmation_pending.before_full_access_you_need_to_confirm_email")
+  %p= t("sessions.confirmation_pending.before_confirmation_only_access_admin_dashboard", {admin_dashboard_link: admin_dashboard_link}).html_safe
+  %p= t("sessions.confirmation_pending.account_confirmation_instructions_admin", {email_address: "<b>#{email_to_confirm}</b>", support_link: contact_support_link}).html_safe
 - else
   %p= t("sessions.confirmation_pending.account_confirmation_instructions")
 

--- a/app/views/community_memberships/confirmation_pending.haml
+++ b/app/views/community_memberships/confirmation_pending.haml
@@ -2,4 +2,4 @@
   %h1= t("sessions.confirmation_pending.confirm_your_email")
 
 #new-message-form.centered-section
-  = render partial: "community_memberships/confirmation_form"
+  = render partial: "community_memberships/confirmation_form", locals: {support_email: support_email}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1817,9 +1817,13 @@ en:
       change_email: Change
       confirm_your_email: "Please confirm your email address"
       account_confirmation_instructions: "You will soon receive an email with a link to confirm your email address. Don't forget to check your spam folder! After confirming your address, you can join %{service_name}."
-      account_confirmation_instructions_title_admin: "Welcome to your marketplace!"
-      your_marketplace_has_now_been_created: "Your marketplace has now been created. That was easy, wasn't it? There's just one more step before you can access your site: we need to confirm your email address."
-      account_confirmation_instructions_admin: "You will soon receive an email with a link to confirm your email address. Don't forget to check your spam folder! Once you open the link, you can start setting up your marketplace."
+      account_confirmation_instructions_title_admin: "Confirm your email address"
+      before_full_access_you_need_to_confirm_email: "Before we can give you full access to your marketplace, there's just one more thing we need to do: confirm your email address."
+      before_confirmation_only_access_admin_dashboard: "Before confirmation you can only access the %{admin_dashboard_link}."
+      admin_dashboard_link_text: "admin dashboard"
+      account_confirmation_instructions_admin: "You should have received an email at %{email_address} with a confirmation link. If you don't see it, check your spam folder or click the button below to resend the email. Once it arrives, open the included link to confirm your address, after which you'll get full access to your marketplace.
+If you need any help, don't hesitate to %{support_link}."
+      contact_support_link_text: "contact Sharetribe support"
   settings:
     account:
       change: Change

--- a/spec/controllers/int_api/marketplaces_controller_spec.rb
+++ b/spec/controllers/int_api/marketplaces_controller_spec.rb
@@ -41,7 +41,7 @@ describe IntApi::MarketplacesController, type: :controller do
       expect(response.status).to eql 201
 
       r = JSON.parse(response.body)
-      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}/admin?auth=#{AuthToken.last.token}"
+      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}/en/admin/getting_started_guide?auth=#{AuthToken.last.token}"
 
       c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil
@@ -81,7 +81,7 @@ describe IntApi::MarketplacesController, type: :controller do
       expect(response.status).to eq(201)
 
       r = JSON.parse(response.body)
-      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
+      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}/en/admin/getting_started_guide?auth=#{AuthToken.last.token}"
 
       c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil
@@ -117,7 +117,7 @@ describe IntApi::MarketplacesController, type: :controller do
       expect(response.status).to eq(201)
 
       r = JSON.parse(response.body)
-      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
+      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}/en/admin/getting_started_guide?auth=#{AuthToken.last.token}"
 
       c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil
@@ -153,7 +153,7 @@ describe IntApi::MarketplacesController, type: :controller do
       expect(response.status).to eq(201)
 
       r = JSON.parse(response.body)
-      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
+      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}/en/admin/getting_started_guide?auth=#{AuthToken.last.token}"
 
       c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil

--- a/spec/controllers/int_api/marketplaces_controller_spec.rb
+++ b/spec/controllers/int_api/marketplaces_controller_spec.rb
@@ -41,7 +41,7 @@ describe IntApi::MarketplacesController, type: :controller do
       expect(response.status).to eql 201
 
       r = JSON.parse(response.body)
-      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}?auth=#{AuthToken.last.token}"
+      expect(r["marketplace_url"]).to eql "http://imaginationtraders.#{APP_CONFIG.domain}/admin?auth=#{AuthToken.last.token}"
 
       c = Community.where(ident: "imaginationtraders").first
       expect(c).to_not be_nil


### PR DESCRIPTION
The idea is that instead of requiring email confirmation as very first step after marketplace creation, we direct new admin to Onboarding Wizard in the Admin Dashboard and allow them to play around in the admin side, and only require email confirmation before accessing the user side of the marketplace.

This PR allows admin to use admin panel without confirmed email, changes the URL that is returned to marketing site after new trial site has been created and changes the instruction texts that admin sees on the confirmation_pending page.

There are few specific questions for the reviewer, marked separately as line comments.