### PR TITLE
Availability :none for all free transactions

### DIFF
--- a/app/controllers/free_transactions_controller.rb
+++ b/app/controllers/free_transactions_controller.rb
@@ -39,7 +39,7 @@ class FreeTransactionsController < ApplicationController
             unit_type: @listing.unit_type,
             unit_price: @listing.price,
             unit_tr_key: @listing.unit_tr_key,
-            availability: @listing.availability,
+            availability: :none, # Always none for free transactions and contacts
             listing_quantity: 1,
             content: contact_form.content,
             payment_gateway: :none,

--- a/db/migrate/20161101104218_change_availability_to_none_for_all_free_transactions.rb
+++ b/db/migrate/20161101104218_change_availability_to_none_for_all_free_transactions.rb
@@ -1,0 +1,11 @@
+class ChangeAvailabilityToNoneForAllFreeTransactions < ActiveRecord::Migration
+  def up
+    name = "Change availability to :none for all :free transactions"
+
+    exec_update([
+                  "UPDATE transactions SET availability = 'none'",
+                  "WHERE availability = 'booking'",
+                  "AND payment_process = 'none'"
+                ].join(" "), name, [])
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1597,7 +1597,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-10-19 15:53:24
+-- Dump completed on 2016-11-01 12:49:50
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3189,4 +3189,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161018105521');
 INSERT INTO schema_migrations (version) VALUES ('20161019125057');
 
 INSERT INTO schema_migrations (version) VALUES ('20161023074355');
+
+INSERT INTO schema_migrations (version) VALUES ('20161101104218');
 


### PR DESCRIPTION
This PR fixes a bug which set the `availability` for a contact to `booking`. The PR also includes a migration that fixes wrong data that was saved to database because of this bug.

Steps to reproduce:

Prerequisite:

- Admin user
- Listing author user
- Buyer user

Steps:

1. As an admin, add an Order Type with availability management turned on.
1. As a listing author, add a new listing using that order type
1. As a buyer, go to the listing page of the newly created listing and click "Contact"

Expected result: Clicking Contact starts a new "free" transaction. The `availability` for that transaction is `none`.

Actual result: Clicking Contact starts a new "free" transaction. The `availability` for that transaction is `booking`.