### PR TITLE
Use Transit to communication to Harmony

### DIFF
--- a/client/app/actions/ManageAvailabilityActions.js
+++ b/client/app/actions/ManageAvailabilityActions.js
@@ -1,6 +1,6 @@
 import * as actionTypes from '../constants/ManageAvailabilityConstants';
-import _ from 'lodash';
 import * as harmony from '../services/harmony';
+import { Map, List } from 'immutable';
 
 export const allowDay = (day) => ({
   type: actionTypes.ALLOW_DAY,
@@ -17,12 +17,9 @@ const changeVisibleMonth = (day) => ({
   payload: day,
 });
 
-export const dataLoaded = (bookings, blocks) => ({
+export const dataLoaded = (slots) => ({
   type: actionTypes.DATA_LOADED,
-  payload: {
-    bookings,
-    blocks,
-  },
+  payload: slots,
 });
 
 export const changeMonth = (day) =>
@@ -36,11 +33,14 @@ export const changeMonth = (day) =>
       marketplaceId: state.get('marketplaceUuid'),
       include: ['blocks', 'bookings'].join(','),
     }).then((response) => {
-      const groups = _.groupBy(response.included, 'type');
-      const bookings = groups.booking || [];
-      const blocks = groups.blocks || [];
+      const groups = response.get(':included').groupBy((v) => v.get(':type'));
 
-      dispatch(dataLoaded(bookings, blocks));
+      const slots = new Map({
+        blocks: groups.get(':block', new List()),
+        bookings: groups.get(':booking', new List()),
+      });
+
+      dispatch(dataLoaded(slots));
     });
 
     // TODO ADD ERROR HANDLING

--- a/client/app/components/composites/ListingCard/ListingCard.story.js
+++ b/client/app/components/composites/ListingCard/ListingCard.story.js
@@ -4,7 +4,8 @@ import Immutable from 'immutable';
 
 import { storify } from '../../Styleguide/withProps';
 import { formatDistance, formatMoney } from '../../../utils/numbers';
-import ListingModel, { Distance, Money } from '../../../models/ListingModel';
+import ListingModel from '../../../models/ListingModel';
+import { Distance, Money } from '../../../types/types'
 import { Image, ListingImage, AvatarImage } from '../../../models/ImageModel';
 
 import ListingCard from './ListingCard';

--- a/client/app/components/composites/ListingCardPanel/ListingCardPanel.story.js
+++ b/client/app/components/composites/ListingCardPanel/ListingCardPanel.story.js
@@ -4,7 +4,8 @@ import Immutable from 'immutable';
 
 import { storify } from '../../Styleguide/withProps';
 import { toFixedNumber } from '../../../utils/numbers';
-import ListingModel, { Distance, Money } from '../../../models/ListingModel';
+import ListingModel from '../../../models/ListingModel';
+import { Distance, Money } from '../../../types/types';
 import { Image, ListingImage, AvatarImage } from '../../../models/ImageModel';
 
 import ListingCardPanel from '../ListingCardPanel/ListingCardPanel';

--- a/client/app/components/sections/SearchPage/SearchPage.story.js
+++ b/client/app/components/sections/SearchPage/SearchPage.story.js
@@ -1,7 +1,8 @@
 import r, { div, h1, h2, p } from 'r-dom';
 import Immutable from 'immutable';
 import { toFixedNumber } from '../../../utils/numbers';
-import ListingModel, { Distance, Money } from '../../../models/ListingModel';
+import ListingModel from '../../../models/ListingModel';
+import { Distance, Money } from '../../../types/types';
 import { Image, ListingImage, AvatarImage } from '../../../models/ImageModel';
 import ListingCard from '../../composites/ListingCard/ListingCard';
 import ListingCardPanel from '../../composites/ListingCardPanel/ListingCardPanel';

--- a/client/app/models/ListingModel.js
+++ b/client/app/models/ListingModel.js
@@ -1,16 +1,7 @@
 import Immutable from 'immutable';
 import { Image, ListingImage } from './ImageModel';
 import { Profile } from './ProfileModel';
-
-export const Distance = Immutable.Record({
-  value: 0,
-  unit: 'km',
-});
-
-export const Money = Immutable.Record({
-  fractionalAmount: 0,
-  currency: 'USD',
-});
+import { Money, Distance } from '../types/types';
 
 const ListingModel = Immutable.Record({
   id: 'uuid',

--- a/client/app/services/harmony.js
+++ b/client/app/services/harmony.js
@@ -1,4 +1,5 @@
 import { paramsToQueryString } from '../utils/url';
+import * as transitConverter from '../utils/transitImmutableConverter';
 
 /**
   harmony.js defines a interface for Harmony API.
@@ -28,6 +29,8 @@ const csrfToken = () => {
   return null;
 };
 
+const converter = transitConverter.createInstance();
+
 const sendRequest = (method, url, queryParams) => {
   const harmonyApiUrl = '/harmony_proxy';
 
@@ -50,7 +53,9 @@ const sendRequest = (method, url, queryParams) => {
   const urlWithQuery = harmonyApiUrl + url + paramsToQueryString(queryParams);
   const requestOpts = Object.assign({}, defaultRequestOpts, { method });
 
-  return window.fetch(urlWithQuery, requestOpts).then((response) => response.json());
+  return window.fetch(urlWithQuery, requestOpts)
+               .then((response) => response.text())
+               .then((text) => Promise.resolve(converter.fromJSON(text)));
 };
 
 const get = (url, queryParams) => sendRequest('get', url, queryParams);

--- a/client/app/startup/ManageAvailabilityApp.js
+++ b/client/app/startup/ManageAvailabilityApp.js
@@ -9,6 +9,7 @@ import { Map, List } from 'immutable';
 import ManageAvailabilityContainer from '../components/sections/ManageAvailability/ManageAvailabilityContainer';
 import { EDIT_VIEW_OPEN_HASH } from '../reducers/ManageAvailabilityReducer';
 import * as cssVariables from '../assets/styles/variables';
+import { UUID } from '../types/types';
 
 export default (props) => {
   const locale = props.i18n.locale;
@@ -25,8 +26,8 @@ export default (props) => {
       reservedDays: new List(),
       blockedDays: new List(),
       changes: new List(),
-      marketplaceUuid: props.marketplace.uuid,
-      listingUuid: props.listing.uuid,
+      marketplaceUuid: new UUID({ value: props.marketplace.uuid }),
+      listingUuid: new UUID({ value: props.listing.uuid }),
     }),
   };
 

--- a/client/app/startup/SearchPageApp.js
+++ b/client/app/startup/SearchPageApp.js
@@ -14,8 +14,8 @@ import SearchPageContainer from '../components/sections/SearchPage/SearchPageCon
 import { SearchPageModel } from '../components/sections/SearchPage/SearchPage';
 import { parse as parseListingModel } from '../models/ListingModel';
 import { parse as parseProfile } from '../models/ProfileModel';
-import { Image } from '../models/ImageModel';
-import TransitImmutableConverter from '../utils/transitImmutableConverter';
+import { Image, parse as parseImage } from '../models/ImageModel';
+import * as transitConverter from '../utils/transitImmutableConverter';
 
 const profilesToMap = (includes, getProfilePath) =>
   includes.reduce((acc, val) => {
@@ -80,7 +80,11 @@ export default (props) => {
     'sign_up',
   ], { locale });
 
-  const bootstrappedData = TransitImmutableConverter.fromJSON(_.get(props, 'searchPage.data', null));
+  const converter = transitConverter.createInstance({
+    im: parseImage,
+  });
+
+  const bootstrappedData = converter.fromJSON(_.get(props, 'searchPage.data', null));
 
   const rawListings = bootstrappedData.get(':data', []);
 

--- a/client/app/types/types.js
+++ b/client/app/types/types.js
@@ -1,0 +1,24 @@
+/**
+   This file contains common types (i.e. defined Immutable Records).
+
+   All types are currently in this one file, but in the future if
+   the number of types grow, we can split the type to smaller chunks.
+ */
+
+import Immutable from 'immutable';
+
+export class UUID extends Immutable.Record({ value: '' }) {
+  toString() {
+    return this.value;
+  }
+}
+
+export const Distance = Immutable.Record({
+  value: 0,
+  unit: 'km',
+});
+
+export const Money = Immutable.Record({
+  fractionalAmount: 0,
+  currency: 'USD',
+});


### PR DESCRIPTION
The original plan was to send JSON to Harmony and back. However, since we have to send `Date`s and `UUID`s, it makes a lot of sense to use Transit for that. This PR makes the required changes to use Transit.

- [X] Generalize Transit converter: There are some Listing specific types and handlers in the `utils/transitImmutableConverter`. Thus, it's needed to:
  - [X] Move generic types (`Money` and `Distance`) to `types/types.js`
  - [X] Move listing specific types and handlers away from `utils/transitImmutableConverter`
  - [X] Don't create a singleton converter. Instead, expose a constructor which lets others to instantiate new converters with a little bit different set of handlers.
- [X] Change Harmony Proxy so that it doesn't necessarily encode/decode request/response
- [X] Use `UUID` type for props
- [X] Use Immutable JS when ever it makes sense

TODO

- [x] Test new Search page layout (I don't have local setup)