### PR TITLE
Add margin to keyword/location search divider border in CLP + fix 3 issues

### DIFF
--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -209,7 +209,7 @@
   @extend .hero__search-input;
   border-radius: 29.5px;
   margin: 0 0 12px 0;
-  padding: 8px 12px 8px 24px;
+  padding: 8px 24px 8px 24px;
 
   @media #{$hero_search-tablet} {
     padding: 8px 12px 8px 0px;

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -339,8 +339,8 @@ $tablet--hero: "(min-width: 480px) and (max-width: 767px)";
   }
 }
 
-
-.hero__search-icon {
+// Common styling for search icon
+.hero__search-icon--base {
   @include enable-flex-shrink-fix;
 
   order: 2;
@@ -366,9 +366,23 @@ $tablet--hero: "(min-width: 480px) and (max-width: 767px)";
   }
 }
 
+.hero__search-icon {
+  @extend .hero__search-icon--base;
+
+  @media #{$mobile-landscape} {
+    order: 0;
+    padding: 19px 0px;
+  }
+}
+
 .hero__search-icon--combined {
-  @extend .hero__search-icon;
+  @extend .hero__search-icon--base;
   display: none;
+
+  @media #{$mobile-landscape--hero} {
+    order: 0;
+    padding: 19px 0px;
+  }
 
   @media #{$mobile-landscape--hero}, #{$tablet--hero}, #{$tablet}, #{$desktop} {
     display: block;

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -242,7 +242,7 @@ $tablet--hero: "(min-width: 480px) and (max-width: 767px)";
     letter-spacing: 0px;
     line-height: 32px;
 
-    padding: 14px 24px 14px 12px;
+    padding: 14px 12px 14px 12px;
   }
 
   &:nth-of-type(2) {

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -206,6 +206,8 @@ $tablet--hero: "(min-width: 480px) and (max-width: 767px)";
   }
 }
 
+// Common styles for both search inputs, keyword and location search in combined mode
+//
 .hero__search-input--combined {
   @extend .hero__search-input;
   border-radius: 29.5px;
@@ -213,12 +215,9 @@ $tablet--hero: "(min-width: 480px) and (max-width: 767px)";
   padding: 8px 24px 8px 24px;
 
   @media #{$mobile-landscape--hero}, #{$tablet--hero} {
-    padding: 8px 12px 8px 0px;
-    margin: 0;
-    border-radius: 0;
-    &:nth-of-type(2) {
-      padding: 8px 12px 8px 12px;
-    }
+    padding-top: 0px;
+    padding-bottom: 0px;
+    margin: 8px 0px;
   }
 
   @media #{$desktop} {
@@ -226,26 +225,40 @@ $tablet--hero: "(min-width: 480px) and (max-width: 767px)";
     letter-spacing: 0px;
     line-height: 32px;
 
-    padding: 14px 24px 14px 18px;
-
-    margin: 0;
-    border-radius: 0;
-    &:nth-of-type(2) {
-      padding: 14px 24px 14px 18px;
-    }
+    padding: 0px 24px 0px 18px;
+    margin: 14px 0px;
   }
 
   @media #{$tablet} {
-    margin: 0;
-    border-radius: 0;
     font-size: 18px;
     letter-spacing: 0px;
     line-height: 32px;
 
-    padding: 14px 12px 14px 12px;
+    padding: 0px 12px;
+    margin: 14px 0px;
+  }
+}
+
+.hero__keyword-search-input--combined {
+  @extend .hero__search-input--combined;
+
+  @media #{$mobile-landscape--hero}, #{$tablet--hero} {
+    padding-right: 12px;
+    padding-left: 0px;
+  }
+}
+
+.hero__location-search-input--combined {
+  @extend .hero__search-input--combined;
+
+  @media #{$mobile-landscape--hero}, #{$tablet--hero} {
+    border-radius: 0;
+    padding-right: 12px;
+    padding-left: 12px;
   }
 
-  &:nth-of-type(2) {
+  @media #{$mobile-landscape--hero}, #{$tablet--hero}, #{$tablet}, #{$desktop} {
+    border-radius: 0;
     border-left: solid 1px #cccccc;
   }
 }

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -160,28 +160,6 @@
 
 }
 
-@mixin hero-search-input-media {
-  @media #{$mobile-landscape} {
-    padding: 14px 24px 14px 12px;
-  }
-
-  @media #{$tablet} {
-    font-size: 18px;
-    letter-spacing: 0px;
-    line-height: 32px;
-
-    padding: 14px 24px 14px 12px;
-  }
-
-  @media #{$desktop} {
-    font-size: 18px;
-    letter-spacing: 0px;
-    line-height: 32px;
-
-    padding: 14px 24px 14px 18px;
-  }
-}
-
 .hero__search-input {
   @include typography__medium;
   order: 1;
@@ -201,8 +179,25 @@
   line-height: 32px;
   padding: 8px 12px 8px 0px;
 
-  @include hero-search-input-media;
+  @media #{$mobile-landscape} {
+    padding: 14px 24px 14px 12px;
+  }
 
+  @media #{$tablet} {
+    font-size: 18px;
+    letter-spacing: 0px;
+    line-height: 32px;
+
+    padding: 14px 24px 14px 12px;
+  }
+
+  @media #{$desktop} {
+    font-size: 18px;
+    letter-spacing: 0px;
+    line-height: 32px;
+
+    padding: 14px 24px 14px 18px;
+  }
 }
 
 .hero__search-input--combined {
@@ -226,7 +221,25 @@
     }
   }
 
-  @include hero-search-input-media;
+  @media #{$mobile-landscape} {
+    padding: 14px 24px 14px 12px;
+  }
+
+  @media #{$tablet} {
+    font-size: 18px;
+    letter-spacing: 0px;
+    line-height: 32px;
+
+    padding: 14px 24px 14px 12px;
+  }
+
+  @media #{$desktop} {
+    font-size: 18px;
+    letter-spacing: 0px;
+    line-height: 32px;
+
+    padding: 14px 24px 14px 18px;
+  }
 
   &:nth-of-type(2) {
     border-left: solid 1px #cccccc;

--- a/app/assets/stylesheets/landing_page/sections/hero.scss
+++ b/app/assets/stylesheets/landing_page/sections/hero.scss
@@ -4,6 +4,12 @@
 /* Hero section                                                                         */
 /* ************************************************************************************ */
 
+// Media queries
+//
+// Some parts of the Hero component use different break-points:
+$mobile-landscape--hero: "(max-width: 479px) and (orientation: landscape)"; // same font-sizes as the mobile, but layout/grid structure from $tablet
+$tablet--hero: "(min-width: 480px) and (max-width: 767px)";
+
 .hero__section {
   width: 100%;
   @include viewport-unit(min-height, 80vh);
@@ -116,14 +122,8 @@
   @extend .hero__search-bar;
   flex-direction: column;
 
-  @media #{$hero_search-tablet} {
+  @media #{$mobile-landscape--hero}, #{$tablet--hero}, #{$tablet}, #{$desktop} {
     flex-direction: row;
-  }
-}
-
-@mixin hero-search-input-container {
-  @media #{$mobile-landscape}, #{$tablet}, #{$desktop} {
-    border-radius: 29.5px 0px 0px 29.5px;
   }
 }
 
@@ -139,7 +139,9 @@
   @include prefix-prop(flex-direction, row);
   padding: 0px 0px 0px 24px;
 
-  @include hero-search-input-container;
+  @media #{$mobile-landscape}, #{$tablet}, #{$desktop} {
+    border-radius: 29.5px 0px 0px 29.5px;
+  }
 }
 
 .hero__search-input-container--combined {
@@ -149,15 +151,19 @@
   padding: 0;
   flex-direction: column;
 
-  @media #{$hero_search-tablet} {
+  @media #{$mobile-landscape--hero}, #{$tablet--hero} {
     background-color: #FFF;
     border-radius: 29.5px;
     padding: 0px 0px 0px 24px;
     flex-direction: row;
   }
 
-  @include hero-search-input-container;
-
+  @media #{$tablet}, #{$desktop} {
+    background-color: #FFF;
+    border-radius: 29.5px 0px 0px 29.5px;
+    padding: 0px 0px 0px 24px;
+    flex-direction: row;
+  }
 }
 
 .hero__search-input {
@@ -206,7 +212,7 @@
   margin: 0 0 12px 0;
   padding: 8px 24px 8px 24px;
 
-  @media #{$hero_search-tablet} {
+  @media #{$mobile-landscape--hero}, #{$tablet--hero} {
     padding: 8px 12px 8px 0px;
     margin: 0;
     border-radius: 0;
@@ -216,29 +222,27 @@
   }
 
   @media #{$desktop} {
-    &:nth-of-type(2) {
-      padding: 14px 24px 14px 18px;
-    }
-  }
-
-  @media #{$mobile-landscape} {
-    padding: 14px 24px 14px 12px;
-  }
-
-  @media #{$tablet} {
-    font-size: 18px;
-    letter-spacing: 0px;
-    line-height: 32px;
-
-    padding: 14px 24px 14px 12px;
-  }
-
-  @media #{$desktop} {
     font-size: 18px;
     letter-spacing: 0px;
     line-height: 32px;
 
     padding: 14px 24px 14px 18px;
+
+    margin: 0;
+    border-radius: 0;
+    &:nth-of-type(2) {
+      padding: 14px 24px 14px 18px;
+    }
+  }
+
+  @media #{$tablet} {
+    margin: 0;
+    border-radius: 0;
+    font-size: 18px;
+    letter-spacing: 0px;
+    line-height: 32px;
+
+    padding: 14px 24px 14px 12px;
   }
 
   &:nth-of-type(2) {
@@ -291,14 +295,15 @@
   border-radius: 29.5px;
   display: block;
 
-  @media #{$hero_search-tablet} {
+  @media #{$mobile-landscape--hero}, #{$tablet--hero} {
     /* hero tablet */
     display: none;
     border-radius: 0px 29.5px 29.5px 0px;
   }
 
-  @media #{$mobile-landscape}, #{$tablet}, #{$desktop} {
+  @media #{$tablet}, #{$desktop} {
     display: block;
+    border-radius: 0px 29.5px 29.5px 0px;
   }
 
 }
@@ -337,7 +342,7 @@
     outline: none;
   }
 
-  @media #{$mobile-landscape}, #{$tablet} {
+  @media #{$tablet} {
     order: 0;
     padding: 19px 0px;
   }
@@ -352,7 +357,7 @@
   @extend .hero__search-icon;
   display: none;
 
-  @media #{$hero_search-tablet} {
+  @media #{$mobile-landscape--hero}, #{$tablet--hero}, #{$tablet}, #{$desktop} {
     display: block;
   }
 }

--- a/app/views/landing_page/_hero.erb
+++ b/app/views/landing_page/_hero.erb
@@ -43,9 +43,11 @@
                   </g>
                 </svg>
               </button>
-              <input type="search" name="q" class="hero__search-input<%= combined_mode %>" placeholder="<%= s["search_placeholder"]["value"] %>"/>
               <% if search_mode == "keyword_and_location_search" %>
-                <input type="search" name="lq" class="hero__search-input<%= combined_mode %>" placeholder="<%= s.dig("search_location_with_keyword_placeholder", "value") %>"/>
+                <input type="search" name="q" class="hero__keyword-search-input--combined" placeholder="<%= s["search_placeholder"]["value"] %>"/>
+                <input type="search" name="lq" class="hero__location-search-input--combined" placeholder="<%= s.dig("search_location_with_keyword_placeholder", "value") %>"/>
+              <% else %>
+                <input type="search" name="q" class="hero__search-input" placeholder="<%= s["search_placeholder"]["value"] %>"/>
               <% end %>
             </div>
             <button type="submit" class="hero__search-button hero__search-button<%= combined_mode %>"><%= s["search_button"]["value"] %></button>


### PR DESCRIPTION
This PR adds a margin to the divider border between the keyword search input and the location search input. In addition, it fixes 2 padding issues and changes the landscape mobile view to the more compact view that is already in use for tablets.

Before and after screenshots:

**Divider before**

![old_divider](https://cloud.githubusercontent.com/assets/429876/20177485/c3910660-a755-11e6-8641-db4f12eaa206.png)

**Divider after**

![new_divider](https://cloud.githubusercontent.com/assets/429876/20177498/ca575558-a755-11e6-865a-20a1813b82b5.png)

**Padding issue 1 before**

![old_tablet_margin](https://cloud.githubusercontent.com/assets/429876/20177504/d1442166-a755-11e6-88ca-85dbbb533f1e.png)

**Padding issue 1 after**

![new_tablet_margin](https://cloud.githubusercontent.com/assets/429876/20177509/d7173f1a-a755-11e6-8bc4-059c40620baa.png)

**Padding issue 2 before**

![old_mobile_margin](https://cloud.githubusercontent.com/assets/429876/20177520/e1676922-a755-11e6-8807-955933d54456.png)

**Padding issue 2 after**

![new_mobile_margin](https://cloud.githubusercontent.com/assets/429876/20177526/e786cf8c-a755-11e6-8a42-40b0ff1ee678.png)

**Mobile landscape before**

![old_landscape](https://cloud.githubusercontent.com/assets/429876/20177530/f0e94028-a755-11e6-89a9-ad411300f27b.png)

**Mobile landscape after**

![new_landscape](https://cloud.githubusercontent.com/assets/429876/20177535/f51799ec-a755-11e6-945b-106a0a0ca99e.png)