### PR TITLE
Show warning when currency is about to change

### DIFF
--- a/app/assets/javascripts/paypal_account_settings.js
+++ b/app/assets/javascripts/paypal_account_settings.js
@@ -31,9 +31,11 @@ window.ST = window.ST || {};
     var $form = $('#' + formId);
     var $currency = $form.find('#paypal_preferences_form_marketplace_currency');
     var $currencyLabels = $form.find('.paypal-preferences-currency-label');
+    var $warning = $form.find('.paypal-currency-change-warning-text');
 
     $currency.on('change', function() {
       $currencyLabels.text($currency.val());
+      $warning.show();
     });
 
     $form.validate({

--- a/app/assets/stylesheets/views/_account-settings.css.scss
+++ b/app/assets/stylesheets/views/_account-settings.css.scss
@@ -256,3 +256,7 @@
   top: 0;
   left: 0;
 }
+
+.paypal-currency-change-warning-text {
+  display: none;
+}

--- a/app/views/admin/paypal_preferences/index.haml
+++ b/app/views/admin/paypal_preferences/index.haml
@@ -69,6 +69,15 @@
               .col-6
                 = form.select :marketplace_currency, options_for_select(available_currencies, currency)
 
+            .row.paypal-currency-change-warning-text
+              .col-12
+                .alert-box-warning
+                  %p
+                    %span.alert-box-icon
+                      = icon_tag("alert", ["icon-fix"])
+                    %span
+                      = t("admin.paypal_accounts.currency_change_warning_text")
+
             .row
               .col-6
                 = form.label :minimum_listing_price, t("admin.paypal_accounts.minimum_listing_price_label"), class: "paypal-horizontal-input-label"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,6 +485,7 @@ en:
       read_more_about_paypal: "Read more about the payment system"
       edit_payment_settings: "Edit payment settings"
       supported_currencies_information_text: "Sharetribe's online payment system supports 24 currencies. If your currency is not on the list, please %{contact_support_link}. If you change the marketplace currency, existing listings will retain their old currency. You need to edit those listings individually to convert them to the new currency."
+      currency_change_warning_text: "Heads up: if you move forward with this currency change, don't forget to ask your sellers to manually edit their existing listings to get the currency update."
       marketplace_currency_label: "Marketplace currency:"
       minimum_listing_price_label: "Minimum transaction size:"
       transaction_fee_label: "Transaction fee:"


### PR DESCRIPTION
Changing the marketplace currency requires potential actions and might not be apparent to the admins. This PR adds a warning to the PayPal preferences page when the currency dropdown value changes.

<img width="689" alt="screen shot 2016-11-09 at 15 57 33" src="https://cloud.githubusercontent.com/assets/53923/20140740/8c4182d6-a695-11e6-8508-14d43fe00c61.png">
