### PR TITLE
Make server and client money formatting consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 - Fixed transaction button styles. Styles were broken in IE Edge. [#2968](https://github.com/sharetribe/sharetribe/pull/2968)
 - Fixed admin UI language change. [#2969](https://github.com/sharetribe/sharetribe/pull/2969)
+- Fix old mobile browser compatibility by removing dependency to Intl api. [#2979](https://github.com/sharetribe/sharetribe/pull/2979)
 
 ### Security
 

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -318,7 +318,7 @@ function initialize_listing_view(locale) {
   });
 }
 
-function updateSellerGetsValue(currency, locale, priceInputSelector, displayTargetSelector, communityCommissionPercentage, minCommission, showReversed) {
+function updateSellerGetsValue(currencyOpts, priceInputSelector, displayTargetSelector, communityCommissionPercentage, minCommission, showReversed) {
   // true == Show the fee instead of what's left after the fee
   showReversed = showReversed || false;
 
@@ -335,8 +335,15 @@ function updateSellerGetsValue(currency, locale, priceInputSelector, displayTarg
       displaySum = sum - ST.paymentMath.totalCommission(sum, communityCommissionPercentage, minCommission);
     }
 
+    displaySumInCents = displaySum * Math.pow(10, currencyOpts.digits);
+
     $display.text(
-      ST.paymentMath.displayMoney(Math.max(0, displaySum), currency, locale, {inCents: false})
+      ST.paymentMath.displayMoney(Math.max(0, displaySumInCents),
+                                  currencyOpts.symbol,
+                                  currencyOpts.digits,
+                                  currencyOpts.format,
+                                  currencyOpts.separator,
+                                  currencyOpts.delimiter)
     );
   }
 

--- a/app/assets/javascripts/listing.js
+++ b/app/assets/javascripts/listing.js
@@ -37,7 +37,7 @@ window.ST = window.ST || {};
     });
   };
 
-  module.initializeShippingPriceTotal = function(currency, locale, quantityInputSelector, shippingPriceSelector){
+  module.initializeShippingPriceTotal = function(currencyOpts, quantityInputSelector, shippingPriceSelector){
     var $quantityInput = $(quantityInputSelector);
     var $shippingPriceElements = $(shippingPriceSelector);
 
@@ -51,7 +51,12 @@ window.ST = window.ST || {};
 
         // To avoid floating point issues, do calculations in cents
         var newShippingPrice = shippingPriceCents + perAdditionalCents * additionalCount;
-        var priceForDisplay = ST.paymentMath.displayMoney(newShippingPrice, currency, locale, {inCents: true})
+        var priceForDisplay = ST.paymentMath.displayMoney(newShippingPrice,
+                                                          currencyOpts.symbol,
+                                                          currencyOpts.digits,
+                                                          currencyOpts.format,
+                                                          currencyOpts.separator,
+                                                          currencyOpts.delimiter)
         $priceEl.text(priceForDisplay);
       });
     };

--- a/app/assets/javascripts/payment_math.js
+++ b/app/assets/javascripts/payment_math.js
@@ -17,19 +17,41 @@ window.ST.paymentMath = (function() {
     return parseFloatFromFieldValue(value) * subunit_to_unit;
   }
 
-  function displayMoney(sum, currency, locale, opts) {
+  function localizeNumber(number, digits, separator, delimiter) {
+    return number
+      .toFixed(digits)
+      .replace(".", separator)
+      .replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1" + delimiter);
+  }
+
+  function localizeCurrency(number, unit, format) {
+    return format
+      .replace("%u", unit)
+      .replace("%n", number);
+  }
+
+  /* Displays a sum of money, localized with the parameters.
+     @param {number} sum - sum of money in cents
+     @param {string} symbol
+     @param {number} digits - amount of fractional units in currency
+     @param {string} format - localization format for money,
+                              e.g. %u%n, where:
+                              %u is unit (symbol)
+                              %n is number (sum)
+     @param {string} separator - decimal separator
+     @param {string} delimiter - thousand delimiter
+     @return {string} Localized sum of money, e.g. "$1,000.23"
+  */
+  function displayMoney(sum, symbol, digits, format, separator, delimiter) {
     if(typeof sum === "number" && !isNaN(sum)){
-      var formatter = Intl.NumberFormat(locale, {style: "currency", currency: currency})
-      var digits = formatter.resolvedOptions().minimumFractionDigits;
-      var total = (digits === 0 || !opts.inCents) ? sum : sum / 100;
-
-      return formatter.format(total);
-
+      var value = sum / Math.pow(10, digits);
+      var localizedNumber = localizeNumber(value, digits, separator, delimiter);
+      return localizeCurrency(localizedNumber,
+                              symbol,
+                              format);
     } else {
       return "-";
     }
-
-    return typeof sum === "number" && !isNaN(sum) ? sum.toFixed(2) : "-";
   }
 
   function totalCommission(totalSum, communityCommissionPercentage, minCommission) {

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -216,6 +216,8 @@ class ListingsController < ApplicationController
         Result::Success.new([])
       end
 
+    currency = Maybe(@listing.price).currency.or_else(Money::Currency.new(@current_community.currency))
+
     view_locals = {
       form_path: form_path,
       payment_gateway: payment_gateway,
@@ -231,7 +233,8 @@ class ListingsController < ApplicationController
       manage_availability_props: manage_availability_props(@current_community, @listing),
       availability_enabled: availability_enabled,
       blocked_dates_result: blocked_dates_result,
-      blocked_dates_end_on: DateUtils.to_midnight_utc(blocked_dates_end_on)
+      blocked_dates_end_on: DateUtils.to_midnight_utc(blocked_dates_end_on),
+      currency_opts: MoneyViewUtils.currency_opts(I18n.locale, currency)
     }
 
     Analytics.record_event(
@@ -638,6 +641,7 @@ class ListingsController < ApplicationController
         end
 
       community_country_code = LocalizationUtils.valid_country_code(@current_community.country)
+      community_currency = Money::Currency.new(@current_community.currency)
 
       commission(@current_community, process).merge({
         shape: shape,
@@ -647,7 +651,8 @@ class ListingsController < ApplicationController
         pickup_enabled: @listing.pickup_enabled?,
         shipping_price_additional: shipping_price_additional,
         always_show_additional_shipping_price: shape[:units].length == 1 && shape[:units].first[:kind] == :quantity,
-        paypal_fees_url: PaypalCountryHelper.fee_link(community_country_code)
+        paypal_fees_url: PaypalCountryHelper.fee_link(community_country_code),
+        currency_opts: MoneyViewUtils.currency_opts(I18n.locale, community_currency)
       })
     end
   end

--- a/app/view_utils/money_view_utils.rb
+++ b/app/view_utils/money_view_utils.rb
@@ -13,16 +13,16 @@ module MoneyViewUtils
 
       # Explicitly resolve formatting. WebTranslateit resolves
       # translations to nils which causes an error with number_to_currency
-      formatting = currency_format(locale)
-      precision = m.currency.exponent.to_i
+      formatting = currency_opts(locale, m.currency)
+      precision = formatting[:digits]
       zero_cents = "0" * precision
 
       number_to_currency(m.amount,
-                         unit: m.symbol,
+                         unit: formatting[:symbol],
                          delimiter: formatting[:delimiter],
                          separator: formatting[:separator],
                          format: formatting[:format],
-                         precision: m.currency.exponent.to_i)
+                         precision: precision)
         .tr(" ", "\u202F")
         .gsub("#{formatting[:separator]}#{zero_cents}", "") # remove cents if they are zero
         .encode('utf-8')
@@ -35,11 +35,14 @@ module MoneyViewUtils
 
   # Return a hash of currency formatting options, sets defaults if
   # translations are not present
-  def currency_format(locale)
+  # Currency needs to be an instance of Money::Currency
+  def currency_opts(locale, currency)
     {
       separator: I18n.t("number.currency.format.separator", locale: locale) || ".",
       delimiter: I18n.t("number.currency.format.delimiter", locale: locale) || ",",
-      format: I18n.t("number.currency.format.format", locale: locale) || "%u%n"
+      format: I18n.t("number.currency.format.format", locale: locale) || "%u%n",
+      digits: currency.exponent.to_i,
+      symbol: currency.symbol
     }
   end
 end

--- a/app/views/listings/_listing_actions.haml
+++ b/app/views/listings/_listing_actions.haml
@@ -136,8 +136,7 @@
             });
             window.ST.initializeQuantityValidation({validate: "positiveIntegers", input: "quantity", errorMessage: "#{t("errors.messages.positive_number")}" });
             if ("#{delivery_type}" == "shipping" && #{shipping_price_additional != nil}) {
-              var currency = '#{Maybe(delivery_opts)[0][:price].currency.iso_code.or_else(@current_community.currency)}'
-              window.ST.initializeShippingPriceTotal(currency, '#{I18n.locale}', '#quantity', '.delivery-price-value');
+              window.ST.initializeShippingPriceTotal(#{currency_opts.to_json}, '#quantity', '.delivery-price-value');
             }
 
         .quantity-wrapper.input-group.clearfix

--- a/app/views/listings/form/_form_content.haml
+++ b/app/views/listings/form/_form_content.haml
@@ -2,7 +2,7 @@
 
 = form_for @listing, :html => {:multipart => true} do |form|
   = render :partial => "listings/form/title", :locals => { :form => form }
-  = render :partial => "listings/form/price", :locals => { :form => form, :seller_commission_in_use => seller_commission_in_use, :payment_gateway => payment_gateway, :run_js_immediately => run_js_immediately, :minimum_commission => minimum_commission, commission_from_seller: commission_from_seller, shape: shape, unit_options: unit_options, shipping_price_additional: shipping_price_additional, paypal_fees_url: paypal_fees_url }
+  = render :partial => "listings/form/price", :locals => { :form => form, :seller_commission_in_use => seller_commission_in_use, :payment_gateway => payment_gateway, :run_js_immediately => run_js_immediately, :minimum_commission => minimum_commission, commission_from_seller: commission_from_seller, shape: shape, unit_options: unit_options, shipping_price_additional: shipping_price_additional, paypal_fees_url: paypal_fees_url, currency_opts: currency_opts }
   = render partial: "listings/form/shipping", locals: { form: form, shape: shape, always_show_additional_shipping_price: always_show_additional_shipping_price, shipping_enabled: shipping_enabled, pickup_enabled: pickup_enabled, shipping_price: shipping_price, shipping_price_additional: shipping_price_additional }
   = render :partial => "listings/form/description", :locals => { :form => form }
   = render :partial => "listings/form/custom_fields", :locals => { :form => form, :listing => @listing, :custom_fields => @custom_field_questions }

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -32,8 +32,7 @@
           :javascript
             $(function() {
               updateSellerGetsValue(
-                "#{@current_community.currency}",
-                "#{I18n.locale}",
+                #{currency_opts.to_json},
                 "#listing_price",
                 "#fee_display",
                 #{commission_from_seller},

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -140,7 +140,7 @@
     .row-with-divider
       .col-12
         #listing-message-links
-          = render :partial => "listing_actions", locals: { form_path: form_path, payment_gateway: payment_gateway, delivery_opts: delivery_opts, process: process, listing_unit_type: listing_unit_type, country_code: country_code, blocked_dates_end_on: blocked_dates_end_on, blocked_dates_result: blocked_dates_result, manage_availability_props: manage_availability_props, availability_enabled: availability_enabled }
+          = render :partial => "listing_actions", locals: { form_path: form_path, payment_gateway: payment_gateway, delivery_opts: delivery_opts, process: process, listing_unit_type: listing_unit_type, country_code: country_code, blocked_dates_end_on: blocked_dates_end_on, blocked_dates_result: blocked_dates_result, manage_availability_props: manage_availability_props, availability_enabled: availability_enabled, currency_opts: currency_opts }
 
     .row-with-divider
       .col-12


### PR DESCRIPTION
### Makes money handling in server and client consistent.
There are two places where JavaScript handles displaying of money: new listing creation and ordering a listing with shipping enabled with a separate price for additional items. This pr unifies how client and server show money.

  Previously:

![image](https://user-images.githubusercontent.com/230815/26925346-2458dde6-4c52-11e7-9088-6d02dbbc9cce.png)

  After:

![image](https://user-images.githubusercontent.com/230815/26925364-36a63a20-4c52-11e7-9594-6bdd09358a93.png)

### Fixes older browser compatibility by removing calls to Intl api, for instance iOS Safari 9 broke because of this
