### PR TITLE
Add more states to FINISHED_TX_STATES to allow user account deletion correctly

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -61,7 +61,7 @@ class Transaction < ApplicationRecord
   # While initiated is technically not a finished state it also
   # doesn't have any payment data to track against, so removing person
   # is still safe.
-  FINISHED_TX_STATES = ['initiated', 'free', 'rejected', 'confirmed', 'canceled', 'errored'].freeze
+  FINISHED_TX_STATES = ['initiated', 'free', 'rejected', 'confirmed', 'canceled', 'errored', 'payment_intent_action_expired', 'payment_intent_failed', 'refunded', 'dismissed', 'disputed'].freeze
 
   attr_accessor :contract_agreed
 


### PR DESCRIPTION
When a user or admin tries to delete their account forever, they can do it only if their transactions have been all finished, as in "no payout is pending".

The list of states that are OK to move forward with an account deletion, `FINISHED_TX_STATES`, is at https://github.com/sharetribe/sharetribe/blob/master/app/models/transaction.rb#L64.

However that list isn't up-to-date: some recently added states are missing. This prevents the deletion of some user accounts for reasons that are not correct.

The full list of states can be found at https://github.com/sharetribe/sharetribe/blob/master/app/state_machines/transaction_process_state_machine.rb#L17

From that full list, the following were already accepted as finished transaction states:
````
state :free
state :initiated
state :rejected
state :confirmed
state :canceled
state :errored
````

The following were not considered as finished transaction states but should be and are added with that PR:
````
state :payment_intent_action_expired
state :payment_intent_failed
state :refunded
state :dismissed
state :disputed
````

This leaves the following list of states that prevents an account deletion:
````
state :not_started, initial: true
state :pending  # Deprecated
state :payment_intent_requires_action
state :preauthorized
state :pending_ext
state :accepted # Deprecated
state :paid
````

