### PR TITLE
Fix load_structure method for static landing page.

### DIFF
--- a/app/services/custom_landing_page/landing_page_store_static.rb
+++ b/app/services/custom_landing_page/landing_page_store_static.rb
@@ -10,7 +10,7 @@ module CustomLandingPage
     end
 
     def load_structure(*)
-      data = if CustomLandingPage.const_defined?("StaticData")
+      data = if CustomLandingPage.const_defined?(:StaticData)
                CustomLandingPage::StaticData::DATA_STR
              else
                CustomLandingPage::ExampleData::DATA_STR


### PR DESCRIPTION
File config/initializers/landing_page.rb was not used by LandingPageStore.