### PR TITLE
Generalize flag disabled to handle dependencies properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 - Fix cropped cover photo in big screens [#2895](https://github.com/sharetribe/sharetribe/pull/2895)
 - Add missing padding to homepage search field in mobile view [#2895](https://github.com/sharetribe/sharetribe/pull/2895)
 - Fix unwanted scrolling in listing page by removing comment text area auto focus [#2917](https://github.com/sharetribe/sharetribe/pull/2917)
+- Fix faulty feature flag dependency handling [#2932](https://github.com/sharetribe/sharetribe/pull/2932)
 
 ### Security
 

--- a/app/view_utils/new_layout_view_utils.rb
+++ b/app/view_utils/new_layout_view_utils.rb
@@ -6,8 +6,8 @@ module NewLayoutViewUtils
     [:name, :symbol, :mandatory],
     [:enabled_for_user, :bool, :mandatory],
     [:enabled_for_community, :bool, :mandatory],
-    [:disabled_for_user, :bool, default: false],
-    [:disabled_for_community, :bool, default: false]
+    [:required_for_user, :bool, default: false],
+    [:required_for_community, :bool, default: false]
   )
 
   # Describes feature relationships:
@@ -53,8 +53,8 @@ module NewLayoutViewUtils
         name: f[:name],
         enabled_for_user: person_flags.include?(f[:name]),
         enabled_for_community: community_flags.include?(f[:name]),
-        disabled_for_user: flag_disabled?(f, person_flags),
-        disabled_for_community: flag_disabled?(f, community_flags)
+        required_for_user: flag_required?(f, person_flags),
+        required_for_community: flag_required?(f, community_flags)
       })}
   end
 
@@ -103,8 +103,8 @@ module NewLayoutViewUtils
     flags.include?(:manage_searchpage) && !private_community || clp_enabled
   end
 
-  def flag_disabled?(fl, flags)
-    # The required flag is enabled in flags and requirement is disabled
+  def flag_required?(fl, flags)
+    # If the required flag is provided in flags, the requirement must be enabled
     flags.include?(FEATURE_RELS.key(fl[:name]))
   end
 end

--- a/app/view_utils/new_layout_view_utils.rb
+++ b/app/view_utils/new_layout_view_utils.rb
@@ -53,8 +53,8 @@ module NewLayoutViewUtils
         name: f[:name],
         enabled_for_user: person_flags.include?(f[:name]),
         enabled_for_community: community_flags.include?(f[:name]),
-        disabled_for_user: topbar_flag_disabled?(f, person_flags),
-        disabled_for_community: topbar_flag_disabled?(f, community_flags)
+        disabled_for_user: flag_disabled?(f, person_flags),
+        disabled_for_community: flag_disabled?(f, community_flags)
       })}
   end
 
@@ -103,9 +103,8 @@ module NewLayoutViewUtils
     flags.include?(:manage_searchpage) && !private_community || clp_enabled
   end
 
-  def topbar_flag_disabled?(fl, flags)
-    #topbar is required with other flags and thus disabled
-    fl[:name] == :topbar_v1 &&
-      !flags.reject{ |f| [:topbar_v1, :manage_searchpage].include?(f) }.empty?
+  def flag_disabled?(fl, flags)
+    # The required flag is enabled in flags and requirement is disabled
+    flags.include?(FEATURE_RELS.key(fl[:name]))
   end
 end

--- a/app/views/admin/communities/new_layout.haml
+++ b/app/views/admin/communities/new_layout.haml
@@ -37,10 +37,10 @@
             = feature[:title]
         .col-3
           .checkbox-centered
-            = check_box_tag "enabled_for_user[#{ feature[:name] }]", true, feature[:enabled_for_user], disabled: feature[:disabled_for_user]
+            = check_box_tag "enabled_for_user[#{ feature[:name] }]", true, feature[:enabled_for_user], disabled: feature[:required_for_user]
         .col-3
           .checkbox-centered
-            = check_box_tag  "enabled_for_community[#{ feature[:name] }]", true, feature[:enabled_for_community], disabled: feature[:disabled_for_community]
+            = check_box_tag  "enabled_for_community[#{ feature[:name] }]", true, feature[:enabled_for_community], disabled: feature[:required_for_community]
     .row
       .col-12
         = form.button t("admin.communities.settings.update_settings")

--- a/spec/view_utils/new_layout_view_utils_spec.rb
+++ b/spec/view_utils/new_layout_view_utils_spec.rb
@@ -50,22 +50,22 @@ describe NewLayoutViewUtils do
             name: :foo,
             enabled_for_user: true,
             enabled_for_community: false,
-            disabled_for_user: false,
-            disabled_for_community: false
+            required_for_user: false,
+            required_for_community: false
           },
           { title: "Bar",
             name: :bar,
             enabled_for_user: true,
             enabled_for_community: false,
-            disabled_for_user: false,
-            disabled_for_community: false
+            required_for_user: false,
+            required_for_community: false
           },
           { title: "Wat",
             name: :wat,
             enabled_for_user: false,
             enabled_for_community: true,
-            disabled_for_user: false,
-            disabled_for_community: false
+            required_for_user: false,
+            required_for_community: false
           }
         ])
       end
@@ -99,22 +99,22 @@ describe NewLayoutViewUtils do
             name: :foo,
             enabled_for_user: false,
             enabled_for_community: false,
-            disabled_for_user: false,
-            disabled_for_community: false
+            required_for_user: false,
+            required_for_community: false
           },
           { title: "Bar",
             name: :bar,
             enabled_for_user: false,
             enabled_for_community: false,
-            disabled_for_user: false,
-            disabled_for_community: false
+            required_for_user: false,
+            required_for_community: false
           },
           { title: "Wat",
             name: :wat,
             enabled_for_user: false,
             enabled_for_community: false,
-            disabled_for_user: false,
-            disabled_for_community: false
+            required_for_user: false,
+            required_for_community: false
           }
         ])
       end


### PR DESCRIPTION
Previously, only topbar dependency was handled properly for feature flags. This lead to a situation where enabling some unrelated feature flag lead to topbar controls to be disabled in admin ui. This pull request generalizes dependency handling.

## Steps to reproduce

1. Enable :admin_intercom_respond feature flag for community
2. Navigate to admin/new_layout
3. Disable the new search page controls if enabled and save

**Expected:** Topbar controls are active 
**Actual:** Tobpar control is disabled



