### PR TITLE
Upgrade to latest ruby 2.3.4 with latest rubygems (2.6.13+)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.3.4
 
 MAINTAINER Sharetribe Team <team@sharetribe.com>
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.3.1'
+ruby '2.3.4'
 
 gem 'rails', '5.1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,7 +637,7 @@ DEPENDENCIES
   zeus (~> 0.15.13)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
   timezone:
     Europe/Helsinki
   ruby:
-    version: ruby-2.3.1
+    version: ruby-2.3.4
   node:
     version: 7.8.0
   environment:


### PR DESCRIPTION
The latest rubygems version contains fixes for several security vulnerabilities:
https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/