### PR TITLE
Harmony proxy can now read Transit

### DIFF
--- a/app/utils/transit_utils.rb
+++ b/app/utils/transit_utils.rb
@@ -36,10 +36,18 @@ module TransitUtils
     io.string
   end
 
+  # Takes `content` (String) and `encoding` and decodes the Transit
+  # message
   def decode(content, encoding)
+    decode_io(StringIO.new(content), encoding)
+  end
+
+  # Takes `content_io` (IO) and `encoding` and decodes the Transit
+  # message
+  def decode_io(content_io, encoding)
     Transit::Reader.new(
       encoding,
-      StringIO.new(content),
+      content_io,
       handlers: {
         "u" => UUIDReadHandler.new
       }).read

--- a/client/app/services/harmony.js
+++ b/client/app/services/harmony.js
@@ -35,8 +35,8 @@ const sendRequest = (method, url, queryParams) => {
   const harmonyApiUrl = '/harmony_proxy';
 
   const headers = new Headers({
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
+    'Content-Type': 'application/transit+json',
+    Accept: 'application/transit+json',
   });
 
   const csrf = csrfToken();


### PR DESCRIPTION
- [X] Harmony proxy can now read Transit and use the decoded body for authorization
- [X] Minor fine-tuning for the authorization logic: Add AND and separate marketplace authorization to own authorization module.