### PR TITLE
Add notification about SES sending confirmation email

### DIFF
--- a/app/views/admin/communities/edit_welcome_email.haml
+++ b/app/views/admin/communities/edit_welcome_email.haml
@@ -130,11 +130,20 @@
           %label.sender-address-label= t("admin.communities.outgoing_email.sender_email_label")
           %input.js-sender-email-input{name: "email", type: :text, placeholder: t("admin.communities.outgoing_email.sender_email_placeholder"), disabled: disabled_attr, class: disabled_class}
 
-      .row.js-sender-address-preview-container.sender-address-preview-container.hidden
-        .col-12
-          .sender-address-preview
-            = t("admin.communities.outgoing_email.this_is_how_it_will_look")
-            %span.js-sender-address-preview-values
+      .js-sender-address-preview-container.sender-address-preview-container.hidden
+        .row
+          .col-12
+            .sender-address-preview
+              = t("admin.communities.outgoing_email.this_is_how_it_will_look")
+              %span.js-sender-address-preview-values
+        .row.js-sender-address-preview-container.sender-address-preview-container.hidden
+          .col-12
+            .alert-box-warning
+              %p
+                %span.alert-box-icon<>
+                  = icon_tag("alert", ["icon-fix"])
+                %span
+                  = t("admin.communities.outgoing_email.amazon_ses_notification", email_sender: "Amazon Web Services", email_subject: "Amazon SES Address Verification Request")
       .row
         %button{disabled: disabled_attr, class: disabled_class}= t("admin.communities.outgoing_email.send_verification_button")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,7 @@ en:
         sender_name_placeholder: "Sender name"
         sender_email_label: "Email address"
         sender_email_placeholder: sender-email@example.com
+        amazon_ses_notification: "You will receive an email from %{email_sender} to confirm your e-mail address. The email subject is '%{email_subject}'. Follow the instructions to verify your email."
         this_is_how_it_will_look: "This is how it will look:"
         send_verification_button: "Send verification email"
         successfully_saved: "Sender address saved successfully. The verification email will be sent soon."


### PR DESCRIPTION
Adds notification on how email verification works. It will appear when a valid email address is entered to the fields.

![screen shot 2017-02-14 at 15 42 32](https://cloud.githubusercontent.com/assets/230815/22931266/b086a1ca-f2cc-11e6-8f18-3d5430f41eab.png)
