### PR TITLE
Update CI to use Ubuntu-based image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     # Call bash as interactive login shell to make sure nvm is loaded through .bashrc
     shell: /bin/bash -ileo pipefail
     docker:
-      - image: circleci/ruby:2.3.4-jessie-browsers
+      - image: sharetribe/ruby:2.3.4-xenial-ci
         environment:
           CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
           MOCHA_FILE: /tmp/circleci-test-results/mocha.xml
@@ -24,12 +24,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - bundler-cache-v2-{{ checksum "Gemfile.lock" }}
-            - bundler-cache-v2-
+            - bundler-cache-v3-{{ checksum "Gemfile.lock" }}
+            - bundler-cache-v3-
       - restore_cache:
           keys:
-            - node-cache-v3-{{ checksum "package.json" }}-{{ checksum "client/package.json" }}
-            - node-cache-v3-
+            - node-cache-v4-{{ checksum "package.json" }}-{{ checksum "client/package.json" }}
+            - node-cache-v4-
       - run:
           name: install system deps
           command: script/ci-install-deps.sh
@@ -40,12 +40,12 @@ jobs:
           name: npm install
           command: npm install
       - save_cache:
-          key: bundler-cache-v2-{{ checksum "Gemfile.lock" }}
+          key: bundler-cache-v3-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
             - ~/.bundle
       - save_cache:
-          key: node-cache-v3-{{ checksum "package.json" }}-{{ checksum "client/package.json" }}
+          key: node-cache-v4-{{ checksum "package.json" }}-{{ checksum "client/package.json" }}
           paths:
             - ~/.nvm
             - ~/.bashrc

--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,8 @@ gem "request_store", '~> 1.3.2'
 # ActionMailer dependency that needs forced update for security patch
 gem 'mail', '~> 2.6.6.rc1'
 
+gem 'tzinfo-data', '~> 1.2017', '>= 1.2017.2'
+
 group :staging, :production do
   gem 'newrelic_rpm', '~> 4.2.0.334'
   gem 'rails_12factor', '~> 0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,6 +556,8 @@ GEM
       tzinfo
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2018.9)
+      tzinfo (>= 1.0.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
@@ -687,6 +689,7 @@ DEPENDENCIES
   truncate_html (~> 0.9.3)
   ts-delayed-delta!
   twitter_cldr
+  tzinfo-data (~> 1.2017, >= 1.2017.2)
   uglifier (~> 3.2.0)
   uuidtools (~> 2.1.5)
   web-console (~> 3.5.1)

--- a/script/ci-install-deps.sh
+++ b/script/ci-install-deps.sh
@@ -2,8 +2,6 @@
 
 set -eo pipefail
 
-echo 'deb http://deb.debian.org/debian jessie-backports main' | sudo tee -a /etc/apt/sources.list
-
 sudo apt-get update && sudo apt-get install -y sphinxsearch mysql-client
 
 if [[ -f ~/.nvm/nvm.sh ]] ; then


### PR DESCRIPTION
Jessie backports are gone and sphinxsearch can't be installed through them.