### PR TITLE
Increase Facebook and Twitter meta images size

### DIFF
--- a/app/models/listing_image.rb
+++ b/app/models/listing_image.rb
@@ -67,6 +67,8 @@ class ListingImage < ApplicationRecord
       {width: 240, height: 160}
     when :medium
       {width: 360, height: 270}
+    when :big
+      {width: 660, height: 440}
     when :thumb
       {width: 120, height: 120}
     when :email
@@ -75,7 +77,7 @@ class ListingImage < ApplicationRecord
       {width: 408, height: 408}
     when :square_2x
       {width: 816, height: 816}
-    when :original, :big
+    when :original
       raise NotImplementedError.new("This feature is not implemented yet for style: #{style}")
     else
       raise ArgumentError.new("Unknown style: #{style}")

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -15,7 +15,7 @@
 - content_for :meta_author, PersonViewUtils.person_display_name(@listing.author, @current_community)
 - content_for :meta_description, StringUtils.first_words(@listing.description, 15)
 - content_for :meta_image, @listing.listing_images.first.image.url(:big) if !@listing.listing_images.empty?
-- dimensions = @listing.listing_images.first.get_dimensions_for_style(:medium) if !@listing.listing_images.empty?
+- dimensions = @listing.listing_images.first.get_dimensions_for_style(:big) if !@listing.listing_images.empty?
 - content_for :meta_image_width, dimensions[:width].to_s if !@listing.listing_images.empty?
 - content_for :meta_image_height, dimensions[:height].to_s if !@listing.listing_images.empty?
 

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -14,7 +14,7 @@
 - content_for :title, raw(@listing.title)
 - content_for :meta_author, PersonViewUtils.person_display_name(@listing.author, @current_community)
 - content_for :meta_description, StringUtils.first_words(@listing.description, 15)
-- content_for :meta_image, @listing.listing_images.first.image.url(:medium) if !@listing.listing_images.empty?
+- content_for :meta_image, @listing.listing_images.first.image.url(:big) if !@listing.listing_images.empty?
 - dimensions = @listing.listing_images.first.get_dimensions_for_style(:medium) if !@listing.listing_images.empty?
 - content_for :meta_image_width, dimensions[:width].to_s if !@listing.listing_images.empty?
 - content_for :meta_image_height, dimensions[:height].to_s if !@listing.listing_images.empty?


### PR DESCRIPTION
In the meta tags of listing pages the social media link preview, the `og:image` or `twitter:image` value, was using the `medium` version of the first listing image. The `medium` version size was 360x270.

Things work but with a bigger image, the type of link preview in Facebook would be better. See https://developers.facebook.com/docs/sharing/webmasters/images/.
To be able to get the larger display, the recommended image should be 600x315.

This PR defines a new `big` style size, 660x440 and takes it into use for the Facebook and Twitter meta tags.