### PR TITLE
Currency formatting

### DIFF
--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -318,7 +318,7 @@ function initialize_listing_view(locale) {
   });
 }
 
-function updateSellerGetsValue(priceInputSelector, displayTargetSelector, currencySelector, communityCommissionPercentage, minCommission, showReversed) {
+function updateSellerGetsValue(currency, locale, priceInputSelector, displayTargetSelector, currencySelector, communityCommissionPercentage, minCommission, showReversed) {
   // true == Show the fee instead of what's left after the fee
   showReversed = showReversed || false;
 
@@ -337,9 +337,8 @@ function updateSellerGetsValue(priceInputSelector, displayTargetSelector, curren
     }
 
     $display.text(
-      [ST.paymentMath.displayMoney(Math.max(0, displaySum)),
-       $currency.val()]
-        .join(" "));
+      ST.paymentMath.displayMoney(Math.max(0, displaySum), currency, locale, {inCents: false})
+    );
   }
 
   $input.keyup(updateYouWillGet);

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -318,13 +318,12 @@ function initialize_listing_view(locale) {
   });
 }
 
-function updateSellerGetsValue(currency, locale, priceInputSelector, displayTargetSelector, currencySelector, communityCommissionPercentage, minCommission, showReversed) {
+function updateSellerGetsValue(currency, locale, priceInputSelector, displayTargetSelector, communityCommissionPercentage, minCommission, showReversed) {
   // true == Show the fee instead of what's left after the fee
   showReversed = showReversed || false;
 
   $display = $(displayTargetSelector);
   $input = $(priceInputSelector);
-  $currency = $(currencySelector);
 
   function updateYouWillGet() {
     var sum = ST.paymentMath.parseFloatFromFieldValue($input.val());
@@ -342,7 +341,6 @@ function updateSellerGetsValue(currency, locale, priceInputSelector, displayTarg
   }
 
   $input.keyup(updateYouWillGet);
-  $currency.change(updateYouWillGet);
 
   // Run once immediately
   updateYouWillGet();

--- a/app/assets/javascripts/listing.js
+++ b/app/assets/javascripts/listing.js
@@ -37,7 +37,7 @@ window.ST = window.ST || {};
     });
   };
 
-  module.initializeShippingPriceTotal = function(quantityInputSelector, shippingPriceSelector, decimalMark){
+  module.initializeShippingPriceTotal = function(currency, locale, quantityInputSelector, shippingPriceSelector){
     var $quantityInput = $(quantityInputSelector);
     var $shippingPriceElements = $(shippingPriceSelector);
 
@@ -51,10 +51,8 @@ window.ST = window.ST || {};
 
         // To avoid floating point issues, do calculations in cents
         var newShippingPrice = shippingPriceCents + perAdditionalCents * additionalCount;
-        var priceText = (newShippingPrice / 100).toFixed(2) + "";
-        var priceTextWithDecimalMark = priceText.replace(".", decimalMark);
-
-        $priceEl.text(priceTextWithDecimalMark);
+        var priceForDisplay = ST.paymentMath.displayMoney(newShippingPrice, currency, locale, {inCents: true})
+        $priceEl.text(priceForDisplay);
       });
     };
 

--- a/app/assets/javascripts/payment_math.js
+++ b/app/assets/javascripts/payment_math.js
@@ -17,7 +17,18 @@ window.ST.paymentMath = (function() {
     return parseFloatFromFieldValue(value) * subunit_to_unit;
   }
 
-  function displayMoney(sum) {
+  function displayMoney(sum, currency, locale, opts) {
+    if(typeof sum === "number" && !isNaN(sum)){
+      var formatter = Intl.NumberFormat(locale, {style: "currency", currency: currency})
+      var digits = formatter.resolvedOptions().minimumFractionDigits;
+      var total = (digits === 0 || !opts.inCents) ? sum : sum / 100;
+
+      return formatter.format(total);
+
+    } else {
+      return "-";
+    }
+
     return typeof sum === "number" && !isNaN(sum) ? sum.toFixed(2) : "-";
   }
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -932,7 +932,7 @@ class ListingsController < ApplicationController
   end
 
   def delivery_config(require_shipping_address, pickup_enabled, shipping_price, shipping_price_additional, currency)
-    shipping = delivery_price_hash(:shipping, shipping_price, shipping_price_additional)
+    shipping = delivery_price_hash(:shipping, shipping_price, shipping_price_additional) if require_shipping_address
     pickup = delivery_price_hash(:pickup, Money.new(0, currency), Money.new(0, currency))
 
     case [require_shipping_address, pickup_enabled]

--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -68,7 +68,7 @@ module ListingsHelper
   end
 
   def price_as_text(listing)
-    humanized_money_with_symbol(listing.price).upcase +
+    MoneyViewUtils.to_humanized(listing.price) +
     unless listing.quantity.blank? then " / #{listing.quantity}" else "" end
   end
 

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -15,8 +15,6 @@ class TransactionMailer < ActionMailer::Base
   default :from => APP_CONFIG.sharetribe_mail_from_address
   layout 'email'
 
-  include MoneyRails::ActionViewExtension # this is for humanized_money_with_symbol
-
   add_template_helper(EmailTemplateHelper)
 
   def transaction_preauthorized(transaction)
@@ -95,15 +93,15 @@ class TransactionMailer < ActionMailer::Base
                    listing_title: transaction[:listing_title],
                    price_per_unit_title: t("emails.new_payment.price_per_unit_type", unit_type: unit_type),
                    quantity_selector_label: quantity_selector_label,
-                   listing_price: humanized_money_with_symbol(transaction[:listing_price]),
+                   listing_price: MoneyViewUtils.to_humanized(transaction[:listing_price]),
                    listing_quantity: transaction[:listing_quantity],
                    duration: transaction[:booking].present? ? transaction[:booking][:duration] : nil,
-                   subtotal: humanized_money_with_symbol(transaction[:item_total]),
-                   payment_total: humanized_money_with_symbol(payment_total),
-                   shipping_total: humanized_money_with_symbol(transaction[:shipping_price]),
-                   payment_service_fee: humanized_money_with_symbol(-service_fee),
-                   paypal_gateway_fee: humanized_money_with_symbol(-gateway_fee),
-                   payment_seller_gets: humanized_money_with_symbol(you_get),
+                   subtotal: MoneyViewUtils.to_humanized(transaction[:item_total]),
+                   payment_total: MoneyViewUtils.to_humanized(payment_total),
+                   shipping_total: MoneyViewUtils.to_humanized(transaction[:shipping_price]),
+                   payment_service_fee: MoneyViewUtils.to_humanized(-service_fee),
+                   paypal_gateway_fee: MoneyViewUtils.to_humanized(-gateway_fee),
+                   payment_seller_gets: MoneyViewUtils.to_humanized(you_get),
                    payer_full_name: buyer_model.name(community),
                    payer_given_name: PersonViewUtils.person_display_name_for_type(buyer_model, "first_name_only"),
                  }
@@ -133,12 +131,12 @@ class TransactionMailer < ActionMailer::Base
                    listing_title: transaction[:listing_title],
                    price_per_unit_title: t("emails.receipt_to_payer.price_per_unit_type", unit_type: unit_type),
                    quantity_selector_label: quantity_selector_label,
-                   listing_price: humanized_money_with_symbol(transaction[:listing_price]),
+                   listing_price: MoneyViewUtils.to_humanized(transaction[:listing_price]),
                    listing_quantity: transaction[:listing_quantity],
                    duration: transaction[:booking].present? ? transaction[:booking][:duration] : nil,
-                   subtotal: humanized_money_with_symbol(transaction[:item_total]),
-                   shipping_total: humanized_money_with_symbol(transaction[:shipping_price]),
-                   payment_total: humanized_money_with_symbol(transaction[:payment_total]),
+                   subtotal: MoneyViewUtils.to_humanized(transaction[:item_total]),
+                   shipping_total: MoneyViewUtils.to_humanized(transaction[:shipping_price]),
+                   payment_total: MoneyViewUtils.to_humanized(transaction[:payment_total]),
                    recipient_full_name: seller_model.name(community),
                    recipient_given_name: PersonViewUtils.person_display_name_for_type(seller_model, "first_name_only"),
                    automatic_confirmation_days: nil,

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -84,6 +84,11 @@ class TransactionMailer < ActionMailer::Base
       unit_type = Maybe(transaction).select { |t| t[:unit_type].present? }.map { |t| ListingViewUtils.translate_unit(t[:unit_type], t[:unit_tr_key]) }.or_else(nil)
       quantity_selector_label = Maybe(transaction).select { |t| t[:unit_type].present? }.map { |t| ListingViewUtils.translate_quantity(t[:unit_type], t[:unit_selector_tr_key]) }.or_else(nil)
 
+      FeatureFlagHelper.init(community_id: community.id,
+                             user_id: seller_model.id,
+                             request: OpenStruct.new(session: {}, params: []), #fake request, will provide fake .session and .params
+                             is_admin: seller_model.is_admin?,
+                             is_marketplace_admin: seller_model.is_marketplace_admin?) # TODO: remove when :currency_formatting flag is removed
       premailer_mail(:to => seller_model.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
                      :subject => t("emails.new_payment.new_payment")) do |format|
@@ -122,6 +127,11 @@ class TransactionMailer < ActionMailer::Base
       unit_type = Maybe(transaction).select { |t| t[:unit_type].present? }.map { |t| ListingViewUtils.translate_unit(t[:unit_type], t[:unit_tr_key]) }.or_else(nil)
       quantity_selector_label = Maybe(transaction).select { |t| t[:unit_type].present? }.map { |t| ListingViewUtils.translate_quantity(t[:unit_type], t[:unit_selector_tr_key]) }.or_else(nil)
 
+      FeatureFlagHelper.init(community_id: community.id,
+                             user_id: buyer_model.id,
+                             request: OpenStruct.new(session: {}, params: []), #fake request, will provide fake .session and .params
+                             is_admin: buyer_model.is_admin?,
+                             is_marketplace_admin: buyer_model.is_marketplace_admin?) # TODO: remove when :currency_formatting flag is removed
       premailer_mail(:to => buyer_model.confirmed_notification_emails_to,
                      :from => community_specific_sender(community),
                      :subject => t("emails.receipt_to_payer.receipt_of_payment")) { |format|

--- a/app/services/feature_flag_service/store.rb
+++ b/app/services/feature_flag_service/store.rb
@@ -20,7 +20,8 @@ module FeatureFlagService::Store
       :export_transactions_as_csv,
       :topbar_v1,
       :searchpage_v1,
-      :manage_searchpage
+      :manage_searchpage,
+      :currency_formatting
     ].to_set
 
     def initialize(additional_flags:)

--- a/app/view_utils/listing_view_utils.rb
+++ b/app/view_utils/listing_view_utils.rb
@@ -79,11 +79,13 @@ module ListingViewUtils
 
   def shipping_info(shipping_type, shipping_price, shipping_price_additional)
     if shipping_type == :shipping && shipping_price_additional.present?
-      I18n.translate("listings.show.shipping_price_additional", price: humanized_money_with_symbol(shipping_price), shipping_price_additional: humanized_money_with_symbol(shipping_price_additional))
+      I18n.translate("listings.show.shipping_price_additional",
+                     price: MoneyViewUtils.to_humanized(shipping_price),
+                     shipping_price_additional: MoneyViewUtils.to_humanized(shipping_price_additional))
     elsif shipping_type == :shipping
-      I18n.translate("listings.show.shipping", price: humanized_money_with_symbol(shipping_price))
+      I18n.translate("listings.show.shipping", price: MoneyViewUtils.to_humanized(shipping_price))
     elsif shipping_type == :pickup
-      I18n.translate("listings.show.pickup", price: humanized_money_with_symbol(shipping_price))
+      I18n.translate("listings.show.pickup", price: MoneyViewUtils.to_humanized(shipping_price))
     else
       raise ArgumentError.new("Delivery type not supported")
     end

--- a/app/view_utils/money_view_utils.rb
+++ b/app/view_utils/money_view_utils.rb
@@ -1,17 +1,25 @@
 module MoneyViewUtils
   extend ActionView::Helpers::NumberHelper
+  extend MoneyRails::ActionViewExtension # TODO: Remove when feature flag is removed
 
   module_function
 
   # Converts instance of Money to properly formatted and localized string for view purposes
   # Replaces spaces with narrow non breaking spaces, we do not want monetary amounts to be split on separate lines
   def to_humanized(m, locale = I18n.locale)
-    separator = I18n.t("number.currency.format.separator", locale: locale)
-    precision = m.currency.exponent.to_i
-    zero_cents = "0" * precision
-    number_to_currency(m.amount, unit: m.symbol, locale: locale, precision: m.currency.exponent.to_i)
-      .tr(" ", "\u202F")
-      .gsub("#{separator}#{zero_cents}", "") # remove cents if they are zero
-      .encode('utf-8')
+    # TODO: Remove feature flag
+    if FeatureFlagHelper.feature_enabled?(:currency_formatting)
+      separator = I18n.t("number.currency.format.separator", locale: locale)
+      precision = m.currency.exponent.to_i
+      zero_cents = "0" * precision
+      number_to_currency(m.amount, unit: m.symbol, locale: locale, precision: m.currency.exponent.to_i)
+        .tr(" ", "\u202F")
+        .gsub("#{separator}#{zero_cents}", "") # remove cents if they are zero
+        .encode('utf-8')
+    else
+      humanized_money_with_symbol(m).upcase
+    end
+  rescue FeatureFlagHelperNotInitialized
+    humanized_money_with_symbol(m).upcase
   end
 end

--- a/app/view_utils/money_view_utils.rb
+++ b/app/view_utils/money_view_utils.rb
@@ -1,0 +1,17 @@
+module MoneyViewUtils
+  extend ActionView::Helpers::NumberHelper
+
+  module_function
+
+  # Converts instance of Money to properly formatted and localized string for view purposes
+  # Replaces spaces with narrow non breaking spaces, we do not want monetary amounts to be split on separate lines
+  def to_humanized(m, locale = I18n.locale)
+    separator = I18n.t("number.currency.format.separator", locale: locale)
+    precision = m.currency.exponent.to_i
+    zero_cents = "0" * precision
+    number_to_currency(m.amount, unit: m.symbol, locale: locale, precision: m.currency.exponent.to_i)
+      .tr(" ", "\u202F")
+      .gsub("#{separator}#{zero_cents}", "") # remove cents if they are zero
+      .encode('utf-8')
+  end
+end

--- a/app/view_utils/money_view_utils.rb
+++ b/app/view_utils/money_view_utils.rb
@@ -9,6 +9,7 @@ module MoneyViewUtils
   def to_humanized(m, locale = I18n.locale)
     # TODO: Remove feature flag
     if FeatureFlagHelper.feature_enabled?(:currency_formatting)
+      return "" if m.nil?
       separator = I18n.t("number.currency.format.separator", locale: locale)
       precision = m.currency.exponent.to_i
       zero_cents = "0" * precision

--- a/app/view_utils/transaction_view_utils.rb
+++ b/app/view_utils/transaction_view_utils.rb
@@ -152,17 +152,17 @@ module TransactionViewUtils
 
     message = case state
     when "preauthorized"
-      t("conversations.message.payment_preauthorized", sum: humanized_money_with_symbol(payment_sum))
+      t("conversations.message.payment_preauthorized", sum: MoneyViewUtils.to_humanized(payment_sum))
     when "accepted"
       ActiveSupport::Deprecation.warn("Transaction state 'accepted' is deprecated and will be removed in the future.")
       t("conversations.message.accepted_request")
     when "rejected"
       t("conversations.message.rejected_request")
     when preauthorize_accepted
-      t("conversations.message.received_payment", sum: humanized_money_with_symbol(payment_sum))
+      t("conversations.message.received_payment", sum: MoneyViewUtils.to_humanized(payment_sum))
     when post_pay_accepted
       ActiveSupport::Deprecation.warn("Transaction state 'paid' without previous state is deprecated and will be removed in the future.")
-      t("conversations.message.paid", sum: humanized_money_with_symbol(payment_sum))
+      t("conversations.message.paid", sum: MoneyViewUtils.to_humanized(payment_sum))
     when "canceled"
       t("conversations.message.canceled_request")
     when "confirmed"

--- a/app/views/accept_preauthorized_conversations/accept.haml
+++ b/app/views/accept_preauthorized_conversations/accept.haml
@@ -37,7 +37,7 @@
           %span.conversation-per-unit-label
             = t("transactions.initiate.price_per_day")
           %span.conversation-per-unit-value
-            = humanized_money_with_symbol(listing.price)
+            = MoneyViewUtils.to_humanized(listing.price)
 
         .conversation-booking-wrapper
           %span.conversation-booking-label
@@ -53,7 +53,7 @@
           %span.conversation-per-unit-label
             = t("transactions.price_per_quantity", unit_type: ListingViewUtils.translate_unit(listing.unit_type, listing.unit_tr_key))
           %span.conversation-per-unit-value
-            = humanized_money_with_symbol(listing.price)
+            = MoneyViewUtils.to_humanized(listing.price)
         .conversation-quantity-wrapper
           %span.conversation-quantity-label
             = ListingViewUtils.translate_quantity(listing.unit_type, listing.unit_selector_tr_key) || t("conversations.accept.quantity_label")
@@ -64,33 +64,33 @@
         %span.conversation-sum-label
           = t("conversations.accept.sum_label")
         %span.conversation-sum-value
-          = humanized_money_with_symbol(sum)
+          = MoneyViewUtils.to_humanized(sum)
       .conversation-service-fee-wrapper
         %span.conversation-service-fee-label
           = t("conversations.accept.service_fee_label")
         %span.conversation-service-fee-value
-          = "-#{humanized_money_with_symbol(fee)}"
+          = "-#{MoneyViewUtils.to_humanized(fee)}"
 
       - if shipping_price
         .conversation-shipping-price-wrapper
           %span.conversation-shipping-price-label
             = t("conversations.accept.shipping_price_label")
           %span.conversation-shipping-price-value
-            = humanized_money_with_symbol(shipping_price)
+            = MoneyViewUtils.to_humanized(shipping_price)
 
       - if payment_gateway == :paypal
         .conversation-total-wrapper
           %span.conversation-total-label
             = t("conversations.accept.total_label")
           %span.conversation-total-paypal-value
-            = t("conversations.accept.total_value", seller_gets: humanized_money_with_symbol(seller_gets))
+            = t("conversations.accept.total_value", seller_gets: MoneyViewUtils.to_humanized(seller_gets))
 
       - else
         .conversation-total-wrapper
           %span.conversation-total-label
             = t("conversations.accept.you_will_get_label")
           %span.conversation-total-value
-            = humanized_money_with_symbol(seller_gets)
+            = MoneyViewUtils.to_humanized(seller_gets)
 
     - if payment_gateway == :paypal
       %p

--- a/app/views/admin/community_transactions/index.haml
+++ b/app/views/admin/community_transactions/index.haml
@@ -33,7 +33,7 @@
           %td
             = link_to person_transaction_path(person_id: @current_user.id, id: conversation[:id]) do
               = t("admin.communities.transactions.status.#{conversation[:status]}")
-          %td=conversation[:payment_total] ? humanized_money_with_symbol(conversation[:payment_total]) : ""
+          %td=conversation[:payment_total] ? MoneyViewUtils.to_humanized(conversation[:payment_total]) : ""
           %td=l(conversation[:created_at], format: :short_date)
           %td=l(conversation[:last_activity_at], format: :short_date)
           %td=Maybe(conversation[:starter]).map { |p| link_to_unless(p[:is_deleted], p[:display_name], p[:url]) }.or_else("")

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -10,7 +10,7 @@
       .home-list-price
         - if listing.price
           .home-list-item-price-value
-            = humanized_money_with_symbol(listing.price).upcase
+            = MoneyViewUtils.to_humanized(listing.price)
           - price_text = nil
           - if listing.quantity.present?
             - price_text = t("listings.form.price.per") + " " + listing.quantity
@@ -35,7 +35,7 @@
       .home-list-price-mobile{:class => (listing.listing_images.size > 0 ? "home-list-price-mobile-with-listing-image" : "home-list-price-mobile-without-listing-image")}
         - if listing.price
           .home-list-price-value-mobile
-            = humanized_money_with_symbol(listing.price).upcase
+            = MoneyViewUtils.to_humanized(listing.price)
           - price_text = nil
           - if listing.quantity.present?
             - price_text = t("listings.form.price.per") + " " + listing.quantity

--- a/app/views/homepage/_list_item_with_distance.haml
+++ b/app/views/homepage/_list_item_with_distance.haml
@@ -12,7 +12,7 @@
         .browsing-list-item-price
           - if listing.price
             .browsing-list-item-price-value
-              = humanized_money_with_symbol(listing.price).upcase
+              = MoneyViewUtils.to_humanized(listing.price)
             - price_text = nil
             - if listing.quantity.present?
               - price_text = t("listings.form.price.per") + " " + listing.quantity
@@ -55,7 +55,7 @@
         .browsing-list-item-price-mobile{ class: (listing.listing_images.size > 0 ? "browsing-list-item-price-mobile-with-listing-image" : "browsing-list-item-price-mobile-without-listing-image")}
           - if listing.price
             .browsing-list-item-price-value-mobile
-              = humanized_money_with_symbol(listing.price).upcase
+              = MoneyViewUtils.to_humanized(listing.price)
             - price_text = nil
             - if listing.quantity.present?
               - price_text = t("listings.form.price.per") + " " + listing.quantity

--- a/app/views/homepage/_listing_bubble.haml
+++ b/app/views/homepage/_listing_bubble.haml
@@ -13,7 +13,7 @@
         = author_link(listing)
       .bubble-price{:title => price_as_text(listing) }
         - if listing.price
-          = humanized_money_with_symbol(listing.price).upcase
+          = MoneyViewUtils.to_humanized(listing.price)
           - if listing.quantity.present?
             %span.bubble-price-quantity
               = t("listings.form.price.per") + " " + listing.quantity

--- a/app/views/layouts/_grid_item_listing_image.haml
+++ b/app/views/layouts/_grid_item_listing_image.haml
@@ -19,7 +19,7 @@
     .fluid-thumbnail-grid-image-price-container{:class => "#{modifier_class}"}
       - if listing.price
         %span.fluid-thumbnail-grid-image-price
-          = humanized_money_with_symbol(listing.price).upcase
+          = MoneyViewUtils.to_humanized(listing.price)
           - price_unit = price_quantity_slash_unit(listing)
         - if !price_unit.blank?
           - price_text = " " + price_unit

--- a/app/views/listings/_delivery_opts.haml
+++ b/app/views/listings/_delivery_opts.haml
@@ -17,10 +17,7 @@
           %span.shipping-options-label
             = t("listings.show.#{delivery_opts.first[:name]}_no_price")
             - if (delivery_opts.first[:name] == :shipping)
-              - price_tag = "<span class=\"delivery-price-value\" data-shipping-price=\"#{delivery_opts.first[:price].cents}\" data-per-additional=\"#{Maybe(delivery_opts).first[:shipping_price_additional].cents.or_else(0)}\">#{humanized_money(delivery_opts.first[:price])}</span>"
-              - symbol = delivery_opts.first[:price].currency.symbol
-              - price_tag_with_currency = delivery_opts.first[:price].currency.symbol_first ? "(+#{symbol}#{price_tag})" : "(+#{price_tag} #{symbol})"
-              = price_tag_with_currency.html_safe
+              = price_tag = "(+<span class=\"delivery-price-value\" data-shipping-price=\"#{delivery_opts.first[:price].cents}\" data-per-additional=\"#{Maybe(delivery_opts).first[:shipping_price_additional].cents.or_else(0)}\">#{MoneyViewUtils.to_humanized(delivery_opts.first[:price])}</span>)".html_safe
     - else
       - delivery_opts.each do |opts|
         .row
@@ -29,7 +26,4 @@
             = label_tag("delivery_#{opts[:name]}", class: "delivery-label shipping-options-label") do
               = t("listings.show.#{opts[:name]}_no_price")
               - if (opts[:name] == :shipping)
-                - price_tag = "<span class=\"delivery-price-value\" data-shipping-price=\"#{opts[:price].cents}\" data-per-additional=\"#{Maybe(opts)[:shipping_price_additional].cents.or_else(0)}\">#{humanized_money(opts[:price])}</span>"
-                - symbol = opts[:price].currency.symbol
-                - price_tag_with_currency = opts[:price].currency.symbol_first ? "(+#{symbol}#{price_tag})" : "(+#{price_tag} #{symbol})"
-                = price_tag_with_currency.html_safe
+                = price_tag = "(+<span class=\"delivery-price-value\" data-shipping-price=\"#{opts[:price].cents}\" data-per-additional=\"#{Maybe(opts)[:shipping_price_additional].cents.or_else(0)}\">#{MoneyViewUtils.to_humanized(opts[:price])}</span>)".html_safe

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -136,7 +136,8 @@
             });
             window.ST.initializeQuantityValidation({validate: "positiveIntegers", input: "quantity", errorMessage: "#{t("errors.messages.positive_number")}" });
             if ("#{delivery_type}" == "shipping" && #{shipping_price_additional != nil}) {
-              window.ST.initializeShippingPriceTotal('#quantity', '.delivery-price-value', '#{Maybe(delivery_opts)[0][:price].currency.decimal_mark.or_else(".")}');
+              var currency = '#{Maybe(delivery_opts)[0][:price].currency.iso_code.or_else(@current_community.currency)}'
+              window.ST.initializeShippingPriceTotal(currency, '#{I18n.locale}', '#quantity', '.delivery-price-value');
             }
 
         .quantity-wrapper.input-group.clearfix

--- a/app/views/listings/_profile_listing.haml
+++ b/app/views/listings/_profile_listing.haml
@@ -7,7 +7,7 @@
         .people-listing-overlay
         - if listing.price
           .people-listing-price
-            = humanized_money_with_symbol(listing.price).upcase
+            = MoneyViewUtils.to_humanized(listing.price)
 
         - if listing.listing_images.size > 0 && listing.listing_images.first.image_processing
           .people-listing-image-processing

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -36,7 +36,6 @@
                 "#{I18n.locale}",
                 "#listing_price",
                 "#fee_display",
-                "#listing_currency",
                 #{commission_from_seller},
                 #{minimum_commission.format(decimal_mark: ".", delimiter: "", symbol: false)},
                 #{payment_gateway == :paypal});

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -32,6 +32,8 @@
           :javascript
             $(function() {
               updateSellerGetsValue(
+                "#{@current_community.currency}",
+                "#{I18n.locale}",
                 "#listing_price",
                 "#fee_display",
                 "#listing_currency",

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -132,7 +132,7 @@
         .col-12
           .listing-price
             %span.listing-price-amount
-              = humanized_money_with_symbol(@listing.price).upcase
+              = MoneyViewUtils.to_humanized(@listing.price)
             - with_quantity_text(@current_community, @listing) do |text|
               %span.listing-price-quantity
                 = text

--- a/app/views/paypal_accounts/index.haml
+++ b/app/views/paypal_accounts/index.haml
@@ -72,7 +72,7 @@
                 - if commission_type == :both # TODO: Tweak copy
                   = render :partial => "layouts/info_text", :locals => {text: t("paypal_accounts.new.paypal_account_billing_agreement_info_both",
                     commission_from_seller: commission_from_seller,
-                    minimum_commission: humanized_money_with_symbol(minimum_commission),
+                    minimum_commission: MoneyViewUtils.to_humanized(minimum_commission),
                     paypal_info_link: paypal_info_link).html_safe }
                 - elsif commission_type == :relative
                   = render :partial => "layouts/info_text", :locals => {text: t("paypal_accounts.new.paypal_account_billing_agreement_info_relative",
@@ -80,7 +80,7 @@
                     paypal_info_link: paypal_info_link).html_safe }
                 - elsif commission_type == :fixed
                   = render :partial => "layouts/info_text", :locals => {text: t("paypal_accounts.new.paypal_account_billing_agreement_info_fixed",
-                    minimum_commission: humanized_money_with_symbol(minimum_commission),
+                    minimum_commission: MoneyViewUtils.to_humanized(minimum_commission),
                     paypal_info_link: paypal_info_link).html_safe }
                 - else # no commission fee
                   = render :partial => "layouts/info_text", :locals => {text: t("paypal_accounts.new.paypal_account_billing_agreement_info_none",

--- a/app/views/transactions/_price_break_down.haml
+++ b/app/views/transactions/_price_break_down.haml
@@ -7,7 +7,7 @@
         - else
           = t("transactions.initiate.price_per_night")
       %span.initiate-transaction-per-unit-value
-        = humanized_money_with_symbol(listing_price)
+        = MoneyViewUtils.to_humanized(listing_price)
 
     .initiate-transaction-booking-wrapper
       %span.initiate-transaction-booking-label
@@ -30,7 +30,7 @@
       %span.initiate-transaction-per-unit-label
         = t("transactions.price_per_quantity", unit_type: localized_unit_type)
       %span.initiate-transaction-per-unit-value
-        = humanized_money_with_symbol(listing_price)
+        = MoneyViewUtils.to_humanized(listing_price)
     - if quantity > 1
       .initiate-transaction-quantity-wrapper
         %span.initiate-transaction-quantity-label
@@ -43,14 +43,14 @@
       %span.initiate-transaction-sum-label
         = t("transactions.initiate.subtotal")
       %span.initiate-transaction-sum-value
-        = humanized_money_with_symbol(subtotal)
+        = MoneyViewUtils.to_humanized(subtotal)
 
   - if shipping_price.present?
     .initiate-transaction-shipping-price-wrapper
       %span.initiate-transaction-shipping-price-label
         = t("transactions.initiate.shipping-price")
       %span.initiate-transaction-shipping-price-value
-        = humanized_money_with_symbol(shipping_price)
+        = MoneyViewUtils.to_humanized(shipping_price)
 
   - if total.present?
     .initiate-transaction-total-wrapper
@@ -60,4 +60,4 @@
         - else
           = t("transactions.total")
       %span.initiate-transaction-total-value
-        = humanized_money_with_symbol(total)
+        = MoneyViewUtils.to_humanized(total)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,10 @@
 en:
+  number:
+    currency:
+      format:
+        separator: "."
+        delimiter: ","
+        format: "%u%n"
   admin:
     categories:
       edit:


### PR DESCRIPTION
Internationalizes currency formatting based on user locale. Adds translation options for currencies where standard Rails currency formatting fails: e.g. guess is Danish krone.

Fixes couple of assumptions in JavaScript code about money precision for currencies where there are no fractional units i.e. JPY. Doesn't take into account in JS some weird currencies that might have three fractional units as we don't support them.

More info about decisions here: https://gist.github.com/sktoiva/79cbc4f72e581b756fc0c770b1966c83

Formatting options are:

```yaml
 en:
   number:
     currency:
       format:
         separator: "."
         delimiter: ","
         format: "%u%n"
```
where:
`separator`: decimal separator
`delimiter`: thousand delimiter
`format`: %u => unit %n => number

## Screenshots

E.g. switches locale `fr`, currency `EUR` from:

![image](https://cloud.githubusercontent.com/assets/230815/25385064/69d41358-29cb-11e7-94ca-f4b935d55966.png)

to:

![image](https://cloud.githubusercontent.com/assets/230815/25385033/3b9d14d0-29cb-11e7-8b2f-3bc1f69b2997.png)

- [x] add general utils for money localization
- [x] replace humanized_money_with_symbol with general money utils
- [x] add formatting options for translations
- [x] add translation formatting
- [x] fix fee calculation in new listing form
- [x] fix additional shipping price calculation in `listing.js`
- [x] deploy to staging for testing
- [x] figure out deploy strategy