### PR TITLE
Fix ssn_last_4 not passed to Stripe when creating account token

### DIFF
--- a/app/assets/javascripts/stripe_form.js
+++ b/app/assets/javascripts/stripe_form.js
@@ -380,7 +380,8 @@ var stripeToken = (function() {
                   },
                   personal_id_number: ["US", "CA", "HK", "SG"].includes(country)
                     ? getValue("personal_id_number")
-                    : null
+                    : null,
+                  ssn_last_4: country == "US" ? getValue("ssn_last_4") : null
                 };
 
                 if (options.update) {


### PR DESCRIPTION
Recently merged #3265, adds `ssn_last_4` to the stripe connect form for US accounts but `ssn_last_4` is not included when creating Stripe account token on client side. As a result, the created Stripe account does not have `ssn_last_4` populated.

![image](https://user-images.githubusercontent.com/109350/38528726-aa04c8fc-3c15-11e8-8f7b-295c5e203d76.png)
