### PR TITLE
Add script for pulling all WTI translation projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ coverage/
 .env
 .session.vim
 
+# WTI real config file. See .wti.main and .wti.admin instead
+.wti
+
 # React on Rails
 npm-debug.log*
 node_modules

--- a/.wti.admin
+++ b/.wti.admin
@@ -1,6 +1,6 @@
-# There are multiple WebTranslateIt for Go, uncomment the api_key you want to use
-api_key: proj_pub_sFyFJRPy8lu-r3AKvMcBEw # Sharetribe Go - Main interface
-# api_key: proj_pub_rAKU_rb4rGIVa1P5nAWy-Q # Sharetribe Go - Admin panel (new version)
+# There are multiple WebTranslateIt for Go, this config file contains the key for the
+# Admin panel (new version) translations
+api_key: proj_pub_rAKU_rb4rGIVa1P5nAWy-Q
 
 # Optional: locales not to sync with WebTranslateIt.
 # Takes a string, a symbol, or an array of string or symbol.

--- a/.wti.main
+++ b/.wti.main
@@ -1,0 +1,21 @@
+# There are multiple WebTranslateIt for Go, this config file contains the kye for the
+# Go main interface translations
+api_key: proj_pub_sFyFJRPy8lu-r3AKvMcBEw
+
+# Optional: locales not to sync with WebTranslateIt.
+# Takes a string, a symbol, or an array of string or symbol.
+# More information here: https://github.com/AtelierConvivialite/webtranslateit/wiki
+# ignore_locales: 'en'
+
+# Or if you prefer a list of locales to sync with WebTranslateIt:
+# needed_locales: ["fi", "pl", "et", "zh", "nl", "sl", "en", "de", "cs", "sk-SK", "es", "fr", "ar", "ti", "he-IL", "lt", "lv", "sq-AL", "is", "ro", "it", "mk", "es-MX", "ca", "az-AZ", "crp", "hr", "ta-IN", "tr-TR", "zh-HK", "es-CL", "id", "hy-AM", "uk", "es-ES", "nb", "ms-MY", "el", "sw", "ru", "sr", "fr-CA", "en-AU", "zh-TW", "th-TH", "eo", "hi-IN", "ja", "hu", "sv", "bg", "en-NZ", "eu-ES", "mn", "ka", "pt-PT", "vi", "ab", "pt-BR", "da-DK", "en-GB", "ko", "bn-BD", "km-KH"]
+
+# Optional
+# before_pull: "echo 'some unix command'"   # Command executed before pulling files
+# after_pull:  "touch tmp/restart.txt"      # Command executed after pulling files
+#
+# before_push: "echo 'some unix command'"   # Command executed before pushing files
+# after_push:  "touch tmp/restart.txt"      # Command executed after pushing files
+
+# Silence SSL errors
+# silence_errors: true

--- a/script/wti-pull-all.sh
+++ b/script/wti-pull-all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+if [[ -f .wti.main && -f .wti.admin ]] ; then
+    echo "Pulling main Go interface translations..."
+    cp .wti.main .wti && wti pull
+
+    echo "Pulling Go Admin panel translations..."
+    cp .wti.admin .wti && wti pull
+
+    rm -f .wti
+else
+    echo "No .wti.main or .wti.admin files found. Are you running this script from the Go project root directory?"
+    exit 1
+fi


### PR DESCRIPTION
Running `./script/wti-pull-all.sh` from the project root directory will
pull all translations.