### PR TITLE
Fix POST body proxying to Harmony in production env

### DIFF
--- a/app/controllers/harmony_proxy_controller.rb
+++ b/app/controllers/harmony_proxy_controller.rb
@@ -190,7 +190,8 @@ class HarmonyProxyController < ApplicationController
   def build_request_context(request)
     path = request.path_parameters[:harmony_path]
     format = request.path_parameters[:format] ? "." + request.path_parameters[:format] : ""
-    body_params = TransitUtils.decode_io(request.body, :json) || {}
+    raw_body = request.body.read
+    body_params = TransitUtils.decode(raw_body, :json) || {}
 
     Result::Success.new(
       request: {
@@ -198,7 +199,7 @@ class HarmonyProxyController < ApplicationController
         path: "/" + path + format,
         query_params: request.query_parameters,
         body: body_params,
-        raw_body: request.raw_post()
+        raw_body: raw_body
       })
   end
 

--- a/app/utils/transit_utils.rb
+++ b/app/utils/transit_utils.rb
@@ -39,17 +39,12 @@ module TransitUtils
   # Takes `content` (String) and `encoding` and decodes the Transit
   # message
   def decode(content, encoding)
-    decode_io(StringIO.new(content), encoding)
-  end
-
-  # Takes `content_io` (IO) and `encoding` and decodes the Transit
-  # message
-  def decode_io(content_io, encoding)
     Transit::Reader.new(
       encoding,
-      content_io,
+      StringIO.new(content),
       handlers: {
         "u" => UUIDReadHandler.new
       }).read
   end
+
 end


### PR DESCRIPTION
The request.body is a `StringIO` in development environment, but a
`PhusionPassenger::Utils::TeeInput` in production. Calling the
`request.raw_post` didn't work with the TeeInput and was changed to
using `request.body.read` which works in both envs. However, it should
be only read once to avoid the Transit decoder draining leaving it
empty for the proxy.