### PR TITLE
Updated copy text to remove mention to a link that was deleted

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1168,7 +1168,7 @@ en:
       join_this_community: "Join marketplace"
       read_more: "Read more"
       feedback: "Your message to %{service_name} team"
-      dont_use_to_contact_support: "We noticed you're an admin of %{service_name}. This form is what your users use to contact you. You cannot use this form to contact Sharetribe support. You can do that via the Support link in your admin panel instead."
+      dont_use_to_contact_support: "We noticed you're an admin of %{service_name}. This form is what your users use to contact you. You cannot use this form to contact Sharetribe support. You can do that via the support widget in the bottom right corner of the admin panel instead."
       feedback_forum: "feedback forum"
       feedback_handle: Feedback
       give_feedback: "Contact us"


### PR DESCRIPTION
"Support" link was removed from the admin panel, this copy text change update a sentence in which it was still used.