### PR TITLE
Unify listing price and shape name font sizes

### DIFF
--- a/app/assets/stylesheets/views/_home.css.scss
+++ b/app/assets/stylesheets/views/_home.css.scss
@@ -328,6 +328,20 @@ $home-list-avatar-padding: lines(0.25);
   }
 }
 
+.home-list-shape-value-mobile,
+.browsing-list-item-shape-value-mobile {
+  font-size: 24px;
+  & > .smaller {
+    font-size: 18px;
+  }
+  @include media(large-mobile) {
+    font-size: 36px;
+    & > .smaller {
+      font-size: 24px;
+    }
+  }
+}
+
 .home-list-price-mobile-with-listing-image {
   @include media(large-mobile) {
     left: auto;
@@ -347,7 +361,7 @@ $home-list-avatar-padding: lines(0.25);
 
 .home-list-item-price-value,
 .browsing-list-item-price-value {
-  font-size: em(44);
+  font-size: em(32);
   line-height: 1;
   font-weight: 400;
 }

--- a/app/assets/stylesheets/views/_home.css.scss
+++ b/app/assets/stylesheets/views/_home.css.scss
@@ -315,29 +315,17 @@ $home-list-avatar-padding: lines(0.25);
 }
 
 .home-list-price-value-mobile,
-.browsing-list-item-price-value-mobile {
-  font-size: 24px;
-  & > .smaller {
-    font-size: 18px;
-  }
-  @include media(large-mobile) {
-    font-size: 36px;
-    & > .smaller {
-      font-size: 24px;
-    }
-  }
-}
-
+.browsing-list-item-price-value-mobile,
 .home-list-shape-value-mobile,
 .browsing-list-item-shape-value-mobile {
-  font-size: 24px;
+  font-size: em(24);
   & > .smaller {
-    font-size: 18px;
+    font-size: em(18);
   }
   @include media(large-mobile) {
-    font-size: 36px;
+    font-size: em(36);
     & > .smaller {
-      font-size: 24px;
+      font-size: em(24);
     }
   }
 }
@@ -360,12 +348,7 @@ $home-list-avatar-padding: lines(0.25);
 }
 
 .home-list-item-price-value,
-.browsing-list-item-price-value {
-  font-size: em(32);
-  line-height: 1;
-  font-weight: 400;
-}
-
+.browsing-list-item-price-value,
 .home-list-listing-shape-value,
 .browsing-list-item-listing-shape-value {
   font-size: em(32);

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -9,7 +9,7 @@
     .home-list-details-right
       .home-list-price
         - if listing.price
-          .home-list-price-value
+          .home-list-item-price-value
             = humanized_money_with_symbol(listing.price).upcase
           - price_text = nil
           - if listing.quantity.present?
@@ -45,7 +45,7 @@
             .home-list-price-quantity{:title => price_text}
               = price_text
         - else
-          %span.smaller
+          .home-list-shape-value-mobile
             = shape_name(listing)
 
 

--- a/app/views/homepage/_list_item_with_distance.haml
+++ b/app/views/homepage/_list_item_with_distance.haml
@@ -65,5 +65,5 @@
               .browsing-list-item-price-quantity{ title: price_text}
                 = price_text
           - else
-            %span.smaller
+            .browsing-list-item-shape-value-mobile
               = shape_name(listing)


### PR DESCRIPTION
Font sizes of prices and order types in listing search results list view are varying between desktop and mobile views and the existence of location parameter:

Old view:
![image](https://cloud.githubusercontent.com/assets/57473/21003050/d98263c8-bd31-11e6-9cee-af8159da7b4e.png)

Old view with distance:
![image](https://cloud.githubusercontent.com/assets/57473/21002780/38a7f5cc-bd30-11e6-968f-1d46e2eda124.png)

Old mobile view:
![image](https://cloud.githubusercontent.com/assets/57473/21003054/e0cabcfc-bd31-11e6-82be-57c9610522ad.png)

Old mobile view with distance:
![image](https://cloud.githubusercontent.com/assets/57473/21002789/46014f0c-bd30-11e6-8347-220d598ebc80.png)

  
This PR unifies the font sizes of price and order type with the following results.


New view:
![image](https://cloud.githubusercontent.com/assets/57473/21002921/fff98d5c-bd30-11e6-87f5-0c52b548b68b.png)

New view with distance:
![image](https://cloud.githubusercontent.com/assets/57473/21002924/05b876d6-bd31-11e6-9acb-37179d38ffce.png)

New mobile view:
![image](https://cloud.githubusercontent.com/assets/57473/21002930/0ba1d2ea-bd31-11e6-9a2c-4022b7044812.png)

New mobile view with distance:
![image](https://cloud.githubusercontent.com/assets/57473/21002937/13fdd52e-bd31-11e6-96dc-efa51239d19f.png)
