### PR TITLE
Improve Intercom custom attributes 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -189,3 +189,5 @@ gem 'transit-ruby', '~> 0.8'
 
 # Markdown parser
 gem 'redcarpet', '~> 3.3', '>= 3.3.4'
+
+gem 'intercom', '~> 3.5.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,8 @@ GEM
     i18n (0.7.0)
     i18n_data (0.7.0)
     innertube (1.1.0)
+    intercom (3.5.12)
+      json (>= 1.8)
     jmespath (1.3.1)
     joiner (0.3.4)
       activerecord (>= 4.1.0)
@@ -567,6 +569,7 @@ DEPENDENCIES
   haml (~> 4.0.5)
   hiredis
   i18n-js!
+  intercom (~> 3.5.10)
   jquery-rails (= 3.1.3)
   js-routes (~> 1.2.5)
   jwt (~> 1.5.2)

--- a/app/view_utils/intercom_helper.rb
+++ b/app/view_utils/intercom_helper.rb
@@ -126,13 +126,22 @@ module IntercomHelper
       end
 
     messages = verification_result[:results].map { |res|
-      if res[:passed] == :passed
-        "#{icons[:check]} #{res[:field_name]}: #{res[:intercom_value]}"
-      elsif res[:passed] == :warning
-        "#{icons[:warning]} #{res[:field_name]}: #{res[:intercom_value]}"
-      else
-        "#{icons[:cross]} #{res[:field_name]}: #{res[:intercom_value]} (in database: #{res[:database_value]})"
-      end
+      result_msg =
+
+        if res[:passed] == :passed
+          "#{icons[:check]} #{res[:field_name]}: #{res[:intercom_value]}"
+        elsif res[:passed] == :warning
+          "#{icons[:warning]} #{res[:field_name]}: #{res[:intercom_value]}"
+        else
+          "#{icons[:cross]} #{res[:field_name]}: #{res[:intercom_value]}"
+        end
+
+      db_diff =
+        if res[:database_value] != res[:intercom_value]
+          "(in database: #{res[:database_value]})"
+        end
+
+      [result_msg, db_diff].compact.join(" ")
     }
 
     [result, ""] + messages
@@ -155,7 +164,7 @@ module IntercomHelper
     ] + verify_identity_information(intercom_user, db_identity_information.except(:info_email_confirmed))
 
     {
-      result: verification_results.reduce(:passed) { |overall_result, current_result| new_overall_result(overall_result, current_result[:passed]) },
+      result: verification_results.reduce(:passed) { |a, e| new_overall_result(a, e[:passed]) },
       results: verification_results
     }
   end

--- a/app/view_utils/intercom_helper.rb
+++ b/app/view_utils/intercom_helper.rb
@@ -1,4 +1,24 @@
+# coding: utf-8
 module IntercomHelper
+
+  CONSOLE_CHECK = "\u{2705} "
+  CONSOLE_CROSS = "\u{274c} "
+  CONSOLE_WARNING = "\u{26A0} "
+  HTML_CHECK = "\u{2705}&nbsp;"
+  HTML_CROSS = "\u{274c}&nbsp;"
+  HTML_WARNING = "\u{26A0}&nbsp;"
+
+  CONSOLE_ICONS = {
+    check: CONSOLE_CHECK,
+    warning: CONSOLE_WARNING,
+    cross: CONSOLE_CROSS
+  }
+
+  HTML_ICONS = {
+    check: HTML_CHECK,
+    warning: HTML_WARNING,
+    cross: HTML_CROSS
+  }
 
   module_function
 
@@ -27,4 +47,178 @@ module IntercomHelper
     Random.rand < ratio
   end
 
+  def email(user_model)
+    (user_model.primary_email || user_model.emails.first).address
+  end
+
+  def identity_information(user_model)
+    marketplace = user_model.community
+
+    {
+      info_user_id_old: user_model.id,
+      info_marketplace_id: marketplace.uuid_object.to_s,
+      info_marketplace_id_old: marketplace.id,
+      info_marketplace_url: marketplace.full_url,
+      info_email_confirmed: user_model.primary_email.present?
+    }
+  end
+
+  def verify(conversation_id)
+    token = APP_CONFIG.admin_intercom_access_token
+    admin_id = APP_CONFIG.admin_intercom_admin_id
+    intercom = Intercom::Client.new(token: token)
+
+    conversation = intercom.conversations.find(id: conversation_id)
+
+    if conversation
+      puts "#{CONSOLE_CHECK} Found conversation"
+    else
+      puts "#{CONSOLE_CROSS} Could not find conversation"
+      return :error
+    end
+
+    intercom_user = intercom.users.load(conversation.user)
+
+    if intercom_user
+      puts "#{CONSOLE_CHECK} Found user from Intercom"
+    else
+      puts "#{CONSOLE_CROSS} Could not find user from Intercom"
+      return :error
+    end
+
+    user_model = find_user_by_uuid(intercom_user.user_id)
+
+    if user_model
+      puts "#{CONSOLE_CHECK} Found user from database"
+    else
+      puts "#{CONSOLE_CROSS} Could not find user from database"
+      return :error
+    end
+
+    verification_result = do_verification(intercom_user, user_model)
+    puts "#{CONSOLE_CHECK} Verification done"
+
+    intercom.conversations.reply(id: conversation_id, type: 'admin', admin_id: admin_id, message_type: 'note', body: format_result_html(verification_result))
+    puts "#{CONSOLE_CHECK} Verification note sent"
+
+    puts ""
+    puts format_result_console(verification_result)
+
+    return verification_result[:result]
+  end
+
+  def format_result_console(verification_result)
+    format_result_array(verification_result, CONSOLE_ICONS).join("\n")
+  end
+
+  def format_result_html(verification_result)
+    format_result_array(verification_result, HTML_ICONS).join("<br />")
+  end
+
+  def format_result_array(verification_result, icons)
+    result =
+      if verification_result[:result] == :passed
+        "#{icons[:check]} Identity verification PASSED"
+      elsif verification_result[:result] == :warning
+        "#{icons[:warning]} Identity verification PASSED, with WARNINGS"
+      else
+        "#{icons[:cross]} Identity verification FAILED"
+      end
+
+    messages = verification_result[:results].map { |res|
+      if res[:passed] == :passed
+        "#{icons[:check]} #{res[:field_name]}: #{res[:intercom_value]}"
+      elsif res[:passed] == :warning
+        "#{icons[:warning]} #{res[:field_name]}: #{res[:intercom_value]}"
+      else
+        "#{icons[:cross]} #{res[:field_name]}: #{res[:intercom_value]} (in database: #{res[:database_value]})"
+      end
+    }
+
+    [result, ""] + messages
+  end
+
+  def find_user_by_uuid(uuid)
+    user_uuid_object = UUIDTools::UUID.parse(uuid)
+    user_uuid_raw = UUIDUtils.raw(user_uuid_object)
+
+    Person.find_by(uuid: user_uuid_raw)
+  end
+
+  def do_verification(intercom_user, user_model)
+    db_user_email = email(user_model)
+    db_identity_information = identity_information(user_model)
+
+    verification_results = [
+      verify_email(intercom_user, user_model),
+      verify_email_confirmation(intercom_user, db_identity_information[:info_email_confirmed])
+    ] + verify_identity_information(intercom_user, db_identity_information.except(:info_email_confirmed))
+
+    {
+      result: verification_results.reduce(:passed) { |overall_result, current_result| new_overall_result(overall_result, current_result[:passed]) },
+      results: verification_results
+    }
+  end
+
+  def new_overall_result(overall_res, current_res)
+    order = [
+      :passed,
+      :warning,
+      :failed
+    ]
+
+    if order.index(overall_res) < order.index(current_res)
+      current_res
+    else
+      overall_res
+    end
+  end
+
+  def verify_email(intercom_user, user_model)
+    db_user_email = email(user_model)
+
+    {
+      passed: intercom_user.email == db_user_email ? :passed : :failed,
+      field_name: :email,
+      intercom_value: intercom_user.email,
+      database_value: db_user_email
+    }
+  end
+
+  def verify_email_confirmation(intercom_user, db_email_confirmed)
+    custom_attributes = intercom_user.custom_attributes
+
+    verify_custom_attribute(:info_email_confirmed, db_email_confirmed, custom_attributes) { |db_value, intercom_value|
+      case [db_value, intercom_value]
+      when [true, true]
+        :passed
+      when [true, false]
+        :warning
+      when [false, true]
+        :failed
+      when [false, false]
+        :warning
+      end
+    }
+  end
+
+  def verify_identity_information(intercom_user, db_identity_information)
+    custom_attributes = intercom_user.custom_attributes
+
+    db_identity_information.map { |key, db_value|
+      verify_custom_attribute(key, db_value, custom_attributes)
+    }
+  end
+
+  def verify_custom_attribute(key, db_value, custom_attributes, &block)
+    passed_lambda = block || ->(a, b) { a == b ? :passed : :failed }
+
+    intercom_value = custom_attributes[key]
+    {
+      passed: passed_lambda.call(db_value, intercom_value),
+      field_name: key,
+      intercom_value: intercom_value,
+      database_value: db_value
+    }
+  end
 end

--- a/app/views/admin/_left_hand_navigation.haml
+++ b/app/views/admin/_left_hand_navigation.haml
@@ -9,7 +9,7 @@
       var mobile_selector = "#support_left_navi_link";
       $([desktop_selector, mobile_selector].join(", ")).click(function(e) {
         e.preventDefault();
-        window.ST.AdminIntercom && window.ST.AdminIntercom('show');
+        Intercom && Intercom('show');
       });
 - else
   = render :partial => "admin/uservoice_widget" if APP_CONFIG.uservoice_widget_url.present?

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -3,15 +3,19 @@
   window.ST = window.ST || {};
   var APP_ID = "<%= app_id %>";
   window.intercomSettings = {
-    app_id: APP_ID,
-    email: <%= email.to_json.html_safe %>,
+    // Identifier
     user_id: "<%= user_uuid %>",
-    user_id_old: "<%= user_id %>",
-    marketplace_id: "<%= marketplace_uuid %>",
-    marketplace_id_old: <%= marketplace_id %>,
-    marketplace_url: "<%= marketplace_url %>",
+    user_hash: <%= user_hash.to_json.html_safe %>,
+    // Standard Intercom fields
+    app_id: APP_ID,
+    email: "<%= email %>",
     name: "<%= name %>",
-    user_hash: <%= user_hash.to_json.html_safe %>
+    // Custom attributes ('info_' prefix)
+    info_user_id_old: "<%= user_id %>",
+    info_marketplace_id: "<%= marketplace_uuid %>",
+    info_marketplace_id_old: <%= marketplace_id %>,
+    info_marketplace_url: "<%= marketplace_url %>",
+    info_email_confirmed: "<%= email_confirmed %>"
   };
   (function(){var w=window;var ic=w.ST.AdminIntercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.ST.AdminIntercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
 })();

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -15,7 +15,14 @@
     info_marketplace_id: "<%= marketplace_uuid %>",
     info_marketplace_id_old: <%= marketplace_id %>,
     info_marketplace_url: "<%= marketplace_url %>",
-    info_email_confirmed: "<%= email_confirmed %>"
+    info_email_confirmed: <%= email_confirmed %>,
+    info_plan_status: "<%= plan[:status] %>",
+    info_plan_features: "<%= plan[:features].select { |_, v| v }.keys.join(", ") %>",
+    info_plan_member_limit: <%= plan[:member_limit].to_json %>,
+    info_plan_created_at: <%= plan[:created_at].to_time.to_i %>,
+    info_plan_updated_at: <%= plan[:updated_at].to_time.to_i %>,
+    info_plan_expires_at: <%= plan[:expires_at]&.to_time&.to_i.to_json %>,
+    info_feature_flags: "<%= feature_flags.to_a.join(", ") %>"
   };
   (function(){var w=window;var ic=w.ST.AdminIntercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.ST.AdminIntercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
 })();

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -2,7 +2,7 @@
 (function(){
   window.ST = window.ST || {};
   var APP_ID = "<%= app_id %>";
-  window.intercomSettings = {
+  window.intercomSettings = Object.assign({
     // Identifier
     user_id: "<%= user_uuid %>",
     user_hash: <%= user_hash.to_json.html_safe %>,
@@ -11,11 +11,6 @@
     email: "<%= email %>",
     name: "<%= name %>",
     // Custom attributes ('info_' prefix)
-    info_user_id_old: "<%= user_id %>",
-    info_marketplace_id: "<%= marketplace_uuid %>",
-    info_marketplace_id_old: <%= marketplace_id %>,
-    info_marketplace_url: "<%= marketplace_url %>",
-    info_email_confirmed: <%= email_confirmed %>,
     info_plan_status: "<%= plan[:status] %>",
     info_plan_features: "<%= plan[:features].select { |_, v| v }.keys.join(", ") %>",
     info_plan_member_limit: <%= plan[:member_limit].to_json %>,
@@ -23,7 +18,7 @@
     info_plan_updated_at: <%= plan[:updated_at].to_time.to_i %>,
     info_plan_expires_at: <%= plan[:expires_at]&.to_time&.to_i.to_json %>,
     info_feature_flags: "<%= feature_flags.to_a.join(", ") %>"
-  };
+  }, <%= identity_information.to_json.html_safe %>);
   (function(){var w=window;var ic=w.ST.AdminIntercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.ST.AdminIntercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
 })();
 </script>

--- a/app/views/layouts/_intercom.erb
+++ b/app/views/layouts/_intercom.erb
@@ -19,6 +19,6 @@
     info_plan_expires_at: <%= plan[:expires_at]&.to_time&.to_i.to_json %>,
     info_feature_flags: "<%= feature_flags.to_a.join(", ") %>"
   }, <%= identity_information.to_json.html_safe %>);
-  (function(){var w=window;var ic=w.ST.AdminIntercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.ST.AdminIntercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/' + APP_ID;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
 })();
 </script>

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -101,5 +101,14 @@
   = @current_community.custom_head_script.try(:html_safe)
 
 - if on_admin? && IntercomHelper.admin_intercom_respond_enabled?
+  - app_id = IntercomHelper.admin_intercom_app_id
+  - email = @current_user.primary_email.address
+  - user_id = @current_user.id
   - user_uuid = @current_user.uuid_object.to_s
-  = render partial: "layouts/intercom", locals: { app_id: IntercomHelper.admin_intercom_app_id, email: @current_user.primary_email&.address, user_id: @current_user.id, user_uuid: user_uuid, name: PersonViewUtils.person_display_name(@current_user, @current_community), marketplace_id: @current_community.id, marketplace_uuid: @current_community.uuid_object.to_s, marketplace_url: @current_community.full_url, user_hash: IntercomHelper.user_hash(user_uuid) }
+  - name = PersonViewUtils.person_display_name(@current_user, @current_community)
+  - marketplace_id = @current_community.id
+  - marketplace_uuid = @current_community.uuid_object.to_s
+  - marketplace_url = @current_community.full_url
+  - user_hash = IntercomHelper.user_hash(user_uuid)
+
+  = render partial: "layouts/intercom", locals: { app_id: app_id, email: email, user_id: user_id, user_uuid: user_uuid, name: name, marketplace_id: marketplace_id, marketplace_uuid: marketplace_uuid, marketplace_url: marketplace_url, user_hash: user_hash }

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -111,5 +111,7 @@
   - marketplace_url = @current_community.full_url
   - user_hash = IntercomHelper.user_hash(user_uuid)
   - email_confirmed = @current_user.primary_email.present?
+  - plan = @current_plan
+  - feature_flags = FeatureFlagHelper.feature_flags
 
-  = render partial: "layouts/intercom", locals: { app_id: app_id, email: email, user_id: user_id, user_uuid: user_uuid, name: name, marketplace_id: marketplace_id, marketplace_uuid: marketplace_uuid, marketplace_url: marketplace_url, user_hash: user_hash, email_confirmed: email_confirmed }
+  = render partial: "layouts/intercom", locals: { app_id: app_id, email: email, user_id: user_id, user_uuid: user_uuid, name: name, marketplace_id: marketplace_id, marketplace_uuid: marketplace_uuid, marketplace_url: marketplace_url, user_hash: user_hash, email_confirmed: email_confirmed, plan: plan, feature_flags: feature_flags }

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -102,16 +102,12 @@
 
 - if on_admin? && IntercomHelper.admin_intercom_respond_enabled?
   - app_id = IntercomHelper.admin_intercom_app_id
-  - email = (@current_user.primary_email || @current_user.emails.first).address
-  - user_id = @current_user.id
   - user_uuid = @current_user.uuid_object.to_s
   - name = PersonViewUtils.person_display_name(@current_user, @current_community)
-  - marketplace_id = @current_community.id
-  - marketplace_uuid = @current_community.uuid_object.to_s
-  - marketplace_url = @current_community.full_url
+  - email = IntercomHelper.email(@current_user)
   - user_hash = IntercomHelper.user_hash(user_uuid)
-  - email_confirmed = @current_user.primary_email.present?
   - plan = @current_plan
   - feature_flags = FeatureFlagHelper.feature_flags
+  - identity_information = IntercomHelper.identity_information(@current_user)
 
-  = render partial: "layouts/intercom", locals: { app_id: app_id, email: email, user_id: user_id, user_uuid: user_uuid, name: name, marketplace_id: marketplace_id, marketplace_uuid: marketplace_uuid, marketplace_url: marketplace_url, user_hash: user_hash, email_confirmed: email_confirmed, plan: plan, feature_flags: feature_flags }
+  = render partial: "layouts/intercom", locals: { app_id: app_id, email: email, user_uuid: user_uuid, name: name, user_hash: user_hash, plan: plan, feature_flags: feature_flags, identity_information: identity_information }

--- a/app/views/layouts/_marketplace_head.haml
+++ b/app/views/layouts/_marketplace_head.haml
@@ -102,7 +102,7 @@
 
 - if on_admin? && IntercomHelper.admin_intercom_respond_enabled?
   - app_id = IntercomHelper.admin_intercom_app_id
-  - email = @current_user.primary_email.address
+  - email = (@current_user.primary_email || @current_user.emails.first).address
   - user_id = @current_user.id
   - user_uuid = @current_user.uuid_object.to_s
   - name = PersonViewUtils.person_display_name(@current_user, @current_community)
@@ -110,5 +110,6 @@
   - marketplace_uuid = @current_community.uuid_object.to_s
   - marketplace_url = @current_community.full_url
   - user_hash = IntercomHelper.user_hash(user_uuid)
+  - email_confirmed = @current_user.primary_email.present?
 
-  = render partial: "layouts/intercom", locals: { app_id: app_id, email: email, user_id: user_id, user_uuid: user_uuid, name: name, marketplace_id: marketplace_id, marketplace_uuid: marketplace_uuid, marketplace_url: marketplace_url, user_hash: user_hash }
+  = render partial: "layouts/intercom", locals: { app_id: app_id, email: email, user_id: user_id, user_uuid: user_uuid, name: name, marketplace_id: marketplace_id, marketplace_uuid: marketplace_uuid, marketplace_url: marketplace_url, user_hash: user_hash, email_confirmed: email_confirmed }

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -423,6 +423,10 @@ default: &default_settings
   #
   admin_intercom_respond_test_group_ratio: 0
 
+  admin_intercom_access_token: ""
+
+  admin_intercom_admin_id: ""
+
   #########
   # Sitemap
   #########


### PR DESCRIPTION
- [X] Prefix all the custom attributes with `info_` to indicate that they are just additional information and can't be fully trusted.
- [X] Add `email` even if it's unconfirmed
- [X] Add additional field `info_email_confirmed`
- [X] Add plan related information
- [X] Add information about enabled feature flags
- [X] Add handy helper `IntercomHelper.verify(conversation_id)` to verify the identity of the user