### PR TITLE
Fix issue with error translation in some languages

### DIFF
--- a/app/models/custom_field_values/dropdown_field_value.rb
+++ b/app/models/custom_field_values/dropdown_field_value.rb
@@ -31,7 +31,7 @@ class DropdownFieldValue < OptionFieldValue
       return true unless question.required?
     end
     unless custom_field_option_selections.size == 1
-      errors.add(:custom_field_option_selections, :'wrong_length.one')
+      errors.add(:custom_field_option_selections, :'wrong_length.one', {count: 1})
     end
   end
 end


### PR DESCRIPTION
Some languages (e.g. Russian), use :count interpolation even in the "one"
variant.