### PR TITLE
Harmony proxy block endpoints

### DIFF
--- a/app/services/harmony_endpoints.rb
+++ b/app/services/harmony_endpoints.rb
@@ -11,6 +11,10 @@ module HarmonyEndpoints
       # Timeslots
       query_timeslots: "/timeslots/query",
 
+      # Blocks
+      create_blocks: "/bookables/createBlocks",
+      delete_blocks: "/bookables/deleteBlocks",
+
       # Bookings
       initiate_booking: "/bookings/initiate",
       accept_booking: "/bookings/accept",


### PR DESCRIPTION
This PR adds two new endpoints to the Harmony Proxy whitelist: `/bookables/createBlocks` and `/bookables/deleteBlocks`. In addition, it changes the authorization logic a bit by adding an `OR` lambda to combine two authentication methods.

- [X] Add `/bookables/createBlocks`
- [X] Add `/bookables/deleteBlocks`
- [X] Add `IsAdmin` authorization
- [X] Add `OR` which can be used to combine two authorization methods