### PR TITLE
Remove Amazon as overwritten ActiveStorage config on development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -113,5 +113,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.active_storage.service = :amazon
 end


### PR DESCRIPTION
`/config/environments/development.rb` already has `config.active_storage.service = :local` in line 73. The Amazon storage config is overwriting this setting at the bottom of the file. Must have been a wrongly checked in line? 

Was causing issues getting the codebase running locally with this config without setting up Amazon for local file storage. 