### PR TITLE
Calendar timezone fixes

### DIFF
--- a/client/app/actions/ManageAvailabilityActions.js
+++ b/client/app/actions/ManageAvailabilityActions.js
@@ -2,7 +2,7 @@ import Immutable from 'immutable';
 import * as actionTypes from '../constants/ManageAvailabilityConstants';
 import * as harmony from '../services/harmony';
 import { t } from '../utils/i18n';
-import { expandRange } from '../utils/moment';
+import { expandRange, fromMidnightUTCDate, toMidnightUTCDate } from '../utils/moment';
 import { addFlashNotification } from './FlashNotificationActions';
 import { blockChanges, unblockChanges } from '../reducers/ManageAvailabilityReducer';
 
@@ -76,6 +76,16 @@ const removeLoadedMonths = (months, loadedMonths) => ({
   end: months.findLast((e) => !loadedMonths.includes(e)),
 });
 
+const convertBlocksFromUTCMidnightDates = (blocks) =>
+  blocks.map((block) =>
+    block.updateIn([':attributes', ':start'], fromMidnightUTCDate)
+         .updateIn([':attributes', ':end'], fromMidnightUTCDate));
+
+const convertBlocksToUTCMidnightDates = (blocks) =>
+  blocks.map((block) =>
+    block.updateIn(['start'], toMidnightUTCDate)
+         .updateIn(['end'], toMidnightUTCDate));
+
 const monthsToLoad = (day, loadedMonths, preloadMonths) =>
   removeLoadedMonths(loadRange(day, preloadMonths), loadedMonths);
 
@@ -92,15 +102,15 @@ export const changeMonth = (day) =>
         refId: state.get('listingUuid'),
         marketplaceId: state.get('marketplaceUuid'),
         include: ['blocks', 'bookings'],
-        start: start,
-        end: end,
+        start: toMidnightUTCDate(start),
+        end: toMidnightUTCDate(end),
       })
       .then((response) => {
         const groups = response.get(':included').groupBy((v) => v.get(':type'));
 
         const slots = Immutable.Map({
-          blocks: groups.get(':block', Immutable.List()),
-          bookings: groups.get(':booking', Immutable.List()),
+          blocks: convertBlocksFromUTCMidnightDates(groups.get(':block', Immutable.List())),
+          bookings: convertBlocksFromUTCMidnightDates(groups.get(':booking', Immutable.List())),
         });
 
         dispatch(dataLoaded(slots, expandRange(start, end, 'months').toSet()));
@@ -133,7 +143,7 @@ export const saveChanges = () =>
     const state = getState().manageAvailability;
     const marketplaceId = state.get('marketplaceUuid');
     const listingId = state.get('listingUuid');
-    const blocks = blockChanges(state);
+    const blocks = convertBlocksToUTCMidnightDates(blockChanges(state));
     const unblocks = unblockChanges(state);
     const requests = [];
 

--- a/client/app/actions/ManageAvailabilityActions.js
+++ b/client/app/actions/ManageAvailabilityActions.js
@@ -88,12 +88,12 @@ export const changeMonth = (day) =>
     const { start, end } = monthsToLoad(day, state.get('loadedMonths'), PRELOAD_MONTHS);
 
     if (start && end) {
-      harmony.get('/bookables/show', {
+      harmony.showBookable({
         refId: state.get('listingUuid'),
         marketplaceId: state.get('marketplaceUuid'),
-        include: ['blocks', 'bookings'].join(','),
-        start: start.toJSON(),
-        end: end.toJSON(),
+        include: ['blocks', 'bookings'],
+        start: start,
+        end: end,
       })
       .then((response) => {
         const groups = response.get(':included').groupBy((v) => v.get(':type'));

--- a/client/app/reducers/ManageAvailabilityReducer.js
+++ b/client/app/reducers/ManageAvailabilityReducer.js
@@ -7,7 +7,6 @@ import { expandRange } from '../utils/moment';
 const initialState = Immutable.Map({
   isOpen: true,
   visibleMonth: moment()
-    .utc()
     .startOf('month'),
 
   // List of days that buyers have booked. These cannot be blocked.
@@ -183,7 +182,6 @@ const clearState = (state) =>
       .set('changes', Immutable.List())
       .set('loadedMonths', Immutable.Set())
       .set('visibleMonth', moment()
-           .utc()
            .startOf('month'));
 
 const manageAvailabilityReducer = (state = initialState, action) => {

--- a/client/app/services/harmony.js
+++ b/client/app/services/harmony.js
@@ -5,11 +5,6 @@ import { createReader, createWriter } from '../utils/transitImmutableConverter';
 /**
   harmony.js defines a interface for Harmony API.
 
-  It exports two functions:
-
-  - get(url, queryParams)
-  - TODO post(url, queryParams, body)
-
   Internally, harmony.js sets the correct headers to the request and
   also extracts the correct CSRF token from the <meta> tag.
  */
@@ -69,19 +64,30 @@ const sendRequest = (method, url, queryParams, body) => {
                });
 };
 
-const get = (url, queryParams) =>
-  sendRequest('get', url, queryParams);
+/**
+   Create blocks
 
+   @param {UUID} refId - listing UUID
+   @param {UUID} marketplaceId - marketplace UUID
+   @param {Immutable.Map} blocks - List of new blocks. `start` and `end` must be midnight UTC Dates
+*/
 export const createBlocks = (marketplaceId, refId, blocks) =>
   sendRequest('post', '/bookables/createBlocks', {}, {
     ':marketplaceId': marketplaceId,
     ':refId': refId,
     ':blocks': blocks.map((b) => Immutable.Map({
-      ':start': b.get('start').toDate(),
-      ':end': b.get('end').toDate(),
+      ':start': b.get('start'),
+      ':end': b.get('end'),
     })),
   });
 
+/**
+   Delete blocks
+
+   @param {UUID} refId - listing UUID
+   @param {UUID} marketplaceId - marketplace UUID
+   @param {Array} blockIds - Array of block UUIDs
+*/
 export const deleteBlocks = (marketplaceId, refId, blockIds) =>
   sendRequest('post', '/bookables/deleteBlocks', {}, {
     ':marketplaceId': marketplaceId,
@@ -91,11 +97,19 @@ export const deleteBlocks = (marketplaceId, refId, blockIds) =>
     })),
   });
 
-export const showBookable = ({refId, marketplaceId, include, start, end}) =>
+/**
+   Show bookables
+
+   @param {UUID} refId - listing UUID
+   @param {UUID} marketplaceId - marketplace UUID
+   @param {Date} start - start date (midnight UTC)
+   @param {Date} end - end date (midnight UTC)
+*/
+export const showBookable = ({ refId, marketplaceId, include, start, end }) =>
   sendRequest('get', '/bookables/show', {
     refId,
     marketplaceId,
     include: (include || []).join(','),
     start: start.toJSON(),
     end: end.toJSON(),
-  })
+  });

--- a/client/app/services/harmony.js
+++ b/client/app/services/harmony.js
@@ -69,7 +69,7 @@ const sendRequest = (method, url, queryParams, body) => {
                });
 };
 
-export const get = (url, queryParams) =>
+const get = (url, queryParams) =>
   sendRequest('get', url, queryParams);
 
 export const createBlocks = (marketplaceId, refId, blocks) =>

--- a/client/app/services/harmony.js
+++ b/client/app/services/harmony.js
@@ -90,3 +90,12 @@ export const deleteBlocks = (marketplaceId, refId, blockIds) =>
       ':id': id,
     })),
   });
+
+export const showBookable = ({refId, marketplaceId, include, start, end}) =>
+  sendRequest('get', '/bookables/show', {
+    refId,
+    marketplaceId,
+    include: (include || []).join(','),
+    start: start.toJSON(),
+    end: end.toJSON(),
+  })

--- a/client/app/specs/date.spec.js
+++ b/client/app/specs/date.spec.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+
+import { fromMidnightUTCDate, toMidnightUTCDate } from '../utils/date';
+
+describe('Date utils', () => {
+  describe('fromMidnightUTCDate', () => {
+    it('converts midnight UTC dates to local midnight dates', () => {
+      // Wednesday 21th Dec, midnight, UTC
+      var utc21dec = new Date(Date.UTC(2016, 11, 21, 0, 0, 0, 0));
+
+      // Wednesday 21th Dec, midnight, local timezone
+      var local21dec = new Date(2016, 11, 21, 0, 0, 0, 0);
+
+      expect(fromMidnightUTCDate(utc21dec).getTime()).to.equal(local21dec.getTime());
+    });
+  });
+
+  describe('toMidnightUTCDate', () => {
+    it('converts local midnight dates to midnight UTC dates', () => {
+      // Wednesday 21th Dec, midnight, UTC
+      var utc21dec = new Date(Date.UTC(2016, 11, 21, 0, 0, 0, 0));
+
+      // Wednesday 21th Dec, midnight, local timezone
+      var local21dec = new Date(2016, 11, 21, 0, 0, 0, 0);
+
+      expect(toMidnightUTCDate(local21dec).getTime()).to.equal(utc21dec.getTime());
+    });
+  });
+});

--- a/client/app/specs/date.spec.js
+++ b/client/app/specs/date.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-magic-numbers */
+
 import { expect } from 'chai';
 
 import { fromMidnightUTCDate, toMidnightUTCDate } from '../utils/date';
@@ -6,10 +8,10 @@ describe('Date utils', () => {
   describe('fromMidnightUTCDate', () => {
     it('converts midnight UTC dates to local midnight dates', () => {
       // Wednesday 21th Dec, midnight, UTC
-      var utc21dec = new Date(Date.UTC(2016, 11, 21, 0, 0, 0, 0));
+      const utc21dec = new Date(Date.UTC(2016, 11, 21, 0, 0, 0, 0));
 
       // Wednesday 21th Dec, midnight, local timezone
-      var local21dec = new Date(2016, 11, 21, 0, 0, 0, 0);
+      const local21dec = new Date(2016, 11, 21, 0, 0, 0, 0);
 
       expect(fromMidnightUTCDate(utc21dec).getTime()).to.equal(local21dec.getTime());
     });
@@ -18,10 +20,10 @@ describe('Date utils', () => {
   describe('toMidnightUTCDate', () => {
     it('converts local midnight dates to midnight UTC dates', () => {
       // Wednesday 21th Dec, midnight, UTC
-      var utc21dec = new Date(Date.UTC(2016, 11, 21, 0, 0, 0, 0));
+      const utc21dec = new Date(Date.UTC(2016, 11, 21, 0, 0, 0, 0));
 
       // Wednesday 21th Dec, midnight, local timezone
-      var local21dec = new Date(2016, 11, 21, 0, 0, 0, 0);
+      const local21dec = new Date(2016, 11, 21, 0, 0, 0, 0);
 
       expect(toMidnightUTCDate(local21dec).getTime()).to.equal(utc21dec.getTime());
     });

--- a/client/app/startup/ManageAvailabilityApp.js
+++ b/client/app/startup/ManageAvailabilityApp.js
@@ -24,7 +24,6 @@ export default (props) => {
     manageAvailability: Immutable.Map({
       isOpen: window.location.hash.replace(/^#/, '') === EDIT_VIEW_OPEN_HASH,
       visibleMonth: moment()
-        .utc()
         .startOf('month'),
       bookings: Immutable.List(),
       blocks: Immutable.List(),

--- a/client/app/utils/date.js
+++ b/client/app/utils/date.js
@@ -1,0 +1,30 @@
+/*
+   Common utilities for handling JavaScript native Date objects
+*/
+
+
+/* Takes a UTC midnight date and converts it to local midnight date */
+export const fromMidnightUTCDate = (d) =>
+  new Date(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate(),
+    0, // h
+    0, // min
+    0, // s
+    0 // ms
+  )
+
+/* Takes a JavaScript Date in local timezone and converts it to UTC
+midnight date */
+export const toMidnightUTCDate = (d) =>
+  new Date(
+    Date.UTC(
+      d.getFullYear(),
+      d.getMonth(),
+      d.getDate(),
+      0, // h
+      0, // min
+      0, // s
+      0 // ms
+    ))

--- a/client/app/utils/date.js
+++ b/client/app/utils/date.js
@@ -2,18 +2,17 @@
    Common utilities for handling JavaScript native Date objects
 */
 
-
 /* Takes a UTC midnight date and converts it to local midnight date */
 export const fromMidnightUTCDate = (d) =>
   new Date(
     d.getUTCFullYear(),
     d.getUTCMonth(),
     d.getUTCDate(),
-    0, // h
-    0, // min
-    0, // s
-    0 // ms
-  )
+    0,
+    0,
+    0,
+    0
+  );
 
 /* Takes a JavaScript Date in local timezone and converts it to UTC
 midnight date */
@@ -23,8 +22,8 @@ export const toMidnightUTCDate = (d) =>
       d.getFullYear(),
       d.getMonth(),
       d.getDate(),
-      0, // h
-      0, // min
-      0, // s
-      0 // ms
-    ))
+      0,
+      0,
+      0,
+      0
+    ));

--- a/client/app/utils/moment.js
+++ b/client/app/utils/moment.js
@@ -4,6 +4,8 @@
  */
 
 import Immutable from 'immutable';
+import * as date from './date';
+import moment from 'moment';
 
 /**
    Takes a time range (`start` and `end` (exclusive)) and returns an Immutable List
@@ -27,3 +29,9 @@ import Immutable from 'immutable';
 export const expandRange = (start, end, duration) =>
   Immutable.Range(0, end.diff(start, duration)).map(
     (i) => start.clone().add(i, duration));
+
+export const fromMidnightUTCDate = (d) =>
+  moment(date.fromMidnightUTCDate(d));
+
+export const toMidnightUTCDate = (d) =>
+  date.toMidnightUTCDate(d.toDate());


### PR DESCRIPTION
This PR fixes the timezone issues in calendar. The main two issues were:

1. Wrong day is shown as the current day, if the system timezone is such that the day of month is different than in UTC timezone
1. Wrong day gets blocked, if the system timezone is such that the day of month is different than in UTC timezone

Harmony server is in UTC and it expects days represented as midnight date in UTC. User's browser is in users local timezone and the calendar expects days in local timezone UTC.

Because of this, two main helper functions were added.

`fromMidnightUTCDate(<Tue, 20 Dec 2016 00:00:00 GMT>) => <Tue Dec 20 2016 00:00:00 GMT+0200>`

`toMidnightUTCDate(<Tue, 20 Dec 2016 00:00:00 GMT+0200>) => <Tue Dec 20 2016 00:00:00 GMT>`

All the dates coming from server, we run through `fromMidnightUTCDate`. All the dates we are about to send to server, we run through `toMidnightUTCDate`

In addition addition to that, two changes have been made to the `harmony` data layer:

- Added `showBookable` method and removed the generic `get` method.
- Changed the data layer so that it expects native JS Date objects, instead of `moment` instances.

**Steps to reproduce the bugs:** See the Trello cards.