### PR TITLE
Added link to Academy in admin panel navigation menu

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -318,6 +318,14 @@ module ApplicationHelper
         :path => "mailto:#{APP_CONFIG.support_email}",
         :name => "support",
         :data_uv_trigger => "contact"
+      },
+	  {
+        :id => "admin-academy-link",
+        :topic => :general,
+        :text => t("admin.left_hand_navigation.academy"),
+        :icon_class => icon_class("academy"),
+        :path => "https://www.sharetribe.com/academy/?utm_source=marketplaceadminpanel&utm_medium=referral&utm_campaign=leftnavi",
+        :name => "academy"
       }
     ]
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -319,7 +319,7 @@ module ApplicationHelper
         :name => "support",
         :data_uv_trigger => "contact"
       },
-	  {
+      {
         :id => "admin-academy-link",
         :topic => :general,
         :text => t("admin.left_hand_navigation.academy"),

--- a/app/view_utils/icon_map.rb
+++ b/app/view_utils/icon_map.rb
@@ -69,6 +69,7 @@ ICON_MAP = {
       "order_types" => "ss-cart",
       "download" => "ss-download",
       "credit_card" => "ss-creditcard",
+      "academy" => "ss-bookmark",
 
 
       # Default category & share type icons

--- a/config/locales/branded/en.yml
+++ b/config/locales/branded/en.yml
@@ -1,0 +1,4 @@
+en:
+  admin:
+    left_hand_navigation:
+      academy: "Marketplace Academy"


### PR DESCRIPTION
This adds a new link in the admin panel (left navi) to the Marketplace Academy homepage.