### PR TITLE
Update from support to help

### DIFF
--- a/TECHNICAL_ROADMAP.md
+++ b/TECHNICAL_ROADMAP.md
@@ -79,4 +79,4 @@ Sharetribe's user interface is currently intertwined with the core Sharetribe ap
 
 ## How can I affect these plans?
 
-Talk to us! These plans are formed based on an overall understanding of Sharetribe customer needs and the Sharetribe vision. Feedback can alter either of these, which will then lead to changes in plans. You can either contact us via [email](mailto:support@sharetribe.com), the Sharetribe [idea forum](http://support.sharetribe.com/forums/240322-sharetribe-development-ideas) or our [community forum](https://www.sharetribe.com/community).
+Talk to us! These plans are formed based on an overall understanding of Sharetribe customer needs and the Sharetribe vision. Feedback can alter either of these, which will then lead to changes in plans. You can either contact us via [email](mailto:hello@sharetribe.com) or our [community forum](https://www.sharetribe.com/community).

--- a/app/views/invitations/new.haml
+++ b/app/views/invitations/new.haml
@@ -10,7 +10,7 @@
   = render :layout => "layouts/lightbox", :partial => "layouts/onboarding_popup", locals: {title: t(popup_title_key), body: t(popup_body_key), action_label: t(popup_button_key), action_link: popup_action_link, image: asset_path(popup_image), id: "onboarding-popup" }
 
 #invitation_form.centered-section
-  - support_link = link_to(t("homepage.invitation_form.this_article_link"), "http://support.sharetribe.com/knowledgebase/articles/675040", target: "_blank")
+  - support_link = link_to(t("homepage.invitation_form.this_article_link"), "https://help.sharetribe.com/configuration-and-how-to/how-to-send-mass-emails-and-invitations", target: "_blank")
   %p= t("homepage.invitation_form.add_email_addresses_description")
   - if has_admin_rights
     %p= t("homepage.invitation_form.add_lots_of_email_addresses", this_article_link: support_link).html_safe

--- a/client/app/components/sections/OnboardingGuide/GuideCoverPhotoPage.js
+++ b/client/app/components/sections/OnboardingGuide/GuideCoverPhotoPage.js
@@ -36,7 +36,7 @@ const GuideCoverPhotoPage = (props) => {
         span(
           t('web.admin.onboarding.guide.cover_photo.advice.content1',
             { link: a({
-              href: 'http://support.sharetribe.com/knowledgebase/articles/744438',
+              href: 'https://help.sharetribe.com/configuration-and-how-to/how-to-get-good-looking-cover-photos-logos-favicon-profiles-and-listing-pictures',
               target: '_blank',
               rel: 'noreferrer',
               alt: t('web.admin.onboarding.guide.cover_photo.advice.alt'),

--- a/client/app/components/sections/OnboardingGuide/GuidePaypalPage.js
+++ b/client/app/components/sections/OnboardingGuide/GuidePaypalPage.js
@@ -30,7 +30,7 @@ const GuidePaypalPage = (props) => {
       }),
       div({ className: css.infoTextContent }, t('web.admin.onboarding.guide.paypal.advice.content', {
         disable_payments_link: a(
-          { href: 'http://support.sharetribe.com/knowledgebase/articles/470085',
+          { href: 'https://help.sharetribe.com/payment-with-paypal/how-to-disable-payments-or-add-free-listings-to-your-marketplace',
             target: '_blank',
             rel: 'noreferrer',
             alt: t('web.admin.onboarding.guide.paypal.advice.disable_payments_alt'),

--- a/client/app/components/sections/OnboardingGuide/GuideStatusPage.js
+++ b/client/app/components/sections/OnboardingGuide/GuideStatusPage.js
@@ -33,7 +33,7 @@ const GuideStatusPage = (props) => {
     p({ className: css.description },
       t('web.admin.onboarding.guide.status_page.congratulation_p1.content',
         { knowledge_base_link: a(
-          { href: 'http://support.sharetribe.com/knowledgebase/articles/892140',
+          { href: 'https://help.sharetribe.com/configuration-and-how-to/what-to-do-after-the-basic-setup-of-your-marketplace',
             target: '_blank',
             rel: 'noreferrer',
             alt: t('web.admin.onboarding.guide.status_page.congratulation_p1.knowledge_base_alt'),
@@ -43,7 +43,7 @@ const GuideStatusPage = (props) => {
     p({ className: css.description },
       t('web.admin.onboarding.guide.status_page.congratulation_p2.content',
         { marketplace_guide_link: a(
-          { href: 'https://www.sharetribe.com/academy/guide/',
+          { href: 'https://www.sharetribe.com/academy/guide/?utm_source=marketplaceadminpanel&utm_medium=referral&utm_campaign=onboarding',
             target: '_blank',
             rel: 'noreferrer',
             alt: t('web.admin.onboarding.guide.status_page.congratulation_p2.marketplace_guide_alt'),
@@ -54,7 +54,7 @@ const GuideStatusPage = (props) => {
       t('web.admin.onboarding.guide.status_page.congratulation_p3.content',
          { contact_support_link: a(
            { 'data-uv-trigger': 'contact',
-             href: 'mailto:support@sharetribe.com',
+             href: 'mailto:help@sharetribe.com',
              title: t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_title'),
            },
            t('web.admin.onboarding.guide.status_page.congratulation_p3.contact_support_link')),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,7 +162,7 @@ en:
         resend_link: Resend
         invalid_email_error: "Invalid email format for '%{email}'"
         invalid_email_domain: "The '%{email}' email address is using an unsupported email provider: '%{domain}'. %{invalid_email_domain_read_more_link}"
-        invalid_email_domain_read_more_link: "Read the knowledge base article for more information."
+        invalid_email_domain_read_more_link: "Read the Help Center article for more information."
         unknown_error: "Something went wrong"
         white_label_offer: "Set your own email address as the sender and remove all Sharetribe branding from outgoing email messages by %{upgrade_pro_plan_link}."
         upgrade_plan_link: "upgrading to the Pro plan or higher"

--- a/config/locales/onboarding/de.yml
+++ b/config/locales/onboarding/de.yml
@@ -77,8 +77,8 @@ de:
             description_p2: "Sobald du fertig bist, ist dein Marktplatz bereit für die ersten Kunden!"
             congratulation_p1:
               content: "Du hast es geschafft! Dein Marktplatz ist eingerichtet. Das ist aber nur der Anfang. Du hast nur ein kleines Teil von den Anpassungsmöglichkeiten von Sharetribe gesehen. Um mehr Informationen über die Anpassung deines Marktplatzes zu bekommen, solltest du %{knowledge_base_link} ansehen. Die meisten Artikel sind leider zur Zeit nur auf Englisch verfügbar."
-              knowledge_base_link: "unseren Knowledge Base"
-              knowledge_base_alt: "knowledge base"
+              knowledge_base_link: "unseren Help Center"
+              knowledge_base_alt: "Help Center"
             congratulation_p2:
               content: "Wenn du mehr darüber lernen willst, wie man ein erfolgreiches Marktplatz-Geschäft führt, empfehlen wir den Artikel %{marketplace_guide_link}. Leider ist dieser Artikel auch zur Zeit nur auf Englisch verfügbar."
               marketplace_guide_link: "Leitfaden für das erfolgreiche Aufbauen von Online Marktplatz-Geschäften"

--- a/config/locales/onboarding/en.yml
+++ b/config/locales/onboarding/en.yml
@@ -77,8 +77,8 @@ en:
             description_p2: "Once finished, your marketplace will be ready to receive its first visitors!"
             congratulation_p1:
               content: "You did it! Your marketplace is now up and running. However, this is just the beginning. You've only seen a fraction of the customization options that Sharetribe offers. To read more about how to customize your marketplace further, check out %{knowledge_base_link}."
-              knowledge_base_link: "our knowledge base"
-              knowledge_base_alt: "knowledge base"
+              knowledge_base_link: "our Help Center"
+              knowledge_base_alt: "Help Center"
             congratulation_p2:
               content: "If you wish to learn more about how to build your marketplace business, we recommend our %{marketplace_guide_link}."
               marketplace_guide_link: "practical guide for building an online marketplace business"

--- a/config/locales/onboarding/es-ES.yml
+++ b/config/locales/onboarding/es-ES.yml
@@ -77,8 +77,8 @@ es-ES:
             description_p2: "Una vez completados estos pasos, tu comunidad estará lista para recibir a sus primeros visitantes!"
             congratulation_p1:
               content: "Lo has conseguido! Tu comunidad esta lista y en funcionamiento. Sin embargo, este es solo el inicio. Sólo has visto una pequeña parte de las posibilidades de personalización que Sharetribe ofrece. Para aprender más acerca de como configurar tu comunidad, checa %{knowledge_base_link}."
-              knowledge_base_link: "nuestra base de conocimiento"
-              knowledge_base_alt: "knowledge base"
+              knowledge_base_link: "nuestra base de conocimiento (Help Center)"
+              knowledge_base_alt: "Help Center"
             congratulation_p2:
               content: "Si deseas aprender más acerca de como hacer crecer tu comunidad como negocio, te recomendamos nuestra %{marketplace_guide_link} (en inglés)."
               marketplace_guide_link: "guía práctica para hacer negocios con tu comunidad en linea"

--- a/config/locales/onboarding/fi.yml
+++ b/config/locales/onboarding/fi.yml
@@ -77,8 +77,8 @@ fi:
             description_p2: "Kun olet valmis, markkinapaikkasi on valmiina ensimmäisille käyttäjilleen!"
             congratulation_p1:
               content: "Hienoa! Markkinapaikkasi on nyt verkossa. Tämä on kuitenkin vasta alkua. Olet nähnyt vasta pienen osan Sharetriben tarjoamista kustomointivaihtoehdoista. Lukeaksesi lisää markkinapaikkasi kustomoinnista, tutki %{knowledge_base_link}."
-              knowledge_base_link: "tietopankkiamme (knowledge base)"
-              knowledge_base_alt: "knowledge base"
+              knowledge_base_link: "tietopankkiamme (Help Center)"
+              knowledge_base_alt: "Help Center"
             congratulation_p2:
               content: "Mikäli haluat oppia lisää markkinapaikan ylläpitämisestä, suosittelemme että luet %{marketplace_guide_link}."
               marketplace_guide_link: "käytännönläheisen oppaamme verkkomarkkinapaikan rakentamisesta ja ylläpidosta"

--- a/config/locales/onboarding/fr.yml
+++ b/config/locales/onboarding/fr.yml
@@ -77,8 +77,8 @@ fr:
             description_p2: "Une fois celles-ci complétées, votre place de marché sera prête à recevoir ses premiers visiteurs !"
             congratulation_p1:
               content: "Vous avez réussi ! Votre place de marché est lancée. Mais ce n'est que le commencement. Vous n'avez aperçu qu'une petite partie des possibilités de personnalisation offertes par Sharetribe. Pour en apprendre plus sur comment configurer votre place de marché, parcourez %{knowledge_base_link}."
-              knowledge_base_link: "notre base de connaissance"
-              knowledge_base_alt: "knowledge base"
+              knowledge_base_link: "notre espace d'aide (Help Center)"
+              knowledge_base_alt: "Help Center"
             congratulation_p2:
               content: "Si vous souhaitez apprendre comment faire de votre place de marché une réussite, nous recommandons notre %{marketplace_guide_link} (en anglais)."
               marketplace_guide_link: "guide pratique pour créer une place de marché"

--- a/config/locales/onboarding/nl.yml
+++ b/config/locales/onboarding/nl.yml
@@ -77,8 +77,8 @@ nl:
             description_p2: "Eenmaal klaar, dan is je marktplaats gereed voor de eerste bezoekers."
             congratulation_p1:
               content: "Het is je gelukt! Je marktplaats is nu van de grond. Dit is echter nog het begin. Je hebt slechts een fractie van de maatwerk opties gezien, dat Sharetribe te bieden heeft. Om te leren hoe je jouw marktplaats verder kan inrichten naar je eigen wensen, lees dan %{knowledge_base_link}."
-              knowledge_base_link: "onze knowledge base"
-              knowledge_base_alt: "knowledge base"
+              knowledge_base_link: "onze Help Center"
+              knowledge_base_alt: "Help Center"
             congratulation_p2:
               content: "Als je meer wilt leren over hoe je je marktplaats bedrijf opbouwt, raden we je onze %{marketplace_guide_link} aan."
               marketplace_guide_link: "practical guide for building an online marketplace business"

--- a/config/locales/welcome_email/de.yml
+++ b/config/locales/welcome_email/de.yml
@@ -11,7 +11,7 @@
       your_marketplace_admin_panel: "Der Administrator-Bereich deines Marktplatzes:"
       follow_suggested_steps: "Hier kannst du, als Eigentümer des Marktplatzes, Änderungen an deinem Marktplatz vornehmen. Folge der empfohlenen Schritte um mit der Einrichtung deines Marktplatzes anzufangen."
       not_alone: "Du bist nicht alleine"
-      support_team_and_book_call: "Das Support Team von Sharetribe ist für dich da! Du kannst unsere %{knowledge_base_link} lesen, um Antworten für häufig gestellten Fragen zu finden. Du kannst unser Team auch per E-mail unter der Adresse support@sharetribe.com erreichen, oder du kannst einfach diese E-Mail antworten. Du kannst auch %{book_a_call_link} um mit einem unserer Experten per Skype oder Telefon zu diskutieren."
+      support_team_and_book_call: "Das Support Team von Sharetribe ist für dich da! Du kannst unsere %{knowledge_base_link} lesen, um Antworten für häufig gestellten Fragen zu finden. Du kannst unser Team auch per E-mail unter der Adresse help@sharetribe.com erreichen, oder du kannst einfach diese E-Mail antworten. Du kannst auch %{book_a_call_link} um mit einem unserer Experten per Skype oder Telefon zu diskutieren."
       knowledge_base_link_text: "Wissensdatenbank"
       book_a_call_link_text: "einen Termin für einen Anruf vereinbaren"
       helping_you: "Wir sind für dich da"

--- a/config/locales/welcome_email/en.yml
+++ b/config/locales/welcome_email/en.yml
@@ -12,7 +12,7 @@ en:
       follow_suggested_steps: "This is where you, as the owner, can make changes to your marketplace. Follow the suggested steps to get started setting up your marketplace."
       not_alone: "You’re not alone"
       support_team_and_book_call: "Sharetribe's support team is here for you! Check out the %{knowledge_base_link} with answers to the most common questions. Contact the team by email at help@sharetribe.com, or by simply replying to this email. You can also %{book_a_call_link} with one of our experts."
-      knowledge_base_link_text: "knowledge base"
+      knowledge_base_link_text: "Help Center"
       book_a_call_link_text: "book a call"
       helping_you: "Helping you along the way"
       drip_emails_academy: "Need more advice about how to build a marketplace business? No worries, we're here to help you out! Have you already checked out our %{marketplace_academy_link}? It contains a comprehensive guide teaching you everything you need to know about building a marketplace business. Furthermore, we will be sending you a series of emails that will help you get the most out of Sharetribe. You can expect the first one to land in your inbox soon."

--- a/config/locales/welcome_email/en.yml
+++ b/config/locales/welcome_email/en.yml
@@ -11,7 +11,7 @@ en:
       your_marketplace_admin_panel: "- Your marketplace admin panel:"
       follow_suggested_steps: "This is where you, as the owner, can make changes to your marketplace. Follow the suggested steps to get started setting up your marketplace."
       not_alone: "You’re not alone"
-      support_team_and_book_call: "Sharetribe's support team is here for you! Check out the %{knowledge_base_link} with answers to the most common questions. Contact the team by email at support@sharetribe.com, or by simply replying to this email. You can also %{book_a_call_link} with one of our experts."
+      support_team_and_book_call: "Sharetribe's support team is here for you! Check out the %{knowledge_base_link} with answers to the most common questions. Contact the team by email at help@sharetribe.com, or by simply replying to this email. You can also %{book_a_call_link} with one of our experts."
       knowledge_base_link_text: "knowledge base"
       book_a_call_link_text: "book a call"
       helping_you: "Helping you along the way"

--- a/config/locales/welcome_email/es-ES.yml
+++ b/config/locales/welcome_email/es-ES.yml
@@ -11,7 +11,7 @@ es-ES:
       your_marketplace_admin_panel: "- El panel de administración de tu comunidad es:"
       follow_suggested_steps: "Este es el lugar donde tú, como dueño, puedes hacer cambios a tu comunidad. Sigue los pasos que te sugerimos para empezar a configurar tu comunidad."
       not_alone: "No estás sólo"
-      support_team_and_book_call: "¡El equipo de soporte de Sharetribe está aquí para ti! Dale un vistazo a nuestra %{knowledge_base_link} que contiene respuestas a las preguntas más frecuentes. Contacta al equipo enviando un correo a support@sharetribe.com, o simplemente respondiendo a este correo. También puedes %{book_a_call_link} con uno de nuestros expertos."
+      support_team_and_book_call: "¡El equipo de soporte de Sharetribe está aquí para ti! Dale un vistazo a nuestra %{knowledge_base_link} que contiene respuestas a las preguntas más frecuentes. Contacta al equipo enviando un correo a help@sharetribe.com, o simplemente respondiendo a este correo. También puedes %{book_a_call_link} con uno de nuestros expertos."
       knowledge_base_link_text: "base de conocimientos"
       book_a_call_link_text: "agendar una llamada"
       helping_you: "Ayudándote a lo lardo del camino"

--- a/config/locales/welcome_email/fi.yml
+++ b/config/locales/welcome_email/fi.yml
@@ -11,7 +11,7 @@ fi:
       your_marketplace_admin_panel: "- Markkinapaikan ylläpitonäkymä:"
       follow_suggested_steps: "Ylläpitonäkymän kautta voit muokata sivustoasi. Seuraa automaattista ohjeistusta aloittaaksesi sivuston pystytyksen."
       not_alone: "Et ole yksin"
-      support_team_and_book_call: "Sharetriben asiakaspalvelutiimi on apunasi! %{knowledge_base_link} löydät vastaukset yleisimpiin kysymyksiin. Saat yhteyden meihin lähettämällä sähköpostia osoitteeseen support@sharetribe.com tai yksinkertaisesti vataamalla tähän viestiin. Voit halutessasi myös %{book_a_call_link} markkinapaikka-asiantuntijamme kanssa."
+      support_team_and_book_call: "Sharetriben asiakaspalvelutiimi on apunasi! %{knowledge_base_link} löydät vastaukset yleisimpiin kysymyksiin. Saat yhteyden meihin lähettämällä sähköpostia osoitteeseen help@sharetribe.com tai yksinkertaisesti vataamalla tähän viestiin. Voit halutessasi myös %{book_a_call_link} markkinapaikka-asiantuntijamme kanssa."
       knowledge_base_link_text: "Tietopankistamme"
       book_a_call_link_text: "varata soittoajan"
       helping_you: "Autamme sinua matkasi varrella"

--- a/config/locales/welcome_email/fr.yml
+++ b/config/locales/welcome_email/fr.yml
@@ -11,7 +11,7 @@ fr:
       your_marketplace_admin_panel: "- Le panneau d'administration de votre place de marché :"
       follow_suggested_steps: "C'est là où, en tant qu'administrateur, vous pouvez apporter des changements à votre place de marché. Suivez les étapes proposées pour commencez à configurer votre place de marché."
       not_alone: "Vous n'êtes pas seul"
-      support_team_and_book_call: "L'équipe support de Sharetribe est là pour vous ! Parcourez la %{knowledge_base_link} qui répond aux questions les plus courantes. Contactez l'équipe par email à support@sharetribe.com ou simplement en répondant à ce message. Vous pouvez aussi %{book_a_call_link} avec un de nos experts."
+      support_team_and_book_call: "L'équipe support de Sharetribe est là pour vous ! Parcourez la %{knowledge_base_link} qui répond aux questions les plus courantes. Contactez l'équipe par email à help@sharetribe.com ou simplement en répondant à ce message. Vous pouvez aussi %{book_a_call_link} avec un de nos experts."
       knowledge_base_link_text: "base de connaissances"
       book_a_call_link_text: "réserver un appel"
       helping_you: "Vous aider à tout moment"

--- a/config/locales/welcome_email/nl.yml
+++ b/config/locales/welcome_email/nl.yml
@@ -11,7 +11,7 @@ nl:
       your_marketplace_admin_panel: "- Jouw marktplaats admin dashboard:"
       follow_suggested_steps: "Dit is waar jij, als beheerder, veranderingen kan maken in je marktplaats. Volg de stappen om snel van start te gaan met het opzetten van je marktplaats."
       not_alone: "Je bent niet alleen!"
-      support_team_and_book_call: "Sharetribe's support team staat voor je klaar! Check de %{knowledge_base_link} met antwoorden op de meest gestelde vragen. Neem contact met ons op over email via support@sharetribe.com, of antwoord simpelweg op deze mail. Je kunt ook %{book_a_call_link} met een van onze experts (in het Engels)."
+      support_team_and_book_call: "Sharetribe's support team staat voor je klaar! Check de %{knowledge_base_link} met antwoorden op de meest gestelde vragen. Neem contact met ons op over email via help@sharetribe.com, of antwoord simpelweg op deze mail. Je kunt ook %{book_a_call_link} met een van onze experts (in het Engels)."
       knowledge_base_link_text: "knowledge base"
       book_a_call_link_text: "een gesprek boeken"
       helping_you: "We blijven je helpen"

--- a/config/locales/welcome_email/nl.yml
+++ b/config/locales/welcome_email/nl.yml
@@ -12,7 +12,7 @@ nl:
       follow_suggested_steps: "Dit is waar jij, als beheerder, veranderingen kan maken in je marktplaats. Volg de stappen om snel van start te gaan met het opzetten van je marktplaats."
       not_alone: "Je bent niet alleen!"
       support_team_and_book_call: "Sharetribe's support team staat voor je klaar! Check de %{knowledge_base_link} met antwoorden op de meest gestelde vragen. Neem contact met ons op over email via help@sharetribe.com, of antwoord simpelweg op deze mail. Je kunt ook %{book_a_call_link} met een van onze experts (in het Engels)."
-      knowledge_base_link_text: "knowledge base"
+      knowledge_base_link_text: "Help Center"
       book_a_call_link_text: "een gesprek boeken"
       helping_you: "We blijven je helpen"
       drip_emails_academy: "Meer advies nodig over het bouwen van een marktplaats bedrijf? Geen probleem, wij zijn hier om te helpen. Heb je al onze %{marketplace_academy_link} gelezen? Dit bevat ook een uitgebreide gids, die je alles leert wat je moet weten over het bouwen van een online marktplaats als bedrijf. Verder zullen we je een serie emails sturen, die je helpen het beste uit Sharetribe te krijgen. De eerste landt binnenkort in je inbox."


### PR DESCRIPTION
- Changed links from support.sharetribe.com to help.sharetribe.com
- Changed emails from support@ to help@
- Changed knowledge base copy text to help center