### PR TITLE
Fix job priorities

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -314,10 +314,6 @@ class ApplicationController < ActionController::Base
   def fetch_community_membership
     if @current_user
       @current_community_membership = CommunityMembership.where(person_id: @current_user.id, community_id: @current_community.id, status: "accepted").first
-
-      if (@current_community_membership && !date_equals?(@current_community_membership.last_page_load_date, Date.today))
-        Delayed::Job.enqueue(PageLoadedJob.new(@current_community_membership.id, request.host))
-      end
     end
   end
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -460,7 +460,7 @@ class ListingsController < ApplicationController
   def notify_about_new_listing
     Delayed::Job.enqueue(ListingCreatedJob.new(@listing.id, @current_community.id))
     if @current_community.follow_in_use? && !@listing.approval_pending?
-      Delayed::Job.enqueue(NotifyFollowersJob.new(@listing.id, @current_community.id), :run_at => NotifyFollowersJob::DELAY.from_now)
+      Delayed::Job.enqueue(NotifyFollowersJob.new(@listing.id, @current_community.id), :run_at => NotifyFollowersJob::DELAY.from_now, priority: 12)
     end
 
     flash[:notice] = t(

--- a/app/jobs/create_member_email_batch_job.rb
+++ b/app/jobs/create_member_email_batch_job.rb
@@ -17,7 +17,7 @@ class CreateMemberEmailBatchJob < Struct.new(:sender_id, :community_id, :content
 
     Delayed::Job.transaction do
       community_members(mode, current_community).pluck(:id).each do |recipient_id|
-        Delayed::Job.enqueue(CommunityMemberEmailSentJob.new(sender_id, recipient_id, community_id, content, locale), :priority => 9)
+        Delayed::Job.enqueue(CommunityMemberEmailSentJob.new(sender_id, recipient_id, community_id, content, locale), :priority => 20)
       end
     end
   end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -275,12 +275,12 @@ class Community < ApplicationRecord
 
   # process_in_background definitions have to be after
   # after all attachments: https://github.com/jrgifford/delayed_paperclip/issues/129
-  process_in_background :logo
-  process_in_background :wide_logo
-  process_in_background :cover_photo
-  process_in_background :small_cover_photo
+  process_in_background :logo, priority: 1
+  process_in_background :wide_logo, priority: 1
+  process_in_background :cover_photo, priority: 1
+  process_in_background :small_cover_photo, priority: 1
 
-  process_in_background :favicon
+  process_in_background :favicon, priority: 1
 
   before_save :cache_previous_image_urls
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -223,7 +223,7 @@ class Person < ApplicationRecord
                       :thumb => "48x48#",
                       :original => "600x800>"}
 
-  process_in_background :image
+  process_in_background :image, priority: 1
 
   #validates_attachment_presence :image
   validates_attachment_size :image, :less_than => 9.megabytes

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -39,3 +39,16 @@ module Paperclip
   end
 end
 
+module DelayedPaperclip
+  class ProcessJob < ActiveJob::Base
+    def self.enqueue_delayed_paperclip(instance_klass, instance_id, attachment_name)
+      delayed_opts = instance_klass.constantize.paperclip_definitions[attachment_name][:delayed]
+
+      # DelayedPaperclip sets priority to 0 (highest) by default, so we switch
+      # the default to 5, as it is the default for all other jobs.
+      priority = delayed_opts[:priority] > 0 ? delayed_opts[:priority] : 5
+
+      set(:queue => delayed_opts[:queue_name], priority: priority).perform_later(instance_klass, instance_id, attachment_name.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Fixes issue with delayed_paperclip ignoring configured job priority (e.g. listing images were supposed to have priotity 1, but instead worked with default priority 5). Adjusts priorities for some email notification and image processing jobs:
* processing of community/user images is now changed to use priority 1, like listing images
* priority for sending follower notifications is reduced
* priority for sending email to community members is set to lowest, as emailing in large communities must not block other operations