### PR TITLE
Add possibility to use storefront name

### DIFF
--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -123,6 +123,8 @@ class Admin::CommunityMembershipsController < Admin::AdminBaseController
     case params[:sort]
     when "name"
       "people.given_name"
+    when "display_name"
+      "people.display_name"
     when "email"
       "emails.address"
     when "join_date"

--- a/app/controllers/admin/community_memberships_controller.rb
+++ b/app/controllers/admin/community_memberships_controller.rb
@@ -76,6 +76,7 @@ class Admin::CommunityMembershipsController < Admin::AdminBaseController
     header_row = %w{
       first_name
       last_name
+      display_name
       username
       phone_number
       address
@@ -95,6 +96,7 @@ class Admin::CommunityMembershipsController < Admin::AdminBaseController
         user_data = [
           user.given_name,
           user.family_name,
+          user.display_name,
           user.username,
           user.phone_number,
           user.location ? user.location.address : "",
@@ -106,7 +108,7 @@ class Admin::CommunityMembershipsController < Admin::AdminBaseController
         user_data.push(membership.can_post_listings) if community.require_verification_to_post_listings
         user.emails.each do |email|
           accept_emails_from_admin = user.preferences["email_from_admins"] && email.send_notifications
-          yielder << user_data.clone.insert(5, email.address, !!email.confirmed_at).insert(10, !!accept_emails_from_admin).to_csv(force_quotes: true)
+          yielder << user_data.clone.insert(6, email.address, !!email.confirmed_at).insert(11, !!accept_emails_from_admin).to_csv(force_quotes: true)
         end
       end
     end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -228,6 +228,7 @@ class PeopleController < Devise::RegistrationsController
       person_params = params.require(:person).permit(
         :given_name,
         :family_name,
+        :display_name,
         :street_address,
         :phone_number,
         :image,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -28,6 +28,7 @@
 #  password_salt                      :string(255)
 #  given_name                         :string(255)
 #  family_name                        :string(255)
+#  display_name                       :string(255)
 #  phone_number                       :string(255)
 #  description                        :text(65535)
 #  image_file_name                    :string(255)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -152,6 +152,7 @@ class Person < ActiveRecord::Base
   validates_length_of :username, :within => 3..20
   validates_length_of :given_name, :within => 1..255, :allow_nil => true, :allow_blank => true
   validates_length_of :family_name, :within => 1..255, :allow_nil => true, :allow_blank => true
+  validates_length_of :display_name, :within => 1..30, :allow_nil => true, :allow_blank => true
 
   validates_format_of :username,
                        :with => /\A[A-Z0-9_]*\z/i

--- a/app/services/custom_landing_page/listing_store.rb
+++ b/app/services/custom_landing_page/listing_store.rb
@@ -30,6 +30,7 @@ module CustomLandingPage
           "author_name" => PersonViewUtils.display_name(
             first_name: author.given_name,
             last_name: author.family_name,
+            display_name: author.display_name,
             username: author.username,
             name_display_type: name_display_type,
             is_deleted: author.deleted?,

--- a/app/services/listing_index_service/data_types.rb
+++ b/app/services/listing_index_service/data_types.rb
@@ -47,6 +47,7 @@ module ListingIndexService::DataTypes
     [:username, :string, :mandatory],
     [:first_name, :string, :optional],
     [:last_name, :string, :optional],
+    [:display_name, :string, :optional],
     [:avatar, entity: AvatarImage],
     [:is_deleted, :bool, default: false],
     [:num_of_reviews, :fixnum, default: 0]

--- a/app/services/listing_index_service/search/converters.rb
+++ b/app/services/listing_index_service/search/converters.rb
@@ -43,6 +43,7 @@ module ListingIndexService::Search::Converters
             username: l.author.username,
             first_name: l.author.given_name,
             last_name: l.author.family_name,
+            display_name: l.author.display_name,
             avatar: {
               thumb: l.author.image.present? ? l.author.image.url(:thumb) : nil
             },

--- a/app/services/marketplace_service/person.rb
+++ b/app/services/marketplace_service/person.rb
@@ -8,6 +8,7 @@ module MarketplaceService
         :username,
         :first_name,
         :last_name,
+        :display_name,
         :avatar,
         :is_deleted
       )
@@ -20,6 +21,7 @@ module MarketplaceService
           username: person_model.username,
           first_name: person_model.given_name,
           last_name: person_model.family_name,
+          display_name: person_model.display_name,
           avatar: person_model.image.present? ? person_model.image.url(:thumb) : ActionController::Base.helpers.image_path("profile_image/thumb/missing.png"),
           is_deleted: person_model.deleted?
         ]

--- a/app/view_utils/listing_index_view_utils.rb
+++ b/app/view_utils/listing_index_view_utils.rb
@@ -25,6 +25,7 @@ module ListingIndexViewUtils
     :username,
     :first_name,
     :last_name,
+    :display_name,
     :avatar,
     :is_deleted,
     :num_of_reviews)
@@ -44,6 +45,7 @@ module ListingIndexViewUtils
             l[:author][:username],
             l[:author][:first_name],
             l[:author][:last_name],
+            l[:author][:display_name],
             ListingImage.new(
               l[:author][:avatar][:thumb]
             ),

--- a/app/view_utils/person_view_utils.rb
+++ b/app/view_utils/person_view_utils.rb
@@ -20,6 +20,7 @@ module PersonViewUtils
       names(
         first_name: nil,
         last_name: nil,
+        display_name: nil,
         username: nil,
         name_display_type: nil,
         is_deleted: true,
@@ -29,6 +30,7 @@ module PersonViewUtils
       names(
         first_name: person.given_name,
         last_name: person.family_name,
+        display_name: person.display_name,
         username: person.username,
 
         name_display_type: name_display_type,
@@ -50,6 +52,7 @@ module PersonViewUtils
       names(
         first_name: nil,
         last_name: nil,
+        display_name: nil,
         username: nil,
         name_display_type: name_display_type,
         is_deleted: true,
@@ -59,6 +62,7 @@ module PersonViewUtils
       names(
         first_name: person_entity[:first_name],
         last_name: person_entity[:last_name],
+        display_name: person_entity[:display_name],
         username: person_entity[:username],
         name_display_type: name_display_type,
         is_deleted: person_entity[:is_deleted],
@@ -70,21 +74,25 @@ module PersonViewUtils
   def names(
         first_name:,
         last_name:,
+        display_name:,
         username:,
         name_display_type:,
         is_deleted:,
         deleted_user_text:
         )
     name_present = first_name.present?
+    display_name_present = display_name.present?
 
-    case [is_deleted, name_present, name_display_type]
+    case [is_deleted, name_present, display_name_present, name_display_type]
     when matches([true])
       [deleted_user_text]
-    when matches([__, true, "first_name_with_initial"])
+    when matches([__, __, true])
+      [display_name]
+    when matches([__, true, __, "first_name_with_initial"])
       first_name_with_initial(first_name, last_name)
-    when matches([__, true, "first_name_only"])
+    when matches([__, true, __, "first_name_only"])
       [first_name]
-    when matches([__, true, "full_name"])
+    when matches([__, true, __, "full_name"])
       full_name(first_name, last_name)
     when matches([__, true])
       first_name_with_initial(first_name, last_name)
@@ -96,6 +104,7 @@ module PersonViewUtils
   def display_name(
         first_name:,
         last_name:,
+        display_name:,
         username:,
         name_display_type:,
         is_deleted:,
@@ -103,6 +112,7 @@ module PersonViewUtils
         )
     names(first_name: first_name,
           last_name: last_name,
+          display_name: display_name,
           username: username,
           name_display_type: name_display_type,
           is_deleted: is_deleted,

--- a/app/views/admin/community_memberships/index.haml
+++ b/app/views/admin/community_memberships/index.haml
@@ -35,7 +35,7 @@
       %thead
         %tr
           %th= render partial: "layouts/sort_link", locals: { column: "name", direction: sort_link_direction("name"), title: t("admin.communities.manage_members.name") }
-          %th= render partial: "layouts/sort_link", locals:{ column: "display_name", direction: sort_link_direction("display_name"), title: t("admin.communities.manage_members.display_name")}
+          %th= render partial: "layouts/sort_link", locals: { column: "display_name", direction: sort_link_direction("display_name"), title: t("admin.communities.manage_members.display_name")}
           %th= render partial: "layouts/sort_link", locals: { column: "email", direction: sort_link_direction("email"), title: t("admin.communities.manage_members.email") }
           %th= render partial: "layouts/sort_link", locals: { column: "join_date", direction: sort_link_direction("join_date"), title: t("admin.communities.manage_members.join_date") }
           - if @current_community.require_verification_to_post_listings

--- a/app/views/admin/community_memberships/index.haml
+++ b/app/views/admin/community_memberships/index.haml
@@ -35,6 +35,7 @@
       %thead
         %tr
           %th= render partial: "layouts/sort_link", locals: { column: "name", direction: sort_link_direction("name"), title: t("admin.communities.manage_members.name") }
+          %th= render partial: "layouts/sort_link", locals:{ column: "display_name", direction: sort_link_direction("display_name"), title: t("admin.communities.manage_members.display_name")}
           %th= render partial: "layouts/sort_link", locals: { column: "email", direction: sort_link_direction("email"), title: t("admin.communities.manage_members.email") }
           %th= render partial: "layouts/sort_link", locals: { column: "join_date", direction: sort_link_direction("join_date"), title: t("admin.communities.manage_members.join_date") }
           - if @current_community.require_verification_to_post_listings
@@ -47,7 +48,9 @@
           - unless member.blank?
             %tr
               %td.admin-members-full-name
-                = link_to member.full_name, member
+                = link_to [member.given_name, member.family_name].join(" "), member
+              %td
+                = member.display_name
               %td
                 = mail_to member.confirmed_notification_email_addresses.first
               %td= l(membership.created_at, :format => :short_date)

--- a/app/views/homepage/_grid_item.haml
+++ b/app/views/homepage/_grid_item.haml
@@ -11,7 +11,7 @@
             = image_tag(listing.author.avatar.thumb || missing_avatar(:thumb), :class => "home-fluid-thumbnail-grid-author-avatar-image")
 
         - distance = Maybe(listing.distance).or_else(nil)
-        - name = PersonViewUtils::person_entity_display_name(listing.author, @current_community.name_display_type)
+        - name = PersonViewUtils.person_entity_display_name(listing.author, @current_community.name_display_type)
         - if(!show_distance || distance.blank?)
           = link_to(person_path(username: listing.author.username), :class => "home-fluid-thumbnail-grid-author-name", title: name) do
             = name

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -55,7 +55,7 @@
           = image_tag(listing.author.avatar.thumb || missing_avatar(:thumb))
       .home-list-author-details
         = link_to(person_path(username: listing.author.username), :class => "home-list-author-name") do
-          = PersonViewUtils::person_entity_display_name(listing.author, @current_community.name_display_type)
+          = PersonViewUtils.person_entity_display_name(listing.author, @current_community.name_display_type)
         .home-list-author-reviews
           - if listing.author.num_of_reviews > 0
             = icon_tag("testimonial")

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -27,14 +27,25 @@
           = t("settings.profile.#{@current_community.name_display_type}")
     = form.text_field :family_name, :class => "text_field", :maxlength => "30"
 
+    -# Display name
+    .inline-label-container
+      = form.label :display_name, t("settings.profile.display_name"), class: "inline"
+    %span.alert-box-icon
+      = icon_tag("alert", ["icon-fix"])
+    %small
+      = t("settings.profile.display_name_description")
+    = form.text_field :display_name, class: "text_field", :maxlength => "30"
+
     -# Location
     .inline-label-container
       = form.label :street_address, t("settings.profile.street_address"), :class => "inline"
       %small
         = t('settings.profile.default_in_listing')
-    = form.text_field :street_address, :class => "text_field", :onkeyup => "timed_input(this)"
+    %span.alert-box-icon
+      = icon_tag("alert", ["icon-fix"])
     %small
       = t("settings.profile.location_description")
+    = form.text_field :street_address, :class => "text_field", :onkeyup => "timed_input(this)"
     #settings_map_canvas.map
       - content_for :extra_javascript do
         :javascript

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -31,7 +31,7 @@
     .inline-label-container
       = form.label :display_name, t("settings.profile.display_name"), class: "inline"
     %span.alert-box-icon
-      = icon_tag("alert", ["icon-fix"])
+      = icon_tag("information", ["icon-fix"])
     %small
       = t("settings.profile.display_name_description")
     = form.text_field :display_name, class: "text_field", :maxlength => "30"
@@ -42,7 +42,7 @@
       %small
         = t('settings.profile.default_in_listing')
     %span.alert-box-icon
-      = icon_tag("alert", ["icon-fix"])
+      = icon_tag("information", ["icon-fix"])
     %small
       = t("settings.profile.location_description")
     = form.text_field :street_address, :class => "text_field", :onkeyup => "timed_input(this)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1887,6 +1887,8 @@ en:
       given_name: "First name"
       first_name_with_initial: "(only first letter shown to other users)"
       first_name_only: "(not shown to other users)"
+      display_name: "Display name"
+      display_name_description: "If you represent an organisation, you can use its name as your display name. Display name is shown instead of your real name when users browse your profile."
       location_description: "You can provide either your street address or only a city or zip/postal code. It’s good to also add your country when adding your location. Examples: \"10117 Berlin, Germany\" or \"2000 Sand Hill Road, CA, USA\"."
       phone_number: "Phone number"
       profile_picture: "Profile picture"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,7 @@ en:
         manage_members: "Manage users"
         email: Email
         name: Name
+        display_name: "Display name"
         join_date: Joined
         admin: Admin
         posting_allowed: "Posting allowed"

--- a/db/migrate/20170220123526_add_display_name_to_person.rb
+++ b/db/migrate/20170220123526_add_display_name_to_person.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToPerson < ActiveRecord::Migration
+  def change
+    add_column :people, :display_name, :string, after: :family_name, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1346,6 +1346,7 @@ CREATE TABLE `people` (
   `password_salt` varchar(255) DEFAULT NULL,
   `given_name` varchar(255) DEFAULT NULL,
   `family_name` varchar(255) DEFAULT NULL,
+  `display_name` varchar(255) DEFAULT NULL,
   `phone_number` varchar(255) DEFAULT NULL,
   `description` text,
   `image_file_name` varchar(255) DEFAULT NULL,
@@ -1598,7 +1599,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-16 15:50:16
+-- Dump completed on 2017-02-20 14:36:16
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3220,4 +3221,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161107141257');
 INSERT INTO schema_migrations (version) VALUES ('20161109094513');
 
 INSERT INTO schema_migrations (version) VALUES ('20170216134444');
+
+INSERT INTO schema_migrations (version) VALUES ('20170220123526');
 

--- a/features/admin/manage_members/admin_lists_members.feature
+++ b/features/admin/manage_members/admin_lists_members.feature
@@ -14,34 +14,34 @@ Feature: Admin lists members
 
   Scenario: Admin views & sorts list of members
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed  | Remove User |
-      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
-      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
-      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
+      | Name          | Display name | Email               | Joined      | Posting allowed | Remove User |
+      | matti manager |              | manager@example.com | Mar 1, 2014 |                 |             |
+      | john doe      |              | test2@example.com   | Mar 1, 2013 |                 |             |
+      | jane doe      |              | test1@example.com   | Mar 1, 2012 |                 |             |
     When I follow "Name"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed  | Remove User |
-      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
-      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
-      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
+      | Name          |  Display name | Email               | Joined     | Posting allowed  | Remove User |
+      | jane doe      |               | test1@example.com   | Mar 1, 2012 |                 |             |
+      | john doe      |               | test2@example.com   | Mar 1, 2013 |                 |             |
+      | matti manager |               | manager@example.com | Mar 1, 2014 |                 |             |
     When I follow "Name"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed  | Remove User |
-      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
-      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
-      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
+      | Name          |  Display name | Email               | Joined     | Posting allowed  | Remove User |
+      | matti manager |               | manager@example.com | Mar 1, 2014 |                 |             |
+      | john doe      |               | test2@example.com   | Mar 1, 2013 |                 |             |
+      | jane doe      |               | test1@example.com   | Mar 1, 2012 |                 |             |
     When I follow "Email"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed  | Remove User |
-      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
-      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
-      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
+      | Name          |  Display name | Email               | Joined     | Posting allowed  | Remove User |
+      | matti manager |               | manager@example.com | Mar 1, 2014 |                 |             |
+      | jane doe      |               | test1@example.com   | Mar 1, 2012 |                 |             |
+      | john doe      |               | test2@example.com   | Mar 1, 2013 |                 |             |
     When I follow "Joined"
     Then I should see list of users with the following details:
-      | Name          | Email               | Joined     | Posting allowed  | Remove User |
-      | jane doe      | test1@example.com   | Mar 1, 2012 |                 |             |
-      | john doe      | test2@example.com   | Mar 1, 2013 |                 |             |
-      | matti manager | manager@example.com | Mar 1, 2014 |                 |             |
+      | Name          |  Display name | Email               | Joined     | Posting allowed  | Remove User |
+      | jane doe      |               | test1@example.com   | Mar 1, 2012 |                 |             |
+      | john doe      |               | test2@example.com   | Mar 1, 2013 |                 |             |
+      | matti manager |               | manager@example.com | Mar 1, 2014 |                 |             |
 
   Scenario: Admin views member count
     Given there are 50 users with name prefix "User" "Number"

--- a/spec/controllers/admin/csv_export_spec.rb
+++ b/spec/controllers/admin/csv_export_spec.rb
@@ -25,12 +25,14 @@ describe Admin::CommunityMembershipsController, type: :controller do
 
       expect(user["first_name"]).to eq(@person.given_name)
       expect(user["last_name"]).to eq(@person.family_name)
+      expect(user["display_name"]).to eq(@person.display_name || "")
       expect(user["phone_number"]).to eq(@person.phone_number)
       expect(user["email_address"]).to eq(@person.emails.first.address)
       expect(user["status"]).to eq("accepted")
 
       expect(user2["first_name"]).to eq(@person.given_name)
       expect(user2["last_name"]).to eq(@person.family_name)
+      expect(user2["display_name"]).to eq(@person.display_name || "")
       expect(user2["phone_number"]).to eq(@person.phone_number)
       expect(user2["email_address"]).to eq(@other_email.address)
       expect(user2["status"]).to eq("accepted")

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -28,6 +28,7 @@
 #  password_salt                      :string(255)
 #  given_name                         :string(255)
 #  family_name                        :string(255)
+#  display_name                       :string(255)
 #  phone_number                       :string(255)
 #  description                        :text(65535)
 #  image_file_name                    :string(255)

--- a/spec/view_utils/person_view_utils_spec.rb
+++ b/spec/view_utils/person_view_utils_spec.rb
@@ -5,6 +5,7 @@ describe PersonViewUtils do
     expect(PersonViewUtils.display_name(
       first_name: "John",
       last_name: "Doe",
+      display_name: "Johnny Walker",
       username: "johnd",
       name_display_type: "first_name_with_initial",
       is_deleted: true,
@@ -13,6 +14,7 @@ describe PersonViewUtils do
     expect(PersonViewUtils.display_name(
       first_name: "John",
       last_name: "Doe",
+      display_name: nil,
       username: "johnd",
       name_display_type: "first_name_with_initial",
       is_deleted: false,
@@ -21,6 +23,7 @@ describe PersonViewUtils do
     expect(PersonViewUtils.display_name(
       first_name: "John",
       last_name: "Doe",
+      display_name: nil,
       username: "johnd",
       name_display_type: "first_name_only",
       is_deleted: false,
@@ -29,6 +32,7 @@ describe PersonViewUtils do
     expect(PersonViewUtils.display_name(
       first_name: "John",
       last_name: "Doe",
+      display_name: nil,
       username: "johnd",
       name_display_type: "full_name",
       is_deleted: false,
@@ -37,6 +41,7 @@ describe PersonViewUtils do
     expect(PersonViewUtils.display_name(
       first_name: "John",
       last_name: "Doe",
+      display_name: nil,
       username: "johnd",
       name_display_type: nil,
       is_deleted: false,
@@ -45,10 +50,20 @@ describe PersonViewUtils do
     expect(PersonViewUtils.display_name(
       first_name: nil,
       last_name: nil,
+      display_name: nil,
       username: "johnd",
       name_display_type: "first_name_with_initial",
       is_deleted: false,
       deleted_user_text: "Deleted user")).to eql("johnd")
+
+    expect(PersonViewUtils.display_name(
+      first_name: nil,
+      last_name: nil,
+      display_name: "Johnny Walker",
+      username: "johnd",
+      name_display_type: "first_name_with_initial",
+      is_deleted: false,
+      deleted_user_text: "Deleted user")).to eql("Johnny Walker")
   end
 
   it "#person_entity_display_name" do


### PR DESCRIPTION
- [x] Adds a possibility to add a display name to user profile that'll replace other names in all views.
- [x] Admin sees both whole name and display name (also added to the csv):
  
![image](https://cloud.githubusercontent.com/assets/230815/23156510/e73eac78-f81f-11e6-91d7-51cabcd49c94.png)



- [x] Unifies how info texts are shown in profile edit page:
![image](https://cloud.githubusercontent.com/assets/230815/23156487/c9f3cffe-f81f-11e6-8bf6-4ef3ab91e912.png)



