### PR TITLE
[Bug] Disabling top bar default links (about, contact) is not possible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@ test-results.xml
 .byebug_history
 .vimrc
 client/.vimrc
+storage/
 

--- a/app/controllers/admin/communities/topbar_controller.rb
+++ b/app/controllers/admin/communities/topbar_controller.rb
@@ -21,10 +21,12 @@ class Admin::Communities::TopbarController < Admin::AdminBaseController
   def update
     menu_links_params = Maybe(params)[:menu_links].permit!.or_else({menu_link_attributes: {}})
 
+    configuration_enabled_params = [:display_about_menu, :display_contact_menu, :display_invite_menu]
     if FeatureFlagHelper.feature_enabled?(:topbar_v1) || CustomLandingPage::LandingPageStore.enabled?(@current_community.id)
-      configuration_params = params[:configuration].permit(:limit_priority_links, :display_about_menu, :display_contact_menu, :display_invite_menu)
-      @current_community.configuration.update(configuration_params)
+      configuration_enabled_params << [:limit_priority_links]
     end
+    configuration_params = params[:configuration].permit(configuration_enabled_params)
+    @current_community.configuration.update(configuration_params)
 
     translations = params.to_unsafe_hash[:post_new_listing_button].map{ |k, v| {locale: k, translation: v}}
 

--- a/app/views/layouts/_header_menu.haml
+++ b/app/views/layouts/_header_menu.haml
@@ -8,18 +8,21 @@
     = icon_map_tag(icons, "new_listing", ["icon-with-text"])
     = t("homepage.index.post_new_listing")
 
-  = link_to about_infos_path do
-    = icon_map_tag(icons, "information", ["icon-with-text"])
-    = t("header.about")
+  - if @current_community.configuration.display_about_menu?
+    = link_to about_infos_path do
+      = icon_map_tag(icons, "information", ["icon-with-text"])
+      = t("header.about")
 
-  = link_to new_user_feedback_path do
-    = icon_map_tag(icons, "feedback", ["icon-with-text"])
-    = t("header.contact_us")
+  - if @current_community.configuration.display_contact_menu?
+    = link_to new_user_feedback_path do
+      = icon_map_tag(icons, "feedback", ["icon-with-text"])
+      = t("header.contact_us")
 
-  - with_invite_link do
-    = link_to new_invitation_path do
-      = icon_map_tag(icons, "invite", ["icon-with-text"])
-      = t("header.invite")
+  - if @current_community.configuration.display_invite_menu?
+    - with_invite_link do
+      = link_to new_invitation_path do
+        = icon_map_tag(icons, "invite", ["icon-with-text"])
+        = t("header.invite")
 
   - Maybe(@current_community).menu_links.each do |menu_links|
     - menu_links.each do |menu_link|

--- a/spec/controllers/admin/communities/topbar_controller_spec.rb
+++ b/spec/controllers/admin/communities/topbar_controller_spec.rb
@@ -28,7 +28,7 @@ describe Admin::Communities::TopbarController, type: :controller do
       RequestStore.store[:clp_enabled] = false
       expect(TranslationService::API::Api.translations).to receive(:create)
         .with(@community.id, translations_group)
-      put :update, params: { id: @community.id, post_new_listing_button: {fi: text_fi, en: text_en} }
+      put :update, params: { id: @community.id, post_new_listing_button: {fi: text_fi, en: text_en}, configuration: { display_about_menu: 1 }}
     end
 
     it "should not update Post new listing button text with an invalid translation param" do
@@ -37,7 +37,7 @@ describe Admin::Communities::TopbarController, type: :controller do
 
       RequestStore.store[:clp_enabled] = false
       expect(TranslationService::API::Api.translations).to_not receive(:create).with(anything())
-      patch :update, params: {post_new_listing_button: {fi: text_fi, en: text_en}}
+      patch :update, params: {post_new_listing_button: {fi: text_fi, en: text_en}, configuration: { display_about_menu: 1 }}
     end
   end
 


### PR DESCRIPTION
  when feature flag :topbar_v1 is disabled