### PR TITLE
Remove default twitter handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ### Removed
 
+- Removed default twitter handle [#2906](https://github.com/sharetribe/sharetribe/pull/2906)
+
 ### Fixed
 
 - Fix cropped cover photo in big screens [#2895](https://github.com/sharetribe/sharetribe/pull/2895)

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -105,7 +105,8 @@
             .listing-fb-like-button
               = facebook_like(current_user?(@listing.author))
             .listing-tweet-button
-              = link_to("", "https://twitter.com/share", :class => "twitter-share-button", "data" => {count: "horizontal", via: (@current_community.twitter_handle || "Sharetribe"), text: @listing.title })
+              - twitter_params =  {count: "horizontal", via: (@current_community.twitter_handle), text: @listing.title }.compact
+              = link_to("", "https://twitter.com/share", :class => "twitter-share-button", "data" => twitter_params)
               - content_for :extra_javascript do
                 :javascript
                   !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");


### PR DESCRIPTION
If marketplace admin hasn't set up a twitter handle we add `via @Sharetribe` at the end of tweets. This doesn't provide value and causes trouble in some cases. This PR removes it.