### PR TITLE
Remove availability flag

### DIFF
--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -34,7 +34,10 @@ class Admin::ListingShapesController < ApplicationController
       return redirect_to action: :index
     end
 
-    render_new_form(template, process_summary, available_locales())
+    render_new_form(form: template,
+                    process_summary: process_summary,
+                    available_locs: available_locales(),
+                    harmony_in_use: APP_CONFIG.harmony_api_in_use)
   end
 
   def edit
@@ -46,7 +49,11 @@ class Admin::ListingShapesController < ApplicationController
 
     return redirect_to error_not_found_path if shape.nil?
 
-    render_edit_form(params[:url_name], shape, process_summary, available_locales())
+    render_edit_form(url_name: params[:url_name],
+                     form: shape,
+                     process_summary: process_summary,
+                     available_locs: available_locales(),
+                     harmony_in_use: APP_CONFIG.harmony_api_in_use)
   end
 
   def create
@@ -65,7 +72,11 @@ class Admin::ListingShapesController < ApplicationController
       redirect_to action: :index
     else
       flash.now[:error] = t("admin.listing_shapes.new.create_failure", error_msg: create_result.error_msg)
-      render_new_form(shape, process_summary, available_locales())
+
+      render_new_form(form: shape,
+                      process_summary: process_summary,
+                      available_locs: available_locales(),
+                      harmony_in_use: APP_CONFIG.harmony_api_in_use)
     end
 
   end
@@ -96,7 +107,12 @@ class Admin::ListingShapesController < ApplicationController
       return redirect_to admin_listing_shapes_path
     else
       flash.now[:error] = t("admin.listing_shapes.edit.update_failure", error_msg: update_result.error_msg)
-      return render_edit_form(params[:url_name], shape, process_summary, available_locales())
+
+      return render_edit_form(url_name: params[:url_name],
+                              form: shape,
+                              process_summary: process_summary,
+                              available_locs: available_locales(),
+                              harmony_in_use: APP_CONFIG.harmony_api_in_use)
     end
   end
 
@@ -184,12 +200,16 @@ class Admin::ListingShapesController < ApplicationController
     }
   end
 
-  def render_new_form(form, process_summary, available_locs)
-    locals = common_locals(form, 0, process_summary, available_locs)
+  def render_new_form(form:, process_summary:, available_locs:, harmony_in_use:)
+    locals = common_locals(form: form,
+                           count: 0,
+                           process_summary: process_summary,
+                           available_locs: available_locs,
+                           harmony_in_use: harmony_in_use)
     render("new", locals: locals)
   end
 
-  def render_edit_form(url_name, form, process_summary, available_locs)
+  def render_edit_form(url_name:, form:, process_summary:, available_locs:, harmony_in_use:)
     can_delete_res = can_delete_shape?(url_name, all_shapes(community_id: @current_community.id, include_categories: true))
     cant_delete = !can_delete_res.success
     cant_delete_reason = cant_delete ? can_delete_res.error_msg : nil
@@ -201,7 +221,11 @@ class Admin::ListingShapesController < ApplicationController
         open: true
       }).data
 
-    locals = common_locals(form, count, process_summary, available_locs).merge(
+    locals = common_locals(form: form,
+                           count: count,
+                           process_summary: process_summary,
+                           available_locs: available_locs,
+                           harmony_in_use: harmony_in_use).merge(
       url_name: url_name,
       name: pick_translation(form[:name]),
       cant_delete: cant_delete,
@@ -210,11 +234,12 @@ class Admin::ListingShapesController < ApplicationController
     render("edit", locals: locals)
   end
 
-  def common_locals(form, count, process_summary, available_locs)
+  def common_locals(form:, count:, process_summary:, available_locs:, harmony_in_use:)
     { selected_left_navi_link: LISTING_SHAPES_NAVI_LINK,
       uneditable_fields: uneditable_fields(process_summary, form[:author_is_seller]),
       shape: FormViewLayer.shape_to_locals(form),
       count: count,
+      harmony_in_use: harmony_in_use,
       locale_name_mapping: available_locs.map { |name, l| [l, name] }.to_h
     }
   end

--- a/app/controllers/admin/listing_shapes_controller.rb
+++ b/app/controllers/admin/listing_shapes_controller.rb
@@ -36,8 +36,7 @@ class Admin::ListingShapesController < ApplicationController
 
     render_new_form(form: template,
                     process_summary: process_summary,
-                    available_locs: available_locales(),
-                    harmony_in_use: APP_CONFIG.harmony_api_in_use)
+                    available_locs: available_locales())
   end
 
   def edit
@@ -52,8 +51,7 @@ class Admin::ListingShapesController < ApplicationController
     render_edit_form(url_name: params[:url_name],
                      form: shape,
                      process_summary: process_summary,
-                     available_locs: available_locales(),
-                     harmony_in_use: APP_CONFIG.harmony_api_in_use)
+                     available_locs: available_locales())
   end
 
   def create
@@ -75,8 +73,7 @@ class Admin::ListingShapesController < ApplicationController
 
       render_new_form(form: shape,
                       process_summary: process_summary,
-                      available_locs: available_locales(),
-                      harmony_in_use: APP_CONFIG.harmony_api_in_use)
+                      available_locs: available_locales())
     end
 
   end
@@ -111,8 +108,7 @@ class Admin::ListingShapesController < ApplicationController
       return render_edit_form(url_name: params[:url_name],
                               form: shape,
                               process_summary: process_summary,
-                              available_locs: available_locales(),
-                              harmony_in_use: APP_CONFIG.harmony_api_in_use)
+                              available_locs: available_locales())
     end
   end
 
@@ -200,16 +196,15 @@ class Admin::ListingShapesController < ApplicationController
     }
   end
 
-  def render_new_form(form:, process_summary:, available_locs:, harmony_in_use:)
+  def render_new_form(form:, process_summary:, available_locs:)
     locals = common_locals(form: form,
                            count: 0,
                            process_summary: process_summary,
-                           available_locs: available_locs,
-                           harmony_in_use: harmony_in_use)
+                           available_locs: available_locs)
     render("new", locals: locals)
   end
 
-  def render_edit_form(url_name:, form:, process_summary:, available_locs:, harmony_in_use:)
+  def render_edit_form(url_name:, form:, process_summary:, available_locs:)
     can_delete_res = can_delete_shape?(url_name, all_shapes(community_id: @current_community.id, include_categories: true))
     cant_delete = !can_delete_res.success
     cant_delete_reason = cant_delete ? can_delete_res.error_msg : nil
@@ -224,8 +219,7 @@ class Admin::ListingShapesController < ApplicationController
     locals = common_locals(form: form,
                            count: count,
                            process_summary: process_summary,
-                           available_locs: available_locs,
-                           harmony_in_use: harmony_in_use).merge(
+                           available_locs: available_locs).merge(
       url_name: url_name,
       name: pick_translation(form[:name]),
       cant_delete: cant_delete,
@@ -234,12 +228,14 @@ class Admin::ListingShapesController < ApplicationController
     render("edit", locals: locals)
   end
 
-  def common_locals(form:, count:, process_summary:, available_locs:, harmony_in_use:)
+  def common_locals(form:, count:, process_summary:, available_locs:)
     { selected_left_navi_link: LISTING_SHAPES_NAVI_LINK,
       uneditable_fields: uneditable_fields(process_summary, form[:author_is_seller]),
       shape: FormViewLayer.shape_to_locals(form),
       count: count,
-      harmony_in_use: harmony_in_use,
+      harmony_in_use: APP_CONFIG.harmony_api_in_use,
+      display_knowledge_base_articles: APP_CONFIG.display_knowledge_base_articles,
+      knowledge_base_url: APP_CONFIG.knowledge_base_url,
       locale_name_mapping: available_locs.map { |name, l| [l, name] }.to_h
     }
   end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -458,13 +458,14 @@ class ListingsController < ApplicationController
       availability: shape[:availability]
     ).merge(open_params).merge(unit_to_listing_opts(m_unit)).except(:unit)
 
+    old_availability = @listing.availability.to_sym
     update_successful = @listing.update_fields(listing_params)
 
     upsert_field_values!(@listing, params[:custom_fields])
 
     if update_successful
       @listing.location.update_attributes(params[:location]) if @listing.location
-      flash[:notice] = t("layouts.notifications.listing_updated_successfully")
+      flash[:notice] = update_flash(old_availability: old_availability, new_availability: shape[:availability])
       Delayed::Job.enqueue(ListingUpdatedJob.new(@listing.id, @current_community.id))
       reprocess_missing_image_styles(@listing) if listing_reopened
       redirect_to @listing
@@ -537,6 +538,17 @@ class ListingsController < ApplicationController
   end
 
   private
+
+  def update_flash(old_availability:, new_availability:)
+    case [new_availability.to_sym == :booking, old_availability.to_sym == :booking]
+    when [true, false]
+      t("layouts.notifications.listing_updated_availability_enabled")
+    when [false, true]
+      t("layouts.notifications.listing_updated_availability_disabled")
+    else
+      t("layouts.notifications.listing_updated_successfully")
+    end
+  end
 
   def create_bookable(community_uuid, listing_uuid, author_uuid, auth_context)
     res = HarmonyClient.post(

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -203,8 +203,7 @@ class ListingsController < ApplicationController
     blocked_dates_end_on = 12.months.from_now.to_date
 
     blocked_dates_result =
-      if FeatureFlagHelper.feature_enabled?(:availability) &&
-         @listing.availability.to_sym == :booking
+      if @listing.availability.to_sym == :booking
 
         get_blocked_dates(
           start_on: blocked_dates_start_on,
@@ -282,7 +281,7 @@ class ListingsController < ApplicationController
     shape = get_shape(Maybe(params)[:listing][:listing_shape_id].to_i.or_else(nil))
     listing_uuid = UUIDUtils.create
 
-    if FeatureFlagHelper.feature_enabled?(:availability) && shape.present? && shape[:availability] == :booking
+    if shape.present? && shape[:availability] == :booking
       auth_context = {
         marketplace_id: @current_community.uuid_object,
         actor_id: @current_user.uuid_object
@@ -421,9 +420,7 @@ class ListingsController < ApplicationController
 
     shape = get_shape(params[:listing][:listing_shape_id])
 
-    if FeatureFlagHelper.feature_enabled?(:availability) &&
-       shape.present? &&
-       shape[:availability] == :booking
+    if shape.present? && shape[:availability] == :booking
 
       auth_context = {
         marketplace_id: @current_community.uuid_object,

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -102,7 +102,7 @@ class PreauthorizeTransactionsController < ApplicationController
       validate_delivery_method(tx_params: tx_params, shipping_enabled: shipping_enabled, pickup_enabled: pickup_enabled)
         .and_then { validate_booking(tx_params: tx_params, quantity_selector: quantity_selector) }
         .and_then { |result|
-          if FeatureFlagHelper.feature_enabled?(:availability) && availability_enabled
+          if availability_enabled
             validate_booking_timeslots(tx_params: tx_params,
                                        marketplace_uuid: marketplace_uuid,
                                        listing_uuid: listing_uuid,

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -19,8 +19,7 @@ module FeatureFlagService::Store
     FLAGS = [
       :export_transactions_as_csv,
       :topbar_v1,
-      :searchpage_v1,
-      :availability
+      :searchpage_v1
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -56,7 +56,7 @@
       = check_box_tag(:shipping_enabled, "true", shape[:shipping_enabled], class: "checkbox-row-checkbox js-shipping-enabled")
       = label_tag(:shipping_enabled, t("admin.listing_shapes.shipping_label"), class: "checkbox-row-label js-shipping-enabled-label")
 
-- if feature_enabled?(:availability)
+- if harmony_in_use
   - unless uneditable_fields[:availability]
 
     .row
@@ -85,7 +85,7 @@
     .js-pricing-units-info.hidden
       = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.units_desc")}
 
-    - if feature_enabled?(:availability)
+    - if harmony_in_use
       .js-pricing-units-disabled-info.hidden
         = render partial: "layouts/info_text", locals: {text: t("admin.listing_shapes.pricing_units_disabled_info")}
 

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -63,6 +63,9 @@
       .col-12
         = label_tag("", t("admin.listing_shapes.availability_title"), class: "input")
 
+        - if display_knowledge_base_articles
+          = render :partial => "layouts/info_text", :locals => { :text => link_to(t("admin.listing_shapes.read_more"), "#{knowledge_base_url}/articles/1097116").html_safe }
+
     .row
       .col-12
         = check_box_tag(:availability, "booking", shape[:availability] == :booking, class: "checkbox-row-checkbox js-availability")

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -14,7 +14,7 @@
   %h2= t(".edit_listing_shape", shape: name)
   = form_tag(admin_listing_shape_path(url_name), method: :put, id: "listing_shape_form") do
 
-    = render partial: "shape_form_content", locals: { name: name, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields, harmony_in_use: harmony_in_use }
+    = render partial: "shape_form_content", locals: { name: name, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields, harmony_in_use: harmony_in_use, display_knowledge_base_articles: display_knowledge_base_articles, knowledge_base_url: knowledge_base_url }
 
     .row
       .col-12

--- a/app/views/admin/listing_shapes/edit.haml
+++ b/app/views/admin/listing_shapes/edit.haml
@@ -14,7 +14,7 @@
   %h2= t(".edit_listing_shape", shape: name)
   = form_tag(admin_listing_shape_path(url_name), method: :put, id: "listing_shape_form") do
 
-    = render partial: "shape_form_content", locals: { name: name, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields }
+    = render partial: "shape_form_content", locals: { name: name, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields, harmony_in_use: harmony_in_use }
 
     .row
       .col-12

--- a/app/views/admin/listing_shapes/new.haml
+++ b/app/views/admin/listing_shapes/new.haml
@@ -13,7 +13,7 @@
   %h2= t(".create_listing_shape")
   = form_tag(admin_listing_shapes_path, method: :post, id: "listing_shape_form") do
 
-    = render partial: "shape_form_content", locals: { id: nil, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields }
+    = render partial: "shape_form_content", locals: { id: nil, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields, harmony_in_use: harmony_in_use }
 
     .row
       .col-12

--- a/app/views/admin/listing_shapes/new.haml
+++ b/app/views/admin/listing_shapes/new.haml
@@ -13,7 +13,7 @@
   %h2= t(".create_listing_shape")
   = form_tag(admin_listing_shapes_path, method: :post, id: "listing_shape_form") do
 
-    = render partial: "shape_form_content", locals: { id: nil, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields, harmony_in_use: harmony_in_use }
+    = render partial: "shape_form_content", locals: { id: nil, shape: shape, count: count, locale_name_mapping: locale_name_mapping, uneditable_fields: uneditable_fields, harmony_in_use: harmony_in_use, display_knowledge_base_articles: display_knowledge_base_articles, knowledge_base_url: knowledge_base_url }
 
     .row
       .col-12

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -285,6 +285,7 @@ default: &default_settings
   external_search_offset_min: 0
 
   # Harmony service API connection
+  harmony_api_in_use: false
   harmony_api_url:
   harmony_api_disable_authentication: false
   harmony_api_token_secret: secret_key1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1248,6 +1248,8 @@ en:
       offer_rejected: "Offer rejected"
       offer_canceled: "Offer canceled"
       listing_updated_successfully: "Listing updated successfully"
+      listing_updated_availability_enabled: "Listing updated successfully. Automatic availability management enabled."
+      listing_updated_availability_disabled: "Listing updated successfully. Automatic availability management disabled."
       only_kassi_administrators_can_access_this_area: "Only %{service_name} administrators can access this area"
       only_listing_author_can_close_a_listing: "Only listing author can close a listing"
       only_listing_author_can_edit_a_listing: "Only listing author can edit a listing"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,6 +384,7 @@ en:
       preview: "Preview site"
     listing_shapes:
       availability_title: Availability
+      read_more: Read more about automatic availability management.
       allow_availability_management: "Enable automatic availability management (prevent double bookings)"
       per_day_availability: "\"Per day\" availability"
       per_night_availability: "\"Per night\" availability"


### PR DESCRIPTION
This PR:

- Removes availability flag (i.e. enables it to everyone)
- Adds `harmony_api_in_use` environment variable
- Adds a flash notification when listing is edited and availability is enabled/disabled
- Adds a link to knowledge base article