### PR TITLE
Side push overlay

### DIFF
--- a/client/.storybook/config.js
+++ b/client/.storybook/config.js
@@ -27,6 +27,7 @@ const loadStories = function loadStories() {
   require('../app/components/composites/MenuMobile/LanguagesMobile.story.js');
   require('../app/components/composites/Branding/Branding.story.js');
   require('../app/components/composites/PageSelection/PageSelection.story.js');
+  require('../app/components/composites/SideWinder/SideWinder.story.js');
   require('../app/components/elements/Avatar/Avatar.story.js');
   require('../app/components/elements/Logo/Logo.story.js');
   require('../app/components/elements/MenuItem/MenuItem.story.js');

--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -358,4 +358,5 @@ module.exports = {
   '--FlashNotification_closeIconSize': `${minimumButtonSize}px`,
   '--FlashNotification_closeIconExtraSpace': '20px',
 
+  '--SideWinder_overlayZIndex': 999,
 };

--- a/client/app/components/Styleguide/withProps.js
+++ b/client/app/components/Styleguide/withProps.js
@@ -14,9 +14,9 @@ const defaultRailsContext = {
   loggedInUsername: 'foo',
 };
 
-const withProps = function withProps(component, props) {
+const withProps = function withProps(component, props, children) {
   return div([
-    r(component, props),
+    r(component, props, children),
     r.strong({ style: { marginTop: '2em', display: 'block' } }, 'Props:'),
     r.pre({
       style: {

--- a/client/app/components/composites/SideWinder/SideWinder.css
+++ b/client/app/components/composites/SideWinder/SideWinder.css
@@ -1,0 +1,82 @@
+.wrapper {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  right: 0;
+  transition: right 0.5s;
+}
+
+.winderOpen {
+  /* Prevent scrolling and hide scrollbars */
+  overflow: hidden;
+}
+
+.root {
+  display: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+
+  @nest .winderOpen & {
+    display: block;
+  }
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 0;
+  width: 100%;
+  background-color: rgb(44, 47, 50);
+  opacity: 0;
+  z-index: var(--SideWinder_overlayZIndex);
+  cursor: pointer;
+  transition: opacity 0.5s;
+
+  @nest .winderOpen & {
+    height: 100%;
+    opacity: 0.5;
+  }
+}
+
+.content {
+  height: 100%;
+}
+
+.closeButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 0;
+  width: 60px;
+  height: 60px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 0;
+  z-index: var(--SideWinder_overlayZIndex);
+
+  & svg {
+    width: 12px;
+    height: 12px;
+    position: absolute;
+    top: 24px;
+    right: 24px;
+
+    & g {
+      stroke: #fff;
+    }
+  }
+
+  &:hover,
+  &:focus {
+    outline: none;
+    background: none;
+
+    & svg g {
+      stroke: #ddd;
+    }
+  }
+}

--- a/client/app/components/composites/SideWinder/SideWinder.js
+++ b/client/app/components/composites/SideWinder/SideWinder.js
@@ -1,0 +1,195 @@
+/* SideWinder - A generic overlay menu that pushes the page to the side
+
+Usage:
+
+  r(SideWinder, {
+    wrapper: document.querySelector('#root'),
+    width: 300,
+    isOpen: false,
+    onClose: handleClose,
+  }, [
+    p('This will be within the side menu'),
+  ]);
+
+This will render the side menu outside the current React render tree
+and within the given wrapper element. This is to enable adding the
+component to a page with other UI components that might not be from
+the same React app (or React at all) that need to be pushed to the
+side for the menu to open.
+
+Controlling the menu open/close animation is done by changing the
+`isOpen` flag.
+
+This is quite a dirty component that breaks away from the React world,
+but tries to contain all the hackiness within itself.
+
+*/
+import { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import r, { div, button } from 'r-dom';
+
+import css from './SideWinder.css';
+import closeIcon from './images/close.svg';
+
+const KEYCODE_ESC = 27;
+
+// Starts syncing the window width to the given element. Returns a
+// function that stops the listening.
+//
+// This can be used to keep the normal responsiveness of the given
+// element intact regardless of rendering it outside the normal window
+// area, e.g. pushed to the side.
+const syncWindowWidthTo = (el) => {
+  /* eslint-disable no-param-reassign */
+
+  const originalWidth = el.style.width;
+  const update = () => {
+    el.style.width = `${window.innerWidth}px`;
+  };
+  update();
+  window.addEventListener('resize', update);
+
+  return () => {
+    window.removeEventListener('resize', update);
+    el.style.width = originalWidth;
+  };
+
+  /* eslint-enable no-param-reassign */
+};
+
+const SideWinderContent = (props) => div(
+  { className: css.content },
+  [
+    button({
+      onClick: props.onClose,
+      className: css.closeButton,
+      dangerouslySetInnerHTML: { __html: closeIcon },
+    }),
+    props.children,
+  ]
+);
+
+SideWinderContent.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
+
+class SideWinder extends Component {
+  constructor(props, context) {
+    super(props, context);
+    this.update = this.update.bind(this);
+    this.onWindowKeyUp = this.onWindowKeyUp.bind(this);
+    this.onBodyTouchMove = this.onBodyTouchMove.bind(this);
+  }
+  componentDidMount() {
+    this.props.wrapper.classList.add(css.wrapper);
+
+    // Two DOM elements are created: el and overlay, where el will be
+    // the root node for the whole side menu and overlay will hide the
+    // wrapper element contents. Both elements are manually rendered
+    // to the wrapper element, and React handles the tree within the
+    // el element.
+
+    this.rootEl = document.createElement('div');
+    this.rootEl.style.width = `${this.props.width}px`;
+    this.rootEl.style.right = `-${this.props.width}px`;
+    this.rootEl.className = css.root;
+
+    this.overlayEl = document.createElement('div');
+    this.overlayEl.className = css.overlay;
+    this.overlayEl.addEventListener('click', this.props.onClose);
+
+    this.props.wrapper.appendChild(this.rootEl);
+    this.props.wrapper.appendChild(this.overlayEl);
+
+    window.addEventListener('keyup', this.onWindowKeyUp);
+    window.addEventListener('resize', this.update);
+
+    // Prevent bg scrolling on touch devices.
+    document.body.addEventListener('touchmove', this.onBodyTouchMove);
+
+    this.update();
+  }
+  componentDidUpdate() {
+    this.update();
+  }
+  componentWillUnmount() {
+    ReactDOM.unmountComponentAtNode(this.rootEl);
+
+    const wrapper = this.props.wrapper;
+    wrapper.removeChild(this.rootEl);
+    wrapper.removeChild(this.overlayEl);
+    wrapper.classList.remove(css.wrapper);
+
+    // There needs to be a class to target the body element e.g. to
+    // prevent bg scrolling.
+    document.body.classList.remove(css.winderOpen);
+
+    window.removeEventListener('keyup', this.onWindowKeyUp);
+    window.removeEventListener('resize', this.update);
+    document.body.removeEventListener('touchmove', this.onBodyTouchMove);
+
+    if (this.stopWidthSync) {
+      this.stopWidthSync();
+      this.stopWidthSync = null;
+    }
+  }
+  onBodyTouchMove(e) {
+    if (this.props.isOpen) {
+      e.preventDefault();
+    }
+  }
+  onWindowKeyUp(e) {
+    if (this.props.isOpen && e.keyCode === KEYCODE_ESC) {
+      this.props.onClose();
+    }
+  }
+  update() {
+    const isOpen = this.props.isOpen;
+    const scrollOffset = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+    const height = window.innerHeight;
+
+    if (isOpen) {
+      document.body.classList.add(css.winderOpen);
+      this.rootEl.style.top = `${scrollOffset}px`;
+      this.overlayEl.style.top = `${scrollOffset}px`;
+      this.rootEl.style.height = `${height}px`;
+      this.overlayEl.style.height = `${height}px`;
+      this.props.wrapper.style.right = `${this.props.width}px`;
+    } else {
+      document.body.classList.remove(css.winderOpen);
+      this.rootEl.style.removeProperty('top');
+      this.rootEl.style.removeProperty('height');
+      this.overlayEl.style.removeProperty('top');
+      this.overlayEl.style.removeProperty('height');
+      this.props.wrapper.style.removeProperty('right');
+    }
+
+    if (isOpen && !this.stopWidthSync) {
+      this.stopWidthSync = syncWindowWidthTo(this.props.wrapper);
+    } else if (!isOpen && this.stopWidthSync) {
+      this.stopWidthSync();
+      this.stopWidthSync = null;
+    }
+
+    ReactDOM.render(r(SideWinderContent, {
+      onClose: this.props.onClose,
+    }, this.props.children), this.rootEl);
+  }
+
+  render() {
+    // The component is rendered manually within the given wrapper
+    // element which is outside the current render tree and might have
+    // other non-React DOM elements that should not be touched.
+    return null;
+  }
+}
+
+SideWinder.propTypes = {
+  wrapper: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  width: PropTypes.number.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  children: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+export default SideWinder;

--- a/client/app/components/composites/SideWinder/SideWinder.story.js
+++ b/client/app/components/composites/SideWinder/SideWinder.story.js
@@ -1,0 +1,56 @@
+/* eslint-disable react/no-set-state */
+
+import { Component, PropTypes } from 'react';
+import r, { div, button, p } from 'r-dom';
+import withProps from '../../Styleguide/withProps';
+import SideWinder from './SideWinder';
+
+const { storiesOf } = storybookFacade;
+
+class WinderWinder extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { isOpen: props.isOpen };
+  }
+  render() {
+    return div({ className: 'WinderWinder' }, [
+      button({
+        style: {
+          float: 'right',
+          marginRight: '1em',
+          fontSize: '1.2em',
+        },
+        onClick: () => this.setState({ isOpen: !this.state.isOpen }),
+      }, this.state.isOpen ? 'Hide SideWinder' : 'Show SideWinder'),
+      r(SideWinder, {
+        ...this.props,
+        isOpen: this.state.isOpen,
+        onClose: () => this.setState({ isOpen: false }),
+      }, [
+        div({
+          style: {
+            height: '100%',
+            backgroundColor: '#eee',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          },
+        }, [
+          p({ style: { margin: 0 } }, 'This is the content of the SideWinder'),
+        ]),
+      ]),
+    ]);
+  }
+}
+
+WinderWinder.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+};
+
+storiesOf('General')
+  .add('SideWinder', () => (
+    withProps(WinderWinder, {
+      wrapper: document.getElementById('root'),
+      width: 300,
+      isOpen: false,
+    })));

--- a/client/app/components/composites/SideWinder/images/close.svg
+++ b/client/app/components/composites/SideWinder/images/close.svg
@@ -1,0 +1,1 @@
+<svg width="12" height="12" viewBox="361 29 12 12" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" stroke="#FFF" stroke-width="1.5"><path d="M362 30l10 10M372 30l-10 10"/></g></svg>


### PR DESCRIPTION
This PR adds a generic side menu that pushes the page contents behind an overlay.

## Example

Latest UI example [In Styleguide](http://sharetribe.github.io/sharetribe/side-push-overlay/?selectedKind=General&selectedStory=SideWinder&full=0&down=1&left=1&panelRight=0&downPanel=storybook-addon-specifications%2Fspecifications-panel)

![side-menu-no-outline](https://cloud.githubusercontent.com/assets/53923/20492474/92a64206-b01d-11e6-9e96-dba4e36f584e.gif)

## TODO

- [x] Generic Side menu component in Styleguide
- [x] Close button + event
- [x] Fade overlay
- [x] Close menu when overlay clicked
- [x] Close menu with ESC
- [x] Clean up native DOM API usage
- [x] X icon SVG
- [x] Tune details based on the Sketch design
- [x] Prevent bg content scrolling
- [x] Extract vars from CSS
- [x] Add documentation
- [x] Git cleanup

## Review/bug fixes

- [x] Style the close button outline
- [x] Fix visible scrollbars when animating (requires a mouse attached)
- [x] Open side menu at the current scroll position instead of scrolling the page to the top
- [x] Fix scrollTop in FF
- [x] Adjust overlay height when window height changes