### PR TITLE
Lower member mail job priority

### DIFF
--- a/app/jobs/create_member_email_batch_job.rb
+++ b/app/jobs/create_member_email_batch_job.rb
@@ -17,7 +17,7 @@ class CreateMemberEmailBatchJob < Struct.new(:sender_id, :community_id, :content
 
     Delayed::Job.transaction do
       community_members(mode, current_community).pluck(:id).each do |recipient_id|
-        Delayed::Job.enqueue(CommunityMemberEmailSentJob.new(sender_id, recipient_id, community_id, content, locale))
+        Delayed::Job.enqueue(CommunityMemberEmailSentJob.new(sender_id, recipient_id, community_id, content, locale), :priority => 9)
       end
     end
   end


### PR DESCRIPTION
Avoids job queueing problems when emails are sent to large communities.