### PR TITLE
Show trial expired message only for logged in users

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -31,8 +31,8 @@
     - else
       = render partial: 'layouts/global_header', locals: header_props()
 
-    - if @display_expiration_notice
-      - if @current_user&.has_admin_rights?
+    - if logged_in? && @display_expiration_notice
+      - if @current_user.has_admin_rights?
         = render partial: "layouts/admin_expiration_notice", locals: {external_plan_service_login_url: admin_plan_path}
       - else
         = render partial: "layouts/expiration_notice", locals: {contact_owner_link: new_user_feedback_path}


### PR DESCRIPTION
Prevent meaningful usage of marketplace when logged in and the marketplace trial is expired.

Enable marketplaces when not logged in.

Enables admins to order a plan when trial has expired.