### PR TITLE
Better error message for PayPal error code 10417

### DIFF
--- a/app/controllers/paypal_service/checkout_orders_controller.rb
+++ b/app/controllers/paypal_service/checkout_orders_controller.rb
@@ -75,7 +75,11 @@ class PaypalService::CheckoutOrdersController < ApplicationController
                                                                       class: "flash-error-link"))
                         .html_safe
         redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)
+      elsif response_data[:paypal_error_code] == "10417"
+        # https://www.paypal.com/us/selfhelp/article/What-is-API-error-code-10417-FAQ3308
 
+        flash[:error] = t("error_messages.paypal.transaction_cannot_complete")
+        redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)
       elsif response_data[:paypal_error_code] == "10425"
         flash[:error] = t("error_messages.paypal.seller_express_checkout_disabled")
         redirect_to person_listing_path(person_id: @current_user.id, id: listing_id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -927,7 +927,7 @@ en:
     transaction_agreement:
       required_error: "You need to accept the agreement"
     paypal:
-      transaction_cannot_complete: "Transaction cannot complete. The most likely cause for this is that the credit card failed bank authorization. You can try purchase again using alternative payment method."
+      transaction_cannot_complete: "Transaction cannot complete. This is most likely caused by the credit card failing bank authorization. Please, try purchasing again with an alternative payment method."
       buyer_cannot_pay_error: "The payment has been declined by PayPal. Please contact their Customer Service for more information: %{customer_service_link}"
       pending_review_error: "The payment was submitted but was flagged by PayPal as 'requiring a review'. When PayPal completes the review, the payment will be automatically authorized."
       seller_express_checkout_disabled: "PayPal Express Checkout has been disabled for the listing author's PayPal account. Please contact the author and let them know that there's an issue with their PayPal account, and advise them to contact PayPal Customer Service."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -927,6 +927,7 @@ en:
     transaction_agreement:
       required_error: "You need to accept the agreement"
     paypal:
+      transaction_cannot_complete: "Transaction cannot complete. The most likely cause for this is that the credit card failed bank authorization. You can try purchase again using alternative payment method."
       buyer_cannot_pay_error: "The payment has been declined by PayPal. Please contact their Customer Service for more information: %{customer_service_link}"
       pending_review_error: "The payment was submitted but was flagged by PayPal as 'requiring a review'. When PayPal completes the review, the payment will be automatically authorized."
       seller_express_checkout_disabled: "PayPal Express Checkout has been disabled for the listing author's PayPal account. Please contact the author and let them know that there's an issue with their PayPal account, and advise them to contact PayPal Customer Service."


### PR DESCRIPTION
Show a more informative error message for error code 10417.

Here's information about the error: https://www.paypal.com/us/selfhelp/article/What-is-API-error-code-10417-FAQ3308

Screenshot:

![screen shot 2016-11-30 at 13 12 16](https://cloud.githubusercontent.com/assets/429876/20750342/f2824bb0-b6fe-11e6-9c65-a415b9d7330b.png)
