### PR TITLE
Add error handling for discovery api errors

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -77,7 +77,8 @@ class HomepageController < ApplicationController
       search_result.on_success { |listings|
         render layout: "layouts/react_page.haml", template: "search_page/search_page", locals: { props: searchpage_props(listings, current_page, per_page) }
       }.on_error {
-        render nothing: true, status: 500
+        flash[:error] = t("homepage.errors.search_engine_not_responding")
+        render layout: "layouts/react_page.haml", template: "search_page/search_page", locals: { props: searchpage_props(nil, current_page, per_page) }
       }
     elsif request.xhr? # checks if AJAX request
       search_result.on_success { |listings|

--- a/client/app/startup/SearchPageApp.js
+++ b/client/app/startup/SearchPageApp.js
@@ -79,13 +79,12 @@ export default (props) => {
     'sign_up',
   ], { locale });
 
-  const bootstrappedData = TransitImmutableConverter.fromJSON(props.searchPage.data);
+  const bootstrappedData = TransitImmutableConverter.fromJSON(_.get(props, 'searchPage.data', null));
 
-  const rawListings = bootstrappedData
-    .get(':data');
+  const rawListings = bootstrappedData.get(':data', []);
 
   const listings = listingsToMap(rawListings, routes.listing_path);
-  const profiles = profilesToMap(bootstrappedData.get(':included'), routes.person_path);
+  const profiles = profilesToMap(bootstrappedData.get(':included', []), routes.person_path);
   const metaData = Immutable.Map({
     page: props.searchPage.page,
     pageSize: props.searchPage.per_page,

--- a/client/app/utils/transitImmutableConverter.js
+++ b/client/app/utils/transitImmutableConverter.js
@@ -41,7 +41,12 @@ const createReader = function createReader() {
 
 const createInstance = () => {
   const reader = createReader();
-  const fromJSON = (json) => reader.read(json);
+  const fromJSON = (json) => {
+    if(json == null){
+      return new Immutable.Map()
+    }
+    return reader.read(json);
+  }
 
   return { fromJSON };
 };


### PR DESCRIPTION
Handles null bootsrapped data and renders empty page with proper flash
notification.

<img width="1154" alt="screen shot 2016-11-04 at 17 12 53" src="https://cloud.githubusercontent.com/assets/230815/20010871/6209bbdc-a2b2-11e6-818d-8282d3cce76d.png">
