### PR TITLE
Add a new, faster npm script: npm run test:devspecs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,8 @@
     "deploy-storybook": "npm run ensure-node-version && storybook-to-ghpages",
     "test:stories": "npm run ensure-node-version && mocha './app/components/**/*.story.js' --reporter mocha-circleci-reporter --require babel-register --require ignore-styles --require ./mochaConfig.js",
     "test:specs": "npm run ensure-node-version && mocha './app/specs/*.spec.js' --reporter mocha-circleci-reporter --require babel-register --require ignore-styles --require ./mochaConfig.js",
-    "test": "npm run ensure-node-version && npm run test:stories && npm run test:specs"
+    "test": "npm run ensure-node-version && npm run test:stories && npm run test:specs",
+    "test:devspecs": "mocha './app/specs/*.spec.js' --require babel-register"
   },
   "dependencies": {
     "babel-cli": "6.18.0",


### PR DESCRIPTION
This PR improves the speed of running specs, which is super important for test driven development. This PR introduces a new `npm` script called `npm tests:devspecs`. That script runs all specs but includes only minimal set of plugins. Results:

**test:specs - Whole suite**

```
➜  client git:(js-transit-writer) ✗ time npm run test:specs

> @ test:specs /Users/mikko/Documents/Projects/sharetribe/sharetribe/client
> npm run ensure-node-version && mocha './app/specs/*.spec.js' --reporter mocha-circleci-reporter --require babel-register --require ignore-styles --require ./mochaConfig.js


> @ ensure-node-version /Users/mikko/Documents/Projects/sharetribe/sharetribe/client
> check-node-version --package

node: v6.9.0
npm: v4.0.1


  FlashNotification
    actions
      ✓ should create an action to add a notification
      ✓ should create an action to remove a notification
    reducer
      ✓ should return the initial state
      ✓ should handle FLASH_NOTIFICATION_ADD

  ManageAvailabilityReducer
    changes
      ✓ has no changes initially
      ✓ has an initial block
      ✓ adds a single block
      ✓ adds a second block
      ✓ blocks and allows a day
      ✓ allows an initially blocked day
      ✓ allows and blocks again an initially blocked day
      ✓ allows an initially allowed day
      ✓ ignores an allow to a reserved day
      ✓ ignores a block to a reserved day

  Number utils
    Formatting distance
      ✓ Should format distance as "10,000 mi" with en-US
      ✓ Should format distance as "10 000 km" with fi-FI
      ✓ Should return null, if no distance given
    Formatting Money
      ✓ Should format price as "$ 10,000" with en-US
      ✓ Should format distance as "10 000 €" with fi-FI
      ✓ Should return null, if no distance given
      ✓ Should throw error with unknown currency
    Formatting Number with toFixedNumber
      ✓ Should format Number(23.56576) with precision 2 to Number(23.57)


  22 passing (166ms)

npm run test:specs  4.84s user 0.68s system 93% cpu 5.926 total
```

**test:specs - One spec only**

```
> @ test:specs /Users/mikko/Documents/Projects/sharetribe/sharetribe/client
> npm run ensure-node-version && mocha './app/specs/*.spec.js' --reporter mocha-circleci-reporter --require babel-register --require ignore-styles --require ./mochaConfig.js


> @ ensure-node-version /Users/mikko/Documents/Projects/sharetribe/sharetribe/client
> check-node-version --package

node: v6.9.0
npm: v4.0.1


  Number utils
    Formatting Number with toFixedNumber
      ✓ Should format Number(23.56576) with precision 2 to Number(23.57)


  1 passing (110ms)

npm run test:specs  4.54s user 0.61s system 98% cpu 5.247 total
```

**test:devspecs - Whole suite**

```
➜  client git:(js-transit-writer) ✗ time npm run test:devspecs

> @ test:devspecs /Users/mikko/Documents/Projects/sharetribe/sharetribe/client
> mocha './app/specs/*.spec.js' --require babel-register



  FlashNotification
    actions
      ✓ should create an action to add a notification
      ✓ should create an action to remove a notification
    reducer
      ✓ should return the initial state
      ✓ should handle FLASH_NOTIFICATION_ADD

  ManageAvailabilityReducer
    changes
      ✓ has no changes initially
      ✓ has an initial block
      ✓ adds a single block
      ✓ adds a second block
      ✓ blocks and allows a day
      ✓ allows an initially blocked day
      ✓ allows and blocks again an initially blocked day
      ✓ allows an initially allowed day
      ✓ ignores an allow to a reserved day
      ✓ ignores a block to a reserved day

  Number utils
    Formatting distance
      ✓ Should format distance as "10,000 mi" with en-US
      ✓ Should format distance as "10 000 km" with fi-FI
      ✓ Should return null, if no distance given
    Formatting Money
      ✓ Should format price as "$ 10,000" with en-US
      ✓ Should format distance as "10 000 €" with fi-FI
      ✓ Should return null, if no distance given
      ✓ Should throw error with unknown currency
    Formatting Number with toFixedNumber
      ✓ Should format Number(23.56576) with precision 2 to Number(23.57)


  22 passing (155ms)

npm run test:devspecs  2.91s user 0.35s system 100% cpu 3.239 total
```

**test:devspecs - One spec only**

```

➜  client git:(js-transit-writer) ✗ time npm run test:devspecs

> @ test:devspecs /Users/mikko/Documents/Projects/sharetribe/sharetribe/client
> mocha './app/specs/*.spec.js' --require babel-register



  Number utils
    Formatting Number with toFixedNumber
      ✓ Should format Number(23.56576) with precision 2 to Number(23.57)


  1 passing (106ms)

npm run test:devspecs  2.89s user 0.33s system 102% cpu 3.157 total

```