### PR TITLE
Switch using msgpack with Harmony

### DIFF
--- a/app/services/harmony_client.rb
+++ b/app/services/harmony_client.rb
@@ -19,7 +19,7 @@ HarmonyClient = ServiceClient::Client.new(
     ServiceClient::Middleware::Timeout.new,
     ServiceClient::Middleware::Logger.new,
     ServiceClient::Middleware::Timing.new,
-    ServiceClient::Middleware::BodyEncoder.new(:transit_json),
+    ServiceClient::Middleware::BodyEncoder.new(:transit_msgpack),
     ServiceClient::Middleware::ParamEncoder.new,
     ServiceClient::Middleware::JwtAuthenticator.new(APP_CONFIG.harmony_api_disable_authentication,
                                                     APP_CONFIG.harmony_api_token_secret),

--- a/app/utils/service_client/middleware/logger.rb
+++ b/app/utils/service_client/middleware/logger.rb
@@ -10,17 +10,17 @@ module ServiceClient
       end
 
       def enter(ctx)
-        @logger.info("Enter", :enter, enter_log(ctx))
+        try_log { @logger.info("Enter stage logging", :enter, enter_log(ctx)) }
         ctx
       end
 
       def leave(ctx)
-        @logger.info("Leave", :leave, leave_log(ctx))
+        try_log { @logger.info("Leave stage logging", :leave, leave_log(ctx)) }
         ctx
       end
 
       def error(ctx)
-        @logger.info("Error", :error, error_log(ctx))
+        try_log { @logger.error("Error stage logging", :error, error_log(ctx)) }
         ctx
       end
 
@@ -28,23 +28,29 @@ module ServiceClient
 
       def enter_log(ctx)
         {
-          req: ctx.fetch(:req)
+          req: ctx.fetch(:req).except(:body)
         }
       end
 
       def leave_log(ctx)
         {
-          req: ctx.fetch(:req),
+          req: ctx.fetch(:req).except(:body),
           res: ctx.fetch(:res).except(:body),
         }.merge(timing(ctx))
       end
 
       def error_log(ctx)
         {
-          req: ctx[:req],
+          req: ctx.fetch(:req).except(:body),
           res: ctx[:res].except(:body),
           error_class: ctx[:error].class.to_s,
         }.merge(timing(ctx))
+      end
+
+      def try_log(&block)
+        block.call()
+      rescue StandardError => e
+        @logger.error("Middleware logging failed with exception: #{e.class}", :error)
       end
 
       # Picks started_at and duration values from the context


### PR DESCRIPTION
- [x] Fix client logging middleware to never log request or response bodies. It is too verbose and the body can be binary so it makes little sense to log it.
- [x] Make logging fail safe by wrapping with rescue so that a failure to serialize to json won't crash the request pipeline.
- [x] Switch on msgpack support for HarmonyClient