### PR TITLE
Guard against nil currency formats

### DIFF
--- a/app/view_utils/money_view_utils.rb
+++ b/app/view_utils/money_view_utils.rb
@@ -10,17 +10,36 @@ module MoneyViewUtils
     # TODO: Remove feature flag
     if FeatureFlagHelper.feature_enabled?(:currency_formatting)
       return "" if m.nil?
-      separator = I18n.t("number.currency.format.separator", locale: locale)
+
+      # Explicitly resolve formatting. WebTranslateit resolves
+      # translations to nils which causes an error with number_to_currency
+      formatting = currency_format(locale)
       precision = m.currency.exponent.to_i
       zero_cents = "0" * precision
-      number_to_currency(m.amount, unit: m.symbol, locale: locale, precision: m.currency.exponent.to_i)
+
+      number_to_currency(m.amount,
+                         unit: m.symbol,
+                         delimiter: formatting[:delimiter],
+                         separator: formatting[:separator],
+                         format: formatting[:format],
+                         precision: m.currency.exponent.to_i)
         .tr(" ", "\u202F")
-        .gsub("#{separator}#{zero_cents}", "") # remove cents if they are zero
+        .gsub("#{formatting[:separator]}#{zero_cents}", "") # remove cents if they are zero
         .encode('utf-8')
     else
       humanized_money_with_symbol(m).upcase
     end
   rescue FeatureFlagHelper::FeatureFlagHelperNotInitialized
     humanized_money_with_symbol(m).upcase
+  end
+
+  # Return a hash of currency formatting options, sets defaults if
+  # translations are not present
+  def currency_format(locale)
+    {
+      separator: I18n.t("number.currency.format.separator", locale: locale) || ".",
+      delimiter: I18n.t("number.currency.format.delimiter", locale: locale) || ",",
+      format: I18n.t("number.currency.format.format", locale: locale) || "%u%n"
+    }
   end
 end


### PR DESCRIPTION
WebTranslateIT adds explicit nil-value translation to all languages when
default language has a key defined. number_to_currency doesn't handle
default values properly after this and guards need to be placed
manually.