### PR TITLE
Fix #2885 Landing page always shows sign up button for private marketplaces

### DIFF
--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -38,14 +38,18 @@ class LandingPageController < ActionController::Metal
   def index
     return if perform_redirect!
 
-    cid = community(request).id
+    com = community(request)
+    cid = com.id
+    is_private = com.private?
+    user_logged_in = user(request).present?
+    cta = is_private && !user_logged_in ? "signup" : "search" # cta: Call to action
     default_locale = community(request).default_locale
     version = CLP::LandingPageStore.released_version(cid)
     locale_param = params[:locale]
 
     begin
       content = nil
-      cache_meta = CLP::Caching.fetch_cache_meta(cid, version, locale_param)
+      cache_meta = CLP::Caching.fetch_cache_meta(cid, version, locale_param, cta)
       cache_hit = true
 
       if cache_meta.nil?
@@ -54,10 +58,11 @@ class LandingPageController < ActionController::Metal
           community_id: cid,
           default_locale: default_locale,
           locale_param: locale_param,
-          version: version
+          version: version,
+          cta: cta
         )
         cache_meta = CLP::Caching.cache_content!(
-          cid, version, locale_param, content, CACHE_TIME)
+          cid, version, locale_param, content, CACHE_TIME, cta)
       end
 
       if stale?(etag: cache_meta[:digest],
@@ -73,7 +78,8 @@ class LandingPageController < ActionController::Metal
             community_id: cid,
             default_locale: default_locale,
             locale_param: locale_param,
-            version: version
+            version: version,
+            cta: cta
           )
         end
 
@@ -85,7 +91,15 @@ class LandingPageController < ActionController::Metal
       # for conditional get.
 
       headers[CACHE_HEADER] = cache_hit ? "1" : "0"
-      expires_in(CACHE_TIME, public: true)
+
+      if is_private
+        # Don't add browser cache to private marketplaces
+        # In private marketplaces, we need to render different
+        # HTML is the user is logged in
+        expires_now
+      else
+        expires_in(CACHE_TIME, public: true)
+      end
     rescue CLP::LandingPageContentNotFound
       render_not_found()
     end
@@ -94,7 +108,12 @@ class LandingPageController < ActionController::Metal
   def preview
     return if perform_redirect!
 
-    cid = community(request).id
+    com = community(request)
+    cid = com.id
+    is_private = com.private?
+    user_logged_in = user(request).present?
+    cta = is_private && !user_logged_in ? "signup" : "search" # cta: Call to action
+
     default_locale = community(request).default_locale
 
     preview_version = parse_int(params[:preview_version])
@@ -113,7 +132,8 @@ class LandingPageController < ActionController::Metal
       self.response_body = render_landing_page(
         default_locale: default_locale,
         locale_param: locale_param,
-        structure: structure
+        structure: structure,
+        cta: cta
       )
     rescue CLP::LandingPageContentNotFound
       render_not_found()
@@ -142,7 +162,7 @@ class LandingPageController < ActionController::Metal
   def append_info_to_payload(payload)
     super
     payload[:community_id] = community(request)&.id
-    payload[:current_user_id] = nil
+    payload[:current_user_id] = user(request)&.id
 
     ControllerLogging.append_request_info_to_payload!(request, payload)
   end
@@ -151,12 +171,13 @@ class LandingPageController < ActionController::Metal
     I18nHelper.initialize_community_backend!(cid, [locale])
   end
 
-  def build_html(community_id:, default_locale:, locale_param:, version:)
+  def build_html(community_id:, default_locale:, locale_param:, version:, cta:)
     structure = CLP::LandingPageStore.load_structure(community_id, version)
     render_landing_page(
       default_locale: default_locale,
       structure: structure,
-      locale_param: locale_param
+      locale_param: locale_param,
+      cta: cta
     )
   end
 
@@ -175,7 +196,7 @@ class LandingPageController < ActionController::Metal
     }
   end
 
-  def build_denormalizer(cid:, default_locale:, locale_param:, landing_page_locale:, sitename:)
+  def build_denormalizer(cid:, default_locale:, locale_param:, landing_page_locale:, sitename:, cta:)
     search_path = ->(opts = {}) {
       PathHelpers.search_path(
         community_id: cid,
@@ -197,7 +218,7 @@ class LandingPageController < ActionController::Metal
     CLP::Denormalizer.new(
       link_resolvers: {
         "path" => CLP::LinkResolver::PathResolver.new(paths),
-        "marketplace_data" => CLP::LinkResolver::MarketplaceDataResolver.new(marketplace_data),
+        "marketplace_data" => CLP::LinkResolver::MarketplaceDataResolver.new(marketplace_data, cta),
         "assets" => CLP::LinkResolver::AssetResolver.new(APP_CONFIG[:clp_asset_url], sitename),
         "translation" => CLP::LinkResolver::TranslationResolver.new(landing_page_locale),
         "category" => CLP::LinkResolver::CategoryResolver.new(category_data),
@@ -214,6 +235,10 @@ class LandingPageController < ActionController::Metal
 
   def community(request)
     @current_community ||= request.env[:current_marketplace]
+  end
+
+  def user(request)
+    @user ||= request.env["warden"]&.user
   end
 
   def plan(request)
@@ -236,7 +261,7 @@ class LandingPageController < ActionController::Metal
       google_analytics_key: c.google_analytics_key }
   end
 
-  def render_landing_page(default_locale:, locale_param:, structure:)
+  def render_landing_page(default_locale:, locale_param:, structure:, cta:)
     c = community(request)
 
     landing_page_locale, sitename = structure["settings"].values_at("locale", "sitename")
@@ -262,6 +287,7 @@ class LandingPageController < ActionController::Metal
 
     denormalizer = build_denormalizer(
       cid: c&.id,
+      cta: cta,
       locale_param: locale_param,
       default_locale: default_locale,
       landing_page_locale: landing_page_locale,

--- a/app/services/custom_landing_page/caching.rb
+++ b/app/services/custom_landing_page/caching.rb
@@ -3,20 +3,20 @@ module CustomLandingPage
 
     module_function
 
-    def fetch_cache_meta(community_id, version, locale)
-      Rails.cache.read("clp/#{community_id}/#{version}/#{locale}")
+    def fetch_cache_meta(community_id, version, locale, cta)
+      Rails.cache.read("clp/#{community_id}/#{version}/#{locale}/#{cta}")
     end
 
     def fetch_cached_content(community_id, version, digest)
       Rails.cache.read("clp/#{community_id}/#{version}/#{digest}")
     end
 
-    def cache_content!(community_id, version, locale, content, cache_time)
+    def cache_content!(community_id, version, locale, content, cache_time, cta)
       cache_meta = build_cache_meta(content)
 
       # write metadata first, so that it expires first
       write_cache_meta!(
-        community_id, version, locale, cache_meta, cache_time)
+        community_id, version, locale, cache_meta, cache_time, cta)
       # cache html longer than metadata, but keyed by content (digest)
       write_cached_content!(
         community_id, version, content, cache_meta[:digest], cache_time + 10.seconds)
@@ -30,8 +30,8 @@ module CustomLandingPage
     end
 
     ## Internal, use cache_content! instead
-    def write_cache_meta!(community_id, version, locale, cache_meta, cache_time)
-      Rails.cache.write("clp/#{community_id}/#{version}/#{locale}", cache_meta, expires_in: cache_time)
+    def write_cache_meta!(community_id, version, locale, cache_meta, cache_time, cta)
+      Rails.cache.write("clp/#{community_id}/#{version}/#{locale}/#{cta}", cache_meta, expires_in: cache_time)
     end
 
     ## Internal, use cache_content! instead

--- a/app/services/custom_landing_page/link_resolver.rb
+++ b/app/services/custom_landing_page/link_resolver.rb
@@ -20,8 +20,9 @@ module CustomLandingPage
     end
 
     class MarketplaceDataResolver
-      def initialize(data)
+      def initialize(data, cta)
         @_data = data
+        @_cta = cta
       end
 
       def call(type, id, _)
@@ -29,8 +30,24 @@ module CustomLandingPage
           raise LinkResolvingError.new("Unknown marketplace data value '#{id}'.")
         end
 
-        value = @_data[id]
+        value =
+          case id
+          when "search_type"
+            search_type
+          else
+            value = @_data[id]
+          end
+
         { "id" => id, "type" => type, "value" => value }
+      end
+
+      def search_type
+        case @_cta
+        when "signup"
+          "private"
+        else
+          @_data["search_type"]
+        end
       end
     end
 

--- a/app/services/custom_landing_page/marketplace_data_store.rb
+++ b/app/services/custom_landing_page/marketplace_data_store.rb
@@ -7,10 +7,9 @@ module CustomLandingPage
 
     def marketplace_data(cid, locale)
       primary_color,
-      private,
       twitter_handle,
       name_display_type = Community.where(id: cid)
-                               .pluck(:custom_color1, :private, :twitter_handle, :name_display_type)
+                               .pluck(:custom_color1, :twitter_handle, :name_display_type)
                                .first
 
       name,
@@ -34,9 +33,7 @@ module CustomLandingPage
                     .first
 
       search_type =
-        if private
-          "private"
-        elsif main_search == "keyword_and_location"
+        if main_search == "keyword_and_location"
           "keyword_and_location_search"
         elsif main_search == "location"
           "location_search"

--- a/spec/requests/landing_pages_spec.rb
+++ b/spec/requests/landing_pages_spec.rb
@@ -217,6 +217,31 @@ describe "Landing page", type: :request do
         expect(response.status).to eq(200)
       end
 
+      it "includes max-age header in the response for public marketplaces" do
+        get "http://#{@domain}"
+
+        expect(response.status).to eq(200)
+        expect(response.headers["Cache-Control"]).to eq("max-age=#{APP_CONFIG.clp_cache_time}, public")
+      end
+
+      describe "private marketplaces" do
+        before(:all) {
+          @orig_private = @community.private
+          @community.update_attributes(private: true)
+        }
+
+        after(:all) {
+          @community.update_attributes(private: @orig_private)
+        }
+
+        it "does not includes max-age header in the response for private marketplaces" do
+          get "http://#{@domain}"
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("no-cache")
+        end
+      end
+
       describe "cache expiration" do
         before(:all) { Rails.cache.clear }
 


### PR DESCRIPTION
**Problem**: See #2885 for detailed description about the issue

**Solution:**

- Disable browser cache for private marketplaces
- Cache two versions based on the `cta` (which can be either `signup` or `search`) for private marketplace.