### PR TITLE
Fix button margin leaking from default styles

### DIFF
--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -4,13 +4,13 @@
 
   /* --- OVERRIDE DEFAULT STYLES START --- */
 
-  & :global(tbody tr) {
+  & tbody tr {
     /* This will reset the <table> element zebra-skin
        coloring coming from the default styles */
     background-color: initial;
   }
 
-  & :global(td) {
+  & td {
     /* This will reset the default border radius for first and last
     <td> element */
     &:first-child,
@@ -19,8 +19,12 @@
     }
   }
 
-  & button:hover {
-    background-color: var(--colorReservedAvailability);
+  & button {
+    margin: 0;
+
+    &:hover {
+      background-color: var(--colorReservedAvailability);
+    }
   }
 
   /* --- OVERRIDE DEFAULT STYLES END --- */


### PR DESCRIPTION
This PR clears the availability save button margin leaking from the default styles.

Unnecessary `:global()` wrappers also removed from non-class selectors.

## Before:

See the bottom white area below the button.

![screen shot 2016-12-14 at 10 37 00](https://cloud.githubusercontent.com/assets/53923/21175088/72ccc8fa-c1e9-11e6-99e1-d32ac0dde1dd.png)

## After:

![screen shot 2016-12-14 at 10 37 42](https://cloud.githubusercontent.com/assets/53923/21175096/78e98930-c1e9-11e6-8c25-c92cdf467ab3.png)

