### PR TITLE
Fix query for booked dates in range

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -40,7 +40,7 @@ class Booking < ApplicationRecord
   scope :per_hour_blocked, -> { hourly_basis.availability_blocking }
   scope :daily_basis, -> { where(per_hour: false) }
   scope :per_day_blocked, -> { daily_basis.availability_blocking }
-  scope :in_per_day_period, ->(start_time, end_time) { where(['start_on >= ? AND end_on <= ?', start_time, end_time]) }
+  scope :in_per_day_period, ->(start_time, end_time) { where(['start_on < ? AND end_on > ?', end_time, start_time]) }
   scope :covers_another_booking_per_day, ->(booking) do
     exclude_self(booking)
     .joins(:tx).per_day_blocked

--- a/app/models/listing/concerns/manage_availability_per_day.rb
+++ b/app/models/listing/concerns/manage_availability_per_day.rb
@@ -13,9 +13,11 @@ module ManageAvailabilityPerDay
   # returns array of datetime at beginning of day
   def booked_dates(start_on, end_on)
     result = []
-    bookings_per_day.in_per_day_period(start_on, end_on).each do |booking|
-      end_on = booking.end_on - 1.day
-      result += (booking.start_on..end_on).to_a.map{|x| x.to_time(:utc)}
+    # end_on is inclusive, but booking model query is exclusive on end
+    bookings_per_day.in_per_day_period(start_on, end_on + 1.day).each do |booking|
+      trimmed_start_on = [booking.start_on, start_on].max
+      trimmed_end_on = [booking.end_on - 1.day, end_on].min
+      result += (trimmed_start_on..trimmed_end_on).to_a.map{|x| x.to_time(:utc)}
     end
     result
   end

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -115,4 +115,22 @@ describe Listing, type: :model do
       expect(booking.valid?).to eq false
     end
   end
+
+  describe "per day period" do
+    it 'booking overlapping with range' do
+      expect(Booking.in_per_day_period('2050-11-19', '2050-11-25')).to eq [booking1]
+
+      expect(Booking.in_per_day_period('2050-11-20', '2050-11-25')).to eq [booking1]
+      expect(Booking.in_per_day_period('2050-11-21', '2050-11-25')).to eq [booking1]
+      expect(Booking.in_per_day_period('2050-11-22', '2050-11-25')).to eq [booking1]
+
+      expect(Booking.in_per_day_period('2050-11-19', '2050-11-23')).to eq [booking1]
+      expect(Booking.in_per_day_period('2050-11-19', '2050-11-22')).to eq [booking1]
+
+      expect(Booking.in_per_day_period('2050-11-21', '2050-11-22')).to eq [booking1]
+
+      expect(Booking.in_per_day_period('2050-11-23', '2050-11-25')).to eq []
+      expect(Booking.in_per_day_period('2050-11-19', '2050-11-20')).to eq []
+    end
+  end
 end


### PR DESCRIPTION
Query did not account for bookings that start before or end after the query
range, but still overlap with the range.