### PR TITLE
Improve data loading

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -162,6 +162,7 @@ module.exports = {
         "Immutable.Map",
         "Immutable.Record",
         "Immutable.Set",
+        "Immutable.Range"
         ]
     }],
     'new-parens': 2,

--- a/client/app/actions/ManageAvailabilityActions.js
+++ b/client/app/actions/ManageAvailabilityActions.js
@@ -1,6 +1,6 @@
 import * as actionTypes from '../constants/ManageAvailabilityConstants';
 import * as harmony from '../services/harmony';
-import { Map, List } from 'immutable';
+import Immutable from 'immutable';
 import { expandRange } from '../utils/moment';
 
 export const allowDay = (day) => ({
@@ -78,9 +78,9 @@ export const changeMonth = (day) =>
       }).then((response) => {
         const groups = response.get(':included').groupBy((v) => v.get(':type'));
 
-        const slots = new Map({
-          blocks: groups.get(':block', new List()),
-          bookings: groups.get(':booking', new List()),
+        const slots = Immutable.Map({
+          blocks: groups.get(':block', Immutable.List()),
+          bookings: groups.get(':booking', Immutable.List()),
         });
 
         dispatch(dataLoaded(slots, expandRange(start, end, 'months').toSet()));

--- a/client/app/actions/ManageAvailabilityActions.js
+++ b/client/app/actions/ManageAvailabilityActions.js
@@ -50,11 +50,21 @@ const loadRange = (date, preloadMonths) => {
 
 /**
    Given a list of `months` and a Set of already `loadedMonths`,
-   return an object { start, end } where already loaded months is removed.
+   return an object { start, end } where months that are already
+   loaded are removed from the beginning and the end of the range.
+
+   Example:
+
+   start: 4
+   end: 11
+   loadedMonths: [2, 3, 4, 5, 6, 9, 11, 12]
+
+   result: { start: 7, end: 10 }
+
  */
 const removeLoadedMonths = (months, loadedMonths) => ({
   start: months.find((s) => !loadedMonths.includes(s)),
-  end: months.reverse().find((e) => !loadedMonths.includes(e)),
+  end: months.findLast((e) => !loadedMonths.includes(e)),
 });
 
 const monthsToLoad = (day, loadedMonths, preloadMonths) =>

--- a/client/app/actions/ManageAvailabilityActions.js
+++ b/client/app/actions/ManageAvailabilityActions.js
@@ -1,6 +1,7 @@
 import * as actionTypes from '../constants/ManageAvailabilityConstants';
 import * as harmony from '../services/harmony';
 import { Map, List } from 'immutable';
+import { expandRange } from '../utils/moment';
 
 export const allowDay = (day) => ({
   type: actionTypes.ALLOW_DAY,
@@ -17,10 +18,47 @@ const changeVisibleMonth = (day) => ({
   payload: day,
 });
 
-export const dataLoaded = (slots) => ({
+export const dataLoaded = (slots, loadedMonths) => ({
   type: actionTypes.DATA_LOADED,
-  payload: slots,
+  payload: slots.merge({ loadedMonths }),
 });
+
+/**
+   Number of extra months to preload.
+   0 mean no preloading.
+ */
+const PRELOAD_MONTHS = 2;
+
+/**
+   Given a `date` and number of months to preload, return a List of
+   moment dates representing the start of the month that should be
+   loaded.
+
+   @param {moment} date - Date representing the month
+   @params {number} preloadMonths - Number of months to preload
+   @return {List[moment]} List of months that should be loaded
+ */
+const loadRange = (date, preloadMonths) => {
+  const startOfMonth = date.clone().startOf('month');
+  const endOfMonthExclusive = startOfMonth.clone().add(1, 'month');
+
+  const start = startOfMonth.clone().subtract(preloadMonths, 'months');
+  const end = endOfMonthExclusive.clone().add(preloadMonths, 'months');
+
+  return expandRange(start, end, 'months');
+};
+
+/**
+   Given a list of `months` and a Set of already `loadedMonths`,
+   return an object { start, end } where already loaded months is removed.
+ */
+const removeLoadedMonths = (months, loadedMonths) => ({
+  start: months.find((s) => !loadedMonths.includes(s)),
+  end: months.reverse().find((e) => !loadedMonths.includes(e)),
+});
+
+const monthsToLoad = (day, loadedMonths, preloadMonths) =>
+  removeLoadedMonths(loadRange(day, preloadMonths), loadedMonths);
 
 export const changeMonth = (day) =>
   (dispatch, getState) => {
@@ -28,20 +66,26 @@ export const changeMonth = (day) =>
 
     const state = getState().manageAvailability;
 
-    harmony.get('/bookables/show', {
-      refId: state.get('listingUuid'),
-      marketplaceId: state.get('marketplaceUuid'),
-      include: ['blocks', 'bookings'].join(','),
-    }).then((response) => {
-      const groups = response.get(':included').groupBy((v) => v.get(':type'));
+    const { start, end } = monthsToLoad(day, state.get('loadedMonths'), PRELOAD_MONTHS);
 
-      const slots = new Map({
-        blocks: groups.get(':block', new List()),
-        bookings: groups.get(':booking', new List()),
+    if (start && end) {
+      harmony.get('/bookables/show', {
+        refId: state.get('listingUuid'),
+        marketplaceId: state.get('marketplaceUuid'),
+        include: ['blocks', 'bookings'].join(','),
+        start: start.toJSON(),
+        end: end.toJSON(),
+      }).then((response) => {
+        const groups = response.get(':included').groupBy((v) => v.get(':type'));
+
+        const slots = new Map({
+          blocks: groups.get(':block', new List()),
+          bookings: groups.get(':booking', new List()),
+        });
+
+        dispatch(dataLoaded(slots, expandRange(start, end, 'months').toSet()));
       });
-
-      dispatch(dataLoaded(slots));
-    });
+    }
 
     // TODO ADD ERROR HANDLING
   };

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.js
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.js
@@ -25,16 +25,38 @@ SaveButton.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
+/**
+   Return `true` if component should load initial data.
+*/
+const shouldLoad = (isOpen, prevIsOpen) => {
+  if (!isOpen) {
+    return false;
+  } else if (prevIsOpen && isOpen) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+/**
+   Load initial data if needed. This should happen only once when
+   component `isOpen` becomes `true`
+*/
+const loadInitialDataIfNeeded = (props, prevProps = null) => {
+  const isOpen = props.winder.isOpen;
+  const prevIsOpen = prevProps && prevProps.winder.isOpen;
+
+  if (shouldLoad(isOpen, prevIsOpen)) {
+    props.calendar.onMonthChanged(props.calendar.initialMonth);
+  }
+};
+
 class ManageAvailability extends Component {
   constructor(props) {
     super(props);
     this.state = { renderCalendar: false };
 
     this.clickHandler = this.clickHandler.bind(this);
-  }
-
-  componentWillMount() {
-    this.props.calendar.onMonthChanged(this.props.calendar.initialMonth);
   }
 
   componentDidMount() {
@@ -50,6 +72,12 @@ class ManageAvailability extends Component {
     if (this.props.availability_link) {
       this.props.availability_link.addEventListener('click', this.clickHandler);
     }
+
+    loadInitialDataIfNeeded(this.props);
+  }
+
+  componentDidUpdate(prevProps) {
+    loadInitialDataIfNeeded(this.props, prevProps);
   }
 
   componentWillUnmount() {

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.js
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.js
@@ -28,15 +28,7 @@ SaveButton.propTypes = {
 /**
    Return `true` if component should load initial data.
 */
-const shouldLoad = (isOpen, prevIsOpen) => {
-  if (!isOpen) {
-    return false;
-  } else if (prevIsOpen && isOpen) {
-    return false;
-  } else {
-    return true;
-  }
-};
+const shouldLoad = (isOpen, prevIsOpen) => isOpen && !prevIsOpen;
 
 /**
    Load initial data if needed. This should happen only once when

--- a/client/app/specs/moment.spec.js
+++ b/client/app/specs/moment.spec.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { expandRange } from '../utils/moment';
+import moment from 'moment';
+import { List, is } from 'immutable';
+
+describe('moment utils', () => {
+  describe('expandRange', () => {
+    it('should return expanded range for days', () => {
+      const actual = expandRange(moment('2016-12-12'), moment('2016-12-14'), 'days');
+      const expected = new List([moment('2016-12-12'), moment('2016-12-13')]);
+
+      expect(is(actual, expected)).to.equal(true);
+    });
+    it('should return expanded range for months', () => {
+      const actual = expandRange(moment('2016-12-01'), moment('2017-02-01'), 'months');
+      const expected = new List([moment('2016-12-01'), moment('2017-01-01')]);
+
+      expect(is(actual, expected)).to.equal(true);
+    });
+    it('should return only full months', () => {
+      const actual = expandRange(moment('2016-12-01'), moment('2017-02-15'), 'months');
+      const expected = new List([moment('2016-12-01'), moment('2017-01-01')]);
+      expect(is(actual, expected)).to.equal(true);
+    });
+  });
+});

--- a/client/app/specs/moment.spec.js
+++ b/client/app/specs/moment.spec.js
@@ -1,26 +1,26 @@
 import { expect } from 'chai';
 import { expandRange } from '../utils/moment';
 import moment from 'moment';
-import { List, is } from 'immutable';
+import Immutable from 'immutable';
 
 describe('moment utils', () => {
   describe('expandRange', () => {
     it('should return expanded range for days', () => {
       const actual = expandRange(moment('2016-12-12'), moment('2016-12-14'), 'days');
-      const expected = new List([moment('2016-12-12'), moment('2016-12-13')]);
+      const expected = Immutable.List([moment('2016-12-12'), moment('2016-12-13')]);
 
-      expect(is(actual, expected)).to.equal(true);
+      expect(Immutable.is(actual, expected)).to.equal(true);
     });
     it('should return expanded range for months', () => {
       const actual = expandRange(moment('2016-12-01'), moment('2017-02-01'), 'months');
-      const expected = new List([moment('2016-12-01'), moment('2017-01-01')]);
+      const expected = Immutable.List([moment('2016-12-01'), moment('2017-01-01')]);
 
-      expect(is(actual, expected)).to.equal(true);
+      expect(Immutable.is(actual, expected)).to.equal(true);
     });
     it('should return only full months', () => {
       const actual = expandRange(moment('2016-12-01'), moment('2017-02-15'), 'months');
-      const expected = new List([moment('2016-12-01'), moment('2017-01-01')]);
-      expect(is(actual, expected)).to.equal(true);
+      const expected = Immutable.List([moment('2016-12-01'), moment('2017-01-01')]);
+      expect(Immutable.is(actual, expected)).to.equal(true);
     });
   });
 });

--- a/client/app/startup/ManageAvailabilityApp.js
+++ b/client/app/startup/ManageAvailabilityApp.js
@@ -5,7 +5,7 @@ import { combineReducers, applyMiddleware, createStore } from 'redux';
 import reducers from '../reducers/reducersIndex';
 import { initialize as initializeI18n } from '../utils/i18n';
 import moment from 'moment';
-import { Map, List } from 'immutable';
+import { Map, List, Set } from 'immutable';
 import ManageAvailabilityContainer from '../components/sections/ManageAvailability/ManageAvailabilityContainer';
 import { EDIT_VIEW_OPEN_HASH } from '../reducers/ManageAvailabilityReducer';
 import * as cssVariables from '../assets/styles/variables';
@@ -23,12 +23,15 @@ export default (props) => {
     flashNotifications: new List(),
     manageAvailability: new Map({
       isOpen: window.location.hash.replace(/^#/, '') === EDIT_VIEW_OPEN_HASH,
-      visibleMonth: moment().startOf('month'),
+      visibleMonth: moment()
+        .utc()
+        .startOf('month'),
       reservedDays: new List(),
       blockedDays: new List(),
       changes: new List(),
       marketplaceUuid: new UUID({ value: props.marketplace.uuid }),
       listingUuid: new UUID({ value: props.listing.uuid }),
+      loadedMonths: new Set(),
     }),
   };
 

--- a/client/app/utils/moment.js
+++ b/client/app/utils/moment.js
@@ -14,10 +14,10 @@ import Immutable from 'immutable';
    expandRange(moment("2016-12-12"), moment("2016-12-14"), "days")
     -> [moment("2016-12-12"), moment("2016-12-13")]
 
-   expandRange(moment("2016-12-01"), moment("2017-02-01"), "days")
+   expandRange(moment("2016-12-01"), moment("2017-02-01"), "months")
     -> [moment("2016-12-01"), moment("2017-01-01")]
 
-   expandRange(moment("2016-12-01"), moment("2017-02-15"), "days")
+   expandRange(moment("2016-12-01"), moment("2017-02-15"), "months")
     -> [moment("2016-12-01"), moment("2017-01-01")]
 
    @param {moment} start - range start (inclusive)

--- a/client/app/utils/moment.js
+++ b/client/app/utils/moment.js
@@ -1,0 +1,29 @@
+/**
+   This file contains utility methods to work with moment JS
+   instances.
+ */
+
+import { Range } from 'immutable';
+
+/**
+   Takes a time range (`start` and `end` (exclusive)) and returns an Immutable List
+   containing the range expanded by the given duration.
+
+   Examples:
+
+   expandRange(moment("2016-12-12"), moment("2016-12-14"), "days")
+    -> [moment("2016-12-12"), moment("2016-12-13")]
+
+   expandRange(moment("2016-12-01"), moment("2017-02-01"), "days")
+    -> [moment("2016-12-01"), moment("2017-01-01")]
+
+   expandRange(moment("2016-12-01"), moment("2017-02-15"), "days")
+    -> [moment("2016-12-01"), moment("2017-01-01")]
+
+   @param {moment} start - range start (inclusive)
+   @param {moment} end - range end (exclusive)
+   @param {String} duration - minutes|days|months|etc.
+*/
+export const expandRange = (start, end, duration) =>
+  new Range(0, end.diff(start, duration)).map(
+    (i) => start.clone().add(i, duration));

--- a/client/app/utils/moment.js
+++ b/client/app/utils/moment.js
@@ -3,7 +3,7 @@
    instances.
  */
 
-import { Range } from 'immutable';
+import Immutable from 'immutable';
 
 /**
    Takes a time range (`start` and `end` (exclusive)) and returns an Immutable List
@@ -25,5 +25,5 @@ import { Range } from 'immutable';
    @param {String} duration - minutes|days|months|etc.
 */
 export const expandRange = (start, end, duration) =>
-  new Range(0, end.diff(start, duration)).map(
+  Immutable.Range(0, end.diff(start, duration)).map(
     (i) => start.clone().add(i, duration));


### PR DESCRIPTION
This PR improves the data fetching. When the user opens the sidebar, we'll load the data for the initial data for the sidebar + +/-2 months for additional preloaded data. When user changes a month, we load more data so that we keep the +/-2 months of data prefetched. In addition, a book keeping is implemented to remember which months have been loaded already. A month that has been loaded will never be reloaded.

TODO:

- [X] Load initial data when sidebar is opened.
- [X] Include `start` and `end` parameters to the fetch request
- [X] Preload +/-2 months
- [X] Keep track of loaded months and do not reload already loaded months.
- [X] Load data only when the edit listing sidebar is opened.