### PR TITLE
Fix marketplace domain routing

### DIFF
--- a/app/utils/marketplace_router.rb
+++ b/app/utils/marketplace_router.rb
@@ -233,16 +233,16 @@ module MarketplaceRouter
     end
   end
 
-  # Takes a Rails Request
+  # Takes an ActionDispatch::Request or Rack::Request
   #
   # Returns a Hash in a form that MarketplaceRouter expects
   #
   def request_hash(request)
     {
       host: request.host,
-      protocol: (request.respond_to?(:protocol) ? request.protocol : request.scheme),
+      protocol: (request.respond_to?(:protocol) ? request.protocol : "#{request.scheme}://"),
       fullpath: request.fullpath,
-      port_string: (request.respond_to?(:port_string) ? request.port_string : request.port),
+      port_string: (request.respond_to?(:port_string) ? request.port_string : ":#{request.port}"),
     }
   end
 


### PR DESCRIPTION
Allow routing methods to accept both Rack::Request and
ActionDispatch::Request and form port and protocol strings so that
they are identical.