### PR TITLE
Fix delayed deltas after Thinking Sphinx upgrade

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -44,6 +44,8 @@ class CustomField < ApplicationRecord
   scope :is_public, ->{ where(public: true) }
   scope :required, ->{ where(required: true) }
 
+  ThinkingSphinx::Callbacks.append(self, behaviours: [:sql, :deltas])
+
   ENTITY_TYPES = {
     for_listing: 0,
     for_person: 1

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -110,6 +110,8 @@ class Listing < ApplicationRecord
   monetize :shipping_price_cents, allow_nil: true, with_model_currency: :currency
   monetize :shipping_price_additional_cents, allow_nil: true, with_model_currency: :currency
 
+  ThinkingSphinx::Callbacks.append(self, behaviours: [:sql, :deltas])
+
   before_validation :set_valid_until_time
 
   validates_presence_of :author_id


### PR DESCRIPTION
The problem that is being fixed here is described in detail on the community forum: https://www.sharetribe.com/community/t/search-not-working-in-sharetribe-go-version-11-delayed-deltas/3720

The problem started happening after `thinking-sphinx` gem was upgraded from 3.3.0 to 5.5.0 in [this commit](https://github.com/sharetribe/sharetribe/commit/f133562eb3d8423ed52967bdbd6a68012d909aed). Apparently, there was a breaking API change in 5.0.0 release of Thinking Sphinx described in its [release notes](https://github.com/pat/thinking-sphinx/releases/tag/v5.0.0). Basically, callbacks aren’t added automatically for all `ActiveRecord` models anymore, you need to add them explicitly. I searched GitHub for examples of other projects that upgraded Thinking Sphinx to 5.0.0 or higher, hoping to see what changes they had to implement. I found a couple examples of such upgrades: [1](https://github.com/public-accountability/littlesis-rails/commit/70516808fe955694f20cbd626fda77a35b48cbb8), [2](https://github.com/JasonBarnabe/greasyfork/commit/da13eff5be59ff02ae91a2a585018372ba0a04a7). I applied the same changes to my copy of Sharetribe and that fixed the issue.