### PR TITLE
Refactor: remove storefront label and person name functions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -548,7 +548,7 @@ class ApplicationController < ActionController::Base
       {
         unread_count: MarketplaceService::Inbox::Query.notification_count(u.id, @current_community.id),
         avatar_url: u.image.present? ? u.image.url(:thumb) : view_context.image_path("profile_image/thumb/missing.png"),
-        current_user_name: u.name(@current_community),
+        current_user_name: PersonViewUtils.person_display_name(u, @current_community),
         inbox_path: person_inbox_path(u),
         profile_path: person_path(u),
         manage_listings_path: person_path(u, show_closed: true),

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -195,7 +195,7 @@ class PeopleController < Devise::RegistrationsController
     @person.store_picture_from_facebook
 
     sign_in(resource_name, @person)
-    flash[:notice] = t("layouts.notifications.login_successful", :person_name => view_context.link_to(@person.given_name_or_username, person_path(@person))).html_safe
+    flash[:notice] = t("layouts.notifications.login_successful", :person_name => view_context.link_to(PersonViewUtils.person_display_name_for_type(@person, "first_name_only"), person_path(@person))).html_safe
 
     CommunityMembership.create(person: @person, community: @current_community, status: "pending_consent")
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -64,7 +64,7 @@ class SessionsController < ApplicationController
       redirect_to terms_path and return
     end
 
-    flash[:notice] = t("layouts.notifications.login_successful", person_name: view_context.link_to(@current_user.given_name_or_username, person_path(@current_user))).html_safe
+    flash[:notice] = t("layouts.notifications.login_successful", person_name: view_context.link_to(PersonViewUtils.person_display_name_for_type(@current_user, "first_name_only"), person_path(@current_user))).html_safe
     if session[:return_to]
       redirect_to session[:return_to]
       session[:return_to] = nil

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -33,7 +33,7 @@ class TermsController < ApplicationController
     session[:temp_cookie] = session[:temp_person_id] = nil
     session[:temp_community_id] = nil
     session[:consent_changed] = nil
-    flash[:notice] = t("layouts.notifications.login_successful", :person_name => view_context.link_to(@current_user.given_name_or_username, person_path(@current_user))).html_safe
+    flash[:notice] = t("layouts.notifications.login_successful", :person_name => view_context.link_to(PersonViewUtils.person_display_name_for_type(@current_user, "first_name_only"), person_path(@current_user))).html_safe
     redirect_to (session[:return_to] || search_path)
   end
 

--- a/app/controllers/testimonials_controller.rb
+++ b/app/controllers/testimonials_controller.rb
@@ -42,7 +42,7 @@ class TestimonialsController < ApplicationController
 
     if @testimonial.save
       Delayed::Job.enqueue(TestimonialGivenJob.new(@testimonial.id, @current_community.id))
-      flash[:notice] = t("layouts.notifications.feedback_sent_to", :target_person => view_context.link_to(@transaction.other_party(@current_user).given_name_or_username, @transaction.other_party(@current_user))).html_safe
+      flash[:notice] = t("layouts.notifications.feedback_sent_to", :target_person => view_context.link_to(PersonViewUtils.person_display_name_for_type(@transaction.other_party(@current_user), "first_name_only"), @transaction.other_party(@current_user))).html_safe
       redirect_to person_transaction_path(:person_id => @current_user.id, :id => @transaction.id)
     else
       render :action => new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,7 +81,7 @@ module ApplicationHelper
   def large_avatar_thumb(person, options={})
     image_url = person.image.present? ? person.image.url(:medium) : missing_avatar(:medium)
 
-    image_tag image_url, { :alt => person.name(@current_community) }.merge(options)
+    image_tag image_url, { :alt => PersonViewUtils.person_display_name(person, @current_community) }.merge(options)
   end
 
   def huge_avatar_thumb(person, options={})
@@ -89,7 +89,7 @@ module ApplicationHelper
 
     image_url = person.image.present? ? person.image.url(:medium) : missing_avatar(:medium)
 
-    image_tag image_url, { :alt => person.name(@current_community) }.merge(options)
+    image_tag image_url, { :alt => PersonViewUtils.person_display_name(person, @current_community) }.merge(options)
   end
 
   def missing_avatar(size = :medium)
@@ -608,7 +608,9 @@ module ApplicationHelper
 
   # Return a link to the listing author
   def author_link(listing)
-    link_to(listing.author.name(@current_community), listing.author, {:title => listing.author.name(@current_community)})
+    link_to(PersonViewUtils.person_display_name(listing.author, @current_community),
+            listing.author,
+            {:title => PersonViewUtils.person_display_name(listing.author, @current_community)})
   end
 
   def with_invite_link(&block)

--- a/app/helpers/transaction_helper.rb
+++ b/app/helpers/transaction_helper.rb
@@ -421,7 +421,7 @@ module TransactionHelper
   def waiting_for_buyer_to_confirm(conversation)
     link = t("conversations.status.waiting_confirmation_from_requester",
       :requester_name => link_to(
-        conversation.other_party(@current_user).given_name_or_username,
+        PersonViewUtils.person_display_name_for_type(conversation.other_party(@current_user), "first_name_only"),
         conversation.other_party(@current_user)
       )
     ).html_safe
@@ -432,7 +432,7 @@ module TransactionHelper
   def waiting_for_author_to_accept_preauthorized(transaction)
     text = t("conversations.status.waiting_for_listing_author_to_accept_request",
       :listing_author_name => link_to(
-        transaction.author.given_name_or_username,
+        PersonViewUtils.person_display_name_for_type(transaction.author, "first_name_only"),
         transaction.author
       )
     ).html_safe

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -37,7 +37,7 @@ class PersonMailer < ActionMailer::Base
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
       @message = message
       sending_params = {:to => recipient.confirmed_notification_emails_to,
-                        :subject => t("emails.new_message.you_have_a_new_message", :sender_name => message.sender.name(community)),
+                        :subject => t("emails.new_message.you_have_a_new_message", :sender_name => PersonViewUtils.person_display_name(message.sender, community)),
                         :from => community_specific_sender(community)}
 
       premailer_mail(sending_params)
@@ -90,7 +90,7 @@ class PersonMailer < ActionMailer::Base
       @testimonial = testimonial
       premailer_mail(:to => recipient.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
-                     :subject => t("emails.new_testimonial.has_given_you_feedback_in_kassi", :name => testimonial.author.name(community)))
+                     :subject => t("emails.new_testimonial.has_given_you_feedback_in_kassi", :name => PersonViewUtils.person_display_name(testimonial.author, community)))
     end
   end
 
@@ -139,7 +139,7 @@ class PersonMailer < ActionMailer::Base
       @other_party = @conversation.other_party(recipient)
       premailer_mail(:to => recipient.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
-                     :subject => t("emails.testimonial_reminder.remember_to_give_feedback_to", :name => @other_party.name(community)))
+                     :subject => t("emails.testimonial_reminder.remember_to_give_feedback_to", :name => PersonViewUtils.person_display_name(@other_party, community)))
     end
   end
 
@@ -151,7 +151,7 @@ class PersonMailer < ActionMailer::Base
       @comment = comment
       premailer_mail(:to => recipient.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
-                     :subject => t("emails.new_comment.you_have_a_new_comment", :author => comment.author.name(community)))
+                     :subject => t("emails.new_comment.you_have_a_new_comment", :author => PersonViewUtils.person_display_name(comment.author, community)))
     end
   end
 
@@ -161,7 +161,7 @@ class PersonMailer < ActionMailer::Base
       @comment = comment
       premailer_mail(:to => recipient.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
-                     :subject => t("emails.new_comment.listing_you_follow_has_a_new_comment", :author => comment.author.name(community)))
+                     :subject => t("emails.new_comment.listing_you_follow_has_a_new_comment", :author => PersonViewUtils.person_display_name(comment.author, community)))
     end
   end
 
@@ -180,7 +180,7 @@ class PersonMailer < ActionMailer::Base
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
       @listing = listing
       @no_recipient_name = true
-      @author_name = listing.author.name(community)
+      @author_name = PersonViewUtils.person_display_name(listing.author, community)
       @listing_url = listing_url(@url_params.merge({:id => listing.id}))
       @translate_scope = [ :emails, :new_listing_by_followed_person ]
       premailer_mail(:to => recipient.confirmed_notification_emails_to,
@@ -198,7 +198,7 @@ class PersonMailer < ActionMailer::Base
     set_up_layout_variables(nil, invitation.community)
     @url_params[:locale] = mail_locale
     with_locale(mail_locale, invitation.community.locales.map(&:to_sym), invitation.community.id) do
-      subject = t("emails.invitation_to_kassi.you_have_been_invited_to_kassi", :inviter => invitation.inviter.name(invitation.community), :community => invitation.community.full_name_with_separator(invitation.inviter.locale))
+      subject = t("emails.invitation_to_kassi.you_have_been_invited_to_kassi", :inviter => PersonViewUtils.person_display_name(invitation.inviter, invitation.community), :community => invitation.community.full_name_with_separator(invitation.inviter.locale))
       premailer_mail(:to => invitation.email,
                      :from => community_specific_sender(invitation.community),
                      :subject => subject,
@@ -317,7 +317,7 @@ class PersonMailer < ActionMailer::Base
       subject = if @recipient.has_admin_rights? && !@test_email
         t("emails.welcome_email_marketplace_creator.welcome_email_subject_for_marketplace_creator")
       else
-        t("emails.welcome_email.welcome_email_subject", :community => community.full_name(recipient.locale), :person => person.given_name_or_username)
+        t("emails.welcome_email.welcome_email_subject", :community => community.full_name(recipient.locale), :person => PersonViewUtils.person_display_name_for_type(person, "first_name_only"))
       end
       premailer_mail(:to => recipient.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -41,7 +41,7 @@ class TransactionMailer < ActionMailer::Base
         mail_params(
           @recipient,
           @community,
-          t("emails.transaction_preauthorized.subject", requester: transaction.starter.name(@community), listing_title: transaction.listing.title))) do |format|
+          t("emails.transaction_preauthorized.subject", requester: PersonViewUtils.person_display_name(transaction.starter, @community), listing_title: transaction.listing.title))) do |format|
         format.html {
           render locals: {
                    payment_expires_in_unit: expires_in[:unit],
@@ -105,7 +105,7 @@ class TransactionMailer < ActionMailer::Base
                    paypal_gateway_fee: humanized_money_with_symbol(-gateway_fee),
                    payment_seller_gets: humanized_money_with_symbol(you_get),
                    payer_full_name: buyer_model.name(community),
-                   payer_given_name: buyer_model.given_name_or_username,
+                   payer_given_name: PersonViewUtils.person_display_name_for_type(buyer_model, "first_name_only"),
                  }
         }
       end
@@ -140,7 +140,7 @@ class TransactionMailer < ActionMailer::Base
                    shipping_total: humanized_money_with_symbol(transaction[:shipping_price]),
                    payment_total: humanized_money_with_symbol(transaction[:payment_total]),
                    recipient_full_name: seller_model.name(community),
-                   recipient_given_name: seller_model.given_name_or_username,
+                   recipient_given_name: PersonViewUtils.person_display_name_for_type(seller_model, "first_name_only"),
                    automatic_confirmation_days: nil,
                    show_money_will_be_transferred_note: false
                  }

--- a/app/models/community_customization.rb
+++ b/app/models/community_customization.rb
@@ -16,7 +16,6 @@
 #  about_page_content                         :text(16777215)
 #  terms_page_content                         :text(16777215)
 #  privacy_page_content                       :text(16777215)
-#  storefront_label                           :string(255)
 #  signup_info_content                        :text(65535)
 #  private_community_homepage_content         :text(16777215)
 #  verification_to_post_listings_info_content :text(16777215)
@@ -42,7 +41,6 @@ class CommunityCustomization < ActiveRecord::Base
     :how_to_use_page_content,
     :terms_page_content,
     :privacy_page_content,
-    :storefront_label,
     :signup_info_content,
     :private_community_homepage_content,
     :verification_to_post_listings_info_content,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -224,8 +224,6 @@ class Person < ActiveRecord::Base
         .present?
   end
 
-  # Deprecated: This is view logic (how to display name) and thus should not be in model layer
-  # Consider using PersonViewUtils
   def name_or_username(community_or_display_type=nil)
     if community_or_display_type.present? && community_or_display_type.class == Community
       display_type = community_or_display_type.name_display_type
@@ -249,15 +247,15 @@ class Person < ActiveRecord::Base
       return username
     end
   end
+  deprecate name_or_username: "This is view logic (how to display name) and thus should not be in model layer. Consider using PersonViewUtils.",
+            deprecator: MethodDeprecator.new
 
-  # Deprecated: This is view logic (how to display name) and thus should not be in model layer
-  # Consider using PersonViewUtils
   def full_name
     "#{given_name} #{family_name}"
   end
+  deprecate full_name: "This is view logic (how to display name) and thus should not be in model layer. Consider using PersonViewUtils.",
+            deprecator: MethodDeprecator.new
 
-  # Deprecated: This is view logic (how to display name) and thus should not be in model layer
-  # Consider using PersonViewUtils
   def first_name_with_initial
     if family_name
       initial = family_name[0,1]
@@ -266,15 +264,15 @@ class Person < ActiveRecord::Base
     end
     "#{given_name} #{initial}"
   end
+  deprecate first_name_with_initial: "This is view logic (how to display name) and thus should not be in model layer. Consider using PersonViewUtils.",
+            deprecator: MethodDeprecator.new
 
-  # Deprecated: This is view logic (how to display name) and thus should not be in model layer
-  # Consider using PersonViewUtils
   def name(community_or_display_type)
     return name_or_username(community_or_display_type)
   end
+  deprecate name: "This is view logic (how to display name) and thus should not be in model layer. Consider using PersonViewUtils.",
+            deprecator: MethodDeprecator.new
 
-  # Deprecated: This is view logic (how to display name) and thus should not be in model layer
-  # Consider using PersonViewUtils
   def given_name_or_username
     if given_name.present?
       return given_name
@@ -282,6 +280,8 @@ class Person < ActiveRecord::Base
       return username
     end
   end
+  deprecate given_name_or_username: "This is view logic (how to display name) and thus should not be in model layer. Consider using PersonViewUtils.",
+            deprecator: MethodDeprecator.new
 
   def set_given_name(name)
     update_attributes({:given_name => name })

--- a/app/view_utils/person_view_utils.rb
+++ b/app/view_utils/person_view_utils.rb
@@ -8,6 +8,14 @@ module PersonViewUtils
   end
 
   def person_display_names(person, community)
+    person_display_names_for_type(person, community.name_display_type)
+  end
+
+  def person_display_name_for_type(person, name_display_type)
+    person_display_names_for_type(person, name_display_type).join(" ")
+  end
+
+  def person_display_names_for_type(person, name_display_type)
     if person.nil?
       names(
         first_name: nil,
@@ -23,7 +31,7 @@ module PersonViewUtils
         last_name: person.family_name,
         username: person.username,
 
-        name_display_type: community.name_display_type,
+        name_display_type: name_display_type,
 
         is_deleted: person.deleted?,
         deleted_user_text: I18n.translate("common.removed_user")

--- a/app/views/admin/communities/_welcome_email_for_marketplace_creator.haml
+++ b/app/views/admin/communities/_welcome_email_for_marketplace_creator.haml
@@ -1,5 +1,5 @@
 %h3
-  = t("emails.welcome_email_marketplace_creator.welcome_to_marketplace_creator", :name => @recipient.given_name_or_username)
+  = t("emails.welcome_email_marketplace_creator.welcome_to_marketplace_creator", :name => PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"))
 
 %p
   = t("emails.welcome_email_marketplace_creator.journey_begins")

--- a/app/views/admin/communities/edit_welcome_email.haml
+++ b/app/views/admin/communities/edit_welcome_email.haml
@@ -160,7 +160,7 @@
       .text-part= t(".send_test_message")
   %p ***
   .welcome-email-editor-background
-    %p= t("emails.common.hey", :name => @recipient.given_name_or_username)
+    %p= t("emails.common.hey", :name => PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"))
     #welcome_email_content{:data => {:mercury => "full"}}
       - if @community_customization && @community_customization.welcome_email_content
         = @community_customization.welcome_email_content.html_safe

--- a/app/views/community_mailer/_community_update_listing.html.haml
+++ b/app/views/community_mailer/_community_update_listing.html.haml
@@ -10,7 +10,7 @@
                   = link_to((image_tag listing.author.image.url(:thumb), :width => 50, :height => 50, :style => "display:block;margin-right:20px;margin-bottom:10px;margin-top:0;border:0"), person_url(listing.author, @url_params))
               %td{:valign => "top", :style => "margin-bottom: 0;padding-bottom: 0;"}
                 %p{:style => "font-family:Helvetica Neue, Helvetica, Arial, sans-serif;font-weight: normal; font-size: 14px; margin-top: 0;margin-bottom:0;padding:0;line-height:14px;"}
-                  - name_link = link_to( listing.author.given_name_or_username, person_url(listing.author, @url_params), :style => "font-weight:bold;")
+                  - name_link = link_to(PersonViewUtils.person_display_name_for_type(listing.author, "first_name_only"), person_url(listing.author, @url_params), :style => "font-weight:bold;")
                   = t("emails.community_updates.added_listing",
                       :name_link => name_link,
                           :default => t("emails.community_updates.added_listing",

--- a/app/views/community_mailer/community_updates.html.haml
+++ b/app/views/community_mailer/community_updates.html.haml
@@ -16,7 +16,7 @@
                             = t("emails.community_updates.update_mail_title", :title_link => link_to(@title_link_text, search_url(@url_params))).html_safe
                         %div{:style => "font-family:Helvetica Neue, Helvetica, Arial, sans-serif;font-size:16px;line-height:22px; padding: 10px 0;text-align:left;"}
                           %p
-                            = t("emails.newsletter.hi", :name => link_to(@recipient.given_name_or_username, person_url(@recipient, @url_params))).html_safe
+                            = t("emails.newsletter.hi", :name => link_to(PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"), person_url(@recipient, @url_params))).html_safe
                           %p
                             = t("emails.community_updates.intro_paragraph", :community_link => link_to(t("emails.community_updates.intro_paragraph_link_text", :community_name => @community.full_name(I18n.locale)), search_url(@url_params)), :time_since_last_update => @time_since_last_update).html_safe
                       %td{:width => "5%"}

--- a/app/views/community_memberships/pending_consent.haml
+++ b/app/views/community_memberships/pending_consent.haml
@@ -19,7 +19,7 @@
       - else
         = t('community_memberships.new.you_can_join_email_confirmation', email_ending: allowed_emails.first)
     - else
-      = t('community_memberships.new.welcome_fb_user', name: @current_user.given_name_or_username)
+      = t('community_memberships.new.welcome_fb_user', name: PersonViewUtils.person_display_name_for_type(@current_user, "first_name_only"))
       = t('community_memberships.new.fb_join_accept_terms')
 
   %p

--- a/app/views/devise/mailer/confirmation_instructions.haml
+++ b/app/views/devise/mailer/confirmation_instructions.haml
@@ -3,7 +3,7 @@
 %tr
   %td{:align => "left", :style => "padding-bottom: 15px;"}
     %font{body_font}
-      = t("emails.common.hey", :name => @resource.given_name_or_username)
+      = t("emails.common.hey", :name => PersonViewUtils.person_display_name_for_type(@resource, "first_name_only"))
 
 %tr
   %td{:align => "left"}

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -21,7 +21,7 @@
                   %tr
                     %td{:align => "left", :style => "padding-top: 20px; padding-bottom: 10px;"}
                       %font{body_font}
-                        = t("emails.common.hey", :name => @recipient.given_name_or_username)
+                        = t("emails.common.hey", :name => PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"))
 
 
                 %span{id: SecureRandom.hex}

--- a/app/views/listing_conversations/contact.haml
+++ b/app/views/listing_conversations/contact.haml
@@ -4,7 +4,7 @@
 #new_message_form.centered-section
 
   %h2
-    = t("conversations.new.send_message_to_user", :person => link_to(@listing.author.given_name_or_username, @listing.author)).html_safe
+    = t("conversations.new.send_message_to_user", :person => link_to(PersonViewUtils.person_display_name_for_type(listing.author, "first_name_only"), @listing.author)).html_safe
 
   = form_for contact_form, :url => create_contact do |form|
 

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -10,7 +10,7 @@
   = javascript_include_tag "https://maps.googleapis.com/maps/api/js#{key_param}" if needs_maps
 
 - content_for :title, raw(@listing.title)
-- content_for :meta_author, @listing.author.name(@current_community)
+- content_for :meta_author, PersonViewUtils.person_display_name(@listing.author, @current_community)
 - content_for :meta_description, StringUtils.first_words(@listing.description, 15)
 - content_for :meta_image, @listing.listing_images.first.image.url(:medium) if !@listing.listing_images.empty?
 - dimensions = @listing.listing_images.first.get_dimensions_for_style(:medium) if !@listing.listing_images.empty?
@@ -148,7 +148,7 @@
             = medium_avatar_thumb(@listing.author, {:class => "listing-author-avatar-image"})
           .listing-author-details
             .listing-author-name
-              = link_to @listing.author.name(@current_community), @listing.author, :id => "listing-author-link", :class => "listing-author-name-link", :title => "#{@listing.author.name(@current_community)}"
+              = link_to PersonViewUtils.person_display_name(@listing.author, @current_community), @listing.author, :id => "listing-author-link", :class => "listing-author-name-link", :title => "#{PersonViewUtils.person_display_name(@listing.author, @current_community)}"
             - if @listing.author != @current_user
               .listing-author-contact
                 %a#listing-contact{href: contact_to_listing_path(:listing_id => @listing.id.to_s), :class => "listing-author-contact-button"}

--- a/app/views/people/_followed_person.haml
+++ b/app/views/people/_followed_person.haml
@@ -4,7 +4,7 @@
       = large_avatar_thumb(person, :class => "fluid-thumbnail-grid-image-image")
       .fluid-thumbnail-grid-image-overlay
       .fluid-thumbnail-grid-image-title
-        = person.name(@current_community)
+        = PersonViewUtils.person_display_name(person, @current_community)
   - if @current_user
     - if current_user?(person)
       = render :partial => "people/edit_profile_button"

--- a/app/views/people/_profile_action_buttons.haml
+++ b/app/views/people/_profile_action_buttons.haml
@@ -3,7 +3,7 @@
 - else
   %a.profile-contact-link{href: new_person_person_message_path(@person)}
     .content
-      = t("people.show.contact", :person => @person.given_name_or_username)
-      
+      = t("people.show.contact", :person => PersonViewUtils.person_display_name_for_type(@person, "first_name_only"))
+
 - if @current_community.follow_in_use? && @current_user && !current_user?(@person)
   = render :partial => "follow_button", :locals => { :person => @person }

--- a/app/views/people/show.haml
+++ b/app/views/people/show.haml
@@ -3,7 +3,7 @@
 
 - content_for :title_header do
   %h1
-    %span.profile-title= @person.name(@current_community)
+    %span.profile-title= PersonViewUtils.person_display_name(@person, @current_community)
 
 .row
   .col-8

--- a/app/views/people/show.haml
+++ b/app/views/people/show.haml
@@ -3,7 +3,7 @@
 
 - content_for :title_header do
   %h1
-    %span.profile-title= @person.name(@current_community) + (@community_customization && @community_customization.storefront_label ? @community_customization.storefront_label : "")
+    %span.profile-title= @person.name(@current_community)
 
 .row
   .col-8

--- a/app/views/person_mailer/automatic_confirmation/_automatically_confirmed_footer.html.haml
+++ b/app/views/person_mailer/automatic_confirmation/_automatically_confirmed_footer.html.haml
@@ -4,9 +4,9 @@
 %tr
   %td{:align => "left", :style => "padding-top: 15px;"}
     %font{body_font}
-      = t("emails.automatically_confirmed_footer.giving_feedback_is_good_idea", :other_party_given_name => transaction.other_party(recipient).given_name_or_username)
+      = t("emails.automatically_confirmed_footer.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(transaction.other_party(recipient), "first_name_only"))
 
-= render :partial => "action_button", :locals => { :text => t("emails.automatically_confirmed_footer.give_feedback_to", :other_party_given_name => transaction.other_party(recipient).given_name_or_username), :url => url}
+= render :partial => "action_button", :locals => { :text => t("emails.automatically_confirmed_footer.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(transaction.other_party(recipient), "first_name_only")), :url => url}
 
 %tr
   %td{:align => "left", :style => "padding-bottom: 25px;"}

--- a/app/views/person_mailer/confirm_reminder.html.haml
+++ b/app/views/person_mailer/confirm_reminder.html.haml
@@ -5,7 +5,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@conversation.created_at.to_date), :request_link => link_to(@conversation.listing_title, conversation_url), :other_party_full_name => @conversation.seller.name(@conversation.community), :other_party_given_name => @conversation.seller.given_name_or_username).html_safe
+      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@conversation.created_at.to_date), :request_link => link_to(@conversation.listing_title, conversation_url), :other_party_full_name => @conversation.seller.name(@conversation.community), :other_party_given_name => PersonViewUtils.person_display_name(@conversation.seller, "first_name_only")).html_safe
 
 %tr
   %td{:align => "left", :style => "padding-top: 25px; padding-bottom: 25px;"}

--- a/app/views/person_mailer/conversation_status_changed.html.haml
+++ b/app/views/person_mailer/conversation_status_changed.html.haml
@@ -6,7 +6,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.conversation_status_changed.has_#{@transaction.status}_your_request", :accepter => @transaction.listing.author.name(@current_community), :listing => @transaction.listing_title)
+      = t("emails.conversation_status_changed.has_#{@transaction.status}_your_request", :accepter => PersonViewUtils.person_display_name(@transaction.listing.author, @current_community), :listing => @transaction.listing_title)
       = additional_text
 
 -# TODO: Should we link transition to message?
@@ -15,7 +15,7 @@
   %tr
     %td{:align => "left", :style => "padding-top: 15px;"}
       %font{body_font}
-        = t("emails.transaction_confirmed.here_is_a_message_from", :other_party_given_name => @transaction.other_party(@recipient).given_name_or_username)
+        = t("emails.transaction_confirmed.here_is_a_message_from", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only"))
   = render :partial => "quote", :locals => { :quote => @transaction.conversation.last_message.content }
 
 = render :partial => "action_button", :locals => { :text => action_text, :url => action_url}

--- a/app/views/person_mailer/invitation_to_kassi.html.haml
+++ b/app/views/person_mailer/invitation_to_kassi.html.haml
@@ -8,9 +8,9 @@
 %tr
   %td{:align => "left", :style => "padding-top: 15px;"}
     %font{body_font}
-      = t("emails.invitation_to_kassi.you_have_been_invited_to_kassi", :inviter => @invitation.inviter.name(@current_community), :community => @invitation.community.full_name_with_separator(@invitation.inviter.locale))
+      = t("emails.invitation_to_kassi.you_have_been_invited_to_kassi", :inviter => PersonViewUtils.person_display_name(@invitation.inviter, @current_community), :community => @invitation.community.full_name_with_separator(@invitation.inviter.locale))
       - if @invitation.message && !@invitation.message.blank?
-        = t("emails.invitation_to_kassi.here_is_a_message_from", :inviter => @invitation.inviter.given_name_or_username)
+        = t("emails.invitation_to_kassi.here_is_a_message_from", :inviter => PersonViewUtils.person_display_name_for_type(@invitation.inviter, "first_name_only"))
 
 - if @invitation.message && !@invitation.message.blank?
   = render :partial => "quote", :locals => { :quote => @invitation.message }

--- a/app/views/person_mailer/new_comment_to_followed_listing_notification.html.haml
+++ b/app/views/person_mailer/new_comment_to_followed_listing_notification.html.haml
@@ -3,6 +3,6 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.new_comment.has_commented_listing_you_follow_in_kassi", :author => @comment.author.name(@community), :listing => @comment.listing.title)
+      = t("emails.new_comment.has_commented_listing_you_follow_in_kassi", :author => PersonViewUtils.person_display_name(@comment.author, @community), :listing => @comment.listing.title)
 
 = render :partial => "action_button", :locals => { :text => t("emails.new_comment.view_comment"), :url => url}

--- a/app/views/person_mailer/new_comment_to_own_listing_notification.html.haml
+++ b/app/views/person_mailer/new_comment_to_own_listing_notification.html.haml
@@ -3,6 +3,6 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.new_comment.has_commented_your_listing_in_kassi", :author => @comment.author.name(@community), :listing => @comment.listing.title)
+      = t("emails.new_comment.has_commented_your_listing_in_kassi", :author => PersonViewUtils.person_display_name(@comment.author, @community), :listing => @comment.listing.title)
 
 = render :partial => "action_button", :locals => { :text => t("emails.new_comment.view_comment"), :url => url}

--- a/app/views/person_mailer/new_member_notification.html.haml
+++ b/app/views/person_mailer/new_member_notification.html.haml
@@ -3,7 +3,7 @@
 
 %div{:style => "margin: 15px 0; padding: 10px; background-color: #d1c9b4;"}
   %b= t("emails.new_member_notification.person_name")
-  = @person.name(@community)
+  = PersonViewUtils.person_display_name(@person, @community)
   %br/
   %b= t("emails.new_member_notification.person_email")
   = @email

--- a/app/views/person_mailer/new_message_notification.html.haml
+++ b/app/views/person_mailer/new_message_notification.html.haml
@@ -4,6 +4,6 @@
   %td{:align => "left"}
     %font{body_font}
 
-      = t("emails.new_message.has_sent_you_a_message_in_kassi", :sender => @message.sender.name(@current_community))
+      = t("emails.new_message.has_sent_you_a_message_in_kassi", :sender => PersonViewUtils.person_display_name(@message.sender, @current_community))
 
 = render :partial => "action_button", :locals => { :text => t("emails.new_message.view_message"), :url => url}

--- a/app/views/person_mailer/new_testimonial.html.haml
+++ b/app/views/person_mailer/new_testimonial.html.haml
@@ -4,7 +4,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.new_testimonial.has_given_you_feedback_in_kassi", :name => @testimonial.author.name(@current_community)) + "."
+      = t("emails.new_testimonial.has_given_you_feedback_in_kassi", :name => PersonViewUtils.person_display_name(@testimonial.author, @current_community)) + "."
 
 = render :partial => "action_button", :locals => { :text => t("emails.new_testimonial.view_feedback"), :url => view_url}
 
@@ -13,7 +13,7 @@
   %tr
     %td{:align => "left"}
       %font{body_font}
-        = t("emails.new_testimonial.you_can_give_feedback_to", :name => @testimonial.author.given_name_or_username)
-        = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => @testimonial.author.given_name_or_username)
+        = t("emails.new_testimonial.you_can_give_feedback_to", :name => PersonViewUtils.person_display_name_for_type(@testimonial.author, "first_name_only"))
+        = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@testimonial.author, "first_name_only"))
 
-  = render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => @testimonial.author.given_name_or_username), :url => give_url}
+  = render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@testimonial.author, "first_name_only")), :url => give_url}

--- a/app/views/person_mailer/reset_password_instructions.haml
+++ b/app/views/person_mailer/reset_password_instructions.haml
@@ -1,5 +1,5 @@
 %p
-  = t("emails.common.hey", :name => @person.given_name_or_username)
+  = t("emails.common.hey", :name => PersonViewUtils.person_display_name_for_type(@person, "first_name_only"))
 %p
   = t("emails.reset_password_instructions.reset_password_instructions", {:username => @person.username, :password_reset_link => link_to(t('emails.reset_password_instructions.change_my_password'), edit_password_url(@person, :reset_password_token => reset_token, :locale => I18n.locale, host: host))}).html_safe
 

--- a/app/views/person_mailer/testimonial_reminder.html.haml
+++ b/app/views/person_mailer/testimonial_reminder.html.haml
@@ -4,11 +4,11 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.testimonial_reminder.you_have_not_given_feedback_yet", :name => @other_party.name(@conversation.community), :event => link_to(@conversation.listing_title, conversation_url), :given_name => @other_party.given_name_or_username).html_safe
+      = t("emails.testimonial_reminder.you_have_not_given_feedback_yet", :name => PersonViewUtils.person_display_name(@other_party, @conversation.community), :event => link_to(@conversation.listing_title, conversation_url), :given_name => PersonViewUtils.person_display_name_for_type(@other_party, "first_name_only")).html_safe
 
 %tr
   %td{:align => "left", :style => "padding-top: 15px"}
     %font{body_font}
-      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => @other_party.given_name_or_username)
+      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@other_party, "first_name_only"))
 
-= render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => @other_party.given_name_or_username), :url => give_url}
+= render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@other_party, "first_name_only")), :url => give_url }

--- a/app/views/person_mailer/transaction_confirmed.html.haml
+++ b/app/views/person_mailer/transaction_confirmed.html.haml
@@ -4,14 +4,14 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.transaction_confirmed.has_marked_request_as_#{@conversation.status}", :other_party_full_name => @conversation.other_party(@recipient).name(@conversation.community), :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username, :request => @conversation.listing.title)
+      = t("emails.transaction_confirmed.has_marked_request_as_#{@conversation.status}", :other_party_full_name => @conversation.other_party(@recipient).name(@conversation.community), :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only"), :request => @conversation.listing.title)
 
 %tr
   %td{:align => "left", :style => "padding-top: 15px;"}
     %font{body_font}
-      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username)
+      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only")))
 
-= render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => @conversation.other_party(@recipient).given_name_or_username), :url => url}
+= render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only")), :url => url}
 
 %tr
   %td{:align => "left", :style => "padding-bottom: 25px;"}

--- a/app/views/person_mailer/welcome_email.html.haml
+++ b/app/views/person_mailer/welcome_email.html.haml
@@ -14,7 +14,7 @@
                         - if @recipient.has_admin_rights? && !@test_email
                           = render :partial => "admin/communities/welcome_email_for_marketplace_creator"
                         - else
-                          %p= t("emails.common.hey", :name => @recipient.given_name_or_username)
+                          %p= t("emails.common.hey", :name => PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"))
                           - customization = @current_community.community_customizations.find_by_locale(@url_params[:locale])
                           - if customization && !customization.welcome_email_content.blank?
                             = customization.welcome_email_content.html_safe

--- a/app/views/person_messages/new.haml
+++ b/app/views/person_messages/new.haml
@@ -2,7 +2,7 @@
   initialize_send_person_message_form('#{I18n.locale}');
 
 #new_message_form.centered-section
-  %h2= t("conversations.new.send_message_to_user", :person => @recipient.given_name_or_username)
+  %h2= t("conversations.new.send_message_to_user", :person => PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"))
 
   = form_for @conversation, :url => person_person_messages_path(:person => @recipient) do |form|
     = fields_for "conversation[message_attributes]", Message.new do |message_form|

--- a/app/views/testimonials/new.haml
+++ b/app/views/testimonials/new.haml
@@ -9,7 +9,7 @@
     });
 .centered-section.testimonial-form
   %h2= t(".give_feedback_to", :person => transaction.other_party(@current_user).name(@current_community))
-  %p= t(".this_will_be_shown_in_profile", :person => transaction.other_party(@current_user).given_name_or_username)
+  %p= t(".this_will_be_shown_in_profile", :person => PersonViewUtils.person_display_name_for_type(transaction.other_party(@current_user), "first_name_only"))
   = form_for testimonial, :url => person_message_feedbacks_path(:person_id => @current_user.id, :message_id => transaction.id) do |form|
     = form.error_messages
     = form.label :text, t('.textual_feedback')

--- a/app/views/transaction_mailer/transaction_preauthorized.haml
+++ b/app/views/transaction_mailer/transaction_preauthorized.haml
@@ -3,7 +3,7 @@
 %tr
   %td{:align => "left", :style => "padding-top: 15px; padding-bottom: 25px;"}
     %font{body_font}
-      = t("emails.transaction_preauthorized.transaction_requested_by_user", :listing_title => @transaction.listing.title, :requester => @transaction.starter.name(@transaction.community))
+      = t("emails.transaction_preauthorized.transaction_requested_by_user", :listing_title => @transaction.listing.title, :requester => PersonViewUtils.person_display_name(@transaction.starter, @transaction.community))
 
 %tr
   %td{:align => "left", :style => "padding-bottom: 15px;"}

--- a/db/migrate/20170216134444_remove_storefront_label.rb
+++ b/db/migrate/20170216134444_remove_storefront_label.rb
@@ -1,0 +1,8 @@
+class RemoveStorefrontLabel < ActiveRecord::Migration
+  def up
+    remove_column :community_customizations, :storefront_label
+  end
+  def down
+    add_column :community_customizations, :storefront_label, :string, null: true, after: :privacy_page_content
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -315,7 +315,6 @@ CREATE TABLE `community_customizations` (
   `about_page_content` mediumtext,
   `terms_page_content` mediumtext,
   `privacy_page_content` mediumtext,
-  `storefront_label` varchar(255) DEFAULT NULL,
   `signup_info_content` text,
   `private_community_homepage_content` mediumtext,
   `verification_to_post_listings_info_content` mediumtext,
@@ -1599,7 +1598,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-11-08 14:13:02
+-- Dump completed on 2017-02-16 15:50:16
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3219,4 +3218,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161107132513');
 INSERT INTO schema_migrations (version) VALUES ('20161107141257');
 
 INSERT INTO schema_migrations (version) VALUES ('20161109094513');
+
+INSERT INTO schema_migrations (version) VALUES ('20170216134444');
 

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -23,7 +23,7 @@ describe PersonMailer, type: :mailer do
     email = MailCarrier.deliver_now(PersonMailer.new_message_notification(@message, @community))
     assert !ActionMailer::Base.deliveries.empty?
     assert_equal @test_person2.confirmed_notification_email_addresses, email.to
-    assert_equal "A new message in Sharetribe from #{@message.sender.name('first_name_with_initial')}", email.subject
+    assert_equal "A new message in Sharetribe from #{PersonViewUtils.person_display_name_for_type(@message.sender, 'first_name_with_initial')}", email.subject
   end
 
   it "should send email about a new comment to own listing" do


### PR DESCRIPTION
- [x] remove storefront label as unecessary
- [x] deprecate name methods in person.rb
- [x] add functions for display type based name formatting
- [x] change all references to name functions as follows:
      - `person.name(community)` -> `PersonViewUtils.person_display_name(person, community)`
      - `person.given_name_or_username` -> `PersonViewUtils.person_display_name_for_type(person, "first_name_only")`
      - `person.name('first_name_with_initial')` -> `PersonViewUtils.person_display_name_for_type(person, 'first_name_with_initial')`