### PR TITLE
Display only filters for selected category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Add support for redis as cache store [#2786](https://github.com/sharetribe/sharetribe/pull/2786)
 - Add support for using PayPal in fake mode for development purposes. [Read more](./docs/using-fakepal.md) [#2598](https://github.com/sharetribe/sharetribe/pull/2598)
 - Add support for linking to member invitation page in CLP [#2859](https://github.com/sharetribe/sharetribe/pull/2859)
+- New feature: Hide irrelevant search filters when a category or subcategory is selected [#2882](https://github.com/sharetribe/sharetribe/pull/2882)
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'ts-delayed-delta', "~>2.0.2",
   :git    => 'https://github.com/pat/ts-delayed-delta.git',
   :branch => 'master',
   :ref    => '839284f2f28b3f4caf3a3bf5ccde9a6d222c7f4d'
-gem 'possibly', '~> 0.2.0'
+gem 'possibly', '~> 1.0.1'
 
 gem 'delayed_job', "~> 4.1.1"
 gem 'delayed_job_active_record', "~> 4.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ GEM
     paypal-sdk-permissions (1.96.4)
       paypal-sdk-core (~> 0.3.0)
     pkg-config (1.1.7)
-    possibly (0.2.0)
+    possibly (1.0.1)
     powerpack (0.1.1)
     premailer (1.8.7)
       css_parser (>= 1.4.5)
@@ -585,7 +585,7 @@ DEPENDENCIES
   passenger (~> 5.0.30)
   paypal-sdk-merchant (~> 1.116.0)
   paypal-sdk-permissions (~> 1.96.4)
-  possibly (~> 0.2.0)
+  possibly (~> 1.0.1)
   premailer (~> 1.8.2)
   protected_attributes (~> 1.1.3)
   pry-byebug

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -16,8 +16,8 @@ class HomepageController < ApplicationController
     filter_params = {}
 
     m_selected_category = Maybe(@current_community.categories.find_by_url_or_id(params[:category]))
-    filter_params[:categories] = m_selected_category.own_and_subcategory_ids.or_else(nil)
-    selected_category = m_selected_category.or_else(nil)
+    filter_params[:categories] = m_selected_category.own_and_subcategory_ids.or_nil
+    selected_category = m_selected_category.or_nil
 
     if FeatureFlagHelper.feature_enabled?(:searchpage_v1)
       @view_type = "grid"

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -40,9 +40,6 @@ class HomepageController < ApplicationController
       @category_menu_enabled = @show_categories || @show_custom_fields
     end
 
-
-    @homepage = true
-
     listing_shape_param = params[:transaction_type]
 
     selected_shape = all_shapes.find { |s| s[:name] == listing_shape_param }

--- a/app/view_utils/custom_field_search_params.rb
+++ b/app/view_utils/custom_field_search_params.rb
@@ -1,4 +1,4 @@
-module SearchParams
+module CustomFieldSearchParams
 
   DROPDOWN_PREFIX = "filter_option_"
   CHECKBOX_PREFIX = "checkbox_filter_option_"
@@ -13,10 +13,11 @@ module SearchParams
 
     params.reject { |name|
       # Remove parameter if:
-      # - it is a (custom field) search parameter
+      # - it is a custom field search parameter
       # - it's not in the set of relevant param names
       #
-      search_param?(name) && !relevant_search_param_names.include?(name)
+      custom_field_search_param?(name) &&
+        !relevant_search_param_names.include?(name)
     }
   end
 
@@ -38,9 +39,9 @@ module SearchParams
     }.compact.to_set
   end
 
-  # CHECK if param is search param
+  # CHECK if param is custom fields search param
 
-  def search_param?(param_name)
+  def custom_field_search_param?(param_name)
     dropdown_param?(param_name) ||
       checkbox_param?(param_name) ||
       numeric_min_param?(param_name) ||

--- a/app/view_utils/search_page_helper.rb
+++ b/app/view_utils/search_page_helper.rb
@@ -61,7 +61,7 @@ module SearchPageHelper
 
   # Return all params starting with `numeric_filter_`
   def numeric_filter_params(all_params)
-    all_params.select { |key, value| key.start_with?(SearchParams::NUMERIC_PREFIX) }
+    all_params.select { |key, value| key.start_with?(CustomFieldSearchParams::NUMERIC_PREFIX) }
   end
 
   def parse_numeric_filter_params(numeric_params)
@@ -90,7 +90,8 @@ module SearchPageHelper
 
   def options_from_params(params, prefix)
     option_ids = params.select { |key, value|
-      key.start_with?(prefix) }.values
+      key.start_with?(prefix)
+    }.values
 
     array_for_search = CustomFieldOption.find(option_ids)
       .group_by { |option| option.custom_field_id }
@@ -98,19 +99,19 @@ module SearchPageHelper
   end
 
   def dropdown_field_options_for_search(params)
-    options_from_params(params, SearchParams::DROPDOWN_PREFIX).map { |dropdown|
+    options_from_params(params, CustomFieldSearchParams::DROPDOWN_PREFIX).map { |dropdown|
       dropdown.merge(
         type: :selection_group,
-        operator: :or,
+        operator: :or
       )
     }
   end
 
   def checkbox_field_options_for_search(params)
-    options_from_params(params, SearchParams::CHECKBOX_PREFIX).map { |checkbox|
+    options_from_params(params, CustomFieldSearchParams::CHECKBOX_PREFIX).map { |checkbox|
       checkbox.merge(
         type: :selection_group,
-        operator: :and,
+        operator: :and
       )
     }
   end

--- a/app/view_utils/search_page_helper.rb
+++ b/app/view_utils/search_page_helper.rb
@@ -36,4 +36,99 @@ module SearchPageHelper
         }),
     }
   end
+
+  # Warning!
+  # Even though it may seem that this function is pure and free from side-effects,
+  # it's actually not. The `dropdown_field_options_for_search` and
+  # `checkbox_field_options_for_search` functions are making database queries.
+  def parse_filters_from_params(params)
+    {
+      dropdowns: dropdown_field_options_for_search(params),
+      checkboxes: checkbox_field_options_for_search(params),
+      numeric: numeric_field_options_for_search(params),
+    }.reject { |_, value|
+      # all means the filter doesn't need to be included
+      value == "all" || value == ["all"]
+    }
+  end
+
+  def numeric_field_options_for_search(params)
+    p = numeric_filter_params(params)
+    p = parse_numeric_filter_params(p)
+    p = group_to_ranges(p)
+    p.map { |numeric| numeric.merge(type: :numeric_range) }
+  end
+
+  # Return all params starting with `numeric_filter_`
+  def numeric_filter_params(all_params)
+    all_params.select { |key, value| key.start_with?("nf_") }
+  end
+
+  def parse_numeric_filter_params(numeric_params)
+    numeric_params.inject([]) do |memo, numeric_param|
+      key, value = numeric_param
+      _, boundary, id = key.split("_")
+
+      hash = {id: id.to_i}
+      hash[boundary.to_sym] = value
+      memo << hash
+    end
+  end
+
+  def group_to_ranges(parsed_params)
+    parsed_params
+      .group_by { |param| param[:id] }
+      .map do |key, values|
+        boundaries = values.inject(:merge)
+
+        {
+          id: key,
+          value: (boundaries[:min].to_f..boundaries[:max].to_f)
+        }
+      end
+  end
+
+  def options_from_params(params, regexp)
+    option_ids = HashUtils.select_by_key_regexp(params, regexp).values
+
+    array_for_search = CustomFieldOption.find(option_ids)
+      .group_by { |option| option.custom_field_id }
+      .map { |key, selected_options| {id: key, value: selected_options.collect(&:id) } }
+  end
+
+  def dropdown_field_options_for_search(params)
+    options_from_params(params, /^filter_option/).map { |dropdown|
+      dropdown.merge(
+        type: :selection_group,
+        operator: :or,
+      )
+    }
+  end
+
+  def checkbox_field_options_for_search(params)
+    options_from_params(params, /^checkbox_filter_option/).map { |checkbox|
+      checkbox.merge(
+        type: :selection_group,
+        operator: :and,
+      )
+    }
+  end
+
+  def selected_view_type(view_param, community_default, app_default, all_types)
+    if view_param.present? and all_types.include?(view_param)
+      view_param
+    elsif community_default.present? and all_types.include?(community_default)
+      community_default
+    else
+      app_default
+    end
+  end
+
+  def remove_irrelevant_search_fields(fields, relevant_filters)
+    relevant_filter_ids = relevant_filters.map(&:id).to_set
+
+    fields.select { |field|
+      relevant_filter_ids.include?(field[:id])
+    }
+  end
 end

--- a/app/view_utils/search_page_helper.rb
+++ b/app/view_utils/search_page_helper.rb
@@ -61,7 +61,7 @@ module SearchPageHelper
 
   # Return all params starting with `numeric_filter_`
   def numeric_filter_params(all_params)
-    all_params.select { |key, value| key.start_with?("nf_") }
+    all_params.select { |key, value| key.start_with?(SearchParams::NUMERIC_PREFIX) }
   end
 
   def parse_numeric_filter_params(numeric_params)
@@ -88,8 +88,9 @@ module SearchPageHelper
       end
   end
 
-  def options_from_params(params, regexp)
-    option_ids = HashUtils.select_by_key_regexp(params, regexp).values
+  def options_from_params(params, prefix)
+    option_ids = params.select { |key, value|
+      key.start_with?(prefix) }.values
 
     array_for_search = CustomFieldOption.find(option_ids)
       .group_by { |option| option.custom_field_id }
@@ -97,7 +98,7 @@ module SearchPageHelper
   end
 
   def dropdown_field_options_for_search(params)
-    options_from_params(params, /^filter_option/).map { |dropdown|
+    options_from_params(params, SearchParams::DROPDOWN_PREFIX).map { |dropdown|
       dropdown.merge(
         type: :selection_group,
         operator: :or,
@@ -106,7 +107,7 @@ module SearchPageHelper
   end
 
   def checkbox_field_options_for_search(params)
-    options_from_params(params, /^checkbox_filter_option/).map { |checkbox|
+    options_from_params(params, SearchParams::CHECKBOX_PREFIX).map { |checkbox|
       checkbox.merge(
         type: :selection_group,
         operator: :and,

--- a/app/view_utils/search_params.rb
+++ b/app/view_utils/search_params.rb
@@ -1,0 +1,83 @@
+module SearchParams
+
+  DROPDOWN_PREFIX = "filter_option_"
+  CHECKBOX_PREFIX = "checkbox_filter_option_"
+  NUMERIC_PREFIX = "nf_"
+  NUMERIC_MIN_PREFIX = NUMERIC_PREFIX + "min_"
+  NUMERIC_MAX_PREFIX = NUMERIC_PREFIX + "max_"
+
+  module_function
+
+  def remove_irrelevant_search_params(params, relevant_search_fields)
+    relevant_search_param_names = search_fields_to_param_names(relevant_search_fields)
+
+    params.reject { |name|
+      # Remove parameter if:
+      # - it is a (custom field) search parameter
+      # - it's not in the set of relevant param names
+      #
+      search_param?(name) && !relevant_search_param_names.include?(name)
+    }
+  end
+
+  def search_fields_to_param_names(search_fields)
+    search_fields.flat_map { |field|
+      field_id, value, type, operator = field.values_at(:id, :value, :type, :operator)
+
+      case [type, operator]
+      when [:selection_group, :and]
+        # Checkbox
+        value.map { |option_id| checkbox_param_name(option_id) }
+      when [:selection_group, :or]
+        # Dropdown
+        value.map { |option_id| dropdown_param_name(option_id) }
+      when [:numeric_range, nil]
+        # Numeric
+        [numeric_min_param_name(field_id), numeric_max_param_name(field_id)]
+      end
+    }.compact.to_set
+  end
+
+  # CHECK if param is search param
+
+  def search_param?(param_name)
+    dropdown_param?(param_name) ||
+      checkbox_param?(param_name) ||
+      numeric_min_param?(param_name) ||
+      numeric_max_param?(param_name)
+  end
+
+  def dropdown_param?(param_name)
+    param_name.starts_with?(DROPDOWN_PREFIX)
+  end
+
+  def checkbox_param?(param_name)
+    param_name.starts_with?(CHECKBOX_PREFIX)
+  end
+
+  def numeric_min_param?(param_name)
+    param_name.starts_with?(NUMERIC_MIN_PREFIX)
+  end
+
+  def numeric_max_param?(param_name)
+    param_name.starts_with?(NUMERIC_MAX_PREFIX)
+  end
+
+  # CONSTRUCT param names
+
+  def dropdown_param_name(option_id)
+    DROPDOWN_PREFIX + option_id.to_s
+  end
+
+  def checkbox_param_name(option_id)
+    CHECKBOX_PREFIX + option_id.to_s
+  end
+
+  def numeric_min_param_name(field_id)
+    NUMERIC_MIN_PREFIX + field_id.to_s
+  end
+
+  def numeric_max_param_name(field_id)
+    NUMERIC_MAX_PREFIX + field_id.to_s
+  end
+end

--- a/app/views/homepage/_custom_filters.haml
+++ b/app/views/homepage/_custom_filters.haml
@@ -11,12 +11,17 @@
             - field.options.sort.each do |option|
               .custom-filter-checkbox-container
                 %label.custom-filter-checkbox-label
-                  - param_name = type == :dropdown ? "filter_option_#{option.id}" : "checkbox_filter_option_#{option.id}"
+                  - param_name = type == :dropdown ? SearchParams.dropdown_param_name(option.id) : SearchParams.checkbox_param_name(option.id)
                   = check_box_tag param_name, "#{option.id}", params[param_name]
                   %span.custom-filter-checkbox-label-text
                     = option.title(I18n.locale)
 
   - field.with(:numeric) do
+    - min_param = SearchParams.numeric_min_param_name(field.id)
+    - max_param = SearchParams.numeric_max_param_name(field.id)
+    - min_value = params[min_param]
+    - max_value = params[max_param]
+
     .row
       .col-12
         .custom-filter-title
@@ -27,7 +32,7 @@
           - id = ["range-slider", field.id].join("-")
           .range-slider{id: id}
             - range = [field.min, field.max]
-            - start = [params["nf_min_" + field.id.to_s] || field.min, params["nf_max_" + field.id.to_s] || field.max]
+            - start = [min_value || field.min, max_value || field.max]
             - labels = ["#custom-filter-min-value-#{id}", "#custom-filter-max-value-#{id}"]
             - fields = ["#nf_min_#{id}", "#nf_max_#{id}"]
 
@@ -40,8 +45,8 @@
         .left
           %span.custom-filter-min-max-title= t(".min")
           %span{id: "custom-filter-min-value-#{id}"}
-          %input{type: "hidden", id: "nf_min_#{id}", name: "nf_min_#{field.id}", value: params["nf_min_#{field.id}"]}
+          %input{type: "hidden", id: "nf_min_#{id}", name: min_param, value: min_value}
         .right
           %span.custom-filter-min-max-title= t(".max")
           %span{id: "custom-filter-max-value-#{id}"}
-          %input{type: "hidden", id: "nf_max_#{id}", name: "nf_max_#{field.id}", value: params["nf_max_#{field.id}"]}
+          %input{type: "hidden", id: "nf_max_#{id}", name: max_param, value: max_value}

--- a/app/views/homepage/_custom_filters.haml
+++ b/app/views/homepage/_custom_filters.haml
@@ -11,14 +11,14 @@
             - field.options.sort.each do |option|
               .custom-filter-checkbox-container
                 %label.custom-filter-checkbox-label
-                  - param_name = type == :dropdown ? SearchParams.dropdown_param_name(option.id) : SearchParams.checkbox_param_name(option.id)
+                  - param_name = type == :dropdown ? CustomFieldSearchParams.dropdown_param_name(option.id) : CustomFieldSearchParams.checkbox_param_name(option.id)
                   = check_box_tag param_name, "#{option.id}", params[param_name]
                   %span.custom-filter-checkbox-label-text
                     = option.title(I18n.locale)
 
   - field.with(:numeric) do
-    - min_param = SearchParams.numeric_min_param_name(field.id)
-    - max_param = SearchParams.numeric_max_param_name(field.id)
+    - min_param = CustomFieldSearchParams.numeric_min_param_name(field.id)
+    - max_param = CustomFieldSearchParams.numeric_max_param_name(field.id)
     - min_value = params[min_param]
     - max_value = params[max_param]
 

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -15,8 +15,6 @@
   - if(@view_type.eql?("map"))
     = javascript_include_tag "markerclusterer.js"
 
-- search_params = SearchParams.remove_irrelevant_search_params(params, relevant_search_fields)
-
 - content_for :title_header do
   - is_homepage = params[:controller] == "homepage" && params[:action] == "index"
   - if @big_cover_photo

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -15,6 +15,8 @@
   - if(@view_type.eql?("map"))
     = javascript_include_tag "markerclusterer.js"
 
+- search_params = SearchParams.remove_irrelevant_search_params(params, relevant_search_fields)
+
 - content_for :title_header do
   - is_homepage = params[:controller] == "homepage" && params[:action] == "index"
   - if @big_cover_photo
@@ -63,7 +65,7 @@
     .home-toolbar-button-group{:class => listing_shape_menu_enabled || @category_menu_enabled ? "filters-enabled" : ""}
       - ["grid", "list", "map"].each do |view_type|
         - selected_class = @view_type == view_type ? "selected" : ""
-        = link_to search_path(params.merge(view: view_type)), :class => "home-toolbar-button-group-button #{selected_class}", :title => t("homepage.filters.#{view_type}_button") do
+        = link_to search_path(search_params.merge(view: view_type)), :class => "home-toolbar-button-group-button #{selected_class}", :title => t("homepage.filters.#{view_type}_button") do
           = icon_tag(view_type, ["icon-fix", "home-button-group-icon"])
           %span.home-toolbar-button-text
             = t("homepage.filters.#{view_type}_button")
@@ -83,9 +85,9 @@
                 = icon_tag("dropdown", ["icon-dropdown"])
 
             .home-toolbar-share-type-menu.toggle-menu.hidden
-              = link_to t("homepage.filters.all_listing_types"), search_path(params.merge({transaction_type: "all"}))
+              = link_to t("homepage.filters.all_listing_types"), search_path(search_params.merge({transaction_type: "all"}))
               - shapes.each do |shape|
-                = link_to search_path(params.merge({transaction_type: shape[:name]})), class:  "toggle-menu-subitem" do
+                = link_to search_path(search_params.merge({transaction_type: shape[:name]})), class:  "toggle-menu-subitem" do
                   = t(shape[:name_tr_key])
 
         - if @show_categories
@@ -100,13 +102,13 @@
 
                 = icon_tag("dropdown", ["icon-dropdown"])
             #home-toolbar-categories-menu.toggle-menu
-              = link_to t("homepage.filters.all_categories"), search_path(params.merge({category: "all"}))
+              = link_to t("homepage.filters.all_categories"), search_path(search_params.merge({category: "all"}))
               - @main_categories.each do |category|
-                = link_to category.display_name(I18n.locale), search_path(params.merge({category: category}))
+                = link_to category.display_name(I18n.locale), search_path(search_params.merge({category: category}))
                 - if category.children
                   - category.children.each do |child|
                     - is_selected = selected_category == child
-                    = link_to child.display_name(I18n.locale), search_path(params.merge({category: child})), :class => "toggle-menu-subitem"
+                    = link_to child.display_name(I18n.locale), search_path(search_params.merge({category: child})), :class => "toggle-menu-subitem"
 
         / Filters
         .hidden-tablet
@@ -120,15 +122,15 @@
         - if @show_categories
           .row
             .col-12
-              = link_to t("homepage.filters.all_categories"), search_path(params.merge({category: "all"})), :class => "home-categories-main #{if selected_category.nil? then 'selected' end}"
+              = link_to t("homepage.filters.all_categories"), search_path(search_params.merge({category: "all"})), :class => "home-categories-main #{if selected_category.nil? then 'selected' end}"
               - @main_categories.each do |category|
                 - show_subcategories = show_subcategory_list(category, Maybe(selected_category).id.to_i.or_else(nil))
-                = link_to category.display_name(I18n.locale), search_path(params.merge({category: category})), :class => "home-categories-main #{if show_subcategories then 'selected' end} #{if category.has_subcategories? then 'has-subcategories' end}", :data => {category: category.id}
+                = link_to category.display_name(I18n.locale), search_path(search_params.merge({category: category})), :class => "home-categories-main #{if show_subcategories then 'selected' end} #{if category.has_subcategories? then 'has-subcategories' end}", :data => {category: category.id}
                 - if category.children
                   - if show_subcategories
                     - category.children.each do |child|
                       - is_selected = selected_category == child
-                      = link_to child.display_name(I18n.locale), search_path(params.merge({category: child})), :class => "home-categories-sub #{if is_selected then 'selected' end}", :data => {:"sub-category" =>child.id}
+                      = link_to child.display_name(I18n.locale), search_path(search_params.merge({category: child})), :class => "home-categories-sub #{if is_selected then 'selected' end}", :data => {:"sub-category" =>child.id}
 
         #desktop-filters
           - # Filters will be relocated here when in desktop

--- a/app/views/homepage/index.haml
+++ b/app/views/homepage/index.haml
@@ -93,8 +93,8 @@
             .toggle.with-borders{data: {toggle: '#home-toolbar-categories-menu'}}
               .toggle-header-container
                 .toggle-header
-                  - if @selected_category
-                    = @selected_category.display_name(I18n.locale)
+                  - if selected_category
+                    = selected_category.display_name(I18n.locale)
                   - else
                     = t("homepage.filters.all_categories")
 
@@ -105,7 +105,7 @@
                 = link_to category.display_name(I18n.locale), search_path(params.merge({category: category}))
                 - if category.children
                   - category.children.each do |child|
-                    - is_selected = @selected_category == child
+                    - is_selected = selected_category == child
                     = link_to child.display_name(I18n.locale), search_path(params.merge({category: child})), :class => "toggle-menu-subitem"
 
         / Filters
@@ -120,14 +120,14 @@
         - if @show_categories
           .row
             .col-12
-              = link_to t("homepage.filters.all_categories"), search_path(params.merge({category: "all"})), :class => "home-categories-main #{if @selected_category.nil? then 'selected' end}"
+              = link_to t("homepage.filters.all_categories"), search_path(params.merge({category: "all"})), :class => "home-categories-main #{if selected_category.nil? then 'selected' end}"
               - @main_categories.each do |category|
-                - show_subcategories = show_subcategory_list(category, Maybe(@selected_category).id.to_i.or_else(nil))
+                - show_subcategories = show_subcategory_list(category, Maybe(selected_category).id.to_i.or_else(nil))
                 = link_to category.display_name(I18n.locale), search_path(params.merge({category: category})), :class => "home-categories-main #{if show_subcategories then 'selected' end} #{if category.has_subcategories? then 'has-subcategories' end}", :data => {category: category.id}
                 - if category.children
                   - if show_subcategories
                     - category.children.each do |child|
-                      - is_selected = @selected_category == child
+                      - is_selected = selected_category == child
                       = link_to child.display_name(I18n.locale), search_path(params.merge({category: child})), :class => "home-categories-sub #{if is_selected then 'selected' end}", :data => {:"sub-category" =>child.id}
 
         #desktop-filters

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -69,7 +69,7 @@
         - search_params = ["q", "lc", "ls", "boundingbox", "distance_max"]
         - excluded_params = search_params unless FeatureFlagHelper.feature_enabled?(:topbar_v1)
         - params.except("action", "controller", "view", "utf8", *excluded_params).each do |param, value|
-          - unless param.match(/^filter_option/) || param.match(/^checkbox_filter_option/) || param.match(/^nf_/) || param.match(/^price_/)
+          - unless CustomFieldSearchParams.custom_field_search_param?(param) || param.match(/^price_/)
             = hidden_field_tag param, value
         = hidden_field_tag "view", @view_type
         = content_for(:page_content)

--- a/spec/view_utils/search_page_helper_spec.rb
+++ b/spec/view_utils/search_page_helper_spec.rb
@@ -33,10 +33,10 @@ describe SearchPageHelper do
       @custom_field_option4 = FactoryGirl.create(:custom_field_option, :custom_field =>  @custom_field2)
 
       array = SearchPageHelper.dropdown_field_options_for_search({
-        "filter_options_#{@custom_field_option1.id}" => @custom_field_option1.id,
-        "filter_options_#{@custom_field_option2.id}" => @custom_field_option2.id,
-        "filter_options_#{@custom_field_option3.id}" => @custom_field_option3.id,
-        "filter_options_#{@custom_field_option4.id}" => @custom_field_option4.id
+        "filter_option_#{@custom_field_option1.id}" => @custom_field_option1.id,
+        "filter_option_#{@custom_field_option2.id}" => @custom_field_option2.id,
+        "filter_option_#{@custom_field_option3.id}" => @custom_field_option3.id,
+        "filter_option_#{@custom_field_option4.id}" => @custom_field_option4.id
       })
 
       expect(array).to eq([

--- a/spec/view_utils/search_page_helper_spec.rb
+++ b/spec/view_utils/search_page_helper_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe HomepageController, type: :controller do
+describe SearchPageHelper do
 
   describe "selected view type" do
 
     it "returns param view type if param is present and it is one of the view types, otherwise comm default" do
       types = ["map", "list", "grid"]
-      expect(HomepageController.selected_view_type("map", "list", "grid", types)).to eq("map")
-      expect(HomepageController.selected_view_type(nil, "list", "grid", types)).to eq("list")
-      expect(HomepageController.selected_view_type("", "list", "grid", types)).to eq("list")
-      expect(HomepageController.selected_view_type("not_existing_view_type", "list", "grid", types)).to eq("list")
+      expect(SearchPageHelper.selected_view_type("map", "list", "grid", types)).to eq("map")
+      expect(SearchPageHelper.selected_view_type(nil, "list", "grid", types)).to eq("list")
+      expect(SearchPageHelper.selected_view_type("", "list", "grid", types)).to eq("list")
+      expect(SearchPageHelper.selected_view_type("not_existing_view_type", "list", "grid", types)).to eq("list")
     end
 
     it "defaults to app default, if comm default is incorrect" do
       types = ["map", "list", "grid"]
-      expect(HomepageController.selected_view_type("", "list", "grid", types)).to eq("list")
-      expect(HomepageController.selected_view_type("", nil, "grid", types)).to eq("grid")
-      expect(HomepageController.selected_view_type("", "", "grid", types)).to eq("grid")
-      expect(HomepageController.selected_view_type("", "not_existing_view_type", "grid", types)).to eq("grid")
+      expect(SearchPageHelper.selected_view_type("", "list", "grid", types)).to eq("list")
+      expect(SearchPageHelper.selected_view_type("", nil, "grid", types)).to eq("grid")
+      expect(SearchPageHelper.selected_view_type("", "", "grid", types)).to eq("grid")
+      expect(SearchPageHelper.selected_view_type("", "not_existing_view_type", "grid", types)).to eq("grid")
     end
 
   end
@@ -32,7 +32,7 @@ describe HomepageController, type: :controller do
       @custom_field_option3 = FactoryGirl.create(:custom_field_option, :custom_field =>  @custom_field2)
       @custom_field_option4 = FactoryGirl.create(:custom_field_option, :custom_field =>  @custom_field2)
 
-      array = HomepageController.dropdown_field_options_for_search({
+      array = SearchPageHelper.dropdown_field_options_for_search({
         "filter_options_#{@custom_field_option1.id}" => @custom_field_option1.id,
         "filter_options_#{@custom_field_option2.id}" => @custom_field_option2.id,
         "filter_options_#{@custom_field_option3.id}" => @custom_field_option3.id,
@@ -40,11 +40,9 @@ describe HomepageController, type: :controller do
       })
 
       expect(array).to eq([
-        {id: @custom_field1.id, value: [@custom_field_option1.id, @custom_field_option2.id]},
-        {id: @custom_field2.id, value: [@custom_field_option3.id, @custom_field_option4.id]},
+        {id: @custom_field1.id, value: [@custom_field_option1.id, @custom_field_option2.id], type: :selection_group, operator: :or},
+        {id: @custom_field2.id, value: [@custom_field_option3.id, @custom_field_option4.id], type: :selection_group, operator: :or},
       ])
     end
-
   end
-
 end


### PR DESCRIPTION
This PR will change the way how filters are shown in the homepage.

### Problem

Currently we are showing all the filters in the homepage, all the time, no matter what category is selected. This creates weird situations, for example:

Let's imagine we have a marketplace that sells Acoustic Guitars, Electric Guitars and Cars. The category structure is following:

* Guitars
  * Acoustic Guitars
  * Electric Guitars
* Cars

There are also three custom fields (filter):

- Number of string (for Acoustic and Electric Guitars) 
- Microphone type (Electric Guitars only)
- Engine size (for Cars only). 

Currently, if the user selects category Cars, the filters Number of strings and Microphone type are still shown. User is even able to make search queries that make no sense, i.e. Cars with 6 strings.

### Solution

The solution to this issue is that we will shown filters only if ANY of the selected category/subcategories has that filter in use. So for example:

- If no category is selected: Show all three filters
- If *Guitars* is selected: Show Number of strings and Microphone type
- If *Acoustic Guitars* is selected: Show Number of strings
- If *Electric Guitars* is selected: Show Number of strings and Microphone type
- If *Cars* is selected: Show Engine size

### Implementation

Two main things needed to be changed:

- In HomepageController, instead of fetching all `filters`, we'll fetch only `relevant_filters`
- We remove irrelevant search parameters from the `search_params` that is used to "store the search state", which is carried from request to request in the URL.

### Detailed TODO list

- [X] Update Maybe gem (adds `.or_nil` method)
- [X] Select only relevant filters (`select_relevant_filters`)
- [X] Parse only relevant search parameters (first parse them all, then call `remove_irrelevant_search_fields`)
- [X] Move a lot of helper methods from HomepageController to SearchPageHelper
- [X] Add a new helper CustomFieldSearchParams
- [X] Remove irrelevant search parameters from the `search_parameters` object that is passed to the view as local variable and used to generate category/view type links etc.