### PR TITLE
Sunset PayPal in India

### DIFF
--- a/app/services/transaction_service/available_currencies.rb
+++ b/app/services/transaction_service/available_currencies.rb
@@ -122,7 +122,6 @@ module TransactionService::AvailableCurrencies
     "GBP" => :country_sets,
     "HKD" => :country_sets,
     "HUF" => :country_sets,
-    "INR" => "IN", # INR is valid only for PayPal accounts in India
     "ILS" => :country_sets,
     "JPY" => :country_sets,
     "MXN" => :country_sets,


### PR DESCRIPTION
PayPal is stopping their operations in India and no longer supports the country and currency.