### PR TITLE
Update et.yml

### DIFF
--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1122,7 +1122,7 @@ et:
         plaanite saata palju kutseid, peaksite kasutama e-posti saatmise tööriista.
         Vaadake %{this_article_link}, et leida sobivate e-teenuste kohta allikaid.'
       this_article_link: see artikkel
-      invitation_emails_field_placeholder: sõber1@näide.com, sõber2@näide.com, ...
+      invitation_emails_field_placeholder: sõber1@example.com, sõber2@example.com, ...
       invitation_message_field_placeholder: Ma liitusin fantastilise rendiplatvormiga
         inimeselt inimesele. Liitu ka!
       errors_in_emails: Kontrolli, kas lisatud e-posti aadressid on õiged ega sisalda


### PR DESCRIPTION
**näide.com** is not the same as **example.com**

Read more - https://secret.näide.com/

## Summary
Localization was fixed, to use example.com domain not a private domain

## Motivation
Security related. Not an urgent(probably seen as a no-issue by many) security issue, but could/should trigger the thought process of the same "example.com" email in other languages

## Testing
Compare the output of
[https://example.com/](https://youtu.be/dQw4w9WgXcQ?Seriously+Watch+Where+You+Are+Clicking)
https://näide.com/
https://secret.example.com/
https://secret.näide.com/
To verify that they are not the same
