### PR TITLE
Fix availability and custom unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 ### Fixed
 
 - Fixed broken transaction button styles [#2723](https://github.com/sharetribe/sharetribe/pull/2723)
+- Fixed number of issues in the Order Types form [#2858](https://github.com/sharetribe/sharetribe/pull/2858)
 
 ### Security
 

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -58,8 +58,25 @@ window.ST.initializeListingShapeForm = function(formId) {
     }
   });
 
+  var initializeState = function(state) {
+    toggleOnlinePaymentEnabled(state.priceEnabled);
+    toggleUnitsEnabled(state.priceEnabled && !state.availabilityEnabled);
+    toggleShippingEnabled(state.onlinePaymentsEnabled);
+    toggleAvailabilityEnabled(state.onlinePaymentsEnabled);
+    toggleAvailabilityUnitsEnabled(state.availabilityEnabled);
+  }
+
+  var isChecked = function(el) {
+    return el.is(':checked');
+  };
+
+  var isPriceEnabled = isChecked;
+  var isOnlinePaymentsEnabled = isChecked;
+  var isAvailabilityEnabled = isChecked;
+
   var priceChanged = function(currentEl) {
-    var enabled = currentEl.is(':checked');
+    var enabled = isPriceEnabled(currentEl);
+
     if(enabled) {
       toggleOnlinePaymentEnabled(true);
       toggleUnitsEnabled(true);
@@ -73,7 +90,8 @@ window.ST.initializeListingShapeForm = function(formId) {
   };
 
   var onlinePaymentsChanged = function(currentEl) {
-    var enabled = currentEl.is(':checked');
+    var enabled = isOnlinePaymentsEnabled(currentEl);
+
     if(enabled) {
       toggleAvailabilityEnabled(true);
       toggleShippingEnabled(true);
@@ -87,7 +105,8 @@ window.ST.initializeListingShapeForm = function(formId) {
   };
 
   var availabilityChanged = function(currentEl) {
-    var enabled = currentEl.is(':checked');
+    var enabled = isAvailabilityEnabled(currentEl);
+
     if(enabled) {
       toggleAvailabilityUnitsEnabled(true);
       toggleUnitsEnabled(false);
@@ -218,7 +237,9 @@ window.ST.initializeListingShapeForm = function(formId) {
   $('.js-remove-custom-unit').click(removeCustomUnit);
 
   // Run once on init
-  priceChanged($('.js-price-enabled'));
-  onlinePaymentsChanged($('.js-online-payments'));
-  availabilityChanged($('.js-availability'));
+  initializeState({
+    priceEnabled: isPriceEnabled($('.js-price-enabled')),
+    onlinePaymentsEnabled: isOnlinePaymentsEnabled($('.js-online-payments')),
+    availabilityEnabled: isAvailabilityEnabled($('.js-availability')),
+  })
 };

--- a/app/assets/javascripts/admin/listing_shapes.js
+++ b/app/assets/javascripts/admin/listing_shapes.js
@@ -111,7 +111,23 @@ window.ST.initializeListingShapeForm = function(formId) {
     toggleCheckboxEnabled($(".js-unit-checkbox"), enabled);
     toggleLabelEnabled($(".js-unit-label"), enabled);
     toggleInfoEnabled($('.js-pricing-units-info'), enabled);
+    toggleCustomUnitsEnabled(enabled);
   };
+
+  var toggleCustomUnitsEnabled = function(enabled) {
+    toggleLabelEnabled($(".js-listing-shape-add-custom-unit-link"), enabled);
+    toggleInputEnabled($('.js-custom-unit input'), enabled);
+
+    // First, turn off the click listener
+    $('.js-listing-shape-add-custom-unit-link').off('click');
+
+    if (enabled) {
+      // Add click listener if custom units are enabled
+      $('.js-listing-shape-add-custom-unit-link').click(function() {
+        addCustomUnitForm();
+      });
+    }
+  }
 
   var toggleAvailabilityEnabled = function(enabled) {
     toggleCheckboxEnabled($(".js-availability"), enabled);
@@ -147,13 +163,20 @@ window.ST.initializeListingShapeForm = function(formId) {
   };
 
   var toggleCheckboxEnabled = function(el, state) {
+    toggleInputEnabled(el, state);
+
+    if (!state) {
+      el.prop('checked', false);
+    }
+  };
+
+  var toggleInputEnabled = function(el, state) {
     if(state) {
       el.prop('disabled', false);
     } else {
       el.prop('disabled', true);
-      el.prop('checked', false);
     }
-  };
+  }
 
   var toggleRadioEnabled = function(el, state) {
     if(state) {
@@ -186,9 +209,6 @@ window.ST.initializeListingShapeForm = function(formId) {
   });
   $('.js-online-payments').change(function() {
     onlinePaymentsChanged($(this));
-  });
-  $('.js-listing-shape-add-custom-unit-link').click(function() {
-    addCustomUnitForm();
   });
   $('.js-availability').click(function() {
     availabilityChanged($(this));

--- a/app/assets/stylesheets/views/admin/_listing_shapes.css.scss
+++ b/app/assets/stylesheets/views/admin/_listing_shapes.css.scss
@@ -1,7 +1,19 @@
 @import "mixins/all";
 
 .listing-shape-label-disabled {
-  color: $border;
+  &,
+  & > a,
+  & > a:hover {
+    color: $border;
+  }
+
+  & > a {
+    cursor: default;
+
+    &:hover {
+      cursor: default;
+    }
+  }
 }
 
 .listing-shape-delete-button {

--- a/app/views/admin/listing_shapes/_shape_form_content.haml
+++ b/app/views/admin/listing_shapes/_shape_form_content.haml
@@ -99,7 +99,7 @@
       = label_tag("units[#{unit[:type]}]", unit[:label], class: "checkbox-row-label js-unit-label")
 
 - shape[:custom_units].each_with_index do |unit, index|
-  .row{class: "js-custom-unit-#{index}"}
+  .row{class: "js-custom-unit js-custom-unit-#{index}"}
     .col-12
       = hidden_field_tag("custom_units[existing][#{index}]", unit[:value])
       = label_tag("custom_units[existing][#{index}]", "#{t('admin.listing_shapes.custom_unit_form.per')} #{unit[:name][I18n.locale.to_s]}", class: "js-unit-label checkbox-row-label")


### PR DESCRIPTION
This PR fixes 3 bugs in the Order Type editing page:

- [X] Fixes listing shape validation bug on update
- [X] Custom units should be disabled in the UI if availability is enabled
- [X] Units should be disabled if listing price is disabled.

See each individual commit message for exact steps to reproduce and more detailed description about the bugs they fix.