### PR TITLE
Pass host to reset password view

### DIFF
--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -291,7 +291,10 @@ class PersonMailer < ActionMailer::Base
          to: email_address,
          from: community_specific_sender(@community),
          subject: t("devise.mailer.reset_password_instructions.subject")) do |format|
-       format.html { render layout: false, locals: { reset_token: reset_token } }
+      format.html {
+        render layout: false, locals: { reset_token: reset_token,
+                                        host: @community.full_domain}
+      }
      end
   end
 

--- a/app/views/person_mailer/reset_password_instructions.haml
+++ b/app/views/person_mailer/reset_password_instructions.haml
@@ -1,7 +1,7 @@
 %p
   = t("emails.common.hey", :name => @person.given_name_or_username)
 %p
-  = t("emails.reset_password_instructions.reset_password_instructions", {:username => @person.username, :password_reset_link => link_to(t('emails.reset_password_instructions.change_my_password'), edit_password_url(@person, :reset_password_token => reset_token, :locale => I18n.locale))}).html_safe
+  = t("emails.reset_password_instructions.reset_password_instructions", {:username => @person.username, :password_reset_link => link_to(t('emails.reset_password_instructions.change_my_password'), edit_password_url(@person, :reset_password_token => reset_token, :locale => I18n.locale, host: host))}).html_safe
 
 %p
   = t("emails.common.thanks")


### PR DESCRIPTION
set_default_url_options was removed in 5f703f1 and this breaks link
generation for mail views that don't have host set explicitly.

Fixes: https://sharetribe.airbrake.io/projects/15448/groups/1815885001330625878/notices/1815884994444617581?tab=overview