### PR TITLE
Fix booking validation

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -34,8 +34,7 @@ class Booking < ApplicationRecord
   scope :covers_another_booking_per_hour, ->(booking) do
     exclude_self(booking)
     .joins(:tx).per_hour_blocked
-    .where(['(start_time <= ? AND end_time > ?) OR (start_time < ? AND end_time >= ?)',
-            booking.start_time, booking.start_time, booking.end_time, booking.end_time])
+    .where(['start_time < ? AND end_time > ?', booking.end_time, booking.start_time])
   end
   scope :availability_blocking, -> { merge(Transaction.availability_blocking) }
   scope :per_hour_blocked, -> { hourly_basis.availability_blocking }
@@ -45,8 +44,7 @@ class Booking < ApplicationRecord
   scope :covers_another_booking_per_day, ->(booking) do
     exclude_self(booking)
     .joins(:tx).per_day_blocked
-    .where(['(start_on <= ? AND end_on > ?) OR (start_on < ? AND end_on >= ?)',
-            booking.start_on, booking.start_on, booking.end_on, booking.end_on])
+    .where(['start_on < ? AND end_on > ?', booking.end_on, booking.start_on])
   end
   scope :exclude_self, ->(booking) do
     booking.persisted? ? where.not(id: booking.id) : self

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -81,7 +81,8 @@ class Booking < ApplicationRecord
     return true if per_hour
 
     self.class.uncached do
-      if tx.listing.bookings.covers_another_booking_per_day(self).any?
+      if tx.listing.bookings.covers_another_booking_per_day(self).any? ||
+         tx.listing.blocked_dates.in_period_end_exclusive(self.start_on, self.end_on).any?
         errors.add(:start_on, :invalid)
         errors.add(:end_on, :invalid)
       end

--- a/app/models/listing/blocked_date.rb
+++ b/app/models/listing/blocked_date.rb
@@ -23,6 +23,10 @@ class Listing::BlockedDate < ApplicationRecord
     where('blocked_at >= ? AND blocked_at <= ?', start_on, end_on)
   end
 
+  scope :in_period_end_exclusive, ->(start_on, end_on) do
+    where('blocked_at >= ? AND blocked_at < ?', start_on, end_on)
+  end
+
   def as_json(options = {})
     super(options.merge(only: [:id, :blocked_at]))
   end


### PR DESCRIPTION
For day-based bookings:

* fix check for existing overlapping bookings (previously it didn't account for all possible ways booking range can overlap)
* add validation ensuring that no blocked dates overlap with the booking dates

For time-based bookings:
* fix check for existing overlapping bookings (previously it didn't account for all possible ways booking range can overlap)

UI is out of scope in this PR - a user may still attempt to book date range that contains other bookings and/or blocked dates, but the server will validate the request correctly.