### PR TITLE
Remove coverphoto max width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ### Fixed
 
+- Fix cropped cover photo in big screens [#2895](https://github.com/sharetribe/sharetribe/pull/2895)
+- Add missing padding to homepage search field in mobile view [#2895](https://github.com/sharetribe/sharetribe/pull/2895)
+
 ### Security
 
 ## [6.2.0] - 2017-03-09

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -1907,7 +1907,6 @@ $network-green: #00a26c;
 
 .coverimage {
   position: relative;
-  max-width: em(1920);
   margin-left: auto;
   margin-right: auto;
 }
@@ -1964,7 +1963,6 @@ figure.fluidratio {
   .coverimage-fade {
     position: absolute;
     top: lines(0);
-    max-width: em(1920);
     width: 100%;
     margin-left: auto;
     margin-right: auto;

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -1981,8 +1981,7 @@ figure.fluidratio {
   }
 
   .marketplace-lander-content {
-    padding-top: 5em;
-    padding-bottom: 5em;
+    padding: 5em 1em;
     text-align: center;
   }
 


### PR DESCRIPTION
This PR fixes two layout issues:

1. Cover image in big screens
1. Missing search form padding in mobile view

Before:

![screen shot 2017-03-10 at 11 35 11](https://cloud.githubusercontent.com/assets/429876/23790089/48dd5a92-0586-11e7-85c2-86647a879058.png)

After:

![screen shot 2017-03-10 at 11 35 40](https://cloud.githubusercontent.com/assets/429876/23790098/522ad3e0-0586-11e7-80cc-23ba041388ab.png)

Before:

![screen shot 2017-03-10 at 11 38 09](https://cloud.githubusercontent.com/assets/429876/23790113/63c563cc-0586-11e7-87f3-1302cef771f7.png)

After:

![screen shot 2017-03-10 at 11 37 49](https://cloud.githubusercontent.com/assets/429876/23790136/7f14a390-0586-11e7-9094-8308b4d3ed1d.png)

