### PR TITLE
Save new user info in transaction. Catch FB pic upload errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Fixed broken transaction button styles [#2723](https://github.com/sharetribe/sharetribe/pull/2723)
 - Fixed number of issues in the Order Types form [#2858](https://github.com/sharetribe/sharetribe/pull/2858)
+- Fixed an issue which caused sign up to fail partially if the Facebook profile picture upload failed [#2886](https://github.com/sharetribe/sharetribe/pull/2886)
 
 ### Security
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -47,7 +47,7 @@ class SessionsController < ApplicationController
       @current_user.update_attribute(:facebook_id, session["devise.facebook_data"]["id"])
       # FIXME: Currently this doesn't work for very unknown reason. Paper clip seems to be processing, but no pic
       if @current_user.image_file_size.nil?
-        @current_user.store_picture_from_facebook
+        @current_user.store_picture_from_facebook!
       end
     end
 


### PR DESCRIPTION
This commit fixes an issue which happens if Amazon S3 is down. The user creation will partially fail, if the profile picture upload to S3 fails. This issue is addressed by:

- Saving person information in transaction
- Catching the possible exception caused by the S3 upload failure