### PR TITLE
Add query_track to find slow SQL queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ end
 group :development, :test do
   gem 'rubocop', '~> 0.67.2', require: false
   gem 'factory_girl_rails', '~> 4.8.0'
+  gem 'query_track', '~> 0.0.7'
 end
 
 group :development, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,11 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
+    dry-configurable (0.8.3)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.4, >= 0.4.7)
+    dry-core (0.4.8)
+      concurrent-ruby (~> 1.0)
     dynamic_form (1.1.4)
     email_spec (2.1.1)
       htmlentities (~> 4.3.3)
@@ -406,6 +411,10 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
+    query_track (0.0.7)
+      activesupport
+      dry-configurable
+      slack_hook
     rack (2.0.7)
     rack-attack (6.0.0)
       rack (>= 1.0, < 3)
@@ -530,6 +539,7 @@ GEM
     sitemap_generator (5.3.1)
       builder (~> 3.0)
     sixarm_ruby_unaccent (1.1.1)
+    slack_hook (0.1.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -682,6 +692,7 @@ DEPENDENCIES
   pry-byebug
   public_suffix (~> 2.0.5)
   puma
+  query_track (~> 0.0.7)
   rack-attack (~> 6.0.0)
   rails (= 5.2.3)
   rails-controller-testing (~> 1.0.2)

--- a/config/initializers/query_track.rb
+++ b/config/initializers/query_track.rb
@@ -1,0 +1,6 @@
+if %w[development test].include?(Rails.env)
+  QueryTrack::Settings.configure do |config|
+    config.duration = 1
+    config.logs = true
+  end
+end


### PR DESCRIPTION
I suggest adding a gem query_track which will be show in the console info about SQL queries which slower than 1s (for example, this is configurable). Can add for `development` and `test` environments, because for `staging` and `production` already used newrelic. Developers will be easier to profile the database and improve performance on development.

Example of log (from another project):
![console](https://user-images.githubusercontent.com/5091851/62295179-2c5d5c00-b475-11e9-9ad1-d5545a99f9e0.jpg)