### PR TITLE
Allow filtering signups by regular expressions and limit name lenght

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -148,8 +148,8 @@ class Person < ApplicationRecord
 
   validates_length_of :phone_number, :maximum => 25, :allow_nil => true, :allow_blank => true
   validates_length_of :username, :within => 3..20
-  validates_length_of :given_name, :within => 1..255, :allow_nil => true, :allow_blank => true
-  validates_length_of :family_name, :within => 1..255, :allow_nil => true, :allow_blank => true
+  validates_length_of :given_name, :within => 1..30, :allow_nil => true, :allow_blank => true
+  validates_length_of :family_name, :within => 1..30, :allow_nil => true, :allow_blank => true
   validates_length_of :display_name, :within => 1..30, :allow_nil => true, :allow_blank => true
 
   validates_format_of :username,

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -87,7 +87,7 @@ class EmailService
     allowed = false
     allowed_array = allowed_emails.split(",")
     allowed_array.each do |allowed_domain_or_address|
-      if allowed_domain_or_address =~ /^\/.+/
+      if allowed_domain_or_address =~ /^\//
         # treat as if this is meant to be a regular expression
         if address =~ Regexp.new(allowed_domain_or_address.delete("/"))
           allowed = true

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -89,7 +89,7 @@ class EmailService
     allowed_array.each do |allowed_domain_or_address|
       if allowed_domain_or_address =~ /^\/.+/
         # treat as if this is meant to be a regular expression
-        if address =~ Regexp.new(allowed_domain_or_address.gsub("/",""))
+        if address =~ Regexp.new(allowed_domain_or_address.delete("/"))
           allowed = true
           break
         end

--- a/app/services/email_service.rb
+++ b/app/services/email_service.rb
@@ -87,11 +87,20 @@ class EmailService
     allowed = false
     allowed_array = allowed_emails.split(",")
     allowed_array.each do |allowed_domain_or_address|
-      allowed_domain_or_address.strip!
-      allowed_domain_or_address.gsub!('.', '\.') #change . to be \. to only match a dot, not any char
-      if address =~ /#{allowed_domain_or_address}$/i
-        allowed = true
-        break
+      if allowed_domain_or_address =~ /^\/.+/
+        # treat as if this is meant to be a regular expression
+        if address =~ Regexp.new(allowed_domain_or_address.gsub("/",""))
+          allowed = true
+          break
+        end
+      else
+        # treat as if this is not meant to be a regular expression
+        allowed_domain_or_address.strip!
+        allowed_domain_or_address.gsub!('.', '\.') #change . to be \. to only match a dot, not any char
+        if address =~ /#{allowed_domain_or_address}$/i
+          allowed = true
+          break
+        end
       end
     end
     return allowed

--- a/app/views/people/new.haml
+++ b/app/views/people/new.haml
@@ -9,7 +9,7 @@
   - if @community_customization && @community_customization.signup_info_content
     %p
       = @community_customization.signup_info_content.html_safe
-  - elsif @current_community.allowed_emails
+  - elsif @current_community.allowed_emails && @current_community.allowed_emails[0] != "/" 
     %p
       = t('.email_restriction_instructions',
             :community_name => @current_community.name(I18n.locale),

--- a/config/locales/es-ES.yml
+++ b/config/locales/es-ES.yml
@@ -449,7 +449,7 @@ es-ES:
         email_sent: "Mensaje enviado."
         to_improve_email_deliverability: "Para mejorar el envío y recepción de correos, el asunto del correo es generado automáticamente y no puede ser cambiado."
         email_subject_text: "Un nuevo mensaje de parte del equipo de %{service_name}"
-        firstname_cannot_be_removed: "Nombre no se puede remover y será reemplazado por el nombre de cada usuario"
+        firstname_cannot_be_removed: "\"Nombre\" no se puede remover y será reemplazado por el nombre de cada usuario"
         hello_firstname: "Hola Nombre,"
         hello_firstname_text: "Hola %{person},"
     left_hand_navigation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -449,7 +449,7 @@ fr:
         email_sent: "Email envoyé."
         to_improve_email_deliverability: "Pour améliorer la distribution des emails, l'objet est créé automatiquement et ne peut être modifié."
         email_subject_text: "Un nouveau message de l'équipe %{service_name}"
-        firstname_cannot_be_removed: "\"Prénom\" ne peut être enlevé et sera remplacé automatiquement par le prénom de chaque destinataire"
+        firstname_cannot_be_removed: "\"Prénom\" ne peut être enlevé et sera remplacé automatiquement par le prénom de chaque destinataire."
         hello_firstname: "Bonjour Prénom,"
         hello_firstname_text: "Bonjour %{person},"
     left_hand_navigation:


### PR DESCRIPTION
This allows allowed_email field to contain regular expressions that are handled more directly. (not replacing a . with \. like it normally does.

Also the max length of given_name and family_name are limited to 30 characters as longer fields were used for spammy content.