### PR TITLE
Fix Airbrake error filtering

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -3,20 +3,6 @@ if APP_CONFIG.use_airbrake
     config.project_id = APP_CONFIG.airbrake_project_id
     config.project_key = APP_CONFIG.airbrake_project_key
 
-    Airbrake.add_filter do |notice|
-      errors_to_ignore = [
-        "AbstractController::ActionNotFound",
-        "ActiveRecord::RecordNotFound",
-        "ActionController::RoutingError",
-        "ActionController::UnknownAction",
-        "PeopleController::PersonDeleted",
-        "PeopleController::PersonBanned",
-        "ListingsController::ListingDeleted"
-      ]
-      if notice[:errors].any? { |error| errors_to_ignore.include?(error[:type]) }
-        notice.ignore!
-      end
-    end
 
     config.root_directory = Rails.root
     config.logger = Rails.logger
@@ -24,5 +10,20 @@ if APP_CONFIG.use_airbrake
 
     config.ignore_environments = %w(development test)
     config.blacklist_keys = Rails.application.config.filter_parameters
+  end
+
+  Airbrake.add_filter do |notice|
+    errors_to_ignore = [
+      "AbstractController::ActionNotFound",
+      "ActiveRecord::RecordNotFound",
+      "ActionController::RoutingError",
+      "ActionController::UnknownAction",
+      "PeopleController::PersonDeleted",
+      "PeopleController::PersonBanned",
+      "ListingsController::ListingDeleted"
+    ]
+    if notice[:errors].any? { |error| errors_to_ignore.include?(error[:type]) }
+      notice.ignore!
+    end
   end
 end


### PR DESCRIPTION
Airbrake error filtering does not work until Airbrake is correctly
configured and initialized.