### PR TITLE
[Bug] "Disable Stripe" link not shown in payment system page

### DIFF
--- a/app/views/admin/payment_preferences/_payment_settings.haml
+++ b/app/views/admin/payment_preferences/_payment_settings.haml
@@ -55,12 +55,11 @@
                         =icon_tag("check", ["icon-fix"])
                         =t("admin.payment_preferences.stripe_connected.title")
                       = link_to t("admin.payment_preferences.change_settings"), "#", id: "config_stripe_toggle"
-                      - if paypal_connected && paypal_enabled_by_admin
-                        %br
-                        = link_to t("admin.payment_preferences.stripe_connected.disable"),
-                          disable_admin_payment_preference_path(payment_gateway: :stripe),
-                          data: {confirm: t("admin.payment_preferences.confirm_disable", gateway: 'STRIPE')},
-                          id: "disable_stripe"
+                      %br
+                      = link_to t("admin.payment_preferences.stripe_connected.disable"),
+                        disable_admin_payment_preference_path(payment_gateway: :stripe),
+                        data: {confirm: t("admin.payment_preferences.confirm_disable", gateway: 'STRIPE')},
+                        id: "disable_stripe"
                   - else
                     .col-6
                       %h3.paypal-account-disabled
@@ -146,4 +145,3 @@
       - content_for :extra_javascript do
         :javascript
           $('#config_paypal_toggle').click();
-


### PR DESCRIPTION
"Disable Stripe" link in payment system page in admin panel is not shown after the set up of stripe payment.