### PR TITLE
ManageAvailabilityHeader component

### DIFF
--- a/client/.storybook/config.js
+++ b/client/.storybook/config.js
@@ -29,6 +29,7 @@ const loadStories = function loadStories() {
   require('../app/components/composites/PageSelection/PageSelection.story.js');
   require('../app/components/composites/SideWinder/SideWinder.story.js');
   require('../app/components/composites/EditAvailability/EditAvailability.story.js');
+  require('../app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.story.js');
   require('../app/components/elements/Avatar/Avatar.story.js');
   require('../app/components/elements/Logo/Logo.story.js');
   require('../app/components/elements/MenuItem/MenuItem.story.js');

--- a/client/app/components/composites/EditAvailability/EditAvailability.story.js
+++ b/client/app/components/composites/EditAvailability/EditAvailability.story.js
@@ -55,6 +55,6 @@ class EditAvailabilityWrapper extends Component {
   }
 }
 
-storiesOf('General')
+storiesOf('Availability')
   .add('EditAvailability', () =>
        withProps(EditAvailabilityWrapper, {}));

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
@@ -1,0 +1,34 @@
+.root {
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundLayer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+  filter: blur(5px);
+}
+
+.listingHeader {
+  position: absolute;
+  bottom: 34px;
+  left: 34px;
+  right: 34px;
+  color: #fff;
+  font-size: 24px;
+  line-height: 1.4;
+}
+
+.availabilityHeader {
+  position: absolute;
+  top: -30px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 2.5px;
+}

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.js
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.js
@@ -1,0 +1,41 @@
+import { PropTypes } from 'react';
+import { div, span } from 'r-dom';
+import { t } from '../../../utils/i18n';
+import { hexToRGB } from '../../../utils/colors';
+
+import css from './ManageAvailabilityHeader.css';
+
+const ManageAvailabilityHeader = (props) => {
+  const bg = hexToRGB(props.backgroundColor);
+
+  return div(
+    {
+      className: css.root,
+      style: {
+        height: `${props.height}px`,
+      },
+    },
+    [
+      div({
+        className: css.backgroundLayer,
+        style: {
+          boxShadow: `inset 0px ${props.height}px rgba(${bg.r}, ${bg.g}, ${bg.b}, 0.9)`,
+          backgroundImage: `url(${props.imageUrl})`,
+        },
+      }),
+      div({ className: css.listingHeader }, [
+        span({ className: css.availabilityHeader }, t('web.listings.edit_availability_header')),
+        props.title,
+      ]),
+    ]
+  );
+};
+
+ManageAvailabilityHeader.propTypes = {
+  backgroundColor: PropTypes.string.isRequired,
+  imageUrl: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  height: PropTypes.number.isRequired,
+};
+
+export default ManageAvailabilityHeader;

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.story.js
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.story.js
@@ -1,0 +1,13 @@
+import withProps from '../../Styleguide/withProps';
+import ManageAvailabilityHeader from './ManageAvailabilityHeader';
+
+const { storiesOf } = storybookFacade;
+
+storiesOf('Availability')
+  .add('ManageAvailabilityHeader', () =>
+       withProps(ManageAvailabilityHeader, {
+         backgroundColor: '347F9D',
+         imageUrl: 'https://placehold.it/1024x1024',
+         title: 'Pelago San Sebastian, in very good condition in Kallio',
+         height: 400,
+       }));

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2059,6 +2059,7 @@ en:
         night: night
         week: week
         month: month
+      edit_availability_header: Availability
     no_listings:
       sorry: "Sorry, no listings could be found for your search criteria."
       try_other_search_terms: "Maybe try other search terms?"


### PR DESCRIPTION
This PR adds the `ManageAvailabilityHeader` component that has the listing title and blurred background image (behind the marketplace color). The component will be used in the side menu of editing the listing availability.

![new-header](https://cloud.githubusercontent.com/assets/53923/20661635/851a7608-b558-11e6-8b85-5658ae336fb5.gif)

