### PR TITLE
Change PayPal upgrade link for Brazilian marketplaces

### DIFF
--- a/app/controllers/paypal_accounts_controller.rb
+++ b/app/controllers/paypal_accounts_controller.rb
@@ -40,9 +40,9 @@ class PaypalAccountsController < ApplicationController
       currency: community_currency,
       paypal_fees_url: PaypalCountryHelper.fee_link(community_country_code),
       create_url: PaypalCountryHelper.create_paypal_account_url(community_country_code),
+      upgrade_url: PaypalCountryHelper.upgrade_paypal_account_url(community_country_code),
       receive_funds_info_label_tr_key: PaypalCountryHelper.receive_funds_info_label_tr_key(community_country_code),
-      receive_funds_info_tr_key: PaypalCountryHelper.receive_funds_info_tr_key(community_country_code),
-      upgrade_url: "https://www.paypal.com/#{community_country_code}/upgrade"
+      receive_funds_info_tr_key: PaypalCountryHelper.receive_funds_info_tr_key(community_country_code)
     })
   end
 

--- a/app/view_utils/paypal_country_helper.rb
+++ b/app/view_utils/paypal_country_helper.rb
@@ -21,7 +21,6 @@ module PaypalCountryHelper
 
   FEE_URL.default = "https://www.paypal.com/cgi-bin/marketingweb?cmd=_display-xborder-fees-outside"
 
-
   POPUP_URL = {
     # List all the contries that have the popup URL available
     "us" => "https://www.paypal.com/us/webapps/mpp/paypal-popup",
@@ -38,13 +37,17 @@ module PaypalCountryHelper
 
   POPUP_URL.default = "https://www.paypal.com/webapps/mpp/paypal-popup"
 
-
   CREATE_ACCOUNT_URL = {
     "au" => "https://www.paypal.com/au/webapps/mpp/account-selection",
   }
 
   CREATE_ACCOUNT_URL.default = "https://www.paypal.com/%{country_code}/webapps/mpp/home"
 
+  UPGRADE_ACCOUNT_URL = {
+    "br" => "https://www.paypal.com/br/cgi-bin/webscr?cmd=_business-upgrade-flow",
+  }
+
+  UPGRADE_ACCOUNT_URL.default = "https://www.paypal.com/%{country_code}/upgrade"
 
   RECEIVE_FUNDS_INFO_LABEL_TR_KEY = {
     "au" => "paypal_accounts.paypal_receive_funds_info_label_australia_only",
@@ -70,6 +73,10 @@ module PaypalCountryHelper
 
   def create_paypal_account_url(country_code)
     CREATE_ACCOUNT_URL[country_code.to_s.downcase] % {country_code: country_code}
+  end
+
+  def upgrade_paypal_account_url(country_code)
+    UPGRADE_ACCOUNT_URL[country_code.to_s.downcase] % {country_code: country_code}
   end
 
   def receive_funds_info_label_tr_key(country_code)


### PR DESCRIPTION
The standard upgrade link `https://www.paypal.com/%{country_code}/upgrade` works fine in all countries but for Brazilian marketplaces `https://www.paypal.com/br/cgi-bin/webscr?cmd=_business-upgrade-flow` takes the user straight to an account upgrade view.