### PR TITLE
User confirmation form is more secure

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -5,6 +5,10 @@ class ConfirmationsController < Devise::ConfirmationsController
               :ensure_consent_given,
               :ensure_user_belongs_to_community
 
+  before_action(only: [:create]) do |controller|
+    controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_view_this_page")
+  end
+
   # This is overridden from Devise::ConfirmationsController
   # to be able to handle better the situations of resending confirmation and
   # confirmation attemt with wrong token.

--- a/app/views/community_memberships/_confirmation_form.haml
+++ b/app/views/community_memberships/_confirmation_form.haml
@@ -18,7 +18,6 @@
 %p
   = form_for(Person, :as => "person", :url => confirmation_path(:locale => I18n.locale), :html => { :method => :put, :id => "resend_email_confirmation"} ) do |form|
     .form_field_container
-      = form.hidden_field :id, :value => @current_user.id
       = form.button t("sessions.confirmation_pending.resend_confirmation_instructions"), :class => "resend_email_confirmation_button send_button"
 %p
   = t("sessions.confirmation_pending.your_current_email_is", :email => email_to_confirm).html_safe
@@ -27,5 +26,4 @@
 
     = form_for(Person, :as => "person", :url => confirmation_path(:locale => I18n.locale), :html => { :method => :put, :id => "change_mistyped_email_form"} ) do |form|
       .form_field_container
-        = form.hidden_field :id, :value => @current_user.id
         = render :partial => "sessions/change_mistyped_email", :locals => {:email_to_confirm => email_to_confirm}


### PR DESCRIPTION
  - removed unused from data
  - check current_user on email change