### PR TITLE
Fix listing image processing for new search view

### DIFF
--- a/db/migrate/20161109094513_process_listing_images_wiht_null_valid_until.rb
+++ b/db/migrate/20161109094513_process_listing_images_wiht_null_valid_until.rb
@@ -1,0 +1,43 @@
+class ProcessListingImagesWihtNullValidUntil < ActiveRecord::Migration
+
+  def up
+    # Select listing images that are related to listings
+    # that are not closed. For every 1000 of those images
+    # create a delayed job that creates square versions
+    # of the images.
+    #
+    # Also select listing images that have NULL valid_unit
+    # value. Restrict those images to the listings created
+    # before 2016-10-01 as listings created after that have
+    # images with the square styles included.
+
+    select_values("
+      SELECT li.id
+      FROM listing_images AS li, listings AS l
+      WHERE 1=1
+        AND li.listing_id = l.id
+        AND l.open = 1
+        AND l.valid_until IS NULL
+        AND l.created_at < '2016-10-01 00:00:00'
+    ").each_slice(1000) { |ids|
+
+      exec_insert("INSERT INTO delayed_jobs
+                  (priority, handler, last_error, run_at, created_at, updated_at, queue)
+                  VALUES #{values(ids)}", "create_delayed_jobs", [])
+    }
+  end
+
+  def down
+    # no op
+  end
+
+  def values(ids)
+    ids.map { |id|
+      "(11, '#{handler(id)}', NULL, NOW(), NOW(), NOW(), 'default')"
+    }.join(",")
+  end
+
+  def handler(id)
+    CreateSquareImagesJob.new(id).to_yaml
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3218,3 +3218,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161107132513');
 
 INSERT INTO schema_migrations (version) VALUES ('20161107141257');
 
+INSERT INTO schema_migrations (version) VALUES ('20161109094513');
+


### PR DESCRIPTION
On 2016-09-29 a listing image processing migration was run that was intended to create new image sizes, `square` and `square_2x`, for all open listings. In this migration was missing a check for listings that are missing a `valid_until` value.

This PR adds a new migration that takes the missing `valid_until` into consideration and is only limited to listings created before the previous migration. Newer images have been created after the new image styles were introduced and therefore do not need to be processed. 