### PR TITLE
[Bug] No listing location makes clicks on "Show in the next newsletter" impossible

### DIFF
--- a/app/assets/javascripts/listing.js
+++ b/app/assets/javascripts/listing.js
@@ -59,7 +59,7 @@ window.ST = window.ST || {};
         text.html(actionError);
       });
     });
-    if (options.fuzzy_location) {
+    if (options.fuzzy_location && options.listing_location) {
       initFuzzyLocation(options);
     }
   };

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -7,7 +7,7 @@
   :javascript
     window.ST.listing({
       fuzzy_location: #{@current_community.fuzzy_location.to_json},
-      listing_location: #{raw @listing.location&.coordinates(@current_community.fuzzy_location)}
+      listing_location: #{raw @listing.location&.coordinates(@current_community.fuzzy_location) || false}
     });
   - if @current_community.fuzzy_location && !(search_mode != :keyword)
     - maps_key = MarketplaceHelper.google_maps_key(@current_community.id)


### PR DESCRIPTION
If a listing doesn't have a location defined (the "Location" field in the listing form is left empty), then when admins click on the "Show in the next newsletter" link in the listing sidebar, it simply doesn't do anything.

This is happening whether or not the location feature is enabled, or whatever the location search setting.

Admins should always be able to click the "Show in the next newsletter" link. 

This fixes it.