### PR TITLE
Add admin controls for toggling new searchpage

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -87,4 +87,5 @@
 //= require transaction
 //= require listing_form
 //= require radio_buttons
+//= require new_layout
 //= require_self

--- a/app/assets/javascripts/new_layout.js
+++ b/app/assets/javascripts/new_layout.js
@@ -4,10 +4,10 @@ window.ST = window.ST || {};
 
   function check_handler(element) {
    return function(){
-      if(!element.prop("checked")){
+      if (!element.prop("checked")){
         element.prop("checked", this.checked);
       }
-      element.attr("disabled", this.checked)
+     element.attr("disabled", this.checked);
     }
   };
 

--- a/app/assets/javascripts/new_layout.js
+++ b/app/assets/javascripts/new_layout.js
@@ -1,0 +1,23 @@
+window.ST = window.ST || {};
+
+(function(module) {
+
+  function check_handler(element) {
+   return function(){
+      if(!element.prop("checked")){
+        element.prop("checked", this.checked);
+      }
+      element.attr("disabled", this.checked)
+    }
+  };
+
+  module.initializeNewLayoutManager = function(){
+    var $topbar_user = $("#enabled_for_user_topbar_v1");
+    var $topbar_community = $("#enabled_for_community_topbar_v1");
+
+    var $user_searchpage = $("#enabled_for_user_searchpage_v1")
+        .click(check_handler($topbar_user));
+    var $community_searchpage = $("#enabled_for_community_searchpage_v1")
+        .click(check_handler($topbar_community));
+  };
+})(window.ST);

--- a/app/assets/javascripts/new_layout.js
+++ b/app/assets/javascripts/new_layout.js
@@ -11,13 +11,17 @@ window.ST = window.ST || {};
     }
   };
 
-  module.initializeNewLayoutManager = function(){
-    var $topbar_user = $("#enabled_for_user_topbar_v1");
-    var $topbar_community = $("#enabled_for_community_topbar_v1");
+  // Disables and enables required checkboxes for parent flags
+  module.initializeNewLayoutManager = function(feature_rels){
+    Object.keys(feature_rels).forEach(function(key,index) {
+      var $parent_for_user = $("#enabled_for_user_" + key);
+      var $required_for_user = $("#enabled_for_user_" + feature_rels[key]);
 
-    var $user_searchpage = $("#enabled_for_user_searchpage_v1")
-        .click(check_handler($topbar_user));
-    var $community_searchpage = $("#enabled_for_community_searchpage_v1")
-        .click(check_handler($topbar_community));
+      var $parent_for_community = $("#enabled_for_community_" + key);
+      var $required_for_community = $("#enabled_for_community_" + feature_rels[key]);
+
+      $parent_for_user.click(check_handler($required_for_user));
+      $parent_for_community.click(check_handler($required_for_community));
+    });
   };
 })(window.ST);

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -130,6 +130,7 @@ class Admin::CommunitiesController < ApplicationController
                                            CustomLandingPage::LandingPageStore.enabled?(@current_community.id))
 
     render :new_layout, locals: { community: @current_community,
+                                  feature_rels: NewLayoutViewUtils::FEATURE_RELS,
                                   features: features }
   end
 

--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -124,12 +124,17 @@ class Admin::CommunitiesController < ApplicationController
   def new_layout
     @selected_left_navi_link = "new_layout"
 
-    render :new_layout, locals: { community: @current_community, features: NewLayoutViewUtils.features(@current_community.id, @current_user.id) }
+    features = NewLayoutViewUtils.features(@current_community.id,
+                                           @current_user.id,
+                                           @current_community.private,
+                                           CustomLandingPage::LandingPageStore.enabled?(@current_community.id))
+
+    render :new_layout, locals: { community: @current_community,
+                                  features: features }
   end
 
   def update_new_layout
     @community = @current_community
-
     enabled_for_user = Maybe(params[:enabled_for_user]).map { |f| NewLayoutViewUtils.enabled_features(f) }.or_else([])
     disabled_for_user = NewLayoutViewUtils.resolve_disabled(enabled_for_user)
 

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -19,7 +19,8 @@ module FeatureFlagService::Store
     FLAGS = [
       :export_transactions_as_csv,
       :topbar_v1,
-      :searchpage_v1
+      :searchpage_v1,
+      :manage_searchpage
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/view_utils/new_layout_view_utils.rb
+++ b/app/view_utils/new_layout_view_utils.rb
@@ -12,7 +12,7 @@ module NewLayoutViewUtils
 
   # Describes feature relationships:
   # { feature: :required }
-  REQUIRED_FEATURES = {
+  FEATURE_RELS = {
     searchpage_v1: :topbar_v1
   }
 
@@ -22,11 +22,13 @@ module NewLayoutViewUtils
     },
   ]
 
-  SEARCHPAGE = [
-    { title: t("admin.communities.new_layout.searchpage"),
+  # Maps flag that is required for toggling the feature in admin ui to the feature
+  EXPERIMENTAL_FEATURES = {
+    manage_searchpage: {
+      title: t("admin.communities.new_layout.searchpage"),
       name:  :searchpage_v1,
     },
-  ]
+  }
 
   module_function
 
@@ -34,12 +36,7 @@ module NewLayoutViewUtils
     person_flags = FeatureFlagService::API::Api.features.get_for_person(community_id: community_id, person_id: person_id).data[:features]
     community_flags = FeatureFlagService::API::Api.features.get_for_community(community_id: community_id).data[:features]
 
-    fs =
-      if(can_manage_searchpage?(person_flags, community_flags, private_community, clp_enabled))
-        FEATURES + SEARCHPAGE
-      else
-        FEATURES
-      end
+    fs = all_features(person_flags, community_flags, private_community, clp_enabled)
 
     fs.map { |f|
       Feature.build({
@@ -60,7 +57,7 @@ module NewLayoutViewUtils
   # and returns the keys as symbols from the entries
   # that hold value "true".
   def enabled_features(feature_params)
-    allowed_features = (FEATURES + SEARCHPAGE).map { |f| f[:name] }
+    allowed_features = (FEATURES + EXPERIMENTAL_FEATURES.values).map { |f| f[:name] }
     features = feature_params.select { |key, value| value == "true" }
                  .keys
                  .map(&:to_sym)
@@ -73,21 +70,28 @@ module NewLayoutViewUtils
   # list of enabled features.
   def resolve_disabled(enabled)
      all_enabled = add_required_features(enabled)
-     features = (FEATURES + SEARCHPAGE).map { |f| f[:name]}
+     features = (FEATURES + EXPERIMENTAL_FEATURES.values).map { |f| f[:name]}
        .select { |f| !all_enabled.include?(f) }
   end
 
-  def can_manage_searchpage?(person_flags, community_flags, private_community, clp_enabled)
-    if(private_community)
-      clp_enabled &&
-      (person_flags + community_flags).include?(:manage_searchpage)
-    else
-      (person_flags + community_flags).include?(:manage_searchpage)
-    end
-  end
+  # private
 
   def add_required_features(features)
-    (features | REQUIRED_FEATURES.values_at(*features)).compact
+    (features | FEATURE_RELS.values_at(*features)).compact
+  end
+
+
+  def all_features(person_flags, community_flags, private_community, clp_enabled)
+    all_flags = (person_flags | community_flags).to_a
+
+    # Additional rules for flags
+    all_flags.delete(:searchpage_v1) unless can_manage_searchpage?(all_flags, private_community, clp_enabled)
+
+    (FEATURES + EXPERIMENTAL_FEATURES.values_at(*all_flags)).compact
+  end
+
+  def can_manage_searchpage?(flags, private_community, clp_enabled)
+    flags.include?(:manage_searchpage) && !private_community || clp_enabled
   end
 
   def topbar_flag_disabled?(fl, flags)

--- a/app/view_utils/new_layout_view_utils.rb
+++ b/app/view_utils/new_layout_view_utils.rb
@@ -5,8 +5,16 @@ module NewLayoutViewUtils
     [:title, :string, :mandatory],
     [:name, :symbol, :mandatory],
     [:enabled_for_user, :bool, :mandatory],
-    [:enabled_for_community, :bool, :mandatory]
+    [:enabled_for_community, :bool, :mandatory],
+    [:disabled_for_user, :bool, default: false],
+    [:disabled_for_community, :bool, default: false]
   )
+
+  # Describes feature relationships:
+  # { feature: :required }
+  REQUIRED_FEATURES = {
+    searchpage_v1: :topbar_v1
+  }
 
   FEATURES = [
     { title: t("admin.communities.new_layout.new_topbar"),
@@ -14,20 +22,34 @@ module NewLayoutViewUtils
     },
   ]
 
+  SEARCHPAGE = [
+    { title: t("admin.communities.new_layout.searchpage"),
+      name:  :searchpage_v1,
+    },
+  ]
+
   module_function
 
-  def features(community_id, person_id)
+  def features(community_id, person_id, private_community, clp_enabled)
     person_flags = FeatureFlagService::API::Api.features.get_for_person(community_id: community_id, person_id: person_id).data[:features]
     community_flags = FeatureFlagService::API::Api.features.get_for_community(community_id: community_id).data[:features]
 
-    FEATURES.map { |f|
+    fs =
+      if(can_manage_searchpage?(person_flags, community_flags, private_community, clp_enabled))
+        FEATURES + SEARCHPAGE
+      else
+        FEATURES
+      end
+
+    fs.map { |f|
       Feature.build({
         title: f[:title],
         name: f[:name],
         enabled_for_user: person_flags.include?(f[:name]),
-        enabled_for_community: community_flags.include?(f[:name])
-      })
-    }
+        enabled_for_community: community_flags.include?(f[:name]),
+        disabled_for_user: topbar_flag_disabled?(f, person_flags),
+        disabled_for_community: topbar_flag_disabled?(f, community_flags)
+      })}
   end
 
   # Takes a map of features
@@ -38,18 +60,39 @@ module NewLayoutViewUtils
   # and returns the keys as symbols from the entries
   # that hold value "true".
   def enabled_features(feature_params)
-    allowed_features = FEATURES.map { |f| f[:name] }
-    feature_params.select { |key, value| value == "true" }
-      .keys
-      .map(&:to_sym)
-      .select { |k| allowed_features.include?(k) }
+    allowed_features = (FEATURES + SEARCHPAGE).map { |f| f[:name] }
+    features = feature_params.select { |key, value| value == "true" }
+                 .keys
+                 .map(&:to_sym)
+                 .select { |k| allowed_features.include?(k) }
+    add_required_features(features)
   end
 
   # From the list of features, selects the ones
   # that are disabled, ie. not included in the
   # list of enabled features.
   def resolve_disabled(enabled)
-    FEATURES.map { |f| f[:name]}
-      .select { |f| !enabled.include?(f) }
+     all_enabled = add_required_features(enabled)
+     features = (FEATURES + SEARCHPAGE).map { |f| f[:name]}
+       .select { |f| !all_enabled.include?(f) }
+  end
+
+  def can_manage_searchpage?(person_flags, community_flags, private_community, clp_enabled)
+    if(private_community)
+      clp_enabled &&
+      (person_flags + community_flags).include?(:manage_searchpage)
+    else
+      (person_flags + community_flags).include?(:manage_searchpage)
+    end
+  end
+
+  def add_required_features(features)
+    (features | REQUIRED_FEATURES.values_at(*features)).compact
+  end
+
+  def topbar_flag_disabled?(fl, flags)
+    #topbar is required with other flags and thus disabled
+    fl[:name] == :topbar_v1 &&
+      !flags.reject{ |f| [:topbar_v1, :manage_searchpage].include?(f) }.empty?
   end
 end

--- a/app/views/admin/communities/new_layout.haml
+++ b/app/views/admin/communities/new_layout.haml
@@ -1,7 +1,7 @@
 - content_for :extra_javascript do
   :javascript
     $(document).ready(function() {
-      window.ST.initializeNewLayoutManager();
+      window.ST.initializeNewLayoutManager(#{feature_rels.to_json});
     });
 
 - support_link = link_to("support@sharetribe.com", "mailto:support@sharetribe.com")

--- a/app/views/admin/communities/new_layout.haml
+++ b/app/views/admin/communities/new_layout.haml
@@ -1,3 +1,9 @@
+- content_for :extra_javascript do
+  :javascript
+    $(document).ready(function() {
+      window.ST.initializeNewLayoutManager();
+    });
+
 - support_link = link_to("support@sharetribe.com", "mailto:support@sharetribe.com")
 - content_for :title_header do
   %h1
@@ -31,10 +37,10 @@
             = feature[:title]
         .col-3
           .checkbox-centered
-            = check_box_tag "enabled_for_user[#{ feature[:name] }]", true, feature[:enabled_for_user]
+            = check_box_tag "enabled_for_user[#{ feature[:name] }]", true, feature[:enabled_for_user], disabled: feature[:disabled_for_user]
         .col-3
           .checkbox-centered
-            = check_box_tag  "enabled_for_community[#{ feature[:name] }]", true, feature[:enabled_for_community]
+            = check_box_tag  "enabled_for_community[#{ feature[:name] }]", true, feature[:enabled_for_community], disabled: feature[:disabled_for_community]
     .row
       .col-12
         = form.button t("admin.communities.settings.update_settings")

--- a/client/app/utils/transitImmutableConverter.js
+++ b/client/app/utils/transitImmutableConverter.js
@@ -42,11 +42,11 @@ const createReader = function createReader() {
 const createInstance = () => {
   const reader = createReader();
   const fromJSON = (json) => {
-    if(json == null){
-      return new Immutable.Map()
+    if (json == null) {
+      return new Immutable.Map();
     }
     return reader.read(json);
-  }
+  };
 
   return { fromJSON };
 };

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,7 @@ en:
         enabled_for_you: "Enabled for you"
         enabled_for_all: "Enabled for all"
         new_topbar: "New top bar (visible on every page)"
+        searchpage: "New search page (requires top bar)"
       social_media:
         social_media: "Social media"
         twitter_handle: "Twitter handle"

--- a/spec/view_utils/new_layout_view_utils_spec.rb
+++ b/spec/view_utils/new_layout_view_utils_spec.rb
@@ -14,6 +14,8 @@ describe NewLayoutViewUtils do
           name: :wat
         }
       ])
+
+    stub_const("NewLayoutViewUtils::SEARCHPAGE", [])
   end
 
   describe "#features" do
@@ -43,21 +45,27 @@ describe NewLayoutViewUtils do
       end
 
       it "should return list of feature flags with corresponding features enabled for person and community" do
-        expect(NewLayoutViewUtils.features(community_id, person_id)).to eql([
+        expect(NewLayoutViewUtils.features(community_id, person_id, false, true)).to eql([
           { title: "Foo",
             name: :foo,
             enabled_for_user: true,
-            enabled_for_community: false
+            enabled_for_community: false,
+            disabled_for_user: false,
+            disabled_for_community: false
           },
           { title: "Bar",
             name: :bar,
             enabled_for_user: true,
-            enabled_for_community: false
+            enabled_for_community: false,
+            disabled_for_user: false,
+            disabled_for_community: false
           },
           { title: "Wat",
             name: :wat,
             enabled_for_user: false,
-            enabled_for_community: true
+            enabled_for_community: true,
+            disabled_for_user: false,
+            disabled_for_community: false
           }
         ])
       end
@@ -86,21 +94,27 @@ describe NewLayoutViewUtils do
       end
 
       it "should return list of feature flags with no features enabled" do
-        expect(NewLayoutViewUtils.features(community_id, person_id)).to eql([
+        expect(NewLayoutViewUtils.features(community_id, person_id, false, true)).to eql([
           { title: "Foo",
             name: :foo,
             enabled_for_user: false,
-            enabled_for_community: false
+            enabled_for_community: false,
+            disabled_for_user: false,
+            disabled_for_community: false
           },
           { title: "Bar",
             name: :bar,
             enabled_for_user: false,
-            enabled_for_community: false
+            enabled_for_community: false,
+            disabled_for_user: false,
+            disabled_for_community: false
           },
           { title: "Wat",
             name: :wat,
             enabled_for_user: false,
-            enabled_for_community: false
+            enabled_for_community: false,
+            disabled_for_user: false,
+            disabled_for_community: false
           }
         ])
       end

--- a/spec/view_utils/new_layout_view_utils_spec.rb
+++ b/spec/view_utils/new_layout_view_utils_spec.rb
@@ -15,7 +15,7 @@ describe NewLayoutViewUtils do
         }
       ])
 
-    stub_const("NewLayoutViewUtils::SEARCHPAGE", [])
+    stub_const("NewLayoutViewUtils::EXPERIMENTAL_FEATURES", {})
   end
 
   describe "#features" do


### PR DESCRIPTION
Adds admin controls for searhpage. New searchpage requires topbar and
it is enabled automatically if searchpage is enabled. JS is used to
disable and enable topbar controls when searchpage is checked and
unchecked.

Adds also a rule for private marketplaces as these cannot have
searchpage if custom landing page isn't enabled.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/230815/20006144/eb5b28ee-a29e-11e6-90f0-76491c27e1da.png)

![image](https://cloud.githubusercontent.com/assets/230815/20006278/85a4964c-a29f-11e6-91e3-3cfbe823cefb.png)

![image](https://cloud.githubusercontent.com/assets/230815/20006172/10b79eb0-a29f-11e6-9fa6-0b48a9f13e69.png)
