### PR TITLE
Fix translation for de.listings.unit_types.person

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2550,7 +2550,7 @@ de:
       week: Woche
       month: Monat
       unit: Einheit
-      person: Persone
+      person: Person
     verification_required:
       verification_required: "Verifizierung erforderlich"
   listing_conversations:


### PR DESCRIPTION
Minor bug, but the misspelled word is visible very prominently.