### PR TITLE
Change constants to functions

### DIFF
--- a/spec/view_utils/new_layout_view_utils_spec.rb
+++ b/spec/view_utils/new_layout_view_utils_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe NewLayoutViewUtils do
   before do
-    stub_const("NewLayoutViewUtils::FEATURES",
+    allow(NewLayoutViewUtils).to receive(:published_features).and_return(
       [
         { title: "Foo",
           name: :foo
@@ -15,7 +15,7 @@ describe NewLayoutViewUtils do
         }
       ])
 
-    stub_const("NewLayoutViewUtils::EXPERIMENTAL_FEATURES", {})
+    allow(NewLayoutViewUtils).to receive(:experimental_features).and_return({})
   end
 
   describe "#features" do


### PR DESCRIPTION
Don't use function calls in constants

Fixes a bug  where new layout admin ui doesn't show correct translations as constants are shared across requests.