### PR TITLE
Add a string marker at the end of image export

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -30,7 +30,9 @@ namespace :export do
         print_image_urls(listing_image.image)
       end
     end
-
+    # Make sure this string is printed in the end. It is used to verify the
+    # image list export.
+    puts "\n# ::image-export-end::"
   end
 
 end


### PR DESCRIPTION
Used to verify that image list was complete.