### PR TITLE
Remove unnecessary indexes

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -53,7 +53,6 @@
 # Indexes
 #
 #  community_author_deleted            (community_id,author_id,deleted)
-#  homepage_query_valid_until          (community_id,open,valid_until,sort_date,deleted)
 #  index_listings_on_category_id       (old_category_id)
 #  index_listings_on_community_id      (community_id)
 #  index_listings_on_listing_shape_id  (listing_shape_id)

--- a/db/migrate/20190305112030_add_state_indexes_to_listings.rb
+++ b/db/migrate/20190305112030_add_state_indexes_to_listings.rb
@@ -1,8 +1,9 @@
 class AddStateIndexesToListings < ActiveRecord::Migration[5.1]
   def change
-    remove_index :listings, name: 'homepage_query'
-    remove_index :listings, name: 'updates_email_listings'
     add_index :listings, [:community_id, :open, :state, :deleted, :valid_until, :sort_date], name: 'listings_homepage_query'
     add_index :listings, [:community_id, :open, :state, :deleted, :valid_until, :updates_email_at, :created_at], name: 'listings_updates_email'
+
+    remove_index :listings, name: 'homepage_query', column: ["community_id", "open", "sort_date"]
+    remove_index :listings, name: 'updates_email_listings', column: ["community_id", "open", "updates_email_at"]
   end
 end

--- a/db/migrate/20190319122745_remove_old_listings_index.rb
+++ b/db/migrate/20190319122745_remove_old_listings_index.rb
@@ -1,0 +1,5 @@
+class RemoveOldListingsIndex < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :listings, name: 'homepage_query_valid_until', column: ["community_id", "open", "valid_until", "sort_date", "deleted"]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -826,7 +826,6 @@ CREATE TABLE `listings` (
   UNIQUE KEY `index_listings_on_uuid` (`uuid`),
   KEY `index_listings_on_new_category_id` (`category_id`) USING BTREE,
   KEY `person_listings` (`community_id`,`author_id`) USING BTREE,
-  KEY `homepage_query_valid_until` (`community_id`,`open`,`valid_until`,`sort_date`,`deleted`) USING BTREE,
   KEY `index_listings_on_community_id` (`community_id`) USING BTREE,
   KEY `index_listings_on_listing_shape_id` (`listing_shape_id`) USING BTREE,
   KEY `index_listings_on_category_id` (`old_category_id`) USING BTREE,
@@ -2373,5 +2372,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190213082646'),
 ('20190227111355'),
 ('20190228084827'),
-('20190305112030');
+('20190305112030'),
+('20190319122745');
+
 

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -53,7 +53,6 @@
 # Indexes
 #
 #  community_author_deleted            (community_id,author_id,deleted)
-#  homepage_query_valid_until          (community_id,open,valid_until,sort_date,deleted)
 #  index_listings_on_category_id       (old_category_id)
 #  index_listings_on_community_id      (community_id)
 #  index_listings_on_listing_shape_id  (listing_shape_id)

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -52,7 +52,6 @@
 # Indexes
 #
 #  community_author_deleted            (community_id,author_id,deleted)
-#  homepage_query_valid_until          (community_id,open,valid_until,sort_date,deleted)
 #  index_listings_on_category_id       (old_category_id)
 #  index_listings_on_community_id      (community_id)
 #  index_listings_on_listing_shape_id  (listing_shape_id)


### PR DESCRIPTION
Old index prevents newer and more efficient one to be used. Also fixes older migration to be reversible and do index manipulation in correct order.