### PR TITLE
JsAdapter class naming convention changes.

### DIFF
--- a/app/controllers/listing_images_controller.rb
+++ b/app/controllers/listing_images_controller.rb
@@ -59,7 +59,7 @@ class ListingImagesController < ApplicationController
     if !listing_image
       render body: nil, status: 404
     else
-      render json: ListingImageJSAdapter.new(listing_image).to_json, status: 200
+      render json: ListingImageJsAdapter.new(listing_image).to_json, status: 200
     end
   end
 
@@ -102,7 +102,7 @@ class ListingImagesController < ApplicationController
         logger.info("Listing image is already downloaded", :image_already_downloaded, listing_image_id: listing_image.id, params: params.except(:image))
       end
 
-      render json: ListingImageJSAdapter.new(listing_image).to_json, status: 202, content_type: 'text/plain' # Browsers without XHR fileupload support do not support other dataTypes than text
+      render json: ListingImageJsAdapter.new(listing_image).to_json, status: 202, content_type: 'text/plain' # Browsers without XHR fileupload support do not support other dataTypes than text
     else
       logger.error("Saving listing image failed", :saving_listing_image_failed, params: params, errors: listing_image.errors.messages)
       render json: {:errors => listing_image.errors.full_messages}, status: 400, content_type: 'text/plain'

--- a/app/models/listing_image_js_adapter.rb
+++ b/app/models/listing_image_js_adapter.rb
@@ -1,4 +1,4 @@
-class ListingImageJSAdapter < JSAdapter
+class ListingImageJsAdapter < JsAdapter
   ASPECT_RATIO = 3/2.to_f
 
   def initialize(listing_image)

--- a/app/models/listing_image_s3_options_js_adapter.rb
+++ b/app/models/listing_image_s3_options_js_adapter.rb
@@ -1,4 +1,4 @@
-class ListingImageS3OptionsJSAdapter < JSAdapter
+class ListingImageS3OptionsJsAdapter < JsAdapter
 
   def initialize(listing)
     s3uploader = S3Uploader.new

--- a/app/services/js_adapter.rb
+++ b/app/services/js_adapter.rb
@@ -1,5 +1,5 @@
 # Helps passing JSON data to JavaScript
-class JSAdapter
+class JsAdapter
   include ApplicationController::DefaultURLOptions
 
   # Due to the way Rails includes the url helpers, this has to be AFTER DefaultURLOptions.

--- a/app/views/listings/form/_javascripts.haml
+++ b/app/views/listings/form/_javascripts.haml
@@ -5,8 +5,8 @@
 - content_for :listing_js do
   :javascript
     $(document).ready(function() {
-      var listingImageOpts = #{raw ListingImageS3OptionsJSAdapter.new(@listing).to_json}
-      var listingImages = #{raw @listing.listing_images.map { |image| ListingImageJSAdapter.new(image) }.to_json }
+      var listingImageOpts = #{raw ListingImageS3OptionsJsAdapter.new(@listing).to_json}
+      var listingImages = #{raw @listing.listing_images.map { |image| ListingImageJsAdapter.new(image) }.to_json }
 
       window.ST.initialize_new_listing_form("#{t('listings.form.images.no_file_selected')}", "#{t('listings.form.images.select_file')}", "#{I18n.locale}", "#{t('error_messages.listings.share_type')}", "#{valid_until_msg}", "#{listing_id}", "#{shape[:price_enabled]}","#{t('error_messages.listings.price')}","#{minimum_price_cents}","#{Money::Currency.new(@current_community.currency).subunit_to_unit}","#{t('error_messages.listings.minimum_price', :minimum_price => Money.new(minimum_price_cents, @current_community.currency), :currency => @current_community.currency)}", #{raw @numeric_field_ids.collect { |numeric_field_id| "custom_fields[#{numeric_field_id}]" }.to_json }, listingImages, listingImageOpts, "#{t('listings.form.images.images_not_uploaded_confirm')}" );
     });

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -53,7 +53,7 @@
 
             - content_for :extra_javascript do
               :javascript
-                var listingImages = #{raw listing_images.map { |image| ListingImageJSAdapter.new(image) }.to_json }
+                var listingImages = #{raw listing_images.map { |image| ListingImageJsAdapter.new(image) }.to_json }
                 var currentImage = #{params[:image].present? ? params[:image].to_i : listing_images.first.id};
                 ST.listingImages(listingImages, currentImage);
           - else


### PR DESCRIPTION
When we try to call ListingImageJSAdapter/ListingImageS3OptionsJSAdapter getting the below error because of wrong naming convention.

Unable to annotate app/models/listing_image_js_adapter.rb: Unable to autoload constant ListingImageJsAdapter, expected /home/unify/git_repo/p21-os-sharetribe/app/models/listing_image_js_adapter.rb to define it
Unable to annotate app/models/listing_image_s3_options_js_adapter.rb: Unable to autoload constant ListingImageS3OptionsJsAdapter, expected /home/unify/git_repo/p21-os-sharetribe/app/models/listing_image_s3_options_js_adapter.rb to define it