### PR TITLE
Remove multicurrency support PHASE 3

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -1382,12 +1382,6 @@ $noscript-height: lines(4);
   max-width: lines(5);
 }
 
-.currency-selector {
-  margin-left: lines(0.25);
-  display: inline;
-  @include big-type;
-}
-
 .quantity-field {
   max-width: lines(7);
 }

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -203,8 +203,8 @@ class Admin::CustomFieldsController < ApplicationController
 
   def update_price
     # To cents
-    params[:community][:price_filter_min] = MoneyUtil.parse_str_to_money(params[:community][:price_filter_min], @current_community.default_currency).cents if params[:community][:price_filter_min]
-    params[:community][:price_filter_max] = MoneyUtil.parse_str_to_money(params[:community][:price_filter_max], @current_community.default_currency).cents if params[:community][:price_filter_max]
+    params[:community][:price_filter_min] = MoneyUtil.parse_str_to_money(params[:community][:price_filter_min], @current_community.currency).cents if params[:community][:price_filter_min]
+    params[:community][:price_filter_max] = MoneyUtil.parse_str_to_money(params[:community][:price_filter_max], @current_community.currency).cents if params[:community][:price_filter_max]
 
     price_params = params.require(:community).permit(
       :show_price_filter,

--- a/app/controllers/admin/paypal_preferences_controller.rb
+++ b/app/controllers/admin/paypal_preferences_controller.rb
@@ -35,7 +35,7 @@ class Admin::PaypalPreferencesController < ApplicationController
   def index
     @selected_left_navi_link = "paypal_account"
     paypal_account = accounts_api.get(community_id: @current_community.id).maybe
-    currency = @current_community.default_currency
+    currency = @current_community.currency
     minimum_commission = paypal_minimum_commissions_api.get(currency)
 
     tx_settings =
@@ -47,8 +47,8 @@ class Admin::PaypalPreferencesController < ApplicationController
     paypal_prefs_form = PaypalPreferencesForm.new(
       minimum_commission: minimum_commission,
       commission_from_seller: tx_settings[:commission_from_seller],
-      minimum_listing_price: Money.new(tx_settings[:minimum_price_cents], @current_community.default_currency),
-      minimum_transaction_fee: Money.new(tx_settings[:minimum_transaction_fee_cents], @current_community.default_currency)
+      minimum_listing_price: Money.new(tx_settings[:minimum_price_cents], @current_community.currency),
+      minimum_transaction_fee: Money.new(tx_settings[:minimum_transaction_fee_cents], @current_community.currency)
     )
 
     community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
@@ -77,7 +77,7 @@ class Admin::PaypalPreferencesController < ApplicationController
   end
 
   def preferences_update
-    currency = @current_community.default_currency
+    currency = @current_community.currency
     minimum_commission = paypal_minimum_commissions_api.get(currency)
 
     paypal_prefs_form = PaypalPreferencesForm.new(

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -252,8 +252,8 @@ class HomepageController < ApplicationController
 
   def filter_range(price_min, price_max)
     if (price_min && price_max)
-      min = MoneyUtil.parse_str_to_money(price_min, @current_community.default_currency).cents
-      max = MoneyUtil.parse_str_to_money(price_max, @current_community.default_currency).cents
+      min = MoneyUtil.parse_str_to_money(price_min, @current_community.currency).cents
+      max = MoneyUtil.parse_str_to_money(price_max, @current_community.currency).cents
 
       if ((@current_community.price_filter_min..@current_community.price_filter_max) != (min..max))
         (min..max)

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -715,7 +715,7 @@ class ListingsController < ApplicationController
   def commission(community, process)
     payment_type = MarketplaceService::Community::Query.payment_type(community.id)
     payment_settings = TransactionService::API::Api.settings.get_active(community_id: community.id).maybe
-    currency = community.default_currency
+    currency = community.currency
 
     case [payment_type, process]
     when matches([__, :none])

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -464,17 +464,20 @@ class ListingsController < ApplicationController
     update_successful = @listing.update_fields(listing_params)
 
     upsert_field_values!(@listing, params[:custom_fields])
+    finalise_update(@listing, shape, @current_community, update_successful, old_availability)
+  end
 
+  def finalise_update(listing, shape, community, update_successful, old_availability)
     if update_successful
-      @listing.location.update_attributes(params[:location]) if @listing.location
+      listing.location.update_attributes(params[:location]) if listing.location
       flash[:notice] = update_flash(old_availability: old_availability, new_availability: shape[:availability])
-      Delayed::Job.enqueue(ListingUpdatedJob.new(@listing.id, @current_community.id))
-      reprocess_missing_image_styles(@listing) if listing_reopened
-      redirect_to @listing
+      Delayed::Job.enqueue(ListingUpdatedJob.new(listing.id, community.id))
+      reprocess_missing_image_styles(listing) if listing.closed?
+      redirect_to listing
     else
-      logger.error("Errors in editing listing: #{@listing.errors.full_messages.inspect}")
+      logger.error("Errors in editing listing: #{listing.errors.full_messages.inspect}")
       flash[:error] = t("layouts.notifications.listing_could_not_be_saved", :contact_admin_link => view_context.link_to(t("layouts.notifications.contact_admin_link_text"), new_user_feedback_path, :class => "flash-error-link")).html_safe
-      redirect_to edit_listing_path(@listing)
+      redirect_to edit_listing_path(listing)
     end
   end
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -297,7 +297,8 @@ class ListingsController < ApplicationController
   end
 
   def create_listing(shape, listing_uuid)
-    listing_params = ListingFormViewUtils.filter(params[:listing], shape)
+    with_currency = params[:listing].merge({currency: @current_community.currency})
+    listing_params = ListingFormViewUtils.filter(with_currency, shape)
     listing_unit = Maybe(params)[:listing][:unit].map { |u| ListingViewUtils::Unit.deserialize(u) }.or_else(nil)
     listing_params = ListingFormViewUtils.filter_additional_shipping(listing_params, listing_unit)
     validation_result = ListingFormViewUtils.validate(listing_params, shape, listing_unit)
@@ -434,7 +435,8 @@ class ListingsController < ApplicationController
       end
     end
 
-    listing_params = ListingFormViewUtils.filter(params[:listing], shape)
+    with_currency = params[:listing].merge({currency: @current_community.currency})
+    listing_params = ListingFormViewUtils.filter(with_currency, shape)
     listing_unit = Maybe(params)[:listing][:unit].map { |u| ListingViewUtils::Unit.deserialize(u) }.or_else(nil)
     listing_params = ListingFormViewUtils.filter_additional_shipping(listing_params, listing_unit)
     validation_result = ListingFormViewUtils.validate(listing_params, shape, listing_unit)

--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -23,7 +23,7 @@ class PaypalAccountsController < ApplicationController
                                 new_user_feedback_path)).html_safe
     end
 
-    community_currency = @current_community.default_currency
+    community_currency = @current_community.currency
     payment_settings = payment_settings_api.get_active(community_id: @current_community.id).maybe.get
     community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -569,8 +569,8 @@ class Community < ActiveRecord::Base
   end
 
   def default_currency
-    if available_currencies
-      available_currencies.gsub(" ","").split(",").first
+    if currency
+      currency
     else
       MoneyRails.default_currency
     end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -49,6 +49,7 @@
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text(65535)
+#  currency                                   :string(3)
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -130,7 +130,7 @@ class Community < ActiveRecord::Base
 
   after_create :initialize_settings
 
-  monetize :minimum_price_cents, :allow_nil => true, :with_model_currency => :default_currency
+  monetize :minimum_price_cents, :allow_nil => true, :with_model_currency => :currency
 
   validates_length_of :ident, :in => 2..50
   validates_format_of :ident, :with => /\A[A-Z0-9_\-\.]*\z/i
@@ -565,14 +565,6 @@ class Community < ActiveRecord::Base
   # There is a method `payment_type` is community service. Use that instead.
   def payments_in_use?
     MarketplaceService::Community::Query.payment_type(id) == :paypal
-  end
-
-  def default_currency
-    if currency
-      currency
-    else
-      MoneyRails.default_currency
-    end
   end
 
   def self.all_with_custom_fb_login

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -48,8 +48,7 @@
 #  stylesheet_url                             :string(255)
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
-#  available_currencies                       :text(65535)
-#  currency                                   :string(3)
+#  currency                                   :string(3)        not null
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)

--- a/app/services/marketplace_service/api/data_types.rb
+++ b/app/services/marketplace_service/api/data_types.rb
@@ -6,7 +6,6 @@ module MarketplaceService::API::DataTypes
     [:url, :mandatory, :string],
     [:locales, :mandatory, :enumerable],
     [:country, :string],
-    [:available_currencies, :string],
     [:currency, :string]
   )
 

--- a/app/services/marketplace_service/api/data_types.rb
+++ b/app/services/marketplace_service/api/data_types.rb
@@ -7,6 +7,7 @@ module MarketplaceService::API::DataTypes
     [:locales, :mandatory, :enumerable],
     [:country, :string],
     [:available_currencies, :string],
+    [:currency, :string]
   )
 
 

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -153,7 +153,8 @@ module MarketplaceService::API
           consent: "SHARETRIBE1.0",
           ident: ident,
           settings: {"locales" => [locale]},
-          available_currencies: available_currencies_based_on(params[:marketplace_country].or_else("us")),
+          available_currencies: country_currency(params[:marketplace_country].or_else("us")),
+          currency: country_currency(params[:marketplace_country].or_else("us")),
           country: params[:marketplace_country].upcase.or_else(nil)
         }
       end
@@ -244,7 +245,7 @@ module MarketplaceService::API
         return current_ident
       end
 
-      def available_currencies_based_on(country_code)
+      def country_currency(country_code)
         Maybe(MarketplaceService::AvailableCurrencies::COUNTRY_CURRENCIES[country_code.upcase]).or_else("USD")
       end
 

--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -153,7 +153,6 @@ module MarketplaceService::API
           consent: "SHARETRIBE1.0",
           ident: ident,
           settings: {"locales" => [locale]},
-          available_currencies: country_currency(params[:marketplace_country].or_else("us")),
           currency: country_currency(params[:marketplace_country].or_else("us")),
           country: params[:marketplace_country].upcase.or_else(nil)
         }

--- a/app/views/admin/custom_fields/edit_price.haml
+++ b/app/views/admin/custom_fields/edit_price.haml
@@ -13,8 +13,8 @@
 .left-navi-section
   = form_for @community, :as => :community, :url => update_price_admin_custom_fields_path, :method => :put do |form|
 
-    - min = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_min, @current_community.default_currency)) || 0
-    - max = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_max, @current_community.default_currency)) || 100000
+    - min = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_min, @current_community.currency)) || 0
+    - max = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_max, @current_community.currency)) || 100000
 
     .row
       .col-12

--- a/app/views/homepage/_price_filter.haml
+++ b/app/views/homepage/_price_filter.haml
@@ -7,8 +7,8 @@
     .custom-filter-options
       - id = ["range-slider", "price"].join("-")
       .range-slider{id: id}
-        - min = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_min, @current_community.default_currency))
-        - max = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_max, @current_community.default_currency))
+        - min = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_min, @current_community.currency))
+        - max = MoneyUtil.to_units(MoneyUtil.to_money(@current_community.price_filter_max, @current_community.currency))
         - range = [min, max]
         - start = [params["price_min"] || min, params["price_max"] || max]
         - labels = ["#price-filter-min-value", "#price-filter-max-value"]

--- a/app/views/listings/form/_currency_selector.haml
+++ b/app/views/listings/form/_currency_selector.haml
@@ -1,3 +1,0 @@
-.currency-selector
-  = Money.new(1, @current_community.currency).symbol
-  = form.hidden_field :currency, :value => @current_community.currency

--- a/app/views/listings/form/_currency_selector.haml
+++ b/app/views/listings/form/_currency_selector.haml
@@ -1,10 +1,6 @@
 .currency-selector
-  - if @current_community.available_currencies
-    - currencies = @current_community.available_currencies.gsub(" ","").split(",")
-    - if currencies.size > 1
-      = form.select :currency, currencies, { :selected => (@listing.currency || currencies.first) }
-    - else
-      = Money.new(1, currencies[0]).symbol
-      = form.hidden_field :currency, :value => currencies[0]
+  - if @current_community.currency
+    = Money.new(1, @current_community.currency).symbol
+    = form.hidden_field :currency, :value => @current_community.currency
   - else
     = form.select :currency, major_currencies(Money::Currency.table), { :selected => (@listing.currency || "EUR") }

--- a/app/views/listings/form/_currency_selector.haml
+++ b/app/views/listings/form/_currency_selector.haml
@@ -1,6 +1,3 @@
 .currency-selector
-  - if @current_community.currency
-    = Money.new(1, @current_community.currency).symbol
-    = form.hidden_field :currency, :value => @current_community.currency
-  - else
-    = form.select :currency, major_currencies(Money::Currency.table), { :selected => (@listing.currency || "EUR") }
+  = Money.new(1, @current_community.currency).symbol
+  = form.hidden_field :currency, :value => @current_community.currency

--- a/app/views/listings/form/_javascripts.haml
+++ b/app/views/listings/form/_javascripts.haml
@@ -8,7 +8,7 @@
       var listingImageOpts = #{ListingImageS3OptionsJSAdapter.new(@listing).to_json}
       var listingImages = #{ @listing.listing_images.map { |image| ListingImageJSAdapter.new(image) }.to_json }
 
-      window.ST.initialize_new_listing_form("#{t('listings.form.images.no_file_selected')}", "#{t('listings.form.images.select_file')}", "#{I18n.locale}", "#{t('error_messages.listings.share_type')}", "#{valid_until_msg}", "#{listing_id}", "#{shape[:price_enabled]}","#{t('error_messages.listings.price')}","#{minimum_price_cents}","#{Money::Currency.new(@current_community.default_currency).subunit_to_unit}","#{t('error_messages.listings.minimum_price', :minimum_price => Money.new(minimum_price_cents, @current_community.default_currency), :currency => @current_community.default_currency)}", #{@numeric_field_ids.collect { |numeric_field_id| "custom_fields[#{numeric_field_id}]" } }, listingImages, listingImageOpts, "#{t('listings.form.images.images_not_uploaded_confirm')}" );
+      window.ST.initialize_new_listing_form("#{t('listings.form.images.no_file_selected')}", "#{t('listings.form.images.select_file')}", "#{I18n.locale}", "#{t('error_messages.listings.share_type')}", "#{valid_until_msg}", "#{listing_id}", "#{shape[:price_enabled]}","#{t('error_messages.listings.price')}","#{minimum_price_cents}","#{Money::Currency.new(@current_community.currency).subunit_to_unit}","#{t('error_messages.listings.minimum_price', :minimum_price => Money.new(minimum_price_cents, @current_community.currency), :currency => @current_community.currency)}", #{@numeric_field_ids.collect { |numeric_field_id| "custom_fields[#{numeric_field_id}]" } }, listingImages, listingImageOpts, "#{t('listings.form.images.images_not_uploaded_confirm')}" );
     });
 
 - if run_js_immediately

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -2,7 +2,6 @@
   - if shape[:price_enabled]
     = form.label :price, t(".price")
     = form.text_field :price, :class => "price-field", :maxlength => "10", :placeholder => "0", :value => (@listing.price ? @listing.price.to_s: 0)
-    = render partial: "listings/form/currency_selector", locals: {form: form}
 
     - if unit_options.empty?
       -# No-op

--- a/app/views/listings/form/_shipping.haml
+++ b/app/views/listings/form/_shipping.haml
@@ -13,8 +13,6 @@
               .delivery-label-cont
                 = form.label :shipping_price, t("listings.form.price.shipping_price"), class: "shipping-options-label"
               .delivery-input-cont
-                .delivery-currency
-                  = render partial: "listings/form/currency_selector", locals: {form: form}
                 = form.text_field :shipping_price, class: "price-field delivery-price-field", maxlength: 10, placeholder: 0, value: shipping_price
           .delivery-row-tall
             .delivery-left-field.shipping-price-container.js-shipping-price-additional{class: always_show_additional_shipping_price ? "" : "hidden"}
@@ -22,8 +20,6 @@
                 .delivery-label-cont
                   = form.label :shipping_price_additional, t("listings.form.price.shipping_price_additional"), class: "shipping-options-label"
                 .delivery-input-cont
-                  .delivery-currency
-                    = render partial: "listings/form/currency_selector", locals: {form: form}
                   = form.text_field :shipping_price_additional, class: "price-field delivery-price-field", maxlength: 10, placeholder: 0, value: shipping_price_additional
       .delivery-row-low
         .delivery-checkbox

--- a/db/migrate/20161107092030_add_currency_column_to_communities.rb
+++ b/db/migrate/20161107092030_add_currency_column_to_communities.rb
@@ -1,0 +1,9 @@
+class AddCurrencyColumnToCommunities < ActiveRecord::Migration
+  def up
+    add_column :communities, :currency, :string, limit: 3, after: :available_currencies
+  end
+
+  def down
+    remove_column :communities, :currency
+  end
+end

--- a/db/migrate/20161107105050_copy_community_currency_to_the_currency_column.rb
+++ b/db/migrate/20161107105050_copy_community_currency_to_the_currency_column.rb
@@ -1,0 +1,13 @@
+class CopyCommunityCurrencyToTheCurrencyColumn < ActiveRecord::Migration
+  def up
+    sql = "UPDATE communities c
+           SET c.currency = c.available_currencies"
+    exec_update(sql, "Copy currency from available_currencies to currency", [])
+  end
+
+  def down
+    sql = "UPDATE communities c
+           SET c.available_currencies = c.currency"
+    exec_update(sql, "Copy currency from currency to available_currencies", [])
+  end
+end

--- a/db/migrate/20161107112025_remove_available_currencies_column_from_communities.rb
+++ b/db/migrate/20161107112025_remove_available_currencies_column_from_communities.rb
@@ -1,0 +1,5 @@
+class RemoveAvailableCurrenciesColumnFromCommunities < ActiveRecord::Migration
+  def change
+    remove_column :communities, :available_currencies, :text, after: :service_logo_style
+  end
+end

--- a/db/migrate/20161107131859_change_community_null_currencies_to_eur.rb
+++ b/db/migrate/20161107131859_change_community_null_currencies_to_eur.rb
@@ -1,0 +1,8 @@
+class ChangeCommunityNullCurrenciesToEur < ActiveRecord::Migration
+  def up
+    sql = 'UPDATE communities c
+           SET c.currency = "EUR"
+           WHERE c.currency IS NULL'
+    exec_update(sql, "Change NULL currencies to EUR", [])
+  end
+end

--- a/db/migrate/20161107132513_change_community_currency_not_to_be_null.rb
+++ b/db/migrate/20161107132513_change_community_currency_not_to_be_null.rb
@@ -1,0 +1,5 @@
+class ChangeCommunityCurrencyNotToBeNull < ActiveRecord::Migration
+  def change
+    change_column_null :communities, :currency, false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -248,6 +248,7 @@ CREATE TABLE `communities` (
   `stylesheet_needs_recompile` tinyint(1) DEFAULT '0',
   `service_logo_style` varchar(255) DEFAULT 'full-logo',
   `available_currencies` text,
+  `currency` varchar(3) DEFAULT NULL,
   `facebook_connect_enabled` tinyint(1) DEFAULT '1',
   `minimum_price_cents` int(11) DEFAULT NULL,
   `hide_expiration_date` tinyint(1) DEFAULT '0',
@@ -1597,7 +1598,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-03  8:49:53
+-- Dump completed on 2016-11-07 11:26:57
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3203,4 +3204,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161102101419');
 INSERT INTO schema_migrations (version) VALUES ('20161102193340');
 
 INSERT INTO schema_migrations (version) VALUES ('20161103063652');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107092030');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1598,7 +1598,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-07 11:26:57
+-- Dump completed on 2016-11-07 14:51:54
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3206,4 +3206,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161102193340');
 INSERT INTO schema_migrations (version) VALUES ('20161103063652');
 
 INSERT INTO schema_migrations (version) VALUES ('20161107092030');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107105050');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -247,8 +247,7 @@ CREATE TABLE `communities` (
   `stylesheet_url` varchar(255) DEFAULT NULL,
   `stylesheet_needs_recompile` tinyint(1) DEFAULT '0',
   `service_logo_style` varchar(255) DEFAULT 'full-logo',
-  `available_currencies` text,
-  `currency` varchar(3) DEFAULT NULL,
+  `currency` varchar(3) NOT NULL,
   `facebook_connect_enabled` tinyint(1) DEFAULT '1',
   `minimum_price_cents` int(11) DEFAULT NULL,
   `hide_expiration_date` tinyint(1) DEFAULT '0',
@@ -1598,7 +1597,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-07 14:51:54
+-- Dump completed on 2016-11-07 15:29:03
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3208,4 +3207,10 @@ INSERT INTO schema_migrations (version) VALUES ('20161103063652');
 INSERT INTO schema_migrations (version) VALUES ('20161107092030');
 
 INSERT INTO schema_migrations (version) VALUES ('20161107105050');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107112025');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107131859');
+
+INSERT INTO schema_migrations (version) VALUES ('20161107132513');
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -188,6 +188,7 @@ FactoryGirl.define do
     ident
     slogan "Test slogan"
     description "Test description"
+    currency "EUR"
 
     has_many(:community_customizations) do |community|
       FactoryGirl.build(:community_customization, community: community)

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -50,6 +50,7 @@
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
 #  available_currencies                       :text(65535)
+#  currency                                   :string(3)
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -49,8 +49,7 @@
 #  stylesheet_url                             :string(255)
 #  stylesheet_needs_recompile                 :boolean          default(FALSE)
 #  service_logo_style                         :string(255)      default("full-logo")
-#  available_currencies                       :text(65535)
-#  currency                                   :string(3)
+#  currency                                   :string(3)        not null
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
 #  hide_expiration_date                       :boolean          default(FALSE)

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -30,13 +30,13 @@ describe MarketplaceService::API::Marketplaces do
 
     it "should set correct currency based on contry selection" do
       c = create(@community_params)
-      expect(c[:available_currencies]).to eql "EUR"
+      expect(c[:currency]).to eql "EUR"
 
       c = create(@community_params.merge({:marketplace_country => "US"}))
-      expect(c[:available_currencies]).to eql "USD"
+      expect(c[:currency]).to eql "USD"
 
       c = create(@community_params.merge({:marketplace_country => "GG"}))
-      expect(c[:available_currencies]).to eql "GBP"
+      expect(c[:currency]).to eql "GBP"
     end
 
     it "should set correct listing shape and category" do


### PR DESCRIPTION
In the third and final phase of removing support for multiple currencies, we clean up the currency data in the DB and change the code to rely on a currency value for a community.

Builds on top of #2722 and #2724 