### PR TITLE
Reverse the asset check script logic

### DIFF
--- a/script/can-reuse-assets.sh
+++ b/script/can-reuse-assets.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# Exit code is 0 (true) if assets should be rebuilt
+# Exit code is 0 (true) if given old version of assets can be reused
 
 set -e
 
 COMPARE_SHA="${1-HEAD}"
 
 # Make sure cached revision exists
-[ "$(git cat-file -t "$COMPARE_SHA")" != "commit" ] && return 0
+[ "$(git cat-file -t "$COMPARE_SHA")" == "commit" ]
 
 # TODO consider if only ancestors should be treated as valid cache
 
@@ -18,4 +18,4 @@ CHANGES=$(git diff --shortstat "$COMPARE_SHA" -- \
               package.json \
               vendor/assets)
 
-[ -n "$CHANGES" ]
+[ -z "$CHANGES" ]


### PR DESCRIPTION
This improves stability as a script error is treated as signal to rebuild assets, rather than to reuse them.
Also fixes wrongly used "return" instead of "exit".