### PR TITLE
[Bug] cast section position to int on reordering of CLP sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This file follows the best practices from [keepachangelog.com](http://keepachang
 
 ### Fixed
 
+- Fixed issue for CLP sections reordering incorrectly when # of sections > 10
+
 ### Security
 
 ## [9.0.0] - 2019-10-02

--- a/app/models/landing_page_version/data_structure.rb
+++ b/app/models/landing_page_version/data_structure.rb
@@ -67,7 +67,7 @@ module LandingPageVersion::DataStructure
 
   def section_positions_attributes=(section_positions_params)
     composition = []
-    section_positions_params.values.sort_by { |a| a['position'] }.each do |section_position|
+    section_positions_params.values.sort_by { |a| a['position'].to_i }.each do |section_position|
       composition << { 'section' => {'type' => 'sections', 'id' =>  section_position['id'] }}
     end
     new_content = parsed_content.dup


### PR DESCRIPTION
There is an issue with CLP editor,  when # of sections is higher than 10, ordering fails. 
This PR fixes the issue