### PR TITLE
Admin2 analytics and event support

### DIFF
--- a/app/controllers/admin2/general/essentials_controller.rb
+++ b/app/controllers/admin2/general/essentials_controller.rb
@@ -18,6 +18,10 @@ module Admin2::General
 
     def update_essential
       update_results = []
+
+      find_or_initialize_customizations(@current_community.locales)
+      slogan_and_description_before = slogan_and_description_present?(@current_community.community_customizations)
+
       analytic = AnalyticService::CommunityCustomizations.new(user: @current_user, community: @current_community)
       @current_community.locales.map do |locale|
         customizations = find_or_initialize_customizations_for_locale(locale)
@@ -37,6 +41,10 @@ module Admin2::General
       end
       analytic.send_properties
       if update_results.all? && (!process_locales || enabled_locales_valid)
+        slogan_and_description_after = slogan_and_description_present?(@current_community.community_customizations.reload)
+        if !slogan_and_description_before && slogan_and_description_after
+          record_event(flash, "km_record", {km_event: "Onboarding slogan/description created"})
+        end
         flash[:notice] = t('admin2.notifications.essentials_updated')
       else
         raise t('admin2.notifications.essentials_update_failed')
@@ -48,6 +56,12 @@ module Admin2::General
     end
 
     private
+
+    def slogan_and_description_present?(community_customizations)
+      slogan_present = community_customizations.all? { |c| c.slogan.present? }
+      description_present = community_customizations.all? { |c| c.description.present? }
+      slogan_present && description_present
+    end
 
     def community_custom_params(locale)
       params.require(:community_customizations)

--- a/app/helpers/admin2_helper.rb
+++ b/app/helpers/admin2_helper.rb
@@ -118,6 +118,10 @@ module Admin2Helper
 
   def flash_messages(opts = {})
     flash.each do |msg_type, message|
+      # The flash is used to pass data (e.g. analytics events) in addition to UI
+      # messages. Only render flash contents that are meant to be UI messages
+      next unless [:success, :error, :alert, :notice].include?(msg_type.to_sym)
+
       concat(content_tag(:div, message, class: "alert #{bootstrap_class_for(msg_type)}", role: "alert") do
         concat content_tag(:button, 'x', class: "close", data: { dismiss: 'alert' })
         concat message

--- a/app/views/layouts/admin.haml
+++ b/app/views/layouts/admin.haml
@@ -7,6 +7,7 @@
     %meta{content: 'width=device-width, initial-scale=1 shrink-to-fit=no', name: 'viewport'}
     %meta{content: admin_description.html_safe, name: 'description'}
     %link{rel: 'shortcut icon', type: 'image/icon', href: @current_community.favicon}
+    = render :partial => 'analytics/head_scripts', locals: { community: @current_community, user: @current_user, plan: @current_plan }
     = csrf_meta_tags
     - path_font = APP_CONFIG[:font_proximasoft_url]
     - if path_font.present?
@@ -38,3 +39,4 @@
       = render 'admin2/expired_popup_admin'
 
     = content_for :extra_javascript
+    = render :partial => 'analytics/bottom_scripts'


### PR DESCRIPTION
Adds missing head/bottom scripts to admin2 panel. Implements the "slogan and description set" analytics event in admin2.