### PR TITLE
[GDPR] Allow admins to disable end-user analytics

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -321,7 +321,12 @@ class Admin::CommunitiesController < Admin::AdminBaseController
     @selected_left_navi_link = "analytics"
 
     params[:community][:google_analytics_key] = nil if params[:community][:google_analytics_key] == ""
-    analytic_params = params.require(:community).permit(:google_analytics_key)
+    analytic_params = if APP_CONFIG.admin_enable_tracking_config
+                        params.require(:community).permit(:google_analytics_key,
+                                                          :end_user_analytics)
+                      else
+                        params.require(:community).permit(:google_analytics_key)
+                      end
 
     update(@current_community,
             analytic_params,

--- a/app/controllers/landing_page_controller.rb
+++ b/app/controllers/landing_page_controller.rb
@@ -258,6 +258,7 @@ class LandingPageController < ActionController::Metal
       facebook_locale: facebook_locale(locale),
       facebook_connect_id: c.facebook_connect_id,
       google_maps_key: MarketplaceHelper.google_maps_key(c.id),
+      end_user_analytics: c.end_user_analytics,
       google_analytics_key: c.google_analytics_key }
   end
 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -89,6 +89,7 @@
 #  small_cover_photo_processing               :boolean
 #  favicon_processing                         :boolean
 #  deleted                                    :boolean
+#  end_user_analytics                         :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/app/views/admin/communities/analytics.haml
+++ b/app/views/admin/communities/analytics.haml
@@ -20,5 +20,16 @@
           = render :partial => "layouts/info_text", :locals => { :text => t(".google_analytics_key_info_text") }
       .col-6
         =form.text_field :google_analytics_key, :maxlength => "15", :class => "text_field", :placeholder => "UA-12345-12"
+    - if APP_CONFIG.admin_enable_tracking_config
+      - sharetribe_analytics_instructions_link = (link_to(t(".sharetribe_analytics_instructions_link_text"), "#{knowledge_base_url}/how-to-disable-sharetribes-analytics"))
+      .row
+        %h3= t(".sharetribe_analytics")
+      .row
+        .col-12
+          = render :partial => "layouts/info_text", :locals => { :text => t(".sharetribe_analytics_info_text_with_instructions", :instructions_link => sharetribe_analytics_instructions_link).html_safe }
+      .row
+        .checkbox-container
+          = form.check_box :end_user_analytics
+          = form.label :end_user_analytics, t(".end_user_analytics"), :class => "settings-checkbox-label"
     .row
       = form.button t("admin.communities.analytics.save")

--- a/app/views/analytics/_google_analytics_script.haml
+++ b/app/views/analytics/_google_analytics_script.haml
@@ -1,10 +1,11 @@
 <script>
 if (typeof onDocumentReady === 'undefined') { onDocumentReady = function() {}; }
-- if APP_CONFIG.use_google_tag_manager.to_s == "true"
-  = render partial: "analytics/google_tag_manager"
+- if user_is_admin || end_user_analytics
+  - if APP_CONFIG.use_google_tag_manager.to_s == "true"
+    = render partial: "analytics/google_tag_manager"
 
-- if APP_CONFIG.use_google_analytics.to_s == "true"
-  = render partial: "analytics/legacy_google_analytics"
+  - if APP_CONFIG.use_google_analytics.to_s == "true"
+    = render partial: "analytics/legacy_google_analytics"
 
 - if google_analytics_key
   = render partial: "analytics/customer_analytics", locals: {google_analytics_key: google_analytics_key}

--- a/app/views/analytics/_head_scripts.haml
+++ b/app/views/analytics/_head_scripts.haml
@@ -16,9 +16,10 @@
 = render :partial => "analytics/google_analytics_script",
   locals: {feature_flags: FeatureFlagHelper.feature_flags,
   community_id: Maybe(community).id.or_else,
-  google_analytics_key: Maybe(community).google_analytics_key.or_else}
+  google_analytics_key: Maybe(community).google_analytics_key.or_else,
+  end_user_analytics: Maybe(community).end_user_analytics.or_else,
+  user_is_admin: community && Maybe(user).is_marketplace_admin?(community).or_else}
 
 -# Intercom for admin area
 - if on_admin? && IntercomHelper.admin_intercom_respond_enabled?
   = render partial: "analytics/intercom", locals: { app_id: IntercomHelper.admin_intercom_app_id}
-

--- a/app/views/landing_page/landing_page.erb
+++ b/app/views/landing_page/landing_page.erb
@@ -55,6 +55,8 @@
     <%= render partial: "analytics/google_analytics_script",
                locals: { feature_flags: feature_flags,
                          community_id: community_context[:id],
+                         user_is_admin: false,
+                         end_user_analytics: community_context[:end_user_analytics],
                          google_analytics_key: community_context[:google_analytics_key] } %>
   <% end %>
 

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -454,7 +454,7 @@ default: &default_settings
   stripe_publishable_key_pattern: "\\Apk_test_.{24}\\z"
 
   # Stripe allows to hold funds up to 90 days
-  # (85 and not 90 or 89 as a security, also because timezones are not 
+  # (85 and not 90 or 89 as a security, also because timezones are not
   # managed and transactions are automatically marked as completed)
   stripe_max_booking_date: 85
 
@@ -462,13 +462,22 @@ default: &default_settings
   # Sharetribe supports only managed accounts, and two payment modes:
   #
   # :separate    - Separate charges and transfers, payment goes to admin account, with delayed transfer to seller
-  # :destination - Destination charges, payment goes to admin account, with instant partial transfer to seller  
+  # :destination - Destination charges, payment goes to admin account, with instant partial transfer to seller
   #
   # By default :destination mode is used
   stripe_charges_mode: :destination
 
   # Used to encrypt Stripe api keys
   app_encryption_key:
+
+  ##########################################
+  # Admin (sharetribe.com internal)
+  ##########################################
+
+  # Enable end-user analytics tracking configuration
+  # in admin panel. Open source users should instead use
+  # the use_google_tag_manager: false
+  admin_enable_tracking_config: false
 
 production: &production_settings
   <<: *default_settings

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -574,3 +574,5 @@ test:
   # Add your test keys to run features/stripe/stripe.feature
   feature_stripe_publishable_key: pk_test_123456789012345678901234
   feature_stripe_private_key: sk_test_123456789012345678901234
+
+  admin_enable_tracking_config: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,6 +291,10 @@ en:
         google_analytics_key_info_text: "Tracking ID of your Google Analytics account."
         google_analytics_key_info_text_with_instructions: "Tracking ID of your Google Analytics account. %{instructions_link}."
         google_analytics_instructions_link_text: "Read more about connecting Google Analytics"
+        sharetribe_analytics: "Sharetribe analytics"
+        sharetribe_analytics_info_text_with_instructions: "To improve Sharetribe's services and support, Sharetribe tracks marketplace members activity. Personal data is not collected and this information is not shared outside the Sharetribe team. This tracking can be disabled entirely. %{instructions_link}"
+        sharetribe_analytics_instructions_link_text: "Read more about Sharetribe's analytics."
+        end_user_analytics: "Allow Sharetribe to track members activity in order to improve Sharetribe's services"
         save: "Save settings"
       menu_links:
         menu_links: "Menu links"

--- a/db/migrate/20180514083133_add_end_user_analytics_to_communities.rb
+++ b/db/migrate/20180514083133_add_end_user_analytics_to_communities.rb
@@ -1,0 +1,5 @@
+class AddEndUserAnalyticsToCommunities < ActiveRecord::Migration[5.1]
+  def change
+    add_column :communities, :end_user_analytics, :boolean, :default => true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -266,6 +266,7 @@ CREATE TABLE `communities` (
   `small_cover_photo_processing` tinyint(1) DEFAULT NULL,
   `favicon_processing` tinyint(1) DEFAULT NULL,
   `deleted` tinyint(1) DEFAULT NULL,
+  `end_user_analytics` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_communities_on_uuid` (`uuid`),
   KEY `index_communities_on_domain` (`domain`) USING BTREE,
@@ -2259,6 +2260,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20171207073027'),
 ('20171207075640'),
 ('20180108061342'),
-('20180108093607');
+('20180108093607'),
+('20180514083133');
 
 

--- a/features/admin/analytics/admin_configures_analytics.feature
+++ b/features/admin/analytics/admin_configures_analytics.feature
@@ -19,3 +19,8 @@ Feature: Admin configures analytics
   And I press submit
   And I refresh the page
   Then I should see "UA-12345-12" in the Google analytics key field
+
+  Scenario: Disable end user analytics
+  When I uncheck "Allow Sharetribe to track"
+  And I press submit
+  Then the "Allow Sharetribe to track" checkbox should not be checked

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -90,6 +90,7 @@
 #  small_cover_photo_processing               :boolean
 #  favicon_processing                         :boolean
 #  deleted                                    :boolean
+#  end_user_analytics                         :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/spec/requests/landing_pages_spec.rb
+++ b/spec/requests/landing_pages_spec.rb
@@ -224,6 +224,36 @@ describe "Landing page", type: :request do
         expect(response.headers["Cache-Control"]).to eq("max-age=#{APP_CONFIG.clp_cache_time}, public")
       end
 
+      describe "end user analytics" do
+        before(:each) do
+          @old_gtm = APP_CONFIG.use_google_tag_manager
+          APP_CONFIG.use_google_tag_manager = true
+          Rails.cache.clear
+        end
+
+        after(:each) do
+          APP_CONFIG.use_google_tag_manager = @old_gtm
+        end
+
+        it "contains GTM" do
+          expect_string("http://#{@domain}", "Google Tag Manager")
+        end
+
+        describe "when end user analytics disabled" do
+          before(:each) do
+            @community.end_user_analytics = false
+            @community.save
+            Rails.cache.clear
+          end
+
+          it "does not contain GTM when disabled" do
+            get "http://#{@domain}"
+
+            expect(response.body).not_to match(/Google Tag Manager/)
+          end
+        end
+      end
+
       describe "private marketplaces" do
         before(:all) {
           @orig_private = @community.private


### PR DESCRIPTION
This feature is intended to be used in Sharetribe Go hosted version.
Open source users should use the `google_tag_manager` configuration variable
instead.