### PR TITLE
Decrease the font size of the Order type name in the list view

### DIFF
--- a/app/assets/stylesheets/views/_home.css.scss
+++ b/app/assets/stylesheets/views/_home.css.scss
@@ -323,7 +323,7 @@ $home-list-avatar-padding: lines(0.25);
     font-size: em(18);
   }
   @include media(large-mobile) {
-    font-size: em(36);
+    font-size: em(24);
     & > .smaller {
       font-size: em(24);
     }
@@ -348,10 +348,15 @@ $home-list-avatar-padding: lines(0.25);
 }
 
 .home-list-item-price-value,
-.browsing-list-item-price-value,
+.browsing-list-item-price-value {
+  font-size: em(32);
+  line-height: 1;
+  font-weight: 400;
+}
+
 .home-list-listing-shape-value,
 .browsing-list-item-listing-shape-value {
-  font-size: em(32);
+  font-size: em(24);
   line-height: 1;
   font-weight: 400;
 }


### PR DESCRIPTION
This PR decreases the font size of the Order type name in the list view.

Here are some screenshots:

**Before:**

Desktop view:

![screen shot 2017-04-10 at 14 48 30](https://cloud.githubusercontent.com/assets/429876/24860646/545b6b80-1dfe-11e7-98e3-fbe8a3700d47.png)

Tablet view: 

![screen shot 2017-04-10 at 14 52 37](https://cloud.githubusercontent.com/assets/429876/24860647/545be236-1dfe-11e7-8a3d-b0338aa9d323.png)


**After:**

Desktop view:

![screen shot 2017-04-10 at 14 51 27](https://cloud.githubusercontent.com/assets/429876/24860655/5b0f74d0-1dfe-11e7-9c91-f0e12759be77.png)

Tablet view:

![screen shot 2017-04-10 at 14 58 40](https://cloud.githubusercontent.com/assets/429876/24860656/5b3239d4-1dfe-11e7-8704-4d218dc18e75.png)
