### PR TITLE
Make active storage service configurable

### DIFF
--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -52,6 +52,10 @@ default: &default_settings
   # Default bucket
   s3_bucket_name:
 
+  # Use local (disk) storage service by default. Set to "amazon" when using S3
+  # for CLP assets. See config/storage.yml.
+  active_storage_service: local
+
   # Bucket for CLP images
   clp_s3_bucket_name:
 
@@ -499,6 +503,8 @@ production: &production_settings
 
   eager_load: true
 
+  active_storage_service: amazon
+
   log_level: INFO
   stripe_private_key_pattern: "\\Ask_live_.{24,200}\\z"
   stripe_publishable_key_pattern: "\\Apk_live_.{24,200}\\z"
@@ -506,6 +512,8 @@ production: &production_settings
 staging:
   <<: *production_settings
   # By default staging has same settings as production, but those can be overridden here.
+
+  active_storage_service: amazon
 
   log_level: INFO
   stripe_private_key_pattern: "\\Ask_(test|live)_.{24,200}\\z"
@@ -567,6 +575,7 @@ test:
 
   # don't use S3 in tests. (this is the default to avoid
   # anyone losing money for paying for the hosting of test images)
+  active_storage_service: test
   s3_bucket_name:
   aws_access_key_id:
   aws_secret_access_key:
@@ -592,4 +601,3 @@ test:
   feature_stripe_private_key: sk_test_123456789012345678901234
 
   admin_enable_tracking_config: true
-

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,7 +70,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  config.active_storage.service = APP_CONFIG.active_storage_service.to_sym
 
   config.action_controller.action_on_unpermitted_parameters = :raise
 
@@ -113,5 +113,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.active_storage.service = :amazon
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -148,5 +148,5 @@ Rails.application.configure do
   # We don't need schema dumps in this environment
   config.active_record.dump_schema_after_migration = false
 
-  config.active_storage.service = :amazon
+  config.active_storage.service = APP_CONFIG.active_storage_service.to_sym
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -148,5 +148,5 @@ Rails.application.configure do
   # We don't need schema dumps in this environment
   config.active_record.dump_schema_after_migration = false
 
-  config.active_storage.service = :amazon
+  config.active_storage.service = APP_CONFIG.active_storage_service.to_sym
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.action_controller.action_on_unpermitted_parameters = :raise
 
   # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
+  config.active_storage.service = APP_CONFIG.active_storage_service.to_sym
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
Local storage makes sense as default, but changing it should be possible via environment variables / config.yml.

Replaces #4039 