### PR TITLE
Turn expiration off by default

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -334,7 +334,6 @@ class Admin::CommunitiesController < Admin::AdminBaseController
       :require_verification_to_post_listings,
       :show_category_in_listing_list,
       :show_listing_publishing_date,
-      :hide_expiration_date,
       :listing_comments_in_use,
       :automatic_confirmation_after_days,
       :automatic_newsletters,

--- a/app/controllers/admin/custom_fields_controller.rb
+++ b/app/controllers/admin/custom_fields_controller.rb
@@ -200,6 +200,14 @@ class Admin::CustomFieldsController < Admin::AdminBaseController
     @community = @current_community
   end
 
+  def edit_expiration
+    @selected_tribe_navi_tab = "admin"
+    @selected_left_navi_link = "listing_fields"
+    @community = @current_community
+
+    render_expiration_form(listing_expiration_enabled: !@current_community.hide_expiration_date)
+  end
+
   def update_price
     # To cents
     params[:community][:price_filter_min] = MoneyUtil.parse_str_to_money(params[:community][:price_filter_min], @current_community.currency).cents if params[:community][:price_filter_min]
@@ -232,6 +240,26 @@ class Admin::CustomFieldsController < Admin::AdminBaseController
       flash[:error] = "Location field editing failed"
       render :action => :edit_location
     end
+  end
+
+  def update_expiration
+    listing_expiration_enabled = params[:listing_expiration_enabled] == "enabled"
+
+    success = @current_community.update_attributes(
+      { hide_expiration_date: !listing_expiration_enabled })
+
+    if success
+      redirect_to admin_custom_fields_path
+    else
+      flash[:error] = "Expiration field editing failed"
+      render_expiration_form(listing_expiration_enabled: !@current_community.hide_expiration_date)
+    end
+  end
+
+  def render_expiration_form(listing_expiration_enabled:)
+    render :edit_expiration, locals: {
+             listing_expiration_enabled: listing_expiration_enabled
+           }
   end
 
   def destroy

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -304,10 +304,16 @@ class ListingsController < ApplicationController
 
   def create_listing(shape, listing_uuid)
     with_currency = params[:listing].merge({currency: @current_community.currency})
-    listing_params = ListingFormViewUtils.filter(with_currency, shape)
+    valid_until_enabled = !@current_community.hide_expiration_date
+    listing_params = ListingFormViewUtils.filter(with_currency, shape, valid_until_enabled)
     listing_unit = Maybe(params)[:listing][:unit].map { |u| ListingViewUtils::Unit.deserialize(u) }.or_else(nil)
     listing_params = ListingFormViewUtils.filter_additional_shipping(listing_params, listing_unit)
-    validation_result = ListingFormViewUtils.validate(listing_params, shape, listing_unit)
+    validation_result = ListingFormViewUtils.validate(
+      params: listing_params,
+      shape: shape,
+      unit: listing_unit,
+      valid_until_enabled: valid_until_enabled
+    )
 
     unless validation_result.success
       flash[:error] = t("listings.error.something_went_wrong", error_code: validation_result.data.join(', '))
@@ -439,11 +445,17 @@ class ListingsController < ApplicationController
       end
     end
 
+    valid_until_enabled = !@current_community.hide_expiration_date
     with_currency = params[:listing].merge({currency: @current_community.currency})
-    listing_params = ListingFormViewUtils.filter(with_currency, shape)
+    listing_params = ListingFormViewUtils.filter(with_currency, shape, valid_until_enabled)
     listing_unit = Maybe(params)[:listing][:unit].map { |u| ListingViewUtils::Unit.deserialize(u) }.or_else(nil)
     listing_params = ListingFormViewUtils.filter_additional_shipping(listing_params, listing_unit)
-    validation_result = ListingFormViewUtils.validate(listing_params, shape, listing_unit)
+    validation_result = ListingFormViewUtils.validate(
+      params: listing_params,
+      shape: shape,
+      unit: listing_unit,
+      valid_until_enabled: valid_until_enabled
+    )
 
     unless validation_result.success
       flash[:error] = t("listings.error.something_went_wrong", error_code: validation_result.data.join(', '))

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -51,7 +51,7 @@
 #  currency                                   :string(3)        not null
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
-#  hide_expiration_date                       :boolean          default(FALSE)
+#  hide_expiration_date                       :boolean          default(TRUE)
 #  facebook_connect_id                        :string(255)
 #  facebook_connect_secret                    :string(255)
 #  google_analytics_key                       :string(255)

--- a/app/view_utils/listing_form_view_utils.rb
+++ b/app/view_utils/listing_form_view_utils.rb
@@ -1,7 +1,7 @@
 module ListingFormViewUtils
   module_function
 
-  def filter(params, shape)
+  def filter(params, shape, valid_until_enabled)
     filter_fields = []
 
     filter_fields << :price unless shape[:price_enabled]
@@ -10,8 +10,9 @@ module ListingFormViewUtils
     filter_fields << :shipping_price unless shape[:shipping_enabled]
     filter_fields << :shipping_price_additional unless shape[:shipping_enabled]
     filter_fields << :delivery_methods unless shape[:shipping_enabled]
+    filter_fields << ["valid_until(1i)", "valid_until(2i)", "valid_until(3i)"] unless valid_until_enabled
 
-    params.except(*filter_fields)
+    params.except(*filter_fields.flatten)
   end
 
   def filter_additional_shipping(params, unit)
@@ -23,7 +24,7 @@ module ListingFormViewUtils
 
   end
 
-  def validate(params, shape, unit)
+  def validate(params:, shape:, unit:, valid_until_enabled: false)
     errors = []
 
     errors << :price_required if shape[:price_enabled] && params[:price].nil?
@@ -33,6 +34,8 @@ module ListingFormViewUtils
 
     errors << :unit_required if shape[:units].present? && unit.blank?
     errors << :unit_does_not_belong if shape[:units].present? && unit.present? && !shape[:units].any? { |u| u == unit }
+
+    errors << :valid_until_missing if valid_until_enabled && ["valid_until(1i)", "valid_until(2i)", "valid_until(3i)"].any? { |key| params[key].blank? }
 
     if errors.empty?
       Result::Success.new

--- a/app/views/admin/communities/settings.haml
+++ b/app/views/admin/communities/settings.haml
@@ -52,9 +52,6 @@
           = form.check_box :show_listing_publishing_date
           = form.label :show_listing_publishing_date, t(".show_listing_publishing_date"), :class => "settings-checkbox-label"
         .checkbox-container
-          = form.check_box :hide_expiration_date
-          = form.label :hide_expiration_date, t(".hide_expiration_date"), :class => "settings-checkbox-label"
-        .checkbox-container
           = form.check_box :listing_comments_in_use
           = form.label :listing_comments_in_use, t(".listing_comments_in_use"), :class => "settings-checkbox-label"
 

--- a/app/views/admin/custom_fields/edit_expiration.haml
+++ b/app/views/admin/custom_fields/edit_expiration.haml
@@ -1,0 +1,23 @@
+- content_for :title_header do
+  %h1
+    = t("layouts.admin.admin")
+    = "-"
+    = t(".edit_expiration_field")
+
+= render :partial => "admin/left_hand_navigation", :locals => { :links => admin_links_for(@current_community) }
+
+.left-navi-section
+  = form_tag update_expiration_admin_custom_fields_path, method: :put do
+    .row
+      .col-12
+        .checkbox-container
+          = check_box_tag :listing_expiration_enabled, :enabled, listing_expiration_enabled
+          = label_tag :listing_expiration_enabled, t(".enable")
+
+    .add-custom-field-buttons
+      .inline-button-container
+        = button_tag t("admin.custom_fields.index.save")
+      .inline-button-container
+        %a{:href => admin_custom_fields_path, :class => "cancel-button"}
+          .content
+            = t("admin.custom_fields.index.cancel")

--- a/app/views/admin/custom_fields/index.haml
+++ b/app/views/admin/custom_fields/index.haml
@@ -88,23 +88,23 @@
     - if show_custom_fields
       = render :partial => "listed_custom_field", :collection => @custom_fields.sort, :as => :custom_field
 
-    - unless @current_community.hide_expiration_date
-      .row
-        .col-5
-          %span.custom-fields-mobile-list-title.hidden-tablet
-            = t("admin.custom_fields.index.field_title")
-          = t("listings.form.valid_until.valid_until")
-        .col-5
-          %span.custom-fields-mobile-list-title.hidden-tablet
-            = t("admin.custom_fields.index.field_type")
-          %div
-            = t("admin.custom_fields.field_types.date")
-          %div.custom-fields-details
-        .col-2
-          = icon_tag("edit", ["icon-fix disabled"])
-          = icon_tag("cross", ["icon-fix disabled"])
-          = icon_tag("directup", ["icon-fix disabled"])
-          = icon_tag("directdown", ["icon-fix disabled"])
+    .row
+      .col-5
+        %span.custom-fields-mobile-list-title.hidden-tablet
+          = t("admin.custom_fields.index.field_title")
+        = t("listings.form.valid_until.valid_until")
+      .col-5
+        %span.custom-fields-mobile-list-title.hidden-tablet
+          = t("admin.custom_fields.index.field_type")
+        %div
+          = t("admin.custom_fields.field_types.date")
+        %div.custom-fields-details
+      .col-2
+        = link_to edit_expiration_admin_custom_fields_path, :class => "custom-fields-expiration-edit" do
+          = icon_tag("edit", ["icon-fix"])
+        = icon_tag("cross", ["icon-fix disabled"])
+        = icon_tag("directup", ["icon-fix disabled"])
+        = icon_tag("directdown", ["icon-fix disabled"])
 
     .row
       .col-5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,7 +203,6 @@ en:
         transaction_preferences: "Order preferences"
         show_listing_publishing_date: "Display publishing date of the listing on the listing page"
         show_category_in_listing_list: "Display listing type in list view"
-        hide_expiration_date: "Do not require listings to have an expiration date"
         listing_comments_in_use: "Allow users to post comments to listings (viewable to all other users)"
         email_preferences: "Email preferences"
         automatic_newsletters: "Send automatic daily / weekly newsletters to all users (unless they opt out)"
@@ -327,6 +326,9 @@ en:
       edit_location:
         edit_location_field: "Edit location field"
         this_field_is_required: "This field is required"
+      edit_expiration:
+        edit_expiration_field: "Edit location field"
+        enable: "Enable expiration date"
       form:
         field_required:
           this_field_is_required: "Make it mandatory to fill in this field when creating a new listing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,6 +285,8 @@ Kassi::Application.routes.draw do
           post :order
           put :update_price
           put :update_location
+          get :edit_expiration
+          put :update_expiration
         end
       end
       resources :categories do

--- a/db/migrate/20170309104456_hide_expiration_date_by_default.rb
+++ b/db/migrate/20170309104456_hide_expiration_date_by_default.rb
@@ -1,0 +1,11 @@
+class HideExpirationDateByDefault < ActiveRecord::Migration
+
+  def up
+    change_column_default(:communities, :hide_expiration_date, true)
+  end
+
+  def down
+    change_column_default(:communities, :hide_expiration_date, false)
+  end
+
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
--- MySQL dump 10.13  Distrib 5.6.32, for osx10.10 (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.16, for osx10.11 (x86_64)
 --
 -- Host: 127.0.0.1    Database: sharetribe_development
 -- ------------------------------------------------------
@@ -250,7 +250,7 @@ CREATE TABLE `communities` (
   `currency` varchar(3) NOT NULL,
   `facebook_connect_enabled` tinyint(1) DEFAULT '1',
   `minimum_price_cents` int(11) DEFAULT NULL,
-  `hide_expiration_date` tinyint(1) DEFAULT '0',
+  `hide_expiration_date` tinyint(1) DEFAULT '1',
   `facebook_connect_id` varchar(255) DEFAULT NULL,
   `facebook_connect_secret` varchar(255) DEFAULT NULL,
   `google_analytics_key` varchar(255) DEFAULT NULL,
@@ -1599,7 +1599,7 @@ CREATE TABLE `transactions` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2017-02-20 14:36:16
+-- Dump completed on 2017-03-09 13:12:16
 INSERT INTO schema_migrations (version) VALUES ('20080806070738');
 
 INSERT INTO schema_migrations (version) VALUES ('20080807071903');
@@ -3223,4 +3223,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161109094513');
 INSERT INTO schema_migrations (version) VALUES ('20170216134444');
 
 INSERT INTO schema_migrations (version) VALUES ('20170220123526');
+
+INSERT INTO schema_migrations (version) VALUES ('20170309104456');
 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -52,7 +52,7 @@
 #  currency                                   :string(3)        not null
 #  facebook_connect_enabled                   :boolean          default(TRUE)
 #  minimum_price_cents                        :integer
-#  hide_expiration_date                       :boolean          default(FALSE)
+#  hide_expiration_date                       :boolean          default(TRUE)
 #  facebook_connect_id                        :string(255)
 #  facebook_connect_secret                    :string(255)
 #  google_analytics_key                       :string(255)

--- a/spec/view_utils/listing_form_view_utils_spec.rb
+++ b/spec/view_utils/listing_form_view_utils_spec.rb
@@ -1,12 +1,24 @@
+[
+  "app/view_utils/listing_form_view_utils",
+  "app/services/result"
+].each { |file| require_relative "../../#{file}" }
+
+require 'pry'
+require 'active_support'
+require 'active_support/core_ext/object'
+
 describe ListingFormViewUtils do
   describe "#filter" do
-    def expect_filter(params, shape_opts)
+    def expect_filter(params, shape_opts, valid_until_enabled = false)
       shape_defaults = {
         price_enabled: true,
         units: []
       }
 
-      expect(ListingFormViewUtils.filter(params, shape_defaults.merge(shape_opts)))
+      expect(ListingFormViewUtils.filter(
+               params,
+               shape_defaults.merge(shape_opts),
+               valid_until_enabled))
     end
 
     it "filters fields that do not belong to the shape" do
@@ -27,26 +39,37 @@ describe ListingFormViewUtils do
 
       expect_filter({shipping_price_additional: "50.00"}, {shipping_enabled: true}).to include(:shipping_price_additional)
       expect_filter({shipping_price_additional: "50.00"}, {shipping_enabled: false}).not_to include(:shipping_price_additional)
+
+      expect_filter({"valid_until(1i)" => "2017", "valid_until(2i)" => "6", "valid_until(3i)" => "9"}, {}, false)
+        .not_to include("valid_until(1i)", "valid_until(2i)", "valid_until(3i)")
+
+      expect_filter({"valid_until(1i)" => "2017", "valid_until(2i)" => "6", "valid_until(3i)" => "9"}, {}, true)
+        .to include("valid_until(1i)", "valid_until(2i)", "valid_until(3i)")
     end
   end
 
   describe "#validate" do
-    def validate(params, shape_opts, unit)
+    def validate(params, shape_opts, unit, valid_until_enabled = false)
       shape_defaults = {
         units: []
       }
-      ListingFormViewUtils.validate(params, shape_defaults.merge(shape_opts), unit)
+      ListingFormViewUtils.validate(
+        params: params,
+        shape: shape_defaults.merge(shape_opts),
+        unit: unit,
+        valid_until_enabled: valid_until_enabled
+      )
     end
 
-    def expect_valid(params, shape_opts, unit = nil)
-      validate_res = validate(params, shape_opts, unit)
+    def expect_valid(params, shape_opts, unit = nil, valid_until_enabled = false)
+      validate_res = validate(params, shape_opts, unit, valid_until_enabled)
       expect(validate_res.success).to eq(true), ->() {validate_res.data}
     end
 
-    def expect_error(params, shape_opts, errors, unit = nil)
+    def expect_error(params, shape_opts, errors, unit = nil, valid_until_enabled = false)
       raise ArgumentError.new("Expecting error codes array") if errors.empty?
 
-      res = validate(params, shape_opts, unit)
+      res = validate(params, shape_opts, unit, valid_until_enabled)
       expect(res.success).to eq false
       errors.each { |error_code|
         expect(res.data).to include(error_code)
@@ -67,6 +90,22 @@ describe ListingFormViewUtils do
       expect_valid({delivery_methods: ["shipping", "pickup"]}, {shipping_enabled: true})
       expect_error({delivery_methods: []}, {shipping_enabled: true}, [:delivery_method_required])
       expect_error({delivery_methods: ["homedelivery"]}, {shipping_enabled: true}, [:unknown_delivery_method])
+
+      expect_valid({price: "50.00", currency: "EUR", "valid_until(1i)" => "2017", "valid_until(2i)" => "6", "valid_until(3i)" => "9"},
+                   {price_enabled: true},
+                   nil,
+                   true)
+
+      expect_error({price: "50.00", currency: "EUR"},
+                   {price_enabled: true},
+                   [:valid_until_missing],
+                   nil,
+                   true)
+
+      expect_valid({price: "50.00", currency: "EUR"},
+                   {price_enabled: true},
+                   nil,
+                   false)
     end
 
     it "validates custom units" do


### PR DESCRIPTION
This PR turn listing expiration off by default for new marketplaces. It also moves the expiration setting from Admin > Settings to Admin > Listing fields & Filters

Screenshots: 

Old:

![screen shot 2017-03-09 at 17 01 25](https://cloud.githubusercontent.com/assets/429876/23755767/21e02b28-04ea-11e7-8a01-4a3d5db96c0a.png)


New:

![screen shot 2017-03-09 at 16 58 37](https://cloud.githubusercontent.com/assets/429876/23755705/ea9c3fd0-04e9-11e7-8efc-47d7c98de8e0.png)

![screen shot 2017-03-09 at 16 58 18](https://cloud.githubusercontent.com/assets/429876/23755711/f0364cd8-04e9-11e7-8518-a95256bd1c14.png)

