### PR TITLE
Redis cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ### Added
 
+- Add support for redis as cache store [#2786](https://github.com/sharetribe/sharetribe/pull/2786)
 - Add support for using PayPal in fake mode for development purposes. [Read more](./docs/using-fakepal.md) [#2598](https://github.com/sharetribe/sharetribe/pull/2598)
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'aws-sdk', '~> 2'
 gem "will_paginate", '~>3.0.5'
 gem 'dalli', "~> 2.6.4"
 gem "memcachier", "~> 0.0.2"
+gem 'readthis', "~> 2.0.1"
+gem 'hiredis'
 gem 'kgio', "~>2.9.2"
 gem 'thinking-sphinx', '~> 3.1.1'
 gem 'flying-sphinx', "~>1.2.0"
@@ -166,7 +168,7 @@ group :test do
   gem 'timecop', '~> 0.6.3'
   gem 'rack-test', "~> 0.6.2"
   gem 'database_cleaner', '~> 1.1'
-  gem 'connection_pool', "~> 0.9.3"
+  gem 'connection_pool', "~> 2.1"
 
   # required for CircleCI automatic test balancing
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       sass (~> 3.2.0.alpha.93)
     compass-rails (2.0.0)
       compass (>= 0.12.2)
-    connection_pool (0.9.3)
+    connection_pool (2.2.1)
     countries (1.2.5)
       currencies (~> 0.4.2)
       i18n_data (~> 0.7.0)
@@ -238,6 +238,7 @@ GEM
       tilt
     hashie (3.4.6)
     hike (1.2.3)
+    hiredis (0.6.1)
     htmlentities (4.3.4)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -418,6 +419,10 @@ GEM
       foreman
       rails (>= 3.2)
       rainbow (~> 2.1)
+    readthis (2.0.1)
+      connection_pool (~> 2.1)
+      redis (~> 3.0)
+    redis (3.3.2)
     ref (2.0.0)
     request_store (1.3.1)
     responders (2.2.0)
@@ -549,7 +554,7 @@ DEPENDENCIES
   color (~> 1.8)
   compass (~> 0.13.alpha)
   compass-rails (~> 2.0)
-  connection_pool (~> 0.9.3)
+  connection_pool (~> 2.1)
   countries (~> 1.2, >= 1.2.2)
   css_parser (~> 1.4.5)
   cucumber-rails (~> 1.4.0)
@@ -570,6 +575,7 @@ DEPENDENCIES
   flying-sphinx (~> 1.2.0)
   guard-rspec (~> 4.6.5)
   haml (~> 4.0.5)
+  hiredis
   i18n-js!
   jquery-rails (= 3.1.3)
   js-routes (~> 1.2.5)
@@ -603,6 +609,7 @@ DEPENDENCIES
   rails_12factor (~> 0.0.3)
   rb-fsevent (~> 0.9.4)
   react_on_rails (~> 6.1.1)
+  readthis (~> 2.0.1)
   request_store (~> 1.3)
   rest-client (~> 1.8.0)
   rspec-rails (~> 3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,16 +53,28 @@ Kassi::Application.configure do
     ActionMailer::Base.logger.level = Logger::INFO
   end
 
-  # Use a different cache store in production
-  config.cache_store = :dalli_store, (ENV["MEMCACHIER_GREEN_SERVERS"] || "").split(","), {
-    username: ENV["MEMCACHIER_GREEN_USERNAME"],
-    password: ENV["MEMCACHIER_GREEN_PASSWORD"],
-    failover:  true,
-    socket_timeout: 1.5,
-    socket_failure_delay:  0.2,
-    namespace: ENV["MEMCACHED_NAMESPACE"] || "sharetribe-production",
-    compress: true
-  }
+  # Prefer redis instead of memcached
+  config.cache.store =
+    if ENV["redis_host"].present?
+      [:readthis_store, {
+         redis: { host: ENV["redis_host"],
+                  port: ENV["redis_port"],
+                  driver: :hiredis},
+         db: ENV["redis_db"],
+         namespace: "cache",
+         expires_in: ENV["redis_expires_in"] || 240 # default, 4 hours in minutes
+       }]
+    else
+      [:dalli_store, (ENV["MEMCACHIER_GREEN_SERVERS"] || "").split(","), {
+         username: ENV["MEMCACHIER_GREEN_USERNAME"],
+         password: ENV["MEMCACHIER_GREEN_PASSWORD"],
+         failover:  true,
+         socket_timeout: 1.5,
+         socket_failure_delay:  0.2,
+         namespace: ENV["MEMCACHED_NAMESPACE"] || "sharetribe-production",
+         compress: true
+       }]
+    end
 
   # Compress JavaScript and CSS
   #

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,16 +55,28 @@ Kassi::Application.configure do
     ActionMailer::Base.logger.level = Logger::INFO
   end
 
-  # Use a different cache store in production
-  config.cache_store = :dalli_store, (ENV["MEMCACHIER_SERVERS"] || "").split(","), {
-    username: ENV["MEMCACHIER_USERNAME"],
-    password: ENV["MEMCACHIER_PASSWORD"],
-    failover:  true,
-    socket_timeout: 1.5,
-    socket_failure_delay:  0.2,
-    namespace: ENV["MEMCACHED_NAMESPACE"] || "sharetribe-staging",
-    compress: true
-  }
+  # Prefer redis instead of memcached
+  config.cache_store =
+    if ENV["redis_host"].present?
+      [:readthis_store, {
+         redis: { host: ENV["redis_host"],
+                  port: ENV["redis_port"],
+                  driver: :hiredis},
+         db: ENV["redis_db"],
+         namespace: "cache",
+         expires_in: ENV["redis_expires_in"] || 240 # default, 4 hours in minutes
+       }]
+    else
+      [:dalli_store, (ENV["MEMCACHIER_SERVERS"] || "").split(","), {
+         username: ENV["MEMCACHIER_USERNAME"],
+         password: ENV["MEMCACHIER_PASSWORD"],
+         failover:  true,
+         socket_timeout: 1.5,
+         socket_failure_delay:  0.2,
+         namespace: ENV["MEMCACHED_NAMESPACE"] || "sharetribe-staging",
+         compress: true
+       }]
+    end
 
   # Compress JavaScript and CSS
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
Adds redis cache, but keeps memcached as an option.

Perf tests show about 15-19 % increase in performance in comparison to memcached when redis and memcached are run in AWS ElastiCache.