### PR TITLE
Delete _map_bubble_spacer.haml

### DIFF
--- a/app/views/homepage/_map_bubble_spacer.haml
+++ b/app/views/homepage/_map_bubble_spacer.haml
@@ -1,1 +1,0 @@
-.bubble-spacer


### PR DESCRIPTION
File first submit at 2014
and never changed after that.

and no other file refer this file.

I think this is a useless file.
should be remove