### PR TITLE
Update airbrake and newrelic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "css_parser", '~> 1.7.0'
 gem 'stringex', '~> 2.7.1'
 gem 'paypal-sdk-permissions', '~> 1.96.4'
 gem 'paypal-sdk-merchant', '~> 1.116.0'
-gem 'airbrake', '~> 9.1.0'
+gem 'airbrake', '~> 9.5.5'
 gem 'stripe', '~> 4.9.0'
 
 gem 'lograge', '~> 0.10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem 'mail', '~> 2.6.6.rc1'
 gem 'tzinfo-data', '~> 1.2017', '>= 1.2017.2'
 
 group :staging, :production do
-  gem 'newrelic_rpm', '~> 4.2.0.334'
+  gem 'newrelic_rpm', '~> 6.11.0'
   gem 'rails_12factor', '~> 0.0.3'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "css_parser", '~> 1.7.0'
 gem 'stringex', '~> 2.7.1'
 gem 'paypal-sdk-permissions', '~> 1.96.4'
 gem 'paypal-sdk-merchant', '~> 1.116.0'
-gem 'airbrake', '~> 9.5.5'
+gem 'airbrake', '~> 10.0.4'
 gem 'stripe', '~> 4.9.0'
 
 gem 'lograge', '~> 0.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
       connection_pool (~> 2.2)
     net_http_ssl_fix (0.0.10)
     netrc (0.11.0)
-    newrelic_rpm (4.2.0.334)
+    newrelic_rpm (6.11.0.365)
     nio4r (2.4.0)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
@@ -693,7 +693,7 @@ DEPENDENCIES
   mini_racer
   money-rails (~> 1.8.0)
   mysql2 (= 0.4.10)
-  newrelic_rpm (~> 4.2.0.334)
+  newrelic_rpm (~> 6.11.0)
   omniauth-facebook (~> 5.0.0)
   omniauth-google-oauth2 (>= 0.6.0)
   omniauth-linkedin-oauth2 (>= 1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    airbrake (9.5.5)
-      airbrake-ruby (~> 4.8)
+    airbrake (10.0.4)
+      airbrake-ruby (~> 4.13)
     airbrake-ruby (4.14.1)
       rbtree3 (~> 0.5)
     annotate (2.7.5)
@@ -638,7 +638,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store (~> 1.1.3)
-  airbrake (~> 9.5.5)
+  airbrake (~> 10.0.4)
   annotate (~> 2.7.5)
   awesome_print (~> 1.7.0)
   aws-sdk-s3 (~> 1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,9 +70,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    airbrake (9.1.0)
-      airbrake-ruby (~> 4.2)
-    airbrake-ruby (4.2.5)
+    airbrake (9.5.5)
+      airbrake-ruby (~> 4.8)
+    airbrake-ruby (4.14.1)
       rbtree3 (~> 0.5)
     annotate (2.7.5)
       activerecord (>= 3.2, < 7.0)
@@ -471,7 +471,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
-    rbtree3 (0.5.0)
+    rbtree3 (0.6.0)
     react_on_rails (11.3.0)
       addressable
       connection_pool
@@ -638,7 +638,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store (~> 1.1.3)
-  airbrake (~> 9.1.0)
+  airbrake (~> 9.5.5)
   annotate (~> 2.7.5)
   awesome_print (~> 1.7.0)
   aws-sdk-s3 (~> 1)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -3,6 +3,9 @@ if APP_CONFIG.use_airbrake
     config.project_id = APP_CONFIG.airbrake_project_id
     config.project_key = APP_CONFIG.airbrake_project_key
 
+    # Disable performance monitoring. Performance monitoring sends metrics on
+    # each request and is priced separately by request volume.
+    config.performance_stats = false
 
     config.root_directory = Rails.root
     config.logger = Rails.logger

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -57,7 +57,7 @@ common: &default_settings
   # encryption involved in SSL communication, but this work is done
   # asynchronously to the threads that process your application code,
   # so it should not impact response times.
-  ssl: false
+  ssl: true
 
   # EXPERIMENTAL: enable verification of the SSL certificate sent by
   # the server. This setting has no effect unless SSL is enabled


### PR DESCRIPTION
Upgrade Airbrake and Newrelic agents to latest versions. Latest Airbrake seemed to cause issues with the old version of Newrelic agent. Anyway, it's great to update both.