### PR TITLE
Removed semicolons in copy texts to improve consistency

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -846,9 +846,9 @@ en:
       you_have_made_new_payment: "You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> to %{recipient_full_name}. Here is a receipt of the payment."
       product: Product
       price_per_unit_type: "Price per %{unit_type}"
-      duration: "Duration:"
-      quantity: "Quantity:"
-      subtotal: "Subtotal:"
+      duration: "Duration"
+      quantity: "Quantity"
+      subtotal: "Subtotal"
       total: Total
       price: Price
       service_fee: "Service fee"


### PR DESCRIPTION
Some rows in buyer receipt email had some semi colons, others didn't. 
Now all are removed.