### PR TITLE
Typo correction on StateMachine comments.

### DIFF
--- a/app/services/transaction_service/state_machine.rb
+++ b/app/services/transaction_service/state_machine.rb
@@ -27,7 +27,7 @@ module TransactionService
           state_machine.transition_to(new_status, metadata_hash)
         rescue StandardError
           # If transaction failed to transition to it's first state (e.g.
-          # :initialized or :free), mark it as deleted. Reload is needed, in
+          # :initiated or :free), mark it as deleted. Reload is needed, in
           # order to get the clean state of the transaction that is recorded in
           # the db and ensure that the model does not contain leftover unsaved
           # data.

--- a/app/services/transaction_service/state_machine.rb
+++ b/app/services/transaction_service/state_machine.rb
@@ -27,7 +27,7 @@ module TransactionService
           state_machine.transition_to(new_status, metadata_hash)
         rescue StandardError
           # If transaction failed to transition to it's first state (e.g.
-          # :initialized or :free), mark it as delted. Reload is needed, in
+          # :initialized or :free), mark it as deleted. Reload is needed, in
           # order to get the clean state of the transaction that is recorded in
           # the db and ensure that the model does not contain leftover unsaved
           # data.


### PR DESCRIPTION
Renaming `:initialized` to `:initiated` since the `:initialized` is not a valid state.