### PR TITLE
Remove listing comment text area autofocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Fix cropped cover photo in big screens [#2895](https://github.com/sharetribe/sharetribe/pull/2895)
 - Add missing padding to homepage search field in mobile view [#2895](https://github.com/sharetribe/sharetribe/pull/2895)
+- Fix unwanted scrolling in listing page by removing comment text area auto focus [#2917](https://github.com/sharetribe/sharetribe/pull/2917)
 
 ### Security
 

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -307,7 +307,6 @@ function initialize_reply_form(locale) {
 function initialize_listing_view(locale) {
   $('#listing-image-link').click(function() { $('#listing-image-lightbox').lightbox_me({centered: true, zIndex: 1000000}); });
   auto_resize_text_areas("listing_comment_content_text_area");
-  $('textarea').focus();
   prepare_ajax_form(
     "#new_comment",
     locale,


### PR DESCRIPTION
Autotically focusing on the comment field caused unwanted scrolling.

Before:

![mar-30-2017 09-56-01](https://cloud.githubusercontent.com/assets/429876/24491264/27997ede-152f-11e7-9d51-ef57166dc0b9.gif)


After:

![mar-30-2017 09-56-07](https://cloud.githubusercontent.com/assets/429876/24491270/2d1be130-152f-11e7-92aa-beec4798d088.gif)
