### PR TITLE
Fix inconsistent tx left after transition fails

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -99,6 +99,7 @@ class Transaction < ApplicationRecord
   monetize :minimum_buyer_fee_cents, with_model_currency: :minimum_buyer_fee_currency
 
   scope :exist, -> { where(deleted: false) }
+  scope :initialized, -> { where.not(current_state: nil) }
   scope :for_person, -> (person){
     where('listing_author_id = ? OR starter_id = ?', person.id, person.id)
   }

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -105,7 +105,7 @@ class Transaction < ApplicationRecord
   scope :availability_blocking, -> do
     where(current_state: ['payment_intent_requires_action', 'preauthorized', 'paid', 'confirmed', 'canceled', 'dismissed', 'disputed'])
   end
-  scope :non_free, -> { where('current_state <> ?', ['free']) }
+  scope :non_free_including_uninitialized, -> { where('current_state IS NULL OR current_state <> ?', ['free']) }
   scope :by_community, -> (community_id) { where(community_id: community_id) }
   scope :with_payment_conversation, -> {
     left_outer_joins(:conversation).merge(Conversation.payment)

--- a/app/services/admin/transactions_service.rb
+++ b/app/services/admin/transactions_service.rb
@@ -27,7 +27,7 @@ module Admin
     end
 
     def transactions_scope
-      scope = Transaction.exist.by_community(community.id)
+      scope = Transaction.exist.initialized.by_community(community.id)
 
       if personal
         scope = scope.for_person(current_user)

--- a/spec/controllers/admin/community_transactions_controller_spec.rb
+++ b/spec/controllers/admin/community_transactions_controller_spec.rb
@@ -57,6 +57,14 @@ describe Admin::CommunityTransactionsController, type: :controller do
                                      last_transition_at: 60.minutes.ago,
                                      conversation: conversation)
   end
+  let(:transaction4) do
+    FactoryGirl.create(:transaction,
+                       community: community,
+                       listing: listing1,
+                       starter: person3,
+                       current_state: nil,
+                       last_transition_at: nil)
+  end
   let(:admin) { create_admin_for(community) }
 
   before(:each) do
@@ -71,6 +79,7 @@ describe Admin::CommunityTransactionsController, type: :controller do
       transaction1
       transaction2
       transaction3
+      transaction4
     end
 
     it 'works' do

--- a/spec/controllers/admin/csv_export_spec.rb
+++ b/spec/controllers/admin/csv_export_spec.rb
@@ -17,7 +17,7 @@ describe Admin::CommunityMembershipsController, type: :controller do
     end
 
     it "returns CSV with actual data" do
-      get :index, params: {format: :csv, community_id: @community.id} 
+      get :index, params: {format: :csv, community_id: @community.id}
       response_arr = CSV.parse(response.body)
       expect(response_arr.count).to eq(3)
       user = Hash[*response_arr[0].zip(response_arr[1]).flatten]
@@ -53,7 +53,7 @@ describe Admin::CommunityTransactionsController, type: :controller do
     sign_in_for_spec(@person)
     @request.host = "#{@community.ident}.lvh.me"
     @request.env[:current_marketplace] = @community
-    @transaction = FactoryGirl.create(:transaction, starter: @person, listing: @listing, community: @community)
+    @transaction = FactoryGirl.create(:transaction, starter: @person, listing: @listing, current_state: :initiated, community: @community)
   end
 
   describe "transactions CSV export" do


### PR DESCRIPTION
- [ ] fix cause for deadlocks
- [x] write transaction to consistent state after failure to initialized (e.g. mark as deleted)
- [x] fix transaction view breaking on uninitialized transactions
- [x] fix conversations view breaking on uninitialized transactions