### PR TITLE
Making fsevents an optional dependency to allow building on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 ### Removed
 
 ### Fixed
+- Fix optional dependency issue on Linux with fsevents [#2161](https://github.com/sharetribe/sharetribe/issues/2161)
 
 ### Security
 

--- a/client/package.json
+++ b/client/package.json
@@ -99,6 +99,9 @@
     "stylelint-config-standard": "13.0.2",
     "webpack-dev-server": "1.16.2"
   },
+  "optionalDependencies": {
+    "fsevents": "*"
+  },
   "browser": {
     "fs": false
   }

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "postinstall": "cd client && npm install",
     "clean": "rm -f app/assets/webpack/*"
   },
-  "cacheDirectories": ["node_modules", "client/node_modules"]
+  "cacheDirectories": ["node_modules", "client/node_modules"],
+  "optionalDependencies": {
+    "fsevents": "*"
+  }
 }


### PR DESCRIPTION
From issue #2161 it seems as some users will experience build errors using node.js depending on their version https://github.com/sharetribe/sharetribe/issues/2161

The solution is to make the package an optional dependency, allowing npm install to work on Linux. On mac platforms, the dependency should be loaded as normal.