### PR TITLE
Fix availability management UI in Mobile Safari

### DIFF
--- a/client/app/assets/styles/variables.js
+++ b/client/app/assets/styles/variables.js
@@ -369,15 +369,14 @@ module.exports = {
   '--SideWinder_animationDuration': '0.5s',
   '--SideWinder_animationDurationMs': 500,
 
-  // Calendar size without margins/paddings: 274px
-  // Our desired padding: 34px
-  // Total size: 274px + (2 * 34px) = 342x
+  // Calendar width without margin/padding is also used for other
+  // content items.
+  '--ManageAvailability_contentWidth': '274px',
   '--ManageAvailability_maxWidth': 342,
   '--ManageAvailability_minWidth': 320,
   '--ManageAvailability_fontFamily': proximaNovaFontFamily,
   '--ManageAvailability_padding': '34px',
   '--ManageAvailability_saveButtonHeight': '60px',
-  '--ManageAvailability_saveButtonPadding': '18px',
   '--ManageAvailabilityHeader_height': 254,
   '--ManageAvailabilityCalendar_fontFamily': proximaNovaFontFamily,
   '--ManageAvailabilityCalendar_fontSize': fontSize,

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
@@ -4,7 +4,7 @@
   overflow: hidden;
 
   /* height is set by React, but min-height we can set here */
-  min-height: 190px;
+  min-height: 135px;
 }
 
 .imageLayer,

--- a/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
+++ b/client/app/components/composites/ManageAvailabilityHeader/ManageAvailabilityHeader.css
@@ -29,11 +29,10 @@
 
 .listingHeader {
   position: absolute;
-  bottom: 0;
-  width: 100%;
-  max-width: var(--ManageAvailability_maxWidth);
-  padding: var(--ManageAvailability_padding);
-  padding-top: 0;
+  bottom: var(--ManageAvailability_padding);
+  width: var(--ManageAvailability_contentWidth);
+  left: 50%;
+  margin-left: calc(-1 * (var(--ManageAvailability_contentWidth) / 2));
   color: #fff;
   font-size: 24px;
   font-weight: 500;

--- a/client/app/components/composites/SideWinder/SideWinder.css
+++ b/client/app/components/composites/SideWinder/SideWinder.css
@@ -23,7 +23,7 @@
 .root {
   position: absolute;
   top: 0;
-  height: 100vh;
+  height: 100%;
 }
 
 .overlay {

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -41,14 +41,11 @@
 }
 
 .saveButtonContainer {
-  padding: var(--ManageAvailability_saveButtonPadding);
-
   /* This will position the button to the flexbox group bottom.
   See excellent SO answer: http://stackoverflow.com/a/33856609/432787 */
   margin-top: auto;
-  height: calc(var(--ManageAvailability_saveButtonHeight) + (2 * var(--ManageAvailability_saveButtonPadding)));
-  min-height: calc(var(--ManageAvailability_saveButtonHeight) + (2 * var(--ManageAvailability_saveButtonPadding)));
-  transition: bottom 0.5s;
+  height: calc(var(--ManageAvailability_saveButtonHeight) + var(--ManageAvailability_padding));
+  min-height: calc(var(--ManageAvailability_saveButtonHeight) + var(--ManageAvailability_padding));
   position: relative;
   overflow: hidden;
 }
@@ -63,10 +60,12 @@
   border-radius: 4px;
   cursor: pointer;
   height: var(--ManageAvailability_saveButtonHeight);
-  width: calc(100% - (2 * var(--ManageAvailability_saveButtonPadding)));
+  width: var(--ManageAvailability_contentWidth);
   transition: bottom 0.5s;
   position: absolute;
-  bottom: -100px;
+  left: 50%;
+  margin: 0 0 0 calc(-1 * (var(--ManageAvailability_contentWidth) / 2));
+  bottom: calc(-2 * var(--ManageAvailability_saveButtonHeight));
 
   &[disabled],
   &[disabled]:hover {
@@ -81,5 +80,5 @@
 }
 
 .saveButtonVisible {
-  bottom: var(--ManageAvailability_saveButtonPadding);
+  bottom: var(--ManageAvailability_padding);
 }

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.css
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.css
@@ -23,6 +23,11 @@
     }
   }
 
+  & button {
+    display: block;
+    line-height: 1;
+  }
+
   /* --- OVERRIDE DEFAULT STYLES END --- */
 }
 
@@ -68,7 +73,8 @@
     background-color: #eee;
   }
 
-  &:hover {
+  &:hover,
+  &:active {
     transition: background-color 0.1s ease-in;
     background-color: var(--colorReservedAvailabilityDark);
   }

--- a/client/app/components/sections/ManageAvailability/ManageAvailability.story.js
+++ b/client/app/components/sections/ManageAvailability/ManageAvailability.story.js
@@ -59,6 +59,7 @@ class ManageAvailabilityWrapper extends Component {
         this.setState({ isOpen: true });
       },
       hasChanges: this.state.hasChanges,
+      saveInProgress: false,
       onSave: () => {
         console.log('Saving availability changes');
         this.setState({ hasChanges: false, isOpen: false });


### PR DESCRIPTION
This PR fixes the availability management UI in iPhone 5/6/7 screen sizes. Fixes include:

 - Use `100%` viewport height instead of `100vh` to avoid browser top/bottom bars [overlay the content](https://github.com/bokand/URLBarSizing)
 - Since the calendar width is fixed, fix the header text and bottom save button widths as well and let the margins be dynamic => unified margins in different container widths
 - Fix header height to take less space on small screens

## Screenshots:

Here are some screenshots with a maximally long listing title and a month that has 6 week rows.

iPhone 5 (Chrome devtools):

![iphone5](https://cloud.githubusercontent.com/assets/53923/21313945/2458d8f4-c5fd-11e6-9e5c-db2edcb8683d.png)

iPhone 6 (Chrome devtools):

![iphone6](https://cloud.githubusercontent.com/assets/53923/21313953/2a9b9ddc-c5fd-11e6-8676-ae153c09e6e5.png)

iPhone 7 (simulator):

![iphone7](https://cloud.githubusercontent.com/assets/53923/21313971/395fbb1e-c5fd-11e6-93d5-1e73069ee3b7.png)
