### PR TITLE
Fix ListingImageJSAdapter -> ListingImageJsAdapter class naming

### DIFF
--- a/app/models/listing_image_js_adapter.rb
+++ b/app/models/listing_image_js_adapter.rb
@@ -1,4 +1,4 @@
-class ListingImageJSAdapter < JSAdapter
+class ListingImageJsAdapter < JSAdapter
   ASPECT_RATIO = 3/2.to_f
 
   def initialize(listing_image)


### PR DESCRIPTION
ListingImageJsAdapter class is (probably) named wrong and fails on migration.