### PR TITLE
Change availability manage copy texts

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -551,9 +551,17 @@ class ListingsController < ApplicationController
   def update_flash(old_availability:, new_availability:)
     case [new_availability.to_sym == :booking, old_availability.to_sym == :booking]
     when [true, false]
-      t("layouts.notifications.listing_updated_availability_enabled")
+      if FeatureFlagHelper.feature_enabled?(:manage_availability)
+        t("layouts.notifications.listing_updated_availability_management_enabled")
+      else
+        t("layouts.notifications.listing_updated_availability_enabled")
+      end
     when [false, true]
-      t("layouts.notifications.listing_updated_availability_disabled")
+      if FeatureFlagHelper.feature_enabled?(:manage_availability)
+        t("layouts.notifications.listing_updated_availability_management_disabled")
+      else
+        t("layouts.notifications.listing_updated_availability_disabled")
+      end
     else
       t("layouts.notifications.listing_updated_successfully")
     end

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -64,12 +64,18 @@
         = label_tag("", t("admin.listing_shapes.availability_title"), class: "input")
 
         - if display_knowledge_base_articles
-          = render :partial => "layouts/info_text", :locals => { :text => link_to(t("admin.listing_shapes.read_more"), "#{knowledge_base_url}/articles/1097116").html_safe }
+          - if feature_enabled?(:manage_availability)
+            = render :partial => "layouts/info_text", :locals => { :text => link_to(t("admin.listing_shapes.read_more_availability_management"), "#{knowledge_base_url}/articles/1116607").html_safe }
+          - else
+            = render :partial => "layouts/info_text", :locals => { :text => link_to(t("admin.listing_shapes.read_more"), "#{knowledge_base_url}/articles/1097116").html_safe }
 
     .row
       .col-12
         = check_box_tag(:availability, "booking", shape[:availability] == :booking, class: "checkbox-row-checkbox js-availability")
-        = label_tag(:availability, t("admin.listing_shapes.allow_availability_management"), class: "checkbox-row-label js-availability-label")
+        - if feature_enabled?(:manage_availability)
+          = label_tag(:availability, t("admin.listing_shapes.allow_providers_to_manage_availability"), class: "checkbox-row-label js-availability-label")
+        - else
+          = label_tag(:availability, t("admin.listing_shapes.allow_availability_management"), class: "checkbox-row-label js-availability-label")
 
     .row
       .col-12

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -386,7 +386,9 @@ en:
     listing_shapes:
       availability_title: Availability
       read_more: "Read more about automatic availability management."
+      read_more_availability_management: "Read more about availability management."
       allow_availability_management: "Enable automatic availability management (prevent double bookings)"
+      allow_providers_to_manage_availability: "Allow providers to manage their availability from a calendar"
       per_day_availability: "\"Per day\" availability"
       per_night_availability: "\"Per night\" availability"
       pricing_units_disabled_info: "Pricing units cannot be used when availability calendar is enabled."
@@ -1255,6 +1257,8 @@ en:
       listing_updated_successfully: "Listing updated successfully"
       listing_updated_availability_enabled: "Listing updated successfully. Automatic availability management enabled."
       listing_updated_availability_disabled: "Listing updated successfully. Automatic availability management disabled."
+      listing_updated_availability_management_enabled: "Listing updated successfully. Availability management enabled."
+      listing_updated_availability_management_disabled: "Listing updated successfully. Availability management disabled."
       only_kassi_administrators_can_access_this_area: "Only %{service_name} administrators can access this area"
       only_listing_author_can_close_a_listing: "Only listing author can close a listing"
       only_listing_author_can_edit_a_listing: "Only listing author can edit a listing"


### PR DESCRIPTION
Following texts have been changes:

- Admin order types: Availability management title
- Admin order types: Link title to availability management KB article
- Admin order types: Link target to availability management KB article
- Listing updated: Flash

All changes are behind a feature flag, meaning that users who don't have the feature flag on will continue to see the old texts.

Listing updated flash: 
![screen shot 2016-12-19 at 10 42 27](https://cloud.githubusercontent.com/assets/429876/21306296/ee00e7a2-c5d8-11e6-8c28-96a0447749e3.png)

Order types admin:

![screen shot 2016-12-19 at 10 39 29](https://cloud.githubusercontent.com/assets/429876/21306297/ee01d2c0-c5d8-11e6-99a8-e2691653f40e.png)
