### PR TITLE
Fixed: can update custom fields

### DIFF
--- a/app/models/custom_field_option.rb
+++ b/app/models/custom_field_option.rb
@@ -36,5 +36,6 @@ class CustomFieldOption < ApplicationRecord
         titles.build(:value => value, :locale => locale)
       end
     end
+    self.updated_at = Time.zone.now # to change TranslationCache key
   end
 end

--- a/features/settings/user_updates_profile_information.feature
+++ b/features/settings/user_updates_profile_information.feature
@@ -14,7 +14,7 @@ Feature: User updates profile information
   Scenario: Updating profile successfully
     When I fill in "First name" with "Test"
     And I fill in "Last name" with "Dude"
-    And I fill in "Location" with "Broadway"
+    And I fill in "Location" with "Broadway, New York"
     And wait for 2 seconds
     And I fill in "Phone number" with "0700-715517"
     And I fill in "About you" with "Some random text about me"
@@ -22,5 +22,5 @@ Feature: User updates profile information
     Then I should see "Information updated" within ".flash-notifications"
     And the "First name" field should contain "Test"
     And the "Last name" field should contain "Dude"
-    And the "Location" field should contain "Broadway"
+    And the "Location" field should contain "Broadway, New York"
     And I should not see my username

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -23,8 +23,10 @@ When /^(?:|I )click "([^"]*)"(?: within "([^"]*)")?$/ do |css_selector, scope_se
 end
 
 Then /^I should see selector "([^"]*)"(?: within "([^"]*)")?$/ do |css_selector, scope_selector|
-  with_scope(scope_selector) do
-    expect(page).to have_selector(css_selector)
+  wait_until do
+    with_scope(scope_selector) do
+      expect(page).to have_selector(css_selector)
+    end
   end
 end
 


### PR DESCRIPTION
BUG: changing the names of custom listing field options is not possible