### PR TITLE
Remove the contact person from default terms template text

### DIFF
--- a/app/views/infos/localized_privacy_policy/privacy_policy.en.haml
+++ b/app/views/infos/localized_privacy_policy/privacy_policy.en.haml
@@ -8,17 +8,6 @@
   info (at) sharetribe.com
 
 %h3
-  Contact person
-%p
-  Antti Virolainen
-  %br
-  Kirjurinkuja 3 F 46 02600 Espoo
-  %br
-  +358-50-5311793
-  %br
-  antti.virolainen (at) sharetribe.com
-
-%h3
   Name of the register
 %p
   User register of the #{service_name} service

--- a/app/views/infos/localized_privacy_policy/privacy_policy.fi.haml
+++ b/app/views/infos/localized_privacy_policy/privacy_policy.fi.haml
@@ -8,17 +8,6 @@
   info@sharetribe.com
 
 %h3
-  Yhteyshenkilö rekisteriä koskevissa asioissa
-%p
-  Antti Virolainen
-  %br
-  Kirjurinkuja 3 F 46 02600 Espoo
-  %br
-  +358-50-5311793
-  %br
-  antti.virolainen@sharetribe.com
-
-%h3
   Rekisterin nimi
 %p
   #{service_name}-palvelun käyttäjärekisteri


### PR DESCRIPTION
This was added back in 2013 when main market was still in Finland and local law required to have one contact person named. Lately it has caused more confusion than helped anyone, so better to remove it. Anyway the marketplaces typically need to update the terms according to their own use case and local regulations.