### PR TITLE
remove 1 route rule: "get :payments" in "resource :settings" at line 443

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -439,7 +439,6 @@ Kassi::Application.routes.draw do
           member do
             get :account
             get :notifications
-            get :payments
             get :unsubscribe
           end
         end


### PR DESCRIPTION
![2016-11-10 11 52 28](https://cloud.githubusercontent.com/assets/1804755/20164022/300862c6-a73c-11e6-9982-3615b8c4c8a0.png)
(image is  app/controllers/settings_controller.rb )

## in config/routes.rb line 443
```ruby
        resource :settings do
          member do
            get :account
            get :notifications
            get :payments
            get :unsubscribe
          end
        end
```


## in app/controllers/settings_controller.rb
``` def account ``` exist
``` def notifications ``` exist
``` def unsubscribe ``` exist

But, There are no 
```
def payments
  ...
end
```

So, I assume this route is useless and should be remove ?