### PR TITLE
Override styles coming from default R&A styles

### DIFF
--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -372,5 +372,6 @@ module.exports = {
   '--ManageAvailability_saveButtonHeight': '60px',
   '--ManageAvailabilityHeader_height': 254,
   '--ManageAvailabilityCalendar_fontFamily': proximaNovaFontFamily,
+  '--ManageAvailabilityCalendar_fontSize': fontSize,
   '--ManageAvailabilityCalendar_width': '318px',
 };

--- a/client/app/components/composites/ManageAvailabilityCalendar/ManageAvailabilityCalendar.css
+++ b/client/app/components/composites/ManageAvailabilityCalendar/ManageAvailabilityCalendar.css
@@ -1,5 +1,6 @@
 .root {
   font-family: var(--ManageAvailabilityCalendar_fontFamily);
+  font-size: var(--ManageAvailabilityCalendar_fontSize);
 
   /* stylelint-disable selector-class-pattern */
 
@@ -50,9 +51,12 @@
   }
 
   & :global(.CalendarMonth__day--reserved) {
-    background-color: var(--colorReservedAvailability);
-    color: #fff;
-    cursor: default;
+    &,
+    &:active {
+      background-color: var(--colorReservedAvailability);
+      color: #fff;
+      cursor: default;
+    }
   }
 
   & :global(.CalendarMonth__day--outside) {

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -1,6 +1,29 @@
 .content {
   height: 100%;
   font-family: var(--ManageAvailability_fontFamily);
+
+  /* --- OVERRIDE DEFAULT STYLES START --- */
+
+  & :global(tbody tr) {
+    /* This will reset the <table> element zebra-skin
+       coloring coming from the default styles */
+    background-color: initial;
+  }
+
+  & :global(td) {
+    /* This will reset the default border radius for first and last
+    <td> element */
+    &:first-child,
+    &:last-child {
+      border-radius: initial;
+    }
+  }
+
+  & button:hover {
+    background-color: var(--colorReservedAvailability);
+  }
+
+  /* --- OVERRIDE DEFAULT STYLES END --- */
 }
 
 .calendar {


### PR DESCRIPTION
This PR fixes couple inconsistencies between the Storybook Calendar component and the Calendar component when it's used in the main application. The reason for the inconsistencies were the default application styles that were affecting on the component.

Fixed issues:

- Based font size changed to 14px instead of 16px
- Removed zebra-skin coloring
- Removed border-radius for the first and last `td`
- Remove active color for reserved date
- Remove hover color for save button

Before:

![screen shot 2016-12-08 at 10 04 25](https://cloud.githubusercontent.com/assets/429876/21002350/f354b07a-bd2d-11e6-925b-dcbf6d296502.png)


After:

![screen shot 2016-12-08 at 10 12 53](https://cloud.githubusercontent.com/assets/429876/21002522/f4ed6322-bd2e-11e6-8f48-d1dfe654c32a.png)



Storybook:

![screen shot 2016-12-08 at 10 05 09](https://cloud.githubusercontent.com/assets/429876/21002340/e778a518-bd2d-11e6-92f3-b3a5bd42be24.png)
