### PR TITLE
Save exclusive booking end date

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -2,12 +2,13 @@
 #
 # Table name: bookings
 #
-#  id             :integer          not null, primary key
-#  transaction_id :integer
-#  start_on       :date
-#  end_on         :date
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id               :integer          not null, primary key
+#  transaction_id   :integer
+#  start_on         :date
+#  end_on           :date
+#  end_on_exclusive :date
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #
@@ -17,8 +18,6 @@
 class Booking < ActiveRecord::Base
 
   belongs_to :tx, class_name: "Transaction", foreign_key: "transaction_id"
-
-  attr_accessible :transaction_id, :end_on, :start_on
 
   validates :start_on, :end_on, presence: true
   validates_with DateValidator,

--- a/app/services/transaction_service/store/transaction.rb
+++ b/app/services/transaction_service/store/transaction.rb
@@ -226,9 +226,14 @@ module TransactionService::Store::Transaction
 
   def build_booking(tx_model, tx_data)
     if is_booking?(tx_data)
-      start_on = tx_data[:booking_fields][:start_on]
-      end_on = tx_data[:booking_fields][:end_on]
-      tx_model.build_booking({start_on: start_on, end_on: end_on})
+      start_on, end_on = tx_data[:booking_fields].values_at(:start_on, :end_on)
+      end_on_exclusive = tx_data[:unit_type] == :day ? end_on + 1.day : end_on
+
+      tx_model.build_booking(
+        start_on: start_on,
+        end_on: end_on,
+        end_on_exclusive: end_on_exclusive
+      )
     end
   end
 

--- a/db/migrate/20161101124317_add_end_on_exclusive_to_bookings.rb
+++ b/db/migrate/20161101124317_add_end_on_exclusive_to_bookings.rb
@@ -1,0 +1,5 @@
+class AddEndOnExclusiveToBookings < ActiveRecord::Migration
+  def change
+    add_column :bookings, :end_on_exclusive, :date, after: :end_on
+  end
+end

--- a/db/migrate/20161101124829_populate_end_on_exclusive.rb
+++ b/db/migrate/20161101124829_populate_end_on_exclusive.rb
@@ -1,0 +1,27 @@
+class PopulateEndOnExclusive < ActiveRecord::Migration
+  def up
+    name = "Populate end_on_exclusive for day bookings"
+    exec_update([
+                  "UPDATE bookings",
+                  "LEFT JOIN transactions ON transactions.id = bookings.transaction_id",
+                  "SET bookings.end_on_exclusive = ",
+                  "CASE transactions.unit_type",
+                  "WHEN 'day' THEN ADDDATE(bookings.end_on, 1)",
+                  "ELSE bookings.end_on",
+                  "END"
+                ].join(" "), name, [])
+  end
+
+  def down
+    name = "Rollback populate end_on_exclusive for day bookings"
+    exec_update([
+                  "UPDATE bookings",
+                  "LEFT JOIN transactions ON transactions.id = bookings.transaction_id",
+                  "SET bookings.end_on = ",
+                  "CASE transactions.unit_type",
+                  "WHEN 'day' THEN SUBDATE(bookings.end_on_exclusive, 1)",
+                  "ELSE bookings.end_on_exclusive",
+                  "END"
+                ].join(" "), name, [])
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -69,6 +69,7 @@ CREATE TABLE `bookings` (
   `transaction_id` int(11) DEFAULT NULL,
   `start_on` date DEFAULT NULL,
   `end_on` date DEFAULT NULL,
+  `end_on_exclusive` date DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
@@ -1597,7 +1598,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-01 12:49:50
+-- Dump completed on 2016-11-01 15:51:38
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3191,4 +3192,8 @@ INSERT INTO schema_migrations (version) VALUES ('20161019125057');
 INSERT INTO schema_migrations (version) VALUES ('20161023074355');
 
 INSERT INTO schema_migrations (version) VALUES ('20161101104218');
+
+INSERT INTO schema_migrations (version) VALUES ('20161101124317');
+
+INSERT INTO schema_migrations (version) VALUES ('20161101124829');
 

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -2,12 +2,13 @@
 #
 # Table name: bookings
 #
-#  id             :integer          not null, primary key
-#  transaction_id :integer
-#  start_on       :date
-#  end_on         :date
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id               :integer          not null, primary key
+#  transaction_id   :integer
+#  start_on         :date
+#  end_on           :date
+#  end_on_exclusive :date
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #


### PR DESCRIPTION
This PR adds a new column `bookings.end_on_exclusive`. When a new booking transaction is created, the `end_on_exclusive` information is saved to the database.

This PR touches the code very little! The main purpose of this PR is to save data in the new form where the end date is always exclusive. There will be follow-up Pull Requests, which will do more code changes, i.e. start reading the end value from `end_on_exclusive`.