### PR TITLE
Add Admin Intercom

### DIFF
--- a/app/controllers/int_api/marketplaces_controller.rb
+++ b/app/controllers/int_api/marketplaces_controller.rb
@@ -57,6 +57,11 @@ class IntApi::MarketplacesController < ApplicationController
     FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], person_id: user[:id], features: [:topbar_v1])
     FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], features: [:topbar_v1])
 
+    # Enable Intercom
+    if IntercomHelper.in_admin_intercom_respond_test_group?
+      FeatureFlagService::API::Api.features.enable(community_id: marketplace[:id], features: [:admin_intercom_respond])
+    end
+
     # TODO handle error cases with proper response
 
     render status: 201, json: {"marketplace_url" => url, "marketplace_id" => marketplace[:id]}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -311,6 +311,7 @@ module ApplicationHelper
         :name => "getting_started_guide"
       },
       {
+        :id => "admin-support-link",
         :topic => :general,
         :text => t("admin.left_hand_navigation.support"),
         :icon_class => icon_class("help"),

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -474,6 +474,17 @@ class Person < ActiveRecord::Base
     EmailService.emails_to_smtp_addresses(send_message_to)
   end
 
+  # Primary email is the first email address that is
+  #
+  # - confirmed
+  # - notifications allowed
+  #
+  # Returns Email record
+  #
+  def primary_email
+    EmailService.emails_to_send_message(emails).first
+  end
+
   # Notice: If no confirmed notification emails is found, this
   # method returns the first confirmed emails
   def confirmed_notification_email_to

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -20,7 +20,8 @@ module FeatureFlagService::Store
       :export_transactions_as_csv,
       :topbar_v1,
       :searchpage_v1,
-      :manage_searchpage
+      :manage_searchpage,
+      :admin_intercom_respond
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/view_utils/intercom_helper.rb
+++ b/app/view_utils/intercom_helper.rb
@@ -13,7 +13,7 @@ module IntercomHelper
     #
     # Remove the feature flag helper when this is published to everyone
     #
-    APP_CONFIG.admin_intercom_respond_enabled.to_s.downcase == "true" &&
+    APP_CONFIG.admin_intercom_respond_enabled.to_s.casecmp("true") &&
       FeatureFlagHelper.feature_enabled?(:admin_intercom_respond)
   end
 

--- a/app/view_utils/intercom_helper.rb
+++ b/app/view_utils/intercom_helper.rb
@@ -2,6 +2,13 @@ module IntercomHelper
 
   module_function
 
+  # Create a user_hash for Secure mode
+  # https://docs.intercom.com/configure-intercom-for-your-product-or-site/staying-secure/enable-secure-mode-on-your-web-product
+  def user_hash(user_id)
+    secret = APP_CONFIG.admin_intercom_secure_mode_secret
+    OpenSSL::HMAC.hexdigest('sha256', secret, user_id) if secret.present?
+  end
+
   def admin_intercom_respond_enabled?
     #
     # Remove the feature flag helper when this is published to everyone

--- a/app/view_utils/intercom_helper.rb
+++ b/app/view_utils/intercom_helper.rb
@@ -1,0 +1,23 @@
+module IntercomHelper
+
+  module_function
+
+  def admin_intercom_respond_enabled?
+    #
+    # Remove the feature flag helper when this is published to everyone
+    #
+    APP_CONFIG.admin_intercom_respond_enabled.to_s.downcase == "true" &&
+      FeatureFlagHelper.feature_enabled?(:admin_intercom_respond)
+  end
+
+  def admin_intercom_app_id
+    APP_CONFIG.admin_intercom_app_id
+  end
+
+  def in_test_group?
+    ratio = (APP_CONFIG.admin_intercom_respond_test_group_ratio || 0).to_f
+
+    Random.rand < ratio
+  end
+
+end

--- a/app/view_utils/intercom_helper.rb
+++ b/app/view_utils/intercom_helper.rb
@@ -14,7 +14,7 @@ module IntercomHelper
     APP_CONFIG.admin_intercom_app_id
   end
 
-  def in_test_group?
+  def in_admin_intercom_respond_test_group?
     ratio = (APP_CONFIG.admin_intercom_respond_test_group_ratio || 0).to_f
 
     Random.rand < ratio

--- a/app/views/admin/_left_hand_navigation.haml
+++ b/app/views/admin/_left_hand_navigation.haml
@@ -1,7 +1,17 @@
 -# Admin navigation is split into link groups.
 - grouped_links = links.group_by {|l| l[:topic]}
 
-= render :partial => "admin/uservoice_widget" if APP_CONFIG.uservoice_widget_url.present?
+- if FeatureFlagHelper.feature_enabled?(:admin_intercom_respond)
+  - content_for :extra_javascript do
+    :javascript
+      var desktop_selector = "#admin-support-link";
+      var mobile_selector = "#support_left_navi_link";
+      $([desktop_selector, mobile_selector].join(", ")).click(function(e) {
+        e.preventDefault();
+        window.Intercom && window.Intercom('show');
+      });
+- else
+  = render :partial => "admin/uservoice_widget" if APP_CONFIG.uservoice_widget_url.present?
 
 - sel_link = (local_assigns.has_key? :selected_left_navi_link) ? selected_left_navi_link : @selected_left_navi_link
 

--- a/app/views/admin/_left_hand_navigation.haml
+++ b/app/views/admin/_left_hand_navigation.haml
@@ -4,11 +4,12 @@
 - if IntercomHelper.admin_intercom_respond_enabled?
   - content_for :extra_javascript do
     :javascript
+      window.ST = window.ST || {};
       var desktop_selector = "#admin-support-link";
       var mobile_selector = "#support_left_navi_link";
       $([desktop_selector, mobile_selector].join(", ")).click(function(e) {
         e.preventDefault();
-        window.Intercom && window.Intercom('show');
+        window.ST.AdminIntercom && window.ST.AdminIntercom('show');
       });
 - else
   = render :partial => "admin/uservoice_widget" if APP_CONFIG.uservoice_widget_url.present?

--- a/app/views/admin/_left_hand_navigation.haml
+++ b/app/views/admin/_left_hand_navigation.haml
@@ -1,7 +1,7 @@
 -# Admin navigation is split into link groups.
 - grouped_links = links.group_by {|l| l[:topic]}
 
-- if FeatureFlagHelper.feature_enabled?(:admin_intercom_respond)
+- if IntercomHelper.admin_intercom_respond_enabled?
   - content_for :extra_javascript do
     :javascript
       var desktop_selector = "#admin-support-link";

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -1,0 +1,14 @@
+<script>
+
+ // Test API key
+ var APP_ID = "jkhxjzg6";
+
+ // Production API key
+ // var APP_ID = "av39ah88";
+
+ window.intercomSettings = {
+   app_id: APP_ID
+ };
+ (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+
+</script>

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -1,8 +1,9 @@
 <script>
 (function(){
   window.ST = window.ST || {};
-  var intercomSettings = {
-    app_id: "<%= app_id %>",
+  var APP_ID = "<%= app_id %>";
+  window.intercomSettings = {
+    app_id: APP_ID,
     email: <%= email.to_json.html_safe %>,
     user_id: "<%= user_uuid %>",
     user_id_old: "<%= user_id %>",

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -7,7 +7,14 @@
  // var APP_ID = "av39ah88";
 
  window.intercomSettings = {
-   app_id: APP_ID
+   app_id: APP_ID,
+   email: <%= email&.to_json.html_safe %>,
+   user_id: "<%= user_uuid %>",
+   user_id_old: "<%= user_id %>",
+   marketplace_id: "<%= marketplace_uuid %>",
+   marketplace_id_old: <%= marketplace_id %>,
+   marketplace_url: "<%= marketplace_url %>",
+   name: "<%= name %>",
  };
  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
 

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -7,7 +7,7 @@
  // var APP_ID = "av39ah88";
 
  window.intercomSettings = {
-   app_id: APP_ID,
+   app_id: "<%= app_id %>",
    email: <%= email&.to_json.html_safe %>,
    user_id: "<%= user_uuid %>",
    user_id_old: "<%= user_id %>",

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -1,21 +1,17 @@
 <script>
-
- // Test API key
- var APP_ID = "jkhxjzg6";
-
- // Production API key
- // var APP_ID = "av39ah88";
-
- window.intercomSettings = {
-   app_id: "<%= app_id %>",
-   email: <%= email&.to_json.html_safe %>,
-   user_id: "<%= user_uuid %>",
-   user_id_old: "<%= user_id %>",
-   marketplace_id: "<%= marketplace_uuid %>",
-   marketplace_id_old: <%= marketplace_id %>,
-   marketplace_url: "<%= marketplace_url %>",
-   name: "<%= name %>",
- };
- (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
-
+(function(){
+  window.ST = window.ST || {};
+  var intercomSettings = {
+    app_id: "<%= app_id %>",
+    email: <%= email.to_json.html_safe %>,
+    user_id: "<%= user_uuid %>",
+    user_id_old: "<%= user_id %>",
+    marketplace_id: "<%= marketplace_uuid %>",
+    marketplace_id_old: <%= marketplace_id %>,
+    marketplace_url: "<%= marketplace_url %>",
+    name: "<%= name %>",
+    user_hash: <%= user_hash.to_json.html_safe %>
+  };
+  (function(){var w=window;var ic=w.ST.AdminIntercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.ST.AdminIntercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+})();
 </script>

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -100,5 +100,5 @@
 - unless on_admin?
   = @current_community.custom_head_script.try(:html_safe)
 
-- if on_admin? && FeatureFlagHelper.feature_enabled?(:admin_intercom_respond)
-  = render partial: "layouts/intercom", locals: { email: @current_user.primary_email&.address, user_id: @current_user.id, user_uuid: @current_user.uuid_object.to_s, name: PersonViewUtils.person_display_name(@current_user, @current_community), marketplace_id: @current_community.id, marketplace_uuid: @current_community.uuid_object.to_s, marketplace_url: @current_community.full_url }
+- if on_admin? && IntercomHelper.admin_intercom_respond_enabled?
+  = render partial: "layouts/intercom", locals: { app_id: IntercomHelper.admin_intercom_app_id, email: @current_user.primary_email&.address, user_id: @current_user.id, user_uuid: @current_user.uuid_object.to_s, name: PersonViewUtils.person_display_name(@current_user, @current_community), marketplace_id: @current_community.id, marketplace_uuid: @current_community.uuid_object.to_s, marketplace_url: @current_community.full_url }

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -101,4 +101,5 @@
   = @current_community.custom_head_script.try(:html_safe)
 
 - if on_admin? && IntercomHelper.admin_intercom_respond_enabled?
-  = render partial: "layouts/intercom", locals: { app_id: IntercomHelper.admin_intercom_app_id, email: @current_user.primary_email&.address, user_id: @current_user.id, user_uuid: @current_user.uuid_object.to_s, name: PersonViewUtils.person_display_name(@current_user, @current_community), marketplace_id: @current_community.id, marketplace_uuid: @current_community.uuid_object.to_s, marketplace_url: @current_community.full_url }
+  - user_uuid = @current_user.uuid_object.to_s
+  = render partial: "layouts/intercom", locals: { app_id: IntercomHelper.admin_intercom_app_id, email: @current_user.primary_email&.address, user_id: @current_user.id, user_uuid: user_uuid, name: PersonViewUtils.person_display_name(@current_user, @current_community), marketplace_id: @current_community.id, marketplace_uuid: @current_community.uuid_object.to_s, marketplace_url: @current_community.full_url, user_hash: IntercomHelper.user_hash(user_uuid) }

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -99,3 +99,6 @@
 
 - unless on_admin?
   = @current_community.custom_head_script.try(:html_safe)
+
+- if on_admin?
+  = render partial: "layouts/intercom"

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -100,5 +100,5 @@
 - unless on_admin?
   = @current_community.custom_head_script.try(:html_safe)
 
-- if on_admin?
+- if on_admin? && FeatureFlagHelper.feature_enabled?(:admin_intercom_respond)
   = render partial: "layouts/intercom", locals: { email: @current_user.primary_email&.address, user_id: @current_user.id, user_uuid: @current_user.uuid_object.to_s, name: PersonViewUtils.person_display_name(@current_user, @current_community), marketplace_id: @current_community.id, marketplace_uuid: @current_community.uuid_object.to_s, marketplace_url: @current_community.full_url }

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -101,4 +101,4 @@
   = @current_community.custom_head_script.try(:html_safe)
 
 - if on_admin?
-  = render partial: "layouts/intercom"
+  = render partial: "layouts/intercom", locals: { email: @current_user.primary_email&.address, user_id: @current_user.id, user_uuid: @current_user.uuid_object.to_s, name: PersonViewUtils.person_display_name(@current_user, @current_community), marketplace_id: @current_community.id, marketplace_uuid: @current_community.uuid_object.to_s, marketplace_url: @current_community.full_url }

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -411,7 +411,7 @@ default: &default_settings
   # Admin Intercom secure mode secret
   admin_intercom_secure_mode_secret: ""
 
-  # The percentage of marketplaces where Admin Intercom Respond
+  # The percentage of new marketplaces where Admin Intercom Respond
   # will be enabled
   #
   # Examples:

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -398,6 +398,16 @@ default: &default_settings
   #
   font_proximanovasoft_url:
 
+  ##########################################
+  # Admin Intercom (sharetribe.com internal)
+  ##########################################
+
+  # Enable/disable Intercom Respond for Admin UI
+  admin_intercom_respond_enabled: false
+
+  # Admin Intercom App Id
+  admin_intercom_app_id: ""
+
   # Maximum number of links in sitemap.xml.
   #
   # The default number is 500. Increasing the limit may affect performance.

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -408,6 +408,22 @@ default: &default_settings
   # Admin Intercom App Id
   admin_intercom_app_id: ""
 
+  # The percentage of marketplaces where Admin Intercom Respond
+  # will be enabled
+  #
+  # Examples:
+  #
+  #   1: Enabled for everyone
+  # 0.8: Enabled for 80%
+  # 0.2: Enabled for 20%
+  #   0: Enabled for no one
+  #
+  admin_intercom_respond_test_group_ratio: 0
+
+  #########
+  # Sitemap
+  #########
+
   # Maximum number of links in sitemap.xml.
   #
   # The default number is 500. Increasing the limit may affect performance.

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -408,6 +408,9 @@ default: &default_settings
   # Admin Intercom App Id
   admin_intercom_app_id: ""
 
+  # Admin Intercom secure mode secret
+  admin_intercom_secure_mode_secret: ""
+
   # The percentage of marketplaces where Admin Intercom Respond
   # will be enabled
   #


### PR DESCRIPTION
This PR adds Intercom widget to Admin UI. 

Intercom has several different products, and the product that we are installing is called **Respond**. Also, the Intercom widget will be only available in **Admin UI**. That's why the configuration variables are names e.g. `admin_intercom_respond_enabled`. 

- [X] Add Intercom Respond widget to Admin UI
- [X] Open Intercom widget when "Support" link in Admin UI is clicked
- [X] Send necessary information to Intercom such as user UUID (main idenfier), email, marketplace UUID, marketplace ID, user ID, etc.
- [X] Add a new Feature Flag
- [X] Add a new environment variable `admin_intercom_respond_enabled`
- [X] Add a new environment variable `admin_intercom_respond_test_group_ratio`. Based on this ratio, add `:admin_intercom_respond` Feature flag to newly created trial marketplace.
- [X] Add a new environment variable `admin_intercom_secure_mode_secret`. This will enable Secure mode. Also, add `IntercomHelper.user_hash` to calculate proper secure hash.

Screenshot:

<img width="412" alt="screen shot 2017-03-28 at 15 41 09" src="https://cloud.githubusercontent.com/assets/429876/24405290/00475634-13cd-11e7-9d8c-2da6be1b2678.png">
