### PR TITLE
Refactor SideWinder component

### DIFF
--- a/client/.storybook/config.js
+++ b/client/.storybook/config.js
@@ -28,6 +28,7 @@ const loadStories = function loadStories() {
   require('../app/components/composites/MenuMobile/LanguagesMobile.story.js');
   require('../app/components/composites/Branding/Branding.story.js');
   require('../app/components/composites/PageSelection/PageSelection.story.js');
+  require('../app/components/composites/Portal/Portal.story.js');
   require('../app/components/composites/SideWinder/SideWinder.story.js');
   require('../app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.story.js');
   require('../app/components/composites/ManageAvailabilityCalendar/ManageAvailabilityCalendar.story.js');

--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -362,7 +362,9 @@ module.exports = {
   '--FlashNotification_closeIconSize': `${minimumButtonSize}px`,
   '--FlashNotification_closeIconExtraSpace': '20px',
 
-  '--SideWinder_overlayZIndex': 999,
+  '--SideWinder_overlayZIndex': zIndexMinimum + 20,
+  '--SideWinder_animationDuration': '0.5s',
+  '--SideWinder_animationDurationMs': 500,
 
   '--ManageAvailability_width': 405,
   '--ManageAvailability_fontFamily': proximaNovaFontFamily,

--- a/client/app/components/composites/Portal/Portal.css
+++ b/client/app/components/composites/Portal/Portal.css
@@ -1,0 +1,3 @@
+.root {}  /* stylelint-disable-line block-no-empty */
+
+.parent {} /* stylelint-disable-line block-no-empty */

--- a/client/app/components/composites/Portal/Portal.js
+++ b/client/app/components/composites/Portal/Portal.js
@@ -4,10 +4,8 @@
   Portal is a React component that is rendered outside the current
   render tree. It takes a parent element and children as props and
   creates a container element with the given children. This container
-  element is then rendered to the given parent element.
-
-  Only one Portal can be created for a single parent element at a
-  time. The children should be a single element.
+  element is then rendered to the given parent element. The children
+  should be a single element.
 
   ## Example:
 
@@ -32,33 +30,20 @@ import css from './Portal.css';
 
 class Portal extends Component {
   componentDidMount() {
-    if (this.props.parentElement.classList.contains(css.parent)) {
-      console.error('Only one Portal component can be rendered for a specific parent element at a time.'); // eslint-disable-line no-console
-      return;
-    }
-
     this.element = document.createElement('div');
     this.element.className = css.root;
-    this.props.parentElement.classList.add(css.parent);
     this.props.parentElement.appendChild(this.element);
     this.componentDidUpdate();
   }
   componentDidUpdate() {
-    if (!this.element) {
-      return;
-    }
     ReactDOM.render(
       this.props.children,
       this.element
     );
   }
   componentWillUnmount() {
-    if (!this.element) {
-      return;
-    }
     ReactDOM.unmountComponentAtNode(this.element);
     this.props.parentElement.removeChild(this.element);
-    this.props.parentElement.classList.remove(css.parent);
   }
   render() {
     return null;

--- a/client/app/components/composites/Portal/Portal.js
+++ b/client/app/components/composites/Portal/Portal.js
@@ -1,0 +1,73 @@
+/*
+  # Portal
+
+  Portal is a React component that is rendered outside the current
+  render tree. It takes a parent element and children as props and
+  creates a container element with the given children. This container
+  element is then rendered to the given parent element.
+
+  Only one Portal can be created for a single parent element at a
+  time. The children should be a single element.
+
+  ## Example:
+
+  const Modal = (props) => r(Portal, {
+    parentElement: document.body,
+  }, div({
+    style: {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    },
+  }, props.children));
+
+*/
+
+import { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+
+import css from './Portal.css';
+
+class Portal extends Component {
+  componentDidMount() {
+    if (this.props.parentElement.classList.contains(css.parent)) {
+      console.error('Only one Portal component can be rendered for a specific parent element at a time.'); // eslint-disable-line no-console
+      return;
+    }
+
+    this.element = document.createElement('div');
+    this.element.className = css.root;
+    this.props.parentElement.classList.add(css.parent);
+    this.props.parentElement.appendChild(this.element);
+    this.componentDidUpdate();
+  }
+  componentDidUpdate() {
+    if (!this.element) {
+      return;
+    }
+    ReactDOM.render(
+      this.props.children,
+      this.element
+    );
+  }
+  componentWillUnmount() {
+    if (!this.element) {
+      return;
+    }
+    ReactDOM.unmountComponentAtNode(this.element);
+    this.props.parentElement.removeChild(this.element);
+    this.props.parentElement.classList.remove(css.parent);
+  }
+  render() {
+    return null;
+  }
+}
+
+Portal.propTypes = {
+  parentElement: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  children: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+export default Portal;

--- a/client/app/components/composites/Portal/Portal.story.js
+++ b/client/app/components/composites/Portal/Portal.story.js
@@ -26,7 +26,7 @@ class PortalWrapper extends Component {
     };
 
     return div([
-      p('Portal contents are rendered outside the current render tree. There can be only a single Portal for every parentElement.'),
+      p('Portal contents are rendered outside the current render tree.'),
       label(labelProps, [
         input({
           type: 'checkbox',

--- a/client/app/components/composites/Portal/Portal.story.js
+++ b/client/app/components/composites/Portal/Portal.story.js
@@ -1,0 +1,62 @@
+/* eslint-disable react/no-set-state */
+
+import { Component } from 'react';
+import r, { div, label, input, p } from 'r-dom';
+import Portal from './Portal';
+import withProps from '../../Styleguide/withProps';
+
+const { storiesOf } = storybookFacade;
+
+class PortalWrapper extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { portal1: true, portal2: false };
+  }
+  render() {
+
+    const update = () => {
+      this.setState({
+        portal1: this.input1.checked,
+        portal2: this.input2.checked,
+      });
+    };
+
+    const labelProps = {
+      style: { display: 'block' },
+    };
+
+    return div([
+      p('Portal contents are rendered outside the current render tree. There can be only a single Portal for every parentElement.'),
+      label(labelProps, [
+        input({
+          type: 'checkbox',
+          checked: this.state.portal1,
+          ref: (el) => {
+            this.input1 = el;
+          },
+          onChange: update,
+        }),
+        'Show Portal 1',
+      ]),
+      label(labelProps, [
+        input({
+          type: 'checkbox',
+          checked: this.state.portal2,
+          ref: (el) => {
+            this.input2 = el;
+          },
+          onChange: update,
+        }),
+        'Show Portal 2',
+      ]),
+      this.state.portal1 ? r(Portal, this.props, [p('Portal 1 contents.')]) : null,
+      this.state.portal2 ? r(Portal, this.props, [p('Portal 2 contents.')]) : null,
+    ]);
+  }
+}
+
+storiesOf('General')
+  .add('Portal', () => (
+    withProps(PortalWrapper, {
+      parentElement: document.getElementById('root'),
+    })));

--- a/client/app/components/composites/SideWinder/SideWinder.css
+++ b/client/app/components/composites/SideWinder/SideWinder.css
@@ -1,26 +1,29 @@
+.transition {}  /* stylelint-disable-line block-no-empty */
+.transitionVisible {} /* stylelint-disable-line block-no-empty */
+.transitionOpen {} /* stylelint-disable-line block-no-empty */
+.transitionEntering {} /* stylelint-disable-line block-no-empty */
+.transitionLeaving {} /* stylelint-disable-line block-no-empty */
+
+.transitionVisible {
+  /* Prevent scrolling and hide scrollbars */
+  overflow: hidden;
+  height: 100%;
+}
+
 .wrapper {
   position: absolute;
   width: 100%;
   height: 100%;
+  top: 0;
   right: 0;
-  transition: right 0.5s;
-}
-
-.winderOpen {
-  /* Prevent scrolling and hide scrollbars */
-  overflow: hidden;
+  transition: right var(--SideWinder_animationDuration);
+  will-change: right;
 }
 
 .root {
-  display: none;
   position: absolute;
   top: 0;
-  right: 0;
-  height: 100%;
-
-  @nest .winderOpen & {
-    display: block;
-  }
+  height: 100vh;
 }
 
 .overlay {
@@ -33,16 +36,17 @@
   opacity: 0;
   z-index: var(--SideWinder_overlayZIndex);
   cursor: pointer;
-  transition: opacity 0.5s;
+  transition: opacity var(--SideWinder_animationDuration);
+  will-change: opacity, height;
 
-  @nest .winderOpen & {
-    height: 100%;
+  @nest .transitionOpen & {
+    height: 100vh;
     opacity: 0.5;
   }
-}
 
-.content {
-  height: 100%;
+  @nest .transitionLeaving & {
+    height: 100vh;
+  }
 }
 
 .closeButton {

--- a/client/app/components/composites/SideWinder/SideWinderTransition.js
+++ b/client/app/components/composites/SideWinder/SideWinderTransition.js
@@ -1,0 +1,82 @@
+/* eslint-disable react/no-set-state  */
+
+import { Component, PropTypes } from 'react';
+import { div } from 'r-dom';
+
+import css from './SideWinder.css';
+
+// ReactTransitionGroup is a low level animation API that handles
+// component mounting, unmounting and leaving/entering between
+// animation states. It works by calling certain lifecycle methods on
+// its child component that can then asynchronously handle the
+// transitions to other states.
+//
+// This component implements the required lifecycle methods to add
+// state classes to its container, allowing for CSS styles to attach
+// to transitions properly.
+//
+// The component also attaches state classes to document.body for
+// styling other components outside the current render tree position.
+//
+// See: https://facebook.github.io/react/docs/animation.html#reacttransitiongroup
+class SideWinderTransition extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: true,
+      entering: false,
+      leaving: false,
+    };
+  }
+  componentWillUnmount() {
+    document.body.classList.remove(css.transitionVisible);
+  }
+  componentWillAppear(callback) {
+    callback();
+  }
+  componentWillEnter(callback) {
+    this.setState({ entering: true, open: true });
+    window.setTimeout(callback, this.props.enterTimeout);
+  }
+  componentDidEnter() {
+    this.setState({ entering: false });
+  }
+  componentWillLeave(callback) {
+    this.setState({ leaving: true, open: false });
+    window.setTimeout(callback, this.props.leaveTimeout);
+  }
+  componentDidLeave() {
+    this.setState({ leaving: false });
+  }
+  render() {
+    document.body.classList.add(css.transitionVisible);
+
+    if (this.state.entering) {
+      document.body.classList.add(css.transitionEntering);
+    } else {
+      document.body.classList.remove(css.transitionEntering);
+    }
+
+    if (this.state.leaving) {
+      document.body.classList.add(css.transitionLeaving);
+    } else {
+      document.body.classList.remove(css.transitionLeaving);
+    }
+
+    if (this.state.open) {
+      document.body.classList.add(css.transitionOpen);
+    } else {
+      document.body.classList.remove(css.transitionOpen);
+    }
+
+    return div({ className: css.transition }, this.props.children);
+  }
+}
+
+SideWinderTransition.propTypes = {
+  enterTimeout: PropTypes.number.isRequired,
+  leaveTimeout: PropTypes.number.isRequired,
+  children: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+};
+
+export default SideWinderTransition;

--- a/client/app/components/composites/SideWinder/SideWinderTransition.js
+++ b/client/app/components/composites/SideWinder/SideWinderTransition.js
@@ -30,20 +30,25 @@ class SideWinderTransition extends Component {
   }
   componentWillUnmount() {
     document.body.classList.remove(css.transitionVisible);
+    document.body.classList.remove(css.transitionEntering);
+    document.body.classList.remove(css.transitionLeaving);
+    document.body.classList.remove(css.transitionOpen);
+    window.clearTimeout(this.enterTimeoutId);
+    window.clearTimeout(this.leaveTimeoutId);
   }
   componentWillAppear(callback) {
     callback();
   }
   componentWillEnter(callback) {
     this.setState({ entering: true, open: true });
-    window.setTimeout(callback, this.props.enterTimeout);
+    this.enterTimeoutId = window.setTimeout(callback, this.props.enterTimeout);
   }
   componentDidEnter() {
     this.setState({ entering: false });
   }
   componentWillLeave(callback) {
     this.setState({ leaving: true, open: false });
-    window.setTimeout(callback, this.props.leaveTimeout);
+    this.leaveTimeoutId = window.setTimeout(callback, this.props.leaveTimeout);
   }
   componentDidLeave() {
     this.setState({ leaving: false });

--- a/client/package.json
+++ b/client/package.json
@@ -58,6 +58,7 @@
     "raw-loader": "0.5.1",
     "react": "15.4.1",
     "react-addons-css-transition-group": "15.4.1",
+    "react-addons-transition-group": "15.4.1",
     "react-addons-shallow-compare": "15.4.1",
     "react-dates": "4.1.0",
     "react-dom": "15.4.1",


### PR DESCRIPTION
This PR refactors/rewrites the SideWinder component to use more generic utilities. The problem with the old component was the hacky native DOM manipulation and not being able to apply styles to all transition states. This resulted at least in not having closing animation working. The following approaches are taken in this PR:

 - Add Portal component to abstract rendering a node outside the current React render tree
 - Use [ReactTransitionGroup](https://facebook.github.io/react/docs/animation.html#reacttransitiongroup) for handle state changes in animations
 - Minimise/abstract native DOM handling

![sidewinder-refactored](https://cloud.githubusercontent.com/assets/53923/20792444/64247628-b7ca-11e6-8bf1-1334c1b7f629.gif)

See interactive examples for a Portal and a SideWinder in the [Styleguide](http://sharetribe.github.io/sharetribe/sidewinder-refactor/?selectedKind=General&selectedStory=SideWinder&full=0&down=1&left=1&panelRight=0&downPanel=storybook-addon-specifications%2Fspecifications-panel).