### PR TITLE
Topbar mouseover hover

### DIFF
--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -157,7 +157,7 @@ module.exports = {
 
   '--Topbar_avatarSize': topbarItemHeight,
   '--Topbar_avatarMediumSize': topbarMediumItemHeight,
-  '--Topbar_avatarPadding': '18px 0',
+  '--Topbar_avatarPadding': '17.5px 0',
   '--Topbar_avatarTabletPadding': '12px 0',
   '--Topbar_avatarMobilePadding': '8px 0',
 

--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.css
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.css
@@ -9,6 +9,9 @@
   & .avatarProfileDropdown {
     visibility: hidden;
     margin-bottom: -32px;
+  }
+
+  & .transitionDelay {
     transition: visibility 0ms;
     transition-delay: 300ms;
   }

--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
@@ -22,7 +22,6 @@ class AvatarDropdown extends Component {
 
     this.state = {
       isOpen: false,
-      isHovering: false,
       isMounted: false,
     };
 
@@ -43,21 +42,19 @@ class AvatarDropdown extends Component {
     window.clearTimeout(this.mouseLeaveTimeout);
     window.clearTimeout(this.mouseOverTimeout);
     this.mouseOverTimeout = window.setTimeout(() => (
-      this.setState({ isHovering: true, isOpen: true }) // eslint-disable-line react/no-set-state
+      this.setState({ isOpen: true }) // eslint-disable-line react/no-set-state
       ), HOVER_TIMEOUT);
   }
 
   handleMouseLeave() {
     window.clearTimeout(this.mouseOverTimeout);
     this.mouseLeaveTimeout = window.setTimeout(() => (
-      this.setState({ isHovering: false, isOpen: false }) // eslint-disable-line react/no-set-state
+      this.setState({ isOpen: false }) // eslint-disable-line react/no-set-state
       ), HOVER_TIMEOUT);
   }
 
   handleClick() {
-    if (!this.state.isHovering) {
-      this.setState({ isOpen: !this.state.isOpen });// eslint-disable-line react/no-set-state
-    }
+    this.setState({ isOpen: !this.state.isOpen });// eslint-disable-line react/no-set-state
   }
 
   handleBlur(event) {

--- a/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/AvatarDropdown.js
@@ -16,7 +16,7 @@ class AvatarDropdown extends Component {
     super(props, context);
 
     this.handleMouseOver = this.handleMouseOver.bind(this);
-    this.handleMouseOut = this.handleMouseOut.bind(this);
+    this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
 
@@ -27,24 +27,29 @@ class AvatarDropdown extends Component {
     };
 
     this.mouseOverTimeout = null;
-    this.mouseOutTimeout = null;
+    this.mouseLeaveTimeout = null;
   }
 
   componentDidMount() {
     this.setState({ isMounted: true });// eslint-disable-line react/no-set-state
   }
 
+  componentWillUnmount() {
+    window.clearTimeout(this.mouseLeaveTimeout);
+    window.clearTimeout(this.mouseOverTimeout);
+  }
+
   handleMouseOver() {
-    clearTimeout(this.mouseOutTimeout);
-    clearTimeout(this.mouseOverTimeout);
-    this.mouseOverTimeout = setTimeout(() => (
+    window.clearTimeout(this.mouseLeaveTimeout);
+    window.clearTimeout(this.mouseOverTimeout);
+    this.mouseOverTimeout = window.setTimeout(() => (
       this.setState({ isHovering: true, isOpen: true }) // eslint-disable-line react/no-set-state
       ), HOVER_TIMEOUT);
   }
 
-  handleMouseOut() {
-    clearTimeout(this.mouseOverTimeout);
-    this.mouseOutTimeout = setTimeout(() => (
+  handleMouseLeave() {
+    window.clearTimeout(this.mouseOverTimeout);
+    this.mouseLeaveTimeout = window.setTimeout(() => (
       this.setState({ isHovering: false, isOpen: false }) // eslint-disable-line react/no-set-state
       ), HOVER_TIMEOUT);
   }
@@ -73,7 +78,7 @@ class AvatarDropdown extends Component {
       [];
     return div({
       onMouseOver: this.handleMouseOver,
-      onMouseLeave: this.handleMouseOut,
+      onMouseLeave: this.handleMouseLeave,
       onClick: this.handleClick,
       onBlur: this.handleBlur,
       tabIndex: 0,

--- a/client/app/components/composites/AvatarDropdown/ProfileDropdown.css
+++ b/client/app/components/composites/AvatarDropdown/ProfileDropdown.css
@@ -104,7 +104,7 @@
   border-width: calc((var(--ProfileDropdown_arrowWidth) - 2 * var(--ProfileDropdown_lineWidth)) / 2);
   margin-left: calc(0 - (var(--ProfileDropdown_arrowWidth) - 2 * var(--ProfileDropdown_lineWidth)) / 2);
   z-index: calc(var(--ProfileDropdown_zIndex) + 1);
-  left: calc(var(--ProfileDropdown_lineWidth) * 2);
+  left: calc(var(--ProfileDropdown_lineWidth) * 2 + 1);
   top: var(--ProfileDropdown_topSeparation);
 }
 

--- a/client/app/components/composites/AvatarDropdown/ProfileDropdown.js
+++ b/client/app/components/composites/AvatarDropdown/ProfileDropdown.js
@@ -1,5 +1,6 @@
 import { Component, PropTypes } from 'react';
 import r, { a, div, span } from 'r-dom';
+import classNames from 'classnames';
 
 import css from './ProfileDropdown.css';
 import inboxEmptyIcon from './images/inboxEmptyIcon.svg';
@@ -38,7 +39,7 @@ ProfileActionCard.propTypes = {
 class ProfileDropdown extends Component {
   render() {
     return div({
-      className: this.props.className,
+      className: classNames(this.props.classNames),
       ref: this.props.profileDropdownRef,
     }, [
       div({ className: css.rootArrowTop }),
@@ -82,7 +83,7 @@ ProfileDropdown.propTypes = {
   }),
   customColor: PropTypes.string.isRequired,
   isAdmin: PropTypes.bool.isRequired,
-  className,
+  classNames: PropTypes.arrayOf(className).isRequired,
   notificationCount: PropTypes.number,
   profileDropdownRef: PropTypes.func.isRequired,
 };

--- a/client/app/components/composites/Menu/Menu.css
+++ b/client/app/components/composites/Menu/Menu.css
@@ -24,7 +24,8 @@
   &.openMenu,
   &.openOnHover:hover {
     & .menuContent {
-      display: block;
+      visibility: visible;
+      transition-delay: 0ms;
     }
   }
 }
@@ -71,7 +72,7 @@
 }
 
 .menuContent {
-  display: none;
+  visibility: hidden;
   z-index: var(--Menu_zIndex);
   background-color: var(--Menu_colorBackground);
   border: 1px solid var(--Menu_borderColor);
@@ -87,6 +88,11 @@
   & :last-child {
     border-bottom-left-radius: 3px;
   }
+}
+
+.transitionDelay {
+  transition: visibility 0ms;
+  transition-delay: 300ms;
 }
 
 .menuContentArrowTop,

--- a/client/app/components/composites/Menu/Menu.css
+++ b/client/app/components/composites/Menu/Menu.css
@@ -10,7 +10,7 @@
 
   &:focus,
   &.openMenu,
-  &.touchless:hover {
+  &.openOnHover:hover {
     & .menuLabel {
       color: var(--Menu_textColorFocus);
     }
@@ -22,7 +22,7 @@
   }
 
   &.openMenu,
-  &.touchless:hover {
+  &.openOnHover:hover {
     & .menuContent {
       display: block;
     }
@@ -56,7 +56,7 @@
 }
 
 .menu.openMenu .menuLabelDropdownIconOpen,
-.menu.touchless:hover .menuLabelDropdownIconOpen {
+.menu.openOnHover:hover .menuLabelDropdownIconOpen {
   display: inline-block;
 }
 
@@ -66,7 +66,7 @@
 }
 
 .menu.openMenu .menuLabelDropdownIconClosed,
-.menu.touchless:hover .menuLabelDropdownIconClosed {
+.menu.openOnHover:hover .menuLabelDropdownIconClosed {
   display: none;
 }
 

--- a/client/app/components/composites/Menu/Menu.js
+++ b/client/app/components/composites/Menu/Menu.js
@@ -57,7 +57,7 @@ class Menu extends Component {
   render() {
     const requestedLabel = MENULABEL_MAP[this.props.menuLabelType];
     const LabelComponent = requestedLabel != null ? requestedLabel : null;
-    const touchClass = hasTouchEvents ? '' : css.touchless;
+    const openOnHoverClass = hasTouchEvents ? '' : css.openOnHover;
     const openClass = this.state.isOpen ? css.openMenu : '';
 
     return div({

--- a/client/app/components/composites/Menu/Menu.js
+++ b/client/app/components/composites/Menu/Menu.js
@@ -28,7 +28,6 @@ class Menu extends Component {
     this.calculateDropdownPosition = this.calculateDropdownPosition.bind(this);
     this.state = {
       isOpen: false,
-      isHovering: false,
       isMounted: false,
       arrowPosition: INITIAL_ARROW_POSITION,
     };
@@ -48,24 +47,22 @@ class Menu extends Component {
   }
 
   handleMouseover() {
-    clearTimeout(this.mouseOutTimout);
-    clearTimeout(this.mouseOverTimout);
+    window.clearTimeout(this.mouseOutTimout);
+    window.clearTimeout(this.mouseOverTimout);
     this.mouseOverTimout = setTimeout(() => (
-      this.setState({ isHovering: true, isOpen: true })  // eslint-disable-line react/no-set-state
+      this.setState({ isOpen: true })  // eslint-disable-line react/no-set-state
       ), HOVER_TIMEOUT);
   }
 
   handleMouseout() {
-    clearTimeout(this.mouseOverTimout);
+    window.clearTimeout(this.mouseOverTimout);
     this.mouseOutTimout = setTimeout(() => (
-      this.setState({ isHovering: false, isOpen: false }) // eslint-disable-line react/no-set-state
+      this.setState({ isOpen: false }) // eslint-disable-line react/no-set-state
       ), HOVER_TIMEOUT);
   }
 
   handleClick() {
-    if (!this.state.isHovering) {
-      this.setState({ isOpen: !this.state.isOpen }); // eslint-disable-line react/no-set-state
-    }
+    this.setState({ isOpen: !this.state.isOpen }); // eslint-disable-line react/no-set-state
   }
 
   handleBlur(event) {

--- a/client/app/components/composites/Menu/MenuContent.js
+++ b/client/app/components/composites/Menu/MenuContent.js
@@ -1,5 +1,8 @@
 import { Component, PropTypes } from 'react';
 import r, { div } from 'r-dom';
+import classNames from 'classnames';
+
+import { className } from '../../../utils/PropTypes';
 import MenuItem from '../../elements/MenuItem/MenuItem';
 import css from './Menu.css';
 
@@ -24,7 +27,7 @@ class MenuContent extends Component {
     return (
       div(
         {
-          className: `MenuContent ${css.menuContent}`,
+          className: classNames('MenuContent', css.menuContent, this.props.className),
         }, [
           div({
             className: css.menuContentArrowBelow,
@@ -59,6 +62,7 @@ MenuContent.propTypes = {
     })
   ).isRequired,
   arrowPosition: number.isRequired,
+  className,
 };
 
 export default MenuContent;


### PR DESCRIPTION
Due to [order of sent events](https://www.html5rocks.com/en/mobile/touchandmouse/#toc-together) hovering state is not useful knowledge - so, it is removed.

Current behaviour:
Scenario 1 - Desktop:
mouseOver -> open menu
mouseLeave - close menu

Scenario 2 - Desktop:
mouseOver -> open menu
click -> close menu
click -> open menu
click -> close menu
mouseLeave - menu is already closed

Scenario 3 - Touch device:
click -> open menu
click -> close menu
