### PR TITLE
Remove multicurrency support PHASE 2

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -569,8 +569,8 @@ class Community < ActiveRecord::Base
   end
 
   def default_currency
-    if available_currencies
-      available_currencies.gsub(" ","").split(",").first
+    if currency
+      currency
     else
       MoneyRails.default_currency
     end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -49,6 +49,7 @@
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text(65535)
+#  currency                                   :string(3)
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)

--- a/app/services/marketplace_service/api/data_types.rb
+++ b/app/services/marketplace_service/api/data_types.rb
@@ -6,7 +6,6 @@ module MarketplaceService::API::DataTypes
     [:url, :mandatory, :string],
     [:locales, :mandatory, :enumerable],
     [:country, :string],
-    [:available_currencies, :string],
     [:currency, :string]
   )
 

--- a/app/services/marketplace_service/api/data_types.rb
+++ b/app/services/marketplace_service/api/data_types.rb
@@ -7,6 +7,7 @@ module MarketplaceService::API::DataTypes
     [:locales, :mandatory, :enumerable],
     [:country, :string],
     [:available_currencies, :string],
+    [:currency, :string]
   )
 
 

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -153,7 +153,8 @@ module MarketplaceService::API
           consent: "SHARETRIBE1.0",
           ident: ident,
           settings: {"locales" => [locale]},
-          available_currencies: available_currencies_based_on(params[:marketplace_country].or_else("us")),
+          available_currencies: country_currency(params[:marketplace_country].or_else("us")),
+          currency: country_currency(params[:marketplace_country].or_else("us")),
           country: params[:marketplace_country].upcase.or_else(nil)
         }
       end
@@ -244,7 +245,7 @@ module MarketplaceService::API
         return current_ident
       end
 
-      def available_currencies_based_on(country_code)
+      def country_currency(country_code)
         Maybe(MarketplaceService::AvailableCurrencies::COUNTRY_CURRENCIES[country_code.upcase]).or_else("USD")
       end
 

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -153,7 +153,6 @@ module MarketplaceService::API
           consent: "SHARETRIBE1.0",
           ident: ident,
           settings: {"locales" => [locale]},
-          available_currencies: country_currency(params[:marketplace_country].or_else("us")),
           currency: country_currency(params[:marketplace_country].or_else("us")),
           country: params[:marketplace_country].upcase.or_else(nil)
         }

--- a/app/views/listings/form/_currency_selector.haml
+++ b/app/views/listings/form/_currency_selector.haml
@@ -1,10 +1,6 @@
 .currency-selector
-  - if @current_community.available_currencies
-    - currencies = @current_community.available_currencies.gsub(" ","").split(",")
-    - if currencies.size > 1
-      = form.select :currency, currencies, { :selected => (@listing.currency || currencies.first) }
-    - else
-      = Money.new(1, currencies[0]).symbol
-      = form.hidden_field :currency, :value => currencies[0]
+  - if @current_community.currency
+    = Money.new(1, @current_community.currency).symbol
+    = form.hidden_field :currency, :value => @current_community.currency
   - else
     = form.select :currency, major_currencies(Money::Currency.table), { :selected => (@listing.currency || "EUR") }

--- a/db/migrate/20161107092030_add_currency_column_to_communities.rb
+++ b/db/migrate/20161107092030_add_currency_column_to_communities.rb
@@ -1,0 +1,9 @@
+class AddCurrencyColumnToCommunities < ActiveRecord::Migration
+  def up
+    add_column :communities, :currency, :string, limit: 3, after: :available_currencies
+  end
+
+  def down
+    remove_column :communities, :currency
+  end
+end

--- a/db/migrate/20161107105050_copy_community_currency_to_the_currency_column.rb
+++ b/db/migrate/20161107105050_copy_community_currency_to_the_currency_column.rb
@@ -1,0 +1,13 @@
+class CopyCommunityCurrencyToTheCurrencyColumn < ActiveRecord::Migration
+  def up
+    sql = "UPDATE communities c
+           SET c.currency = c.available_currencies"
+    exec_update(sql, "Copy currency from available_currencies to currency", [])
+  end
+
+  def down
+    sql = "UPDATE communities c
+           SET c.available_currencies = c.currency"
+    exec_update(sql, "Copy currency from currency to available_currencies", [])
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -248,6 +248,7 @@ CREATE TABLE `communities` (
   `stylesheet_needs_recompile` tinyint(1) DEFAULT '0',
   `service_logo_style` varchar(255) DEFAULT 'full-logo',
   `available_currencies` text,
+  `currency` varchar(3) DEFAULT NULL,
   `facebook_connect_enabled` tinyint(1) DEFAULT '1',
   `minimum_price_cents` int(11) DEFAULT NULL,
   `hide_expiration_date` tinyint(1) DEFAULT '0',
@@ -1597,7 +1598,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-03  8:49:53
+-- Dump completed on 2016-11-07 11:26:57
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3203,4 +3204,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161102101419');
 INSERT INTO schema_migrations (version) VALUES ('20161102193340');
 
 INSERT INTO schema_migrations (version) VALUES ('20161103063652');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107092030');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1598,7 +1598,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-07 11:26:57
+-- Dump completed on 2016-11-07 14:51:54
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3206,4 +3206,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161102193340');
 INSERT INTO schema_migrations (version) VALUES ('20161103063652');
 
 INSERT INTO schema_migrations (version) VALUES ('20161107092030');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107105050');
 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -50,6 +50,7 @@
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text(65535)
+#  currency                                   :string(3)
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -30,13 +30,13 @@ describe MarketplaceService::API::Marketplaces do
 
     it "should set correct currency based on contry selection" do
       c = create(@community_params)
-      expect(c[:available_currencies]).to eql "EUR"
+      expect(c[:currency]).to eql "EUR"
 
       c = create(@community_params.merge({:marketplace_country => "US"}))
-      expect(c[:available_currencies]).to eql "USD"
+      expect(c[:currency]).to eql "USD"
 
       c = create(@community_params.merge({:marketplace_country => "GG"}))
-      expect(c[:available_currencies]).to eql "GBP"
+      expect(c[:currency]).to eql "GBP"
     end
 
     it "should set correct listing shape and category" do


### PR DESCRIPTION
This PR is the second phase in removing the support for multiple currencies and builds on top of #2722 

The old currency value in `communities.available_currencies` is copied to the new `communities.currency` column and the value is read from the new column from now on.