### PR TITLE
Replace removed locale with default locale for marketplace users

### DIFF
--- a/app/services/marketplace_service/api/marketplaces.rb
+++ b/app/services/marketplace_service/api/marketplaces.rb
@@ -116,6 +116,14 @@ module MarketplaceService::API
       community_name = community.name(default_locale)
       locales.each { |locale| Helper.first_or_create_community_customization!(community, community_name, locale) }
 
+      # Replace removed locale with default for users of marketplace
+      removed_locales = community.locales - locales
+      if removed_locales.present?
+        UserService::API::Users.replace_with_default_locale(community_id: community.id,
+                                                            locales: removed_locales,
+                                                            default_locale: locales.first)
+      end
+
       settings = community.settings || {}
       settings["locales"] = locales
       community.settings = settings

--- a/app/services/user_service/api/users.rb
+++ b/app/services/user_service/api/users.rb
@@ -117,6 +117,10 @@ module UserService::API
       generate_username_from_base(base, community_id)
     end
 
+    def replace_with_default_locale(community_id:, locales:, default_locale:)
+      Person.where(community_id: community_id, locale: locales).update_all(locale: default_locale)
+    end
+
     # private
 
     def generate_username(given_name, family_name, community_id)


### PR DESCRIPTION
Replaces removed locale with default locale for marketplace users and fixes bugs where marketplace has customization for language that's not anymore available.

## To reproduce:

1. Have a marketplace with two languages: English and Swedish
2. Set marketplace names accordingly: English: "Eng" & Swedish: "Swe"
3. Set users locale to Swedish
4. Remove Swedish from available languages
5. Set new membership notifications on
6. Create a new membership

## Expected 

* Email has marketplace name "Eng"

## Actual

* Email has marketplace name "Swe"

There are probably other places also where we rely on locale that's not available.