### PR TITLE
Bump nokogiri and sprockets to secure versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (4.2.0.334)
     nio4r (2.1.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -509,7 +509,7 @@ GEM
       builder (~> 3.0)
     sixarm_ruby_unaccent (1.1.1)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)
@@ -686,4 +686,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
- [Nokogiri vulnerability](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/nokogiri/CVE-2018-8048.yml) fixed
- [Sprockets vulnerability](https://github.com/rubysec/ruby-advisory-db/blob/master/gems/sprockets/CVE-2018-3760.yml) fixed