### PR TITLE
Remove multicurrency support PHASE 1

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -49,6 +49,7 @@
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text(65535)
+#  currency                                   :string(3)
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)

--- a/app/services/marketplace_service/api/data_types.rb
+++ b/app/services/marketplace_service/api/data_types.rb
@@ -7,6 +7,7 @@ module MarketplaceService::API::DataTypes
     [:locales, :mandatory, :enumerable],
     [:country, :string],
     [:available_currencies, :string],
+    [:currency, :string]
   )
 
 

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -153,7 +153,8 @@ module MarketplaceService::API
           consent: "SHARETRIBE1.0",
           ident: ident,
           settings: {"locales" => [locale]},
-          available_currencies: available_currencies_based_on(params[:marketplace_country].or_else("us")),
+          available_currencies: country_currency(params[:marketplace_country].or_else("us")),
+          currency: country_currency(params[:marketplace_country].or_else("us")),
           country: params[:marketplace_country].upcase.or_else(nil)
         }
       end
@@ -244,7 +245,7 @@ module MarketplaceService::API
         return current_ident
       end
 
-      def available_currencies_based_on(country_code)
+      def country_currency(country_code)
         Maybe(MarketplaceService::AvailableCurrencies::COUNTRY_CURRENCIES[country_code.upcase]).or_else("USD")
       end
 

--- a/db/migrate/20161107092030_add_currency_column_to_communities.rb
+++ b/db/migrate/20161107092030_add_currency_column_to_communities.rb
@@ -1,0 +1,9 @@
+class AddCurrencyColumnToCommunities < ActiveRecord::Migration
+  def up
+    add_column :communities, :currency, :string, limit: 3, after: :available_currencies
+  end
+
+  def down
+    remove_column :communities, :currency
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -248,6 +248,7 @@ CREATE TABLE `communities` (
   `stylesheet_needs_recompile` tinyint(1) DEFAULT '0',
   `service_logo_style` varchar(255) DEFAULT 'full-logo',
   `available_currencies` text,
+  `currency` varchar(3) DEFAULT NULL,
   `facebook_connect_enabled` tinyint(1) DEFAULT '1',
   `minimum_price_cents` int(11) DEFAULT NULL,
   `hide_expiration_date` tinyint(1) DEFAULT '0',
@@ -1597,7 +1598,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-03  8:49:53
+-- Dump completed on 2016-11-07 11:26:57
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3203,4 +3204,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161102101419');
 INSERT INTO schema_migrations (version) VALUES ('20161102193340');
 
 INSERT INTO schema_migrations (version) VALUES ('20161103063652');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107092030');
 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -50,6 +50,7 @@
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text(65535)
+#  currency                                   :string(3)
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)


### PR DESCRIPTION
Currently there is partial support for multiple currencies for marketplaces, but no UI to manage those. Since we only officially support a single currency, removing the support in code makes it easier to handle currencies for other features like changing the marketplace currency in the admin UI.

This PR is the first phase in removing the multicurrency support. The production DB already only contains single currency codes `communities.available_currencies`, and this PR adds a separate `currency` column where the currency of a marketplace is stored (in addition to the `available_currencies` column) when a marketplace is created.

The next phase(s) will migrate the currency data to the new column and start reading the value from the new column.