### PR TITLE
Handle missing listing image in availability menu header

### DIFF
--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.js
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.js
@@ -12,10 +12,12 @@ const ManageAvailabilityHeader = (props) => div(
     },
   },
   [
-    div({
-      className: css.imageLayer,
-      style: { backgroundImage: `url(${props.imageUrl})` },
-    }),
+    props.imageUrl ?
+      div({
+        className: css.imageLayer,
+        style: { backgroundImage: `url(${props.imageUrl})` },
+      }) :
+      null,
     div({
       className: css.colorLayer,
       style: { backgroundColor: props.backgroundColor },
@@ -29,7 +31,7 @@ const ManageAvailabilityHeader = (props) => div(
 
 ManageAvailabilityHeader.propTypes = {
   backgroundColor: PropTypes.string.isRequired,
-  imageUrl: PropTypes.string.isRequired,
+  imageUrl: PropTypes.string,
   title: PropTypes.string.isRequired,
   height: PropTypes.number.isRequired,
 };

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.story.js
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.story.js
@@ -6,8 +6,14 @@ const { storiesOf } = storybookFacade;
 storiesOf('Availability')
   .add('ManageAvailabilityHeader', () =>
        withProps(ManageAvailabilityHeader, {
-         backgroundColor: '347F9D',
+         backgroundColor: '#347F9D',
          imageUrl: 'https://placehold.it/1024x1024',
+         title: 'Pelago San Sebastian, in very good condition in Kallio',
+         height: 400,
+       }))
+  .add('ManageAvailabilityHeader without image', () =>
+       withProps(ManageAvailabilityHeader, {
+         backgroundColor: '#347F9D',
          title: 'Pelago San Sebastian, in very good condition in Kallio',
          height: 400,
        }));


### PR DESCRIPTION
This PR changes the `ManageAvailabilityHeader` component not to require the `imageUrl` prop and just renders the background color (marketplace color) without the blurred image if one is not given.

## Header with image:

![screen shot 2016-12-14 at 10 50 30](https://cloud.githubusercontent.com/assets/53923/21175517/544dbb3a-c1eb-11e6-9297-7450128db5e4.png)

## Header without image:

![screen shot 2016-12-14 at 10 51 03](https://cloud.githubusercontent.com/assets/53923/21175523/5af3639a-c1eb-11e6-9cc1-e73e9813fb15.png)
