### PR TITLE
Add extension request link to expiration notice

### DIFF
--- a/app/views/layouts/_admin_expiration_notice.html.erb
+++ b/app/views/layouts/_admin_expiration_notice.html.erb
@@ -18,7 +18,7 @@
     </div>
     <p class="expiration-footer">
         <%= t("expiration.admin.need_more_info") %> <a href="mailto:sales@sharetribe.com"><%= t("expiration.admin.contact_us") %></a>.
-        <br/><%= t("expiration.admin.need_more_time") %> <a href="https://sharetribe.typeform.com/to/UR8QPq?email=<%= @current_user.primary_email %>&marketplace_domain=<%= @current_community.full_domain %>&marketplace_id=<%= @current_community.id %>"><%= t("expiration.admin.let_us_extend_2_weeks") %></a>.
+        <br/><%= t("expiration.admin.need_more_time") %> <a href="https://sharetribe.typeform.com/to/UR8QPq?email=<%= @current_user.primary_email.address %>&marketplace_domain=<%= @current_community.full_domain %>&marketplace_id=<%= @current_community.id %>"><%= t("expiration.admin.let_us_extend_2_weeks") %></a>.
     </p>
   </div>
 </div>

--- a/app/views/layouts/_admin_expiration_notice.html.erb
+++ b/app/views/layouts/_admin_expiration_notice.html.erb
@@ -17,7 +17,7 @@
       </div>
     </div>
     <p class="expiration-footer">
-        <%= t("expiration.admin.need_more_info") %> <a href="mailto:sales@sharetribe.com"><%= t("expiration.admin.contact_us") %></a>
+        <%= t("expiration.admin.need_more_info") %> <a href="mailto:sales@sharetribe.com"><%= t("expiration.admin.contact_us") %></a>.
         <br/><%= t("expiration.admin.need_more_time") %> <a href="https://sharetribe.typeform.com/to/UR8QPq?email=<%= @current_user.primary_email %>&marketplace_domain=<%= @current_community.full_domain %>&marketplace_id=<%= @current_community.id %>"><%= t("expiration.admin.let_us_extend_2_weeks") %></a>.
     </p>
   </div>

--- a/app/views/layouts/_admin_expiration_notice.html.erb
+++ b/app/views/layouts/_admin_expiration_notice.html.erb
@@ -16,6 +16,9 @@
         </a>
       </div>
     </div>
-    <p class="expiration-footer"><%= t("expiration.admin.need_more_info") %> <a href="mailto:sales@sharetribe.com"><%= t("expiration.admin.contact_us") %></a></p>
+    <p class="expiration-footer">
+        <%= t("expiration.admin.need_more_info") %> <a href="mailto:sales@sharetribe.com"><%= t("expiration.admin.contact_us") %></a>
+        <br/><%= t("expiration.admin.need_more_time") %> <a href="https://sharetribe.typeform.com/to/UR8QPq?email=<%= @current_user.primary_email %>&marketplace_domain=<%= @current_community.full_domain %>&marketplace_id=<%= @current_community.id %>"><%= t("expiration.admin.let_us_extend_2_weeks") %></a>.
+    </p>
   </div>
 </div>

--- a/config/locales/expiration_lightbox/en.yml
+++ b/config/locales/expiration_lightbox/en.yml
@@ -7,6 +7,8 @@ en:
       link_to_external_service: "Choose a plan"
       need_more_info: "Need more information?"
       contact_us: "Contact us."
+      need_more_time: "Need more time?"
+      let_us_extend_2_weeks: "Let us extend your trial for 2 weeks"
     title: "The free trial of this marketplace has expired."
     unavailable_info: "The marketplace is temporarily unavailable. None of the listings, pictures or other data has been deleted. "
     all_available_info: "All will be available again when the marketplace owner subscribes to a paid <a href='https://www.sharetribe.com/?utm_source=expired-trial&utm_medium=modal&utm_campaign=end-user-modal-expired-trial'>Sharetribe</a> plan."

--- a/config/locales/expiration_lightbox/en.yml
+++ b/config/locales/expiration_lightbox/en.yml
@@ -6,7 +6,7 @@ en:
       sub_title_new: "Don't worry, your data has not been deleted. You can unlock your marketplace immediately by subscribing to one of our paid plans."
       link_to_external_service: "Choose a plan"
       need_more_info: "Need more information?"
-      contact_us: "Contact us."
+      contact_us: "Contact us"
       need_more_time: "Need more time?"
       let_us_extend_2_weeks: "Let us extend your trial for 2 weeks"
     title: "The free trial of this marketplace has expired."

--- a/config/locales/expiration_lightbox/es-ES.yml
+++ b/config/locales/expiration_lightbox/es-ES.yml
@@ -3,10 +3,12 @@ es-ES:
   expiration:
     admin:
       title: "El periodo de prueba de tu comunidad ha expirado."
-      contact_us: "Contáctanos"
       sub_title_new: "No te preocupes, toda la información de tu comunidad ha sido guardada. Puedes reactivar tu comunidad al suscribirte a alguno de nuestros planes."
-      need_more_info: "Necesitas más información?"
       link_to_external_service: "Escoge un plan"
+      need_more_info: "Necesitas más información?"
+      contact_us: "Contáctanos"
+      need_more_time: "Necesitas más tiempo?"
+      let_us_extend_2_weeks: "¿Podemos añadir 2 semanas más a tu periodo de prueba"
     title: "El periodo de prueba de esta comunidad ha terminado."
     unavailable_info: "La comunidad no está disponible por el momento. Sin embargo, todos los anuncios, imágenes y demás información han sido guardados."
     all_available_info: "Toda la información estará disponible nuevamente cuando el administrador de la comunidad se suscriba a uno de los planes de <a href='https://www.sharetribe.com/?utm_source=expired-trial&utm_medium=modal&utm_campaign=end-user-modal-expired-trial'>Sharetribe</a>."

--- a/config/locales/expiration_lightbox/fi.yml
+++ b/config/locales/expiration_lightbox/fi.yml
@@ -3,10 +3,12 @@ fi:
   expiration:
     admin:
       title: "Sharetribe-palvelun kokeilujakso on päättynyt."
-      contact_us: "Ota yhteyttä."
       sub_title_new: "Ei huolta, markkinapaikan tietoja ei ole poistettu. Voit jatkaa markkinapaikkasi käyttöä välittömästi tilaamalla jonkin maksullisista paketeistamme."
-      need_more_info: "Tarvitsetko enemmän tietoa?"
       link_to_external_service: "Valitse paketti"
+      need_more_info: "Tarvitsetko enemmän tietoa?"
+      contact_us: "Ota yhteyttä."
+      need_more_time: "Tarvitsetko lisää aikaa?"
+      let_us_extend_2_weeks: "Voimme jatkaa kokeilujaksoasi kahdella viikolla"
     title: "Markkinapaikan kokeilujakso on päättynyt."
     unavailable_info: "Markkinapaikka on tilapäisesti pois käytöstä. Ei huolta, markkinapaikan tietoja ei ole poistettu."
     all_available_info: "Markkinapaikka palaa käyttöön tietoineen, kun markkinapaikan omistaja tilaa jonkin <a href='https://www.sharetribe.com/?utm_source=expired-trial&utm_medium=modal&utm_campaign=end-user-modal-expired-trial'>Sharetriben</a> maksullisista paketeista."

--- a/config/locales/expiration_lightbox/fr.yml
+++ b/config/locales/expiration_lightbox/fr.yml
@@ -3,10 +3,12 @@ fr:
   expiration:
     admin:
       title: "Votre place de marché d'essai a expiré."
-      contact_us: "Contactez-nous."
       sub_title_new: "Ne vous inquiétez pas, aucune donnée n'a été supprimée. Vous pouvez réactiver votre place de marché immédiatement en souscrivant à l'une de nos offres."
-      need_more_info: "Besoin de plus d'informations ?"
       link_to_external_service: "Choisir une offre"
+      need_more_info: "Besoin de plus d'informations ?"
+      contact_us: "Contactez-nous."
+      need_more_time: "Besoin d'un peu plus de temps ?"
+      let_us_extend_2_weeks: "Prolongez de 2 semaines votre essai gratuit"
     title: "La période d'essai gratuite de cette place de marché est terminée."
     unavailable_info: "La place de marché est pour le moment indisponible. Les annonces, images et données n'ont pas été supprimées."
     all_available_info: "Tout sera utilisable de nouveau dès que l'administrateur de la place de marché aura souscrit à une offre payante de <a href='https://www.sharetribe.com/?utm_source=expired-trial&utm_medium=modal&utm_campaign=end-user-modal-expired-trial'>Sharetribe</a>."

--- a/config/locales/expiration_lightbox/nl.yml
+++ b/config/locales/expiration_lightbox/nl.yml
@@ -7,6 +7,8 @@ nl:
       link_to_external_service: "Kies een plan"
       need_more_info: "Meer informatie nodig?"
       contact_us: "Neem contact op."
+      need_more_time: "Meer tijd nodig?"
+      let_us_extend_2_weeks: "Laat je proefperiode twee weken verlengen"
     title: "De gratis proefperiode van deze marktplaats is verlopen."
     unavailable_info: "De marktplaats is tijdelijk niet beschikbaar. Alle advertenties, foto’s en andere data zijn bewaard."
     all_available_info: "Alles wordt automatisch weer beschikbaar zodra de marktplaats beheerder zich abonneert op een van de premium plannen van <a href='https://www.sharetribe.com/?utm_source=expired-trial&utm_medium=modal&utm_campaign=end-user-modal-expired-trial'>Sharetribe</a>."


### PR DESCRIPTION
This adds a link in the expired trial notice popup so that admins can request a trial extension.