### PR TITLE
Update passenger and avoid writing to a local log file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jquery-rails', '3.1.3'
 # Bundle the extra gems:
 
 # gem 'heroku' install the Heroku toolbelt (https://toolbelt.heroku.com/) instead (as gem had some problems)
-gem "passenger", "~> 5.0.18"
+gem "passenger", "~> 5.0.30"
 
 gem "mysql2", "~> 0.4.4"
 gem 'haml', "~> 4.0.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
       websocket (~> 1.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-contrib (1.4.0)
       git-version-bump (~> 0.15)
       rack (~> 1.4)
@@ -588,7 +588,7 @@ DEPENDENCIES
   oauth2!
   omniauth-facebook (~> 4.0.0)
   paperclip (~> 5.1.0)
-  passenger (~> 5.0.18)
+  passenger (~> 5.0.30)
   paypal-sdk-merchant (~> 1.116.0)
   paypal-sdk-permissions (~> 1.96.4)
   possibly (~> 0.2.0)

--- a/script/startup.sh
+++ b/script/startup.sh
@@ -15,6 +15,7 @@ case "$APP_MODE" in
             exec bundle exec passenger \
                  start \
                  -p "${PORT-3000}" \
+                 --log-file "/dev/stdout" \
                  --min-instances "${PASSENGER_MIN_INSTANCES-1}" \
                  --max-pool-size "${PASSENGER_MAX_POOL_SIZE-1}"
         fi


### PR DESCRIPTION
Passenger gem updated. Start making use of feature from 5.0.29 to pass `--log file /dev/stdout` to avoid writing to a local log file. Container output is anyway the real log.