### PR TITLE
Redirect user to previous page after sign up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ### Changed
 
+- Redirect user to the page where user was before login/sign up [#2758](https://github.com/sharetribe/sharetribe/pull/2758)
+
 ### Deprecated
 
 ### Removed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -369,6 +369,21 @@ class ApplicationController < ActionController::Base
     @minutes_to_maintenance = NextMaintenance.minutes_to(now)
   end
 
+  # This hook will be called by Devise after successful Facebook
+  # login.
+  #
+  # Return path where you want the user to be redirected to.
+  #
+  def after_sign_in_path_for(resourse)
+    if session[:return_to]
+      return_to_path = session[:return_to]
+      session[:return_to] = nil
+      return_to_path
+    else
+      search_path
+    end
+  end
+
   private
 
   # Override basic instrumentation and provide additional info for

--- a/app/controllers/community_memberships_controller.rb
+++ b/app/controllers/community_memberships_controller.rb
@@ -74,7 +74,13 @@ class CommunityMembershipsController < ApplicationController
       Analytics.record_event(flash, "GaveConsent")
 
       flash[:notice] = t("layouts.notifications.you_are_now_member")
-      redirect_to search_path
+
+      if session[:return_to]
+        redirect_to session[:return_to]
+        session[:return_to] = nil
+      else
+        redirect_to search_path
+      end
 
     }.on_error { |msg, data|
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -51,7 +51,14 @@ class ConfirmationsController < Devise::ConfirmationsController
         report_to_gtm({event: "admin_email_confirmed"})
         redirect_to admin_getting_started_guide_path and return
       elsif @current_user # normal logged in user
-        redirect_to search_path and return
+        if session[:return_to]
+          redirect_to session[:return_to]
+          session[:return_to] = nil
+        else
+          redirect_to search_path
+        end
+
+        return
       else # no logged in session
         redirect_to login_path and return
       end


### PR DESCRIPTION
Steps to reproduce:

1. As an unlogged user, go to listing page and click "Buy"
2. In the login page, click "Create new user", fill the form and save
3. Go to your email and click the confirmation link

Expected result: You are redirect to the buy page

Actual result: You are redirected to the search page