### PR TITLE
Enable availability management for all

### DIFF
--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -55,7 +55,7 @@ class IntApi::MarketplacesController < ApplicationController
 
     # Enable specific features for all new trials
     FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], person_id: user[:id], features: [:topbar_v1])
-    FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], features: [:topbar_v1])
+    FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], features: [:topbar_v1, :manage_availability])
 
     # TODO handle error cases with proper response
 

--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -55,7 +55,7 @@ class IntApi::MarketplacesController < ApplicationController
 
     # Enable specific features for all new trials
     FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], person_id: user[:id], features: [:topbar_v1])
-    FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], features: [:topbar_v1, :manage_availability])
+    FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], features: [:topbar_v1])
 
     # TODO handle error cases with proper response
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -364,7 +364,7 @@ class ListingsController < ApplicationController
           flash[:show_onboarding_popup] = true
         end
 
-        if shape[:availability] == :booking && FeatureFlagHelper.feature_enabled?(:manage_availability)
+        if shape[:availability] == :booking
           redirect_to listing_path(@listing, anchor: 'manage-availability'), status: 303 and return
         end
 
@@ -551,17 +551,9 @@ class ListingsController < ApplicationController
   def update_flash(old_availability:, new_availability:)
     case [new_availability.to_sym == :booking, old_availability.to_sym == :booking]
     when [true, false]
-      if FeatureFlagHelper.feature_enabled?(:manage_availability)
-        t("layouts.notifications.listing_updated_availability_management_enabled")
-      else
-        t("layouts.notifications.listing_updated_availability_enabled")
-      end
+      t("layouts.notifications.listing_updated_availability_management_enabled")
     when [false, true]
-      if FeatureFlagHelper.feature_enabled?(:manage_availability)
-        t("layouts.notifications.listing_updated_availability_management_disabled")
-      else
-        t("layouts.notifications.listing_updated_availability_disabled")
-      end
+      t("layouts.notifications.listing_updated_availability_management_disabled")
     else
       t("layouts.notifications.listing_updated_successfully")
     end

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -20,7 +20,6 @@ module FeatureFlagService::Store
       :export_transactions_as_csv,
       :topbar_v1,
       :searchpage_v1,
-      :manage_availability,
       :manage_searchpage
     ].to_set
 

--- a/app/services/transaction_type_creator.rb
+++ b/app/services/transaction_type_creator.rb
@@ -21,8 +21,9 @@ module TransactionTypeCreator
     },
     "Rent" => {
       price_enabled: true,
+      availability: :booking,
       units: [
-        {type: :day, quantity_selector: :day}
+        {type: :night, quantity_selector: :night}
       ]
     },
     "Request" => {

--- a/app/view_utils/listing_shape_templates.rb
+++ b/app/view_utils/listing_shape_templates.rb
@@ -57,7 +57,8 @@ class ListingShapeTemplates
         online_payments: true,
         template: :renting_products,
         author_is_seller: true,
-        units: [{type: :day, quantity_selector: :day}, {type: :week, quantity_selector: :number}, {type: :month, quantity_selector: :number}]
+        availability: :booking,
+        units: [{type: :night, quantity_selector: :night}]
       },
       {
         label: "admin.listing_shapes.templates.offering_services",

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -70,15 +70,16 @@
       .col-12
         = check_box_tag(:availability, "booking", shape[:availability] == :booking, class: "checkbox-row-checkbox js-availability")
         = label_tag(:availability, t("admin.listing_shapes.allow_providers_to_manage_availability"), class: "checkbox-row-label js-availability-label")
-    .row
-      .col-12
-        = radio_button_tag(:availability_unit, "day", shape[:availability] == :booking && shape[:availability_unit] == :day, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
-        = label_tag(:availability, t("admin.listing_shapes.per_day_availability"), class: "checkbox-row-label js-availability-unit-label")
 
     .row
       .col-12
         = radio_button_tag(:availability_unit, "night", shape[:availability] == :booking && shape[:availability_unit] == :night, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
         = label_tag(:availability, t("admin.listing_shapes.per_night_availability"), class: "checkbox-row-label js-availability-unit-label")
+
+    .row
+      .col-12
+        = radio_button_tag(:availability_unit, "day", shape[:availability] == :booking && shape[:availability_unit] == :day, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")
+        = label_tag(:availability, t("admin.listing_shapes.per_day_availability"), class: "checkbox-row-label js-availability-unit-label")
 
 .row
   .col-12

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -64,19 +64,12 @@
         = label_tag("", t("admin.listing_shapes.availability_title"), class: "input")
 
         - if display_knowledge_base_articles
-          - if feature_enabled?(:manage_availability)
-            = render :partial => "layouts/info_text", :locals => { :text => link_to(t("admin.listing_shapes.read_more_availability_management"), "#{knowledge_base_url}/articles/1116607").html_safe }
-          - else
-            = render :partial => "layouts/info_text", :locals => { :text => link_to(t("admin.listing_shapes.read_more"), "#{knowledge_base_url}/articles/1097116").html_safe }
+          = render :partial => "layouts/info_text", :locals => { :text => link_to(t("admin.listing_shapes.read_more_availability_management"), "#{knowledge_base_url}/articles/1116607").html_safe }
 
     .row
       .col-12
         = check_box_tag(:availability, "booking", shape[:availability] == :booking, class: "checkbox-row-checkbox js-availability")
-        - if feature_enabled?(:manage_availability)
-          = label_tag(:availability, t("admin.listing_shapes.allow_providers_to_manage_availability"), class: "checkbox-row-label js-availability-label")
-        - else
-          = label_tag(:availability, t("admin.listing_shapes.allow_availability_management"), class: "checkbox-row-label js-availability-label")
-
+        = label_tag(:availability, t("admin.listing_shapes.allow_providers_to_manage_availability"), class: "checkbox-row-label js-availability-label")
     .row
       .col-12
         = radio_button_tag(:availability_unit, "day", shape[:availability] == :booking && shape[:availability_unit] == :day, class: "checkbox-row-checkbox js-availability-unit", style: "margin-left: 1em")

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -171,7 +171,7 @@
         %a.icon-with-text-container{href: edit_listing_path(@listing)}
           = icon_tag("edit", ["icon-part"])
           .text-part= t("listings.edit_links.edit_listing")
-      - if show_manage_availability && FeatureFlagHelper.feature_enabled?(:manage_availability)
+      - if show_manage_availability
         - availability_link_id = "edit-listing-availability-#{SecureRandom.urlsafe_base64(5)}"
         .listing-view-admin-link
           %a.icon-with-text-container{id: availability_link_id, href: "#manage-availability"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -387,7 +387,6 @@ en:
       availability_title: Availability
       read_more: "Read more about automatic availability management."
       read_more_availability_management: "Read more about availability management."
-      allow_availability_management: "Enable automatic availability management (prevent double bookings)"
       allow_providers_to_manage_availability: "Allow providers to manage their availability from a calendar"
       per_day_availability: "\"Per day\" availability"
       per_night_availability: "\"Per night\" availability"
@@ -1255,8 +1254,6 @@ en:
       offer_rejected: "Offer rejected"
       offer_canceled: "Offer canceled"
       listing_updated_successfully: "Listing updated successfully"
-      listing_updated_availability_enabled: "Listing updated successfully. Automatic availability management enabled."
-      listing_updated_availability_disabled: "Listing updated successfully. Automatic availability management disabled."
       listing_updated_availability_management_enabled: "Listing updated successfully. Availability management enabled."
       listing_updated_availability_management_disabled: "Listing updated successfully. Availability management disabled."
       only_kassi_administrators_can_access_this_area: "Only %{service_name} administrators can access this area"

--- a/spec/services/marketplace_service/marketplaces_spec.rb
+++ b/spec/services/marketplace_service/marketplaces_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe MarketplaceService::API::Marketplaces do
   include MarketplaceService::API::Marketplaces
 
@@ -44,19 +46,22 @@ describe MarketplaceService::API::Marketplaces do
       c = Community.find(community_hash[:id])
       s = listings_api.shapes.get(community_id: c.id).data.first
       expect(s[:units].empty?).to eql true
+      expect(s[:availability]).to eql :none
       expect(s[:price_enabled]).to eql true
       expect(s[:shipping_enabled]).to eql true
 
       community_hash = create(@community_params.merge({:marketplace_type => "rental"}))
       c = Community.find(community_hash[:id])
       s = listings_api.shapes.get(community_id: c.id).data.first
-      expect(s[:units][0][:type]).to eql :day
+      expect(s[:availability]).to eql :booking
+      expect(s[:units][0][:type]).to eql :night
       expect(s[:price_enabled]).to eql true
       expect(s[:shipping_enabled]).to eql false
 
       community_hash = create(@community_params.merge({:marketplace_type => "service"}))
       c = Community.find(community_hash[:id])
       s = listings_api.shapes.get(community_id: c.id).data.first
+      expect(s[:availability]).to eql :none
       expect(s[:units][0][:type]).to eql :day
       expect(s[:price_enabled]).to eql true
       expect(s[:shipping_enabled]).to eql false


### PR DESCRIPTION
This PR enables availability management for all marketplaces.

Changes:

- [X] Remove `:availability_management` feature flag
- [X] Add Order Types with night availability enabled to new marketplaces that select the "rental" marketplace type
- [X] By default, make night availability management enabled for Order Types that are created with Order Types template "Renting products"
- [X] Change the order of "day" and "night" radio buttons. We decided to make "night" the default one, so night should be the first radio button.
- [X] Remove some unused translations
- [ ] Remove outdated knowledge base article: 1097116