### PR TITLE
Update Stripe Australia bank account number regexp

### DIFF
--- a/app/assets/javascripts/stripe_form.js
+++ b/app/assets/javascripts/stripe_form.js
@@ -21,7 +21,7 @@ window.ST.stripe_form_i18n = {
 
   var BANK_RULES = {
     AU: { 
-      account_number: { format: '123456789', regexp: '[0-9]{9}', test_regexp: '[0-9][9]'}, 
+      account_number: { format: 'format_varies_by_bank', regexp: '[0-9]{6,10}', test_regexp: '[0-9]{6,10}'}, 
       routing_number: { title: 'bsb',  format: '123456', regexp: '[0-9]{6}', test_regexp: '[0-9]{6}'} 
     },
     AT: { 


### PR DESCRIPTION
Bank account numbers can be between 6 and 10 digits.