### PR TITLE
Changed Confirmed to Completed in some transaction flow statuses

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,7 +316,7 @@ en:
           accepted: Accepted
           rejected: Rejected
           paid: Paid
-          confirmed: Confirmed
+          confirmed: Completed
           canceled: Canceled
           initiated: "Waiting PayPal payment"
           pending_ext: "Waiting PayPal payment"
@@ -1262,7 +1262,7 @@ en:
       news_item_updated: "Article updated"
       news_item_deleted: "Article removed"
       offer_accepted: "Offer accepted"
-      offer_confirmed: "Offer confirmed"
+      offer_confirmed: "Offer completed"
       offer_closed: "Offer closed"
       listing_created_successfully: "Listing created successfully. %{new_listing_link}."
       offer_rejected: "Offer rejected"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -769,7 +769,7 @@ en:
       create_own: "Want to create your own online marketplace website like %{service_name}? %{learn_more}."
       learn_more: "Learn more"
     confirm_reminder:
-      you_have_not_yet_confirmed_or_canceled_request: "You have not yet confirmed or canceled the order %{request_link}. If the order has been completed, you should confirm that. After that you can give feedback to %{other_party_given_name}."
+      you_have_not_yet_confirmed_or_canceled_request: "You have not yet completed or canceled the order %{request_link}. If the order has been completed, you should confirm that. After that you can give feedback to %{other_party_given_name}."
       remember_to_confirm_request: "Remember to confirm or cancel a request"
       if_will_not_happen_you_should_cancel: "If you think this order will not be completed for one reason or another, you can %{cancel_it_link}."
       cancel_it_link_text: "cancel it"


### PR DESCRIPTION
Right now most statuses and notifications have _Completed_ as the final step of a transaction. However in three places, _Confirmed_ was still used which was confusing.

Now the status will be _Completed_ everywhere.