### PR TITLE
Manage availability size fixes

### DIFF
--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -369,10 +369,14 @@ module.exports = {
   '--SideWinder_animationDuration': '0.5s',
   '--SideWinder_animationDurationMs': 500,
 
-  '--ManageAvailability_width': 405,
+  // Calendar size without margins/paddings: 274px
+  // Our desired padding: 34px
+  // Total size: 274px + (2 * 34px) = 342x
+  '--ManageAvailability_width': 342,
   '--ManageAvailability_fontFamily': proximaNovaFontFamily,
-  '--ManageAvailability_padding': '20px',
+  '--ManageAvailability_padding': '34px',
   '--ManageAvailability_saveButtonHeight': '60px',
+  '--ManageAvailability_saveButtonPadding': '18px',
   '--ManageAvailabilityHeader_height': 254,
   '--ManageAvailabilityCalendar_fontFamily': proximaNovaFontFamily,
   '--ManageAvailabilityCalendar_fontSize': fontSize,

--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -372,7 +372,8 @@ module.exports = {
   // Calendar size without margins/paddings: 274px
   // Our desired padding: 34px
   // Total size: 274px + (2 * 34px) = 342x
-  '--ManageAvailability_width': 342,
+  '--ManageAvailability_maxWidth': 342,
+  '--ManageAvailability_minWidth': 320,
   '--ManageAvailability_fontFamily': proximaNovaFontFamily,
   '--ManageAvailability_padding': '34px',
   '--ManageAvailability_saveButtonHeight': '60px',

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
@@ -29,9 +29,9 @@
 
 .listingHeader {
   position: absolute;
-  bottom: 34px;
-  left: 34px;
-  right: 34px;
+  bottom: var(--ManageAvailability_padding);
+  left: var(--ManageAvailability_padding);
+  right: var(--ManageAvailability_padding);
   color: #fff;
   font-size: 24px;
   line-height: 1.4;

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
@@ -29,9 +29,11 @@
 
 .listingHeader {
   position: absolute;
-  bottom: var(--ManageAvailability_padding);
-  left: var(--ManageAvailability_padding);
-  right: var(--ManageAvailability_padding);
+  bottom: 0;
+  width: 100%;
+  max-width: var(--ManageAvailability_maxWidth);
+  padding: var(--ManageAvailability_padding);
+  padding-top: 0;
   color: #fff;
   font-size: 24px;
   line-height: 1.4;

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
@@ -2,6 +2,9 @@
   position: relative;
   width: 100%;
   overflow: hidden;
+
+  /* height is set by React, but min-height we can set here */
+  min-height: 190px;
 }
 
 .imageLayer,

--- a/client/app/components/composites/SideWinder/SideWinder.js
+++ b/client/app/components/composites/SideWinder/SideWinder.js
@@ -70,7 +70,7 @@ const syncWindowWidthTo = (el) => {
   /* eslint-enable no-param-reassign */
 };
 
-const calculateWidth = ({max, min}) =>
+const calculateWidth = ({ max, min }) =>
   Math.max((canUseDOM ? Math.min(window.innerWidth, max) : max), min);
 
 class SideWinder extends Component {
@@ -121,7 +121,7 @@ class SideWinder extends Component {
 
     const width = calculateWidth({
       max: this.props.maxWidth,
-      min: this.props.minWidth
+      min: this.props.minWidth,
     });
 
     if (isOpen) {
@@ -152,7 +152,7 @@ class SideWinder extends Component {
             div({
               className: css.root,
               style: {
-                width: width,
+                width,
                 right: -1 * width,
                 top: scrollOffset,
               },

--- a/client/app/components/composites/SideWinder/SideWinder.js
+++ b/client/app/components/composites/SideWinder/SideWinder.js
@@ -4,7 +4,8 @@ Usage:
 
   r(SideWinder, {
     wrapper: document.querySelector('#root'),
-    width: 300,
+    maxWidth: 300,
+    minWidth: 200,
     isOpen: false,
     onClose: handleClose,
   }, [
@@ -30,6 +31,7 @@ import r, { div, button } from 'r-dom';
 import Portal from '../Portal/Portal';
 import SideWinderTransition from './SideWinderTransition';
 import * as cssVariables from '../../../assets/styles/variables';
+import { canUseDOM } from '../../../utils/featureDetection';
 
 import css from './SideWinder.css';
 import closeIcon from './images/close.svg';
@@ -67,6 +69,9 @@ const syncWindowWidthTo = (el) => {
 
   /* eslint-enable no-param-reassign */
 };
+
+const calculateWidth = ({max, min}) =>
+  Math.max((canUseDOM ? Math.min(window.innerWidth, max) : max), min);
 
 class SideWinder extends Component {
   constructor(props) {
@@ -109,12 +114,18 @@ class SideWinder extends Component {
       this.render();
     }
   }
+
   render() {
     const isOpen = this.props.isOpen;
     const scrollOffset = currentScrollOffset();
 
+    const width = calculateWidth({
+      max: this.props.maxWidth,
+      min: this.props.minWidth
+    });
+
     if (isOpen) {
-      this.props.wrapper.style.right = `${this.props.width}px`;
+      this.props.wrapper.style.right = `${width}px`;
     } else {
       this.props.wrapper.style.removeProperty('right');
     }
@@ -141,8 +152,8 @@ class SideWinder extends Component {
             div({
               className: css.root,
               style: {
-                width: this.props.width,
-                right: -1 * this.props.width,
+                width: width,
+                right: -1 * width,
                 top: scrollOffset,
               },
               onTouchMove: (e) => {
@@ -165,7 +176,8 @@ class SideWinder extends Component {
 
 SideWinder.propTypes = {
   wrapper: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  width: PropTypes.number.isRequired,
+  maxWidth: PropTypes.number.isRequired,
+  minWidth: PropTypes.number.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   children: PropTypes.any, // eslint-disable-line react/forbid-prop-types

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -28,11 +28,15 @@
 
 .calendar {
   width: var(--ManageAvailabilityCalendar_width);
-  margin: var(--ManageAvailability_padding) auto 0 auto;
+  /* The desired space between header and calendar month title is 24px.
+  The calendar component already includes 22px padding/margins, so
+  we add only 2px */
+  margin: 2px auto 0 auto;
 }
 
 .saveButton {
-  margin: var(--ManageAvailability_padding);
+  margin: var(--ManageAvailability_saveButtonPadding);
+  padding: 0;
 
   /* This will position the button to the flexbox group bottom.
   See excellent SO answer: http://stackoverflow.com/a/33856609/432787 */

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -27,7 +27,7 @@
 }
 
 .calendar {
-  width: var(--ManageAvailabilityCalendar_width);
+  width: var(--ManageAvailabilityCalendar_width)px;
   /* The desired space between header and calendar month title is 24px.
   The calendar component already includes 22px padding/margins, so
   we add only 2px */

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -27,7 +27,7 @@
 }
 
 .calendar {
-  width: var(--ManageAvailabilityCalendar_width) px;
+  width: var(--ManageAvailabilityCalendar_width);
 
   /* The desired space between header and calendar month title is 24px.
   The calendar component already includes 22px padding/margins, so

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -27,7 +27,8 @@
 }
 
 .calendar {
-  width: var(--ManageAvailabilityCalendar_width)px;
+  width: var(--ManageAvailabilityCalendar_width) px;
+
   /* The desired space between header and calendar month title is 24px.
   The calendar component already includes 22px padding/margins, so
   we add only 2px */

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -1,6 +1,10 @@
 .content {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
   height: 100%;
   font-family: var(--ManageAvailability_fontFamily);
+  overflow-y: auto;
 
   /* --- OVERRIDE DEFAULT STYLES START --- */
 
@@ -19,10 +23,6 @@
     }
   }
 
-  & button {
-    margin: 0;
-  }
-
   /* --- OVERRIDE DEFAULT STYLES END --- */
 }
 
@@ -32,12 +32,13 @@
 }
 
 .saveButton {
-  position: absolute;
-  bottom: -100px;
-  left: var(--ManageAvailability_padding);
-  right: var(--ManageAvailability_padding);
-  width: calc(100% - 2 * var(--ManageAvailability_padding));
+  margin: var(--ManageAvailability_padding);
+
+  /* This will position the button to the flexbox group bottom.
+  See excellent SO answer: http://stackoverflow.com/a/33856609/432787 */
+  margin-top: auto;
   height: var(--ManageAvailability_saveButtonHeight);
+  min-height: var(--ManageAvailability_saveButtonHeight);
   font-size: 16px;
   color: #fff;
   background-color: var(--colorReservedAvailability);

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.story.js
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.story.js
@@ -66,7 +66,8 @@ class ManageAvailabilityWrapper extends Component {
       winder: {
         wrapper: document.querySelector('#root'),
         isOpen: this.state.isOpen,
-        width: cssVariables['--ManageAvailability_width'],
+        maxWidth: cssVariables['--ManageAvailability_maxWidth'],
+        minWidth: cssVariables['--ManageAvailability_minWidth'],
         onClose: () => {
           if (!this.state.hasChanges) {
             console.log('No availability changes to save');

--- a/client/app/components/sections/ManageAvailability/ManageAvailabilityContainer.js
+++ b/client/app/components/sections/ManageAvailability/ManageAvailabilityContainer.js
@@ -27,7 +27,8 @@ const ManageAvailabilityContainer = ({
         onSave: actions.saveChanges,
         winder: {
           wrapper: document.querySelector('#sidewinder-wrapper'),
-          width: cssVariables['--ManageAvailability_width'],
+          maxWidth: cssVariables['--ManageAvailability_maxWidth'],
+          minWidth: cssVariables['--ManageAvailability_minWidth'],
           isOpen,
           onClose: actions.closeEditView,
         },


### PR DESCRIPTION
This PR makes the content a Flexbox, changes the content size and aligns the content. In addition, the PR makes the content scrollable for smaller screens.

The new container width is 342px. The size of the react-dates calendar's day grid without any paddings is 274px (and we can't change this). Our own desired padding is 34px. The total size of the container is 274px + (2 * 34px) = 342x

TODO

- [x] iPhone 5 size (320)

Screenshots:

![dec-15-2016 11-34-54](https://cloud.githubusercontent.com/assets/429876/21219191/62d0b474-c2bc-11e6-8eb9-86149870ec2a.gif)

![screen shot 2016-12-15 at 11 35 59](https://cloud.githubusercontent.com/assets/429876/21219199/6b602502-c2bc-11e6-9527-e24fd334c1bb.png)

![screen shot 2016-12-15 at 15 24 49](https://cloud.githubusercontent.com/assets/429876/21225694/b0589248-c2da-11e6-974d-a145ab0bfce0.png)

![screen shot 2016-12-15 at 15 24 32](https://cloud.githubusercontent.com/assets/429876/21225693/b05833fc-c2da-11e6-974c-b3eccfc755d9.png)


