### PR TITLE
Fix Save button transition

### DIFF
--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -35,15 +35,20 @@
   margin: 2px auto 0 auto;
 }
 
-.saveButton {
-  margin: var(--ManageAvailability_saveButtonPadding);
-  padding: 0;
+.saveButtonContainer {
+  padding: var(--ManageAvailability_saveButtonPadding);
 
   /* This will position the button to the flexbox group bottom.
   See excellent SO answer: http://stackoverflow.com/a/33856609/432787 */
   margin-top: auto;
-  height: var(--ManageAvailability_saveButtonHeight);
-  min-height: var(--ManageAvailability_saveButtonHeight);
+  height: calc(var(--ManageAvailability_saveButtonHeight) + (2 * var(--ManageAvailability_saveButtonPadding)));
+  min-height: calc(var(--ManageAvailability_saveButtonHeight) + (2 * var(--ManageAvailability_saveButtonPadding)));
+  transition: bottom 0.5s;
+  position: relative;
+  overflow: hidden;
+}
+
+.saveButton {
   font-size: 16px;
   font-weight: 600;
   letter-spacing: 0.2px;
@@ -51,8 +56,12 @@
   background-color: var(--colorReservedAvailability);
   border: none;
   border-radius: 4px;
-  transition: bottom 0.5s;
   cursor: pointer;
+  height: var(--ManageAvailability_saveButtonHeight);
+  width: calc(100% - (2 * var(--ManageAvailability_saveButtonPadding)));
+  transition: bottom 0.5s;
+  position: absolute;
+  bottom: -100px;
 
   &[disabled],
   &[disabled]:hover {
@@ -66,5 +75,5 @@
 }
 
 .saveButtonVisible {
-  bottom: var(--ManageAvailability_padding);
+  bottom: var(--ManageAvailability_saveButtonPadding);
 }

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.js
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.js
@@ -12,14 +12,16 @@ import css from './ManageAvailability.css';
 
 const CALENDAR_RENDERING_TIMEOUT = 100;
 
-const SaveButton = (props) => button({
+const SaveButton = (props) => div({
+  className: css.saveButtonContainer,
+}, button({
   className: classNames({
     [css.saveButton]: true,
     [css.saveButtonVisible]: props.isVisible,
   }),
   disabled: props.isDisabled,
   onClick: props.onClick,
-}, t('web.listings.save_and_close_availability_editing'));
+}, t('web.listings.save_and_close_availability_editing')));
 
 SaveButton.propTypes = {
   isVisible: PropTypes.bool.isRequired,


### PR DESCRIPTION
Fix regression: Save button always visible.

This PR adds a container around the save button. The container is needed in order to reserve the right amount of space for the button, even if it's not visible. 