### PR TITLE
Change custom_field_values.numeric_value to double

### DIFF
--- a/app/models/custom_field_value.rb
+++ b/app/models/custom_field_value.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/custom_field_values/checkbox_field_value.rb
+++ b/app/models/custom_field_values/checkbox_field_value.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/custom_field_values/date_field_value.rb
+++ b/app/models/custom_field_values/date_field_value.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/custom_field_values/dropdown_field_value.rb
+++ b/app/models/custom_field_values/dropdown_field_value.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/custom_field_values/numeric_field_value.rb
+++ b/app/models/custom_field_values/numeric_field_value.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/custom_field_values/option_field_value.rb
+++ b/app/models/custom_field_values/option_field_value.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/custom_field_values/text_field_value.rb
+++ b/app/models/custom_field_values/text_field_value.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/db/migrate/20170613153960_change_numberic_value_to_double.rb
+++ b/db/migrate/20170613153960_change_numberic_value_to_double.rb
@@ -1,0 +1,9 @@
+class ChangeNumbericValueToDouble < ActiveRecord::Migration
+  def up
+    change_column :custom_field_values, :numeric_value, :double
+  end
+
+  def down
+    change_column :custom_field_values, :numeric_value, :float
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -525,7 +525,7 @@ CREATE TABLE `custom_field_values` (
   `custom_field_id` int(11) DEFAULT NULL,
   `listing_id` int(11) DEFAULT NULL,
   `text_value` text,
-  `numeric_value` float DEFAULT NULL,
+  `numeric_value` double DEFAULT NULL,
   `date_value` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -3254,4 +3254,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170313201104');
 INSERT INTO schema_migrations (version) VALUES ('20170314075755');
 
 INSERT INTO schema_migrations (version) VALUES ('20170613153959');
+
+INSERT INTO schema_migrations (version) VALUES ('20170613153960');
 

--- a/spec/models/date_field_value_spec.rb
+++ b/spec/models/date_field_value_spec.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/dropdown_field_value_spec.rb
+++ b/spec/models/dropdown_field_value_spec.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/numeric_field_value_spec.rb
+++ b/spec/models/numeric_field_value_spec.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/text_field_value_spec.rb
+++ b/spec/models/text_field_value_spec.rb
@@ -6,7 +6,7 @@
 #  custom_field_id :integer
 #  listing_id      :integer
 #  text_value      :text(65535)
-#  numeric_value   :float(24)
+#  numeric_value   :float(53)
 #  date_value      :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null


### PR DESCRIPTION
Steps to reproduce:

Prerequisite: Marketplace with numeric custom fields

1. Create a new listing with numeric custom field
2. Add `1234567890` as a numberic custom field value for the new listing
3. Save the listing

Expected: In listing page, you see value `1234567890`

Actual: In listing page, you see value `123457000`