### PR TITLE
Lightbox paragraphs had different font-size than list items

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -608,6 +608,9 @@ label.error {
 
   p {
     margin-bottom: lines(0.5);
+  }
+
+  p, li {
     @include small-type;
   }
 
@@ -619,7 +622,7 @@ label.error {
     h2 {
       @include big-type;
     }
-    p {
+    p, li {
       @include normal-type;
     }
   }


### PR DESCRIPTION
Hopefully this helps with that strange list item font-size bug.
(Who ever is able to review this - feel free to merge too.)