### PR TITLE
Changed Confirmed to Completed in some transaction flow statuses

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,7 +316,7 @@ en:
           accepted: Accepted
           rejected: Rejected
           paid: Paid
-          confirmed: Confirmed
+          confirmed: Completed
           canceled: Canceled
           initiated: "Waiting PayPal payment"
           pending_ext: "Waiting PayPal payment"
@@ -769,7 +769,7 @@ en:
       create_own: "Want to create your own online marketplace website like %{service_name}? %{learn_more}."
       learn_more: "Learn more"
     confirm_reminder:
-      you_have_not_yet_confirmed_or_canceled_request: "You have not yet confirmed or canceled the order %{request_link}. If the order has been completed, you should confirm that. After that you can give feedback to %{other_party_given_name}."
+      you_have_not_yet_confirmed_or_canceled_request: "You have not yet completed or canceled the order %{request_link}. If the order has been completed, you should confirm that. After that you can give feedback to %{other_party_given_name}."
       remember_to_confirm_request: "Remember to confirm or cancel a request"
       if_will_not_happen_you_should_cancel: "If you think this order will not be completed for one reason or another, you can %{cancel_it_link}."
       cancel_it_link_text: "cancel it"
@@ -1262,7 +1262,7 @@ en:
       news_item_updated: "Article updated"
       news_item_deleted: "Article removed"
       offer_accepted: "Offer accepted"
-      offer_confirmed: "Offer confirmed"
+      offer_confirmed: "Offer completed"
       offer_closed: "Offer closed"
       listing_created_successfully: "Listing created successfully. %{new_listing_link}."
       offer_rejected: "Offer rejected"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -683,7 +683,7 @@ fr:
       offer_accepted: Acceptée
       offer_rejected: Refusée
       offer_canceled: Annulée
-      offer_confirmed: Terminée
+      offer_confirmed: Terminé
       offer_paid: "Paiement réussi"
       offer_preauthorized: "Paiement réussi"
       offer_waiting_for_payment: "En attente du paiement par %{requester_name}"
@@ -699,7 +699,7 @@ fr:
       waiting_for_listing_author_to_deliver_listing: "En attente de %{listing_author_name} de la réalisation de la commande relative à %{listing_title}"
       request_accepted: Acceptée
       request_rejected: Refusée
-      request_confirmed: Terminée
+      request_confirmed: Terminé
       request_canceled: Annulée
       request_paid: "Paiement réussi"
       request_preauthorized: "Paiement autorisé"


### PR DESCRIPTION
In most places one transaction flow status is _Completed_ but for some reasons it was _Confirmed_ in a few places. This solves it.

Also a `wti pull`.