### PR TITLE
Don't add redirect_to params to links

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -557,15 +557,23 @@ class ApplicationController < ActionController::Base
       }
     }.or_else({})
 
+    locale_change_links = available_locales.map { |(title, locale_code)|
+      {
+        url: PathHelpers.change_locale_path(is_logged_in: @current_user.present?,
+                                            locale: locale_code,
+                                            redirect_uri: @return_to),
+        title: title
+      }
+    }
+
     common = {
       logged_in: @current_user.present?,
       homepage_path: @homepage_path,
-      return_after_locale_change: @return_to,
       current_locale_name: get_full_locale_name(I18n.locale),
       sign_up_path: sign_up_path,
       login_path: login_path,
       new_listing_path: new_listing_path,
-      available_locales: available_locales,
+      locale_change_links: locale_change_links,
       icons: pick_icons(
         APP_CONFIG.icon_pack,
         [

--- a/app/controllers/i18n_controller.rb
+++ b/app/controllers/i18n_controller.rb
@@ -6,7 +6,10 @@ class I18nController < ApplicationController
   # Changes locale and returns to the previous view
   def change_locale
     @current_user.update_attribute(:locale, params[:locale]) if @current_user
-    redirect_to("/#{params[:locale]}/#{params[:redirect_uri]}")
+    redirect_to PathHelpers.path_after_locale_change(
+                  locale: params[:locale],
+                  redirect_uri: params[:redirect_uri]
+                )
   end
 
 end

--- a/app/view_utils/path_helpers.rb
+++ b/app/view_utils/path_helpers.rb
@@ -59,4 +59,25 @@ module PathHelpers
     @_url_helpers ||= Rails.application.routes.url_helpers
   end
 
+  # Path for locale change
+  #
+  # - If logged in: URL points to I18nController with redirect_url query string
+  # - If not logged in: Change the locale in the URL. No redirect_url query string
+  #
+  # For non-logged users, we don't want to include redirect_url query string, because
+  # it will create a number of unique links that the crawlers will request even though
+  # the page is the same
+  def change_locale_path(is_logged_in:, locale:, redirect_uri:)
+    if is_logged_in
+      paths.change_locale_path(locale: locale, redirect_uri: redirect_uri)
+    else
+      path_after_locale_change(locale: locale, redirect_uri: redirect_uri)
+    end
+  end
+
+  # Path after the current_user locale has been changed OR
+  # the new locale path, if anonymous user.
+  def path_after_locale_change(locale:, redirect_uri:)
+    "/#{locale}/#{redirect_uri}"
+  end
 end

--- a/app/view_utils/topbar_helper.rb
+++ b/app/view_utils/topbar_helper.rb
@@ -44,7 +44,7 @@ module TopbarHelper
         links: links,
         limit_priority_links: Maybe(MarketplaceService::API::Api.configurations.get(community_id: community.id).data)[:limit_priority_links].or_else(nil)
       },
-      locales: landing_page ? nil : locale_props(community, I18n.locale, path_after_locale_change),
+      locales: landing_page ? nil : locale_props(community, I18n.locale, path_after_locale_change, user.present?),
       avatarDropdown: {
         avatar: {
           image: user&.image.present? ? { url: user.image.url(:thumb) } : nil,
@@ -119,14 +119,16 @@ module TopbarHelper
     links + user_links
   end
 
-  def locale_props(community, current_locale, path_after_locale_change)
+  def locale_props(community, current_locale, path_after_locale_change, is_logged_in)
     community_locales = community.locales.map { |loc_ident|
       Sharetribe::AVAILABLE_LOCALES.find { |app_loc| app_loc[:ident] == loc_ident }
     }.compact.map { |loc|
       {
         locale_name: loc[:name],
         locale_ident: loc[:ident],
-        change_locale_uri: paths.change_locale_path({locale: loc[:ident], redirect_uri: path_after_locale_change})
+        change_locale_uri: PathHelpers.change_locale_path(is_logged_in: is_logged_in,
+                                                          locale: loc[:ident],
+                                                          redirect_uri: path_after_locale_change)
       }
     }
 

--- a/app/views/layouts/_global_header.haml
+++ b/app/views/layouts/_global_header.haml
@@ -21,7 +21,9 @@
             = current_locale_name
             = icon_map_tag(icons, "dropdown", ["icon-dropdown"])
         #header-locales-toggle-menu.toggle-menu.header-toggle-menu-language.hidden
-          = render :partial => "layouts/locale_select", :collection => available_locales, :as => :loc_array, locals: {return_after_locale_change: return_after_locale_change}
+          - locale_change_links.each do |locale_change_link|
+            %a{href: locale_change_link[:url]}
+              = locale_change_link[:title]
 
     - unless logged_in
       .header-right
@@ -38,7 +40,7 @@
           %span.visible-tablet-inline
             = t("header.menu")
 
-    = render :partial => "layouts/header_menu", locals: { return_after_locale_change: return_after_locale_change, available_locales: available_locales, icons: icons}
+    = render :partial => "layouts/header_menu", locals: { locale_change_links: locale_change_links, icons: icons}
 
     -#
       If necessary, the buttons will overlap with the logo. Buttons should be on top, that's

--- a/app/views/layouts/_header_menu.haml
+++ b/app/views/layouts/_header_menu.haml
@@ -37,4 +37,6 @@
       .toggle-menu-title
         = t("layouts.global-header.select_language")
 
-      = render :partial => "layouts/locale_select", :collection => available_locales, :as => :loc_array, locals: { return_after_locale_change: return_after_locale_change }
+      - locale_change_links.each do |locale_change_link|
+        %a{href: locale_change_link[:url]}
+          = locale_change_link[:title]

--- a/app/views/layouts/_locale_select.haml
+++ b/app/views/layouts/_locale_select.haml
@@ -1,1 +1,0 @@
-%a{href: change_locale_path(:locale => "#{loc_array[1]}", :redirect_uri => "#{return_after_locale_change}")} #{loc_array[0]}

--- a/client/app/components/sections/Topbar/Topbar.js
+++ b/client/app/components/sections/Topbar/Topbar.js
@@ -135,8 +135,7 @@ class Topbar extends Component {
     const newListingRoute = this.props.routes && this.props.routes.new_listing_path ?
             this.props.routes.new_listing_path() :
             '#';
-    const pathParams = { return_to: location };
-    const loginRoute = this.props.routes.login_path ? this.props.routes.login_path(pathParams) : '#';
+    const loginRoute = this.props.routes.login_path ? this.props.routes.login_path() : '#';
     const signupRoute = this.props.routes.sign_up_path ? this.props.routes.sign_up_path() : '#';
 
     // language menu props


### PR DESCRIPTION
Locale change and login links in the sign up had the `redirect_to`/`return_to` query strings in the links. This is problematic, since it makes the URLs unique in the eyes of a search engine crawler bot.

This PR removes those query strings from those URLs.

**Locale change:** If the user is not logged in, the locale change URL can be changed so that it points the user directly to the old redirect URL. We need to go to the `change_locale` endpoint only if the user is logged in and we really want to change the user preferences.

**Login:** Apparently, the `return_to` session value was already in use in the login URL. The new topbar used `return_to` parameter.

In this PR I decided to remove the `return_to` parameters from the new topbar because a) that was easiest and fastest thing to do b) in this PR the main purpose is to solve the crawler bot issue and this solution solves it c) new topbar and old topbar are now in sync.

In the future we might want to carry the `return_to` URL in the query string and use robots.txt to prevent search bots from crawling those. This should be done if we want to avoid creating sessions for anonymous users.