### PR TITLE
Fix license formatting issue

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -28,8 +28,9 @@ Sharetribe grants You a permanent, non-exclusive, royalty-free, worldwide, non-t
 1. use the Software;
 2. prepare modifications and derivative works of the Software;
 3. distribute the Software (including without limitation in source code or object code form); and
-reproduce copies of the Software.
-4. The licensed rights exclude the right to make the Software available as a software-as-a-service or platform-as-a-service where You host the Software for multiple clients or other similar online services that compete with Sharetribe products or services that provide the Software (“Excluded Purpose”).
+4. reproduce copies of the Software.
+
+The licensed rights exclude the right to make the Software available as a software-as-a-service or platform-as-a-service where You host the Software for multiple clients or other similar online services that compete with Sharetribe products or services that provide the Software (“Excluded Purpose”).
 
 ### 1.2 Attribution requirement.
 You may make the Software available if you meet the following attribution conditions:


### PR DESCRIPTION
I noticed a formatting error in the license text, where a following
paragraph was enumerated in a list, rather than the final element.

I am NOT reviewing or approving the legal substance of the license.  Do
not rely on this patch for legal advice.  See https://notlegaladvice.law
for more information.