### PR TITLE
Use a valid git clone link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Before you get started, the following needs to be installed:
 1.  Get the code. Clone this git repository and check out the latest release:
 
     ```bash
-    git clone git://github.com/sharetribe/sharetribe.git
+    git clone git@github.com:sharetribe/sharetribe.git
     cd sharetribe
     git checkout latest
     ```


### PR DESCRIPTION
I was puzzled as to why my `git clone` command wasn't doing anything and then I realised that the link in the installation guide is invalid.